### PR TITLE
ci: fix release artifact uploads and add PR artifact builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,12 @@ jobs:
           fi
 
   build-pr:
-    name: Build PR artifacts
+    name: Build (${{ matrix.goos }}/${{ matrix.goarch }})
     if: github.event_name == 'pull_request'
     needs: [test, lint]
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     strategy:
       matrix:
         include:
@@ -59,6 +58,12 @@ jobs:
             goarch: amd64
           - goos: linux
             goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
 
     steps:
       - uses: actions/checkout@v4
@@ -74,69 +79,44 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: 0
         run: |
+          BINARY=dicode
+          if [ "$GOOS" = "windows" ]; then BINARY=dicode.exe; fi
           mkdir -p dist
           go build \
             -ldflags "-X main.version=pr-${{ github.event.pull_request.number }} -s -w" \
-            -o "dist/dicode-${{ matrix.goos }}-${{ matrix.goarch }}" \
+            -o "dist/${BINARY}" \
             ./cmd/dicode/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: dicode-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: dist/dicode-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/
           retention-days: 7
 
   comment-pr:
-    name: Comment on PR
+    name: Comment artifacts on PR
     if: github.event_name == 'pull_request'
     needs: build-pr
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
-      - name: Post artifact links
-        uses: actions/github-script@v7
+      - name: Post sticky comment
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          script: |
-            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const sha = context.payload.pull_request.head.sha.slice(0, 7);
-            const body = [
-              '## Build Artifacts',
-              '',
-              `Dev binaries for commit \`${sha}\` (Linux only — macOS/Windows built on release):`,
-              '',
-              '| Platform | Download |',
-              '| --- | --- |',
-              `| linux/amd64 | [dicode-linux-amd64](${runUrl}#artifacts) |`,
-              `| linux/arm64 | [dicode-linux-arm64](${runUrl}#artifacts) |`,
-              '',
-              `> Artifacts expire after 7 days. [View run](${runUrl})`,
-              '<!-- dicode-build-artifacts -->',
-            ].join('\n');
+          header: build-artifacts
+          message: |
+            ## Build Artifacts
 
-            const marker = '<!-- dicode-build-artifacts -->';
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-            });
-            const existing = comments.find(c =>
-              c.user.type === 'Bot' && c.body.includes(marker)
-            );
+            Dev binaries for `${{ github.event.pull_request.head.sha }}` — all platforms built from Linux via cross-compilation (`CGO_ENABLED=0`):
 
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body,
-              });
-            }
+            | Platform | Artifact |
+            | --- | --- |
+            | linux/amd64 | [dicode-linux-amd64](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) |
+            | linux/arm64 | [dicode-linux-arm64](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) |
+            | darwin/amd64 | [dicode-darwin-amd64](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) |
+            | darwin/arm64 | [dicode-darwin-arm64](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) |
+            | windows/amd64 | [dicode-windows-amd64](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) |
+
+            > Artifacts expire after 7 days. Systray is disabled in these builds (`CGO_ENABLED=0`); release builds are identical.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,100 @@ jobs:
             echo "$unformatted"
             exit 1
           fi
+
+  build-pr:
+    name: Build PR artifacts
+    if: github.event_name == 'pull_request'
+    needs: [test, lint]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 0
+        run: |
+          mkdir -p dist
+          go build \
+            -ldflags "-X main.version=pr-${{ github.event.pull_request.number }} -s -w" \
+            -o "dist/dicode-${{ matrix.goos }}-${{ matrix.goarch }}" \
+            ./cmd/dicode/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dicode-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/dicode-${{ matrix.goos }}-${{ matrix.goarch }}
+          retention-days: 7
+
+  comment-pr:
+    name: Comment on PR
+    if: github.event_name == 'pull_request'
+    needs: build-pr
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post artifact links
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const sha = context.payload.pull_request.head.sha.slice(0, 7);
+            const body = [
+              '## Build Artifacts',
+              '',
+              `Dev binaries for commit \`${sha}\` (Linux only — macOS/Windows built on release):`,
+              '',
+              '| Platform | Download |',
+              '| --- | --- |',
+              `| linux/amd64 | [dicode-linux-amd64](${runUrl}#artifacts) |`,
+              `| linux/arm64 | [dicode-linux-arm64](${runUrl}#artifacts) |`,
+              '',
+              `> Artifacts expire after 7 days. [View run](${runUrl})`,
+              '<!-- dicode-build-artifacts -->',
+            ].join('\n');
+
+            const marker = '<!-- dicode-build-artifacts -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            }

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,6 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
-      upload_url: ${{ steps.release.outputs.upload_url }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -32,30 +31,20 @@ jobs:
     name: Build (${{ matrix.goos }}/${{ matrix.goarch }})
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
           - goos: linux
             goarch: amd64
-            runs-on: ubuntu-latest
-            cgo: 0
           - goos: linux
             goarch: arm64
-            runs-on: ubuntu-latest
-            cgo: 0
           - goos: darwin
             goarch: amd64
-            runs-on: macos-13
-            cgo: 1
           - goos: darwin
             goarch: arm64
-            runs-on: macos-latest
-            cgo: 1
           - goos: windows
             goarch: amd64
-            runs-on: windows-latest
-            cgo: 1
 
     steps:
       - uses: actions/checkout@v4
@@ -66,11 +55,10 @@ jobs:
           cache: true
 
       - name: Build binary
-        shell: bash
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: ${{ matrix.cgo }}
+          CGO_ENABLED: 0
         run: |
           TAG=${{ needs.release-please.outputs.tag_name }}
           BINARY=dicode
@@ -82,10 +70,9 @@ jobs:
             ./cmd/dicode/
 
       - name: Create archive
-        shell: bash
         run: |
           TAG=${{ needs.release-please.outputs.tag_name }}
-          # Strip the package-name prefix so the archive is just dicode-v0.0.2-linux-amd64
+          # Strip package-name prefix: dicode-v0.0.2 → v0.0.2
           VERSION=${TAG#dicode-}
           ARCHIVE="dicode-${VERSION}-${{ matrix.goos }}-${{ matrix.goarch }}"
           if [ "${{ matrix.goos }}" = "windows" ]; then
@@ -97,11 +84,9 @@ jobs:
           fi
 
       - name: Upload release asset
-        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release upload ${{ needs.release-please.outputs.tag_name }} "$ASSET"
+        run: gh release upload ${{ needs.release-please.outputs.tag_name }} "$ASSET"
 
   publish:
     name: Publish release

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [main]
 
+# Prevent concurrent runs on main so that a release-please follow-up commit
+# never cancels the build jobs started by the release commit.
+concurrency:
+  group: release-please-main
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write
@@ -14,6 +20,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      upload_url: ${{ steps.release.outputs.upload_url }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -65,27 +72,28 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: ${{ matrix.cgo }}
         run: |
-          VERSION=${{ needs.release-please.outputs.tag_name }}
-          BINARY_NAME=dicode
-          if [ "$GOOS" = "windows" ]; then
-            BINARY_NAME=dicode.exe
-          fi
+          TAG=${{ needs.release-please.outputs.tag_name }}
+          BINARY=dicode
+          if [ "$GOOS" = "windows" ]; then BINARY=dicode.exe; fi
           mkdir -p dist
           go build \
-            -ldflags "-X main.version=${VERSION} -s -w" \
-            -o "dist/${BINARY_NAME}" \
+            -ldflags "-X main.version=${TAG} -s -w" \
+            -o "dist/${BINARY}" \
             ./cmd/dicode/
 
       - name: Create archive
         shell: bash
         run: |
-          ARCHIVE_NAME="dicode-${{ needs.release-please.outputs.tag_name }}-${{ matrix.goos }}-${{ matrix.goarch }}"
+          TAG=${{ needs.release-please.outputs.tag_name }}
+          # Strip the package-name prefix so the archive is just dicode-v0.0.2-linux-amd64
+          VERSION=${TAG#dicode-}
+          ARCHIVE="dicode-${VERSION}-${{ matrix.goos }}-${{ matrix.goarch }}"
           if [ "${{ matrix.goos }}" = "windows" ]; then
-            cd dist && zip "${ARCHIVE_NAME}.zip" dicode.exe && cd ..
-            echo "ASSET_PATH=dist/${ARCHIVE_NAME}.zip" >> $GITHUB_ENV
+            cd dist && zip "${ARCHIVE}.zip" dicode.exe && cd ..
+            echo "ASSET=dist/${ARCHIVE}.zip" >> $GITHUB_ENV
           else
-            tar -czf "dist/${ARCHIVE_NAME}.tar.gz" -C dist dicode
-            echo "ASSET_PATH=dist/${ARCHIVE_NAME}.tar.gz" >> $GITHUB_ENV
+            tar -czf "dist/${ARCHIVE}.tar.gz" -C dist dicode
+            echo "ASSET=dist/${ARCHIVE}.tar.gz" >> $GITHUB_ENV
           fi
 
       - name: Upload release asset
@@ -93,4 +101,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ needs.release-please.outputs.tag_name }} "$ASSET_PATH"
+          gh release upload ${{ needs.release-please.outputs.tag_name }} "$ASSET"
+
+  publish:
+    name: Publish release
+    needs: [release-please, build]
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Undraft release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit ${{ needs.release-please.outputs.tag_name }} \
+            --draft=false \
+            --repo ${{ github.repository }}

--- a/pkg/tray/icon.go
+++ b/pkg/tray/icon.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package tray
 
 // icon generates a 32×32 PNG icon at init time: purple background (#7c3aed),

--- a/pkg/tray/tray.go
+++ b/pkg/tray/tray.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 // Package tray manages the system-tray icon for dicode.
 // On Linux it uses the StatusNotifierItem DBus protocol (no GTK needed).
 // On macOS it uses the native NSStatusItem.

--- a/pkg/tray/tray_nocgo.go
+++ b/pkg/tray/tray_nocgo.go
@@ -1,0 +1,12 @@
+//go:build !cgo
+
+package tray
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+// Run is a no-op when CGO is disabled (cross-compiled build without systray support).
+func Run(_ context.Context, _ context.CancelFunc, _ int, _ *zap.Logger) {}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "package-name": "dicode"
     }
   },
+  "draft": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,


### PR DESCRIPTION
## Summary

### Root cause of release failures

1. **Archive naming bug** — tag is \`dicode-v0.0.2\` but archive was named \`dicode-dicode-v0.0.2-linux-amd64\` (double prefix). Fixed by stripping the package-name prefix.
2. **HTTP 422 "immutable release"** — release-please publishes the release immediately then makes a follow-up commit to update \`.release-please-manifest.json\`. That second push triggered a new workflow run which cancelled the in-progress build jobs mid-upload. Fixed with \`draft: true\` + \`cancel-in-progress: false\` + a \`publish\` job that un-drafts only after all assets are uploaded.

### Cross-compilation from Linux

Go can cross-compile to all platforms with \`CGO_ENABLED=0\`. The only blocker was \`fyne.io/systray\` which uses Objective-C/Win32 CGO on macOS/Windows. Fixed by adding \`//go:build cgo\` constraints to the tray package and a \`!cgo\` no-op stub — the tray just doesn't show up in cross-compiled builds (it's already config-gated anyway).

All 5 platform builds now run on \`ubuntu-latest\`. No macOS or Windows runners needed.

### PR artifact comment

- \`build-pr\` job: builds all 5 platforms after test+lint pass
- \`comment-pr\` job: uses \`marocchino/sticky-pull-request-comment@v2\` to create/update a single sticky comment with artifact download links (keyed by \`header: build-artifacts\`, updated on each push)

## Test plan

- [ ] Open a PR → CI passes → bot posts sticky comment with 5 artifact links
- [ ] Push another commit → same comment is updated (not a new one)
- [ ] Merge to main → release-please creates a **draft** release
- [ ] All 5 platform builds succeed on \`ubuntu-latest\`
- [ ] \`publish\` job un-drafts the release after all assets uploaded
- [ ] Archive names are \`dicode-v0.x.x-linux-amd64.tar.gz\` (no double prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)