### PR TITLE
ci: replace custom build matrix with goreleaser

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Keep GitHub Actions up to date
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # Keep Go modules up to date
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      go-deps:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      url-linux-amd64:   ${{ steps.upload-linux-amd64.outputs.artifact-url }}
+      url-linux-arm64:   ${{ steps.upload-linux-arm64.outputs.artifact-url }}
+      url-darwin-amd64:  ${{ steps.upload-darwin-amd64.outputs.artifact-url }}
+      url-darwin-arm64:  ${{ steps.upload-darwin-arm64.outputs.artifact-url }}
+      url-windows-amd64: ${{ steps.upload-windows-amd64.outputs.artifact-url }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -71,11 +77,47 @@ jobs:
         env:
           GORELEASER_CURRENT_TAG: pr-${{ github.event.pull_request.number }}
 
-      - name: Upload artifacts
+      - name: List dist
+        run: find dist -type f | sort
+
+      - name: Upload linux/amd64
+        id: upload-linux-amd64
         uses: actions/upload-artifact@v4
         with:
-          name: dicode-pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
-          path: dist/
+          name: dicode-linux-amd64
+          path: dist/dicode_linux_amd64_v1/dicode
+          retention-days: 7
+
+      - name: Upload linux/arm64
+        id: upload-linux-arm64
+        uses: actions/upload-artifact@v4
+        with:
+          name: dicode-linux-arm64
+          path: dist/dicode_linux_arm64/dicode
+          retention-days: 7
+
+      - name: Upload darwin/amd64
+        id: upload-darwin-amd64
+        uses: actions/upload-artifact@v4
+        with:
+          name: dicode-darwin-amd64
+          path: dist/dicode_darwin_amd64_v1/dicode
+          retention-days: 7
+
+      - name: Upload darwin/arm64
+        id: upload-darwin-arm64
+        uses: actions/upload-artifact@v4
+        with:
+          name: dicode-darwin-arm64
+          path: dist/dicode_darwin_arm64/dicode
+          retention-days: 7
+
+      - name: Upload windows/amd64
+        id: upload-windows-amd64
+        uses: actions/upload-artifact@v4
+        with:
+          name: dicode-windows-amd64
+          path: dist/dicode_windows_amd64_v1/dicode.exe
           retention-days: 7
 
   comment-pr:
@@ -93,16 +135,14 @@ jobs:
           message: |
             ## Build Artifacts
 
-            Dev binaries for `${{ github.event.pull_request.head.sha }}` (all platforms, cross-compiled from Linux):
+            Dev binaries for `${{ github.event.pull_request.head.sha }}`:
 
-            | Platform | File |
+            | Platform | Download |
             | --- | --- |
-            | linux/amd64 | `dicode-linux-amd64` |
-            | linux/arm64 | `dicode-linux-arm64` |
-            | darwin/amd64 | `dicode-darwin-amd64` |
-            | darwin/arm64 (Apple Silicon) | `dicode-darwin-arm64` |
-            | windows/amd64 | `dicode-windows-amd64.exe` |
-
-            [Download all from this run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            | linux/amd64 | [dicode-linux-amd64](${{ needs.build-pr.outputs.url-linux-amd64 }}) |
+            | linux/arm64 | [dicode-linux-arm64](${{ needs.build-pr.outputs.url-linux-arm64 }}) |
+            | darwin/amd64 | [dicode-darwin-amd64](${{ needs.build-pr.outputs.url-darwin-amd64 }}) |
+            | darwin/arm64 (Apple Silicon) | [dicode-darwin-arm64](${{ needs.build-pr.outputs.url-darwin-arm64 }}) |
+            | windows/amd64 | [dicode-windows-amd64.exe](${{ needs.build-pr.outputs.url-windows-amd64 }}) |
 
             > Artifacts expire after 7 days.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,52 +45,33 @@ jobs:
           fi
 
   build-pr:
-    name: Build (${{ matrix.goos }}/${{ matrix.goarch }})
+    name: Build PR artifacts
     if: github.event_name == 'pull_request'
     needs: [test, lint]
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy:
-      matrix:
-        include:
-          - goos: linux
-            goarch: amd64
-          - goos: linux
-            goarch: arm64
-          - goos: darwin
-            goarch: amd64
-          - goos: darwin
-            goarch: arm64
-          - goos: windows
-            goarch: amd64
-
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           cache: true
 
-      - name: Build
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: build --clean --snapshot
         env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: 0
-        run: |
-          BINARY=dicode
-          if [ "$GOOS" = "windows" ]; then BINARY=dicode.exe; fi
-          mkdir -p dist
-          go build \
-            -ldflags "-X main.version=pr-${{ github.event.pull_request.number }} -s -w" \
-            -o "dist/${BINARY}" \
-            ./cmd/dicode/
+          GORELEASER_CURRENT_TAG: pr-${{ github.event.pull_request.number }}
 
-      - name: Upload artifact
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dicode-${{ matrix.goos }}-${{ matrix.goarch }}
+          name: dicode-pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           path: dist/
           retention-days: 7
 
@@ -109,14 +90,16 @@ jobs:
           message: |
             ## Build Artifacts
 
-            Dev binaries for `${{ github.event.pull_request.head.sha }}` — all platforms built from Linux via cross-compilation (`CGO_ENABLED=0`):
+            Dev binaries for `${{ github.event.pull_request.head.sha }}` (all platforms, cross-compiled from Linux):
 
-            | Platform | Artifact |
+            | Platform | File |
             | --- | --- |
-            | linux/amd64 | [dicode-linux-amd64](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) |
-            | linux/arm64 | [dicode-linux-arm64](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) |
-            | darwin/amd64 | [dicode-darwin-amd64](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) |
-            | darwin/arm64 | [dicode-darwin-arm64](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) |
-            | windows/amd64 | [dicode-windows-amd64](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) |
+            | linux/amd64 | `dicode-linux-amd64` |
+            | linux/arm64 | `dicode-linux-arm64` |
+            | darwin/amd64 | `dicode-darwin-amd64` |
+            | darwin/arm64 (Apple Silicon) | `dicode-darwin-arm64` |
+            | windows/amd64 | `dicode-windows-amd64.exe` |
 
-            > Artifacts expire after 7 days. Systray is disabled in these builds (`CGO_ENABLED=0`); release builds are identical.
+            [Download all from this run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+            > Artifacts expire after 7 days.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,9 @@ concurrency:
   group: release-please-main
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [main]
 
-# Prevent concurrent runs on main so that a release-please follow-up commit
-# never cancels the build jobs started by the release commit.
 concurrency:
   group: release-please-main
   cancel-in-progress: false
@@ -27,77 +25,27 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  build:
-    name: Build (${{ matrix.goos }}/${{ matrix.goarch }})
+  goreleaser:
+    name: GoReleaser
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - goos: linux
-            goarch: amd64
-          - goos: linux
-            goarch: arm64
-          - goos: darwin
-            goarch: amd64
-          - goos: darwin
-            goarch: arm64
-          - goos: windows
-            goarch: amd64
-
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           cache: true
 
-      - name: Build binary
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: 0
-        run: |
-          TAG=${{ needs.release-please.outputs.tag_name }}
-          BINARY=dicode
-          if [ "$GOOS" = "windows" ]; then BINARY=dicode.exe; fi
-          mkdir -p dist
-          go build \
-            -ldflags "-X main.version=${TAG} -s -w" \
-            -o "dist/${BINARY}" \
-            ./cmd/dicode/
-
-      - name: Create archive
-        run: |
-          TAG=${{ needs.release-please.outputs.tag_name }}
-          # Strip package-name prefix: dicode-v0.0.2 → v0.0.2
-          VERSION=${TAG#dicode-}
-          ARCHIVE="dicode-${VERSION}-${{ matrix.goos }}-${{ matrix.goarch }}"
-          if [ "${{ matrix.goos }}" = "windows" ]; then
-            cd dist && zip "${ARCHIVE}.zip" dicode.exe && cd ..
-            echo "ASSET=dist/${ARCHIVE}.zip" >> $GITHUB_ENV
-          else
-            tar -czf "dist/${ARCHIVE}.tar.gz" -C dist dicode
-            echo "ASSET=dist/${ARCHIVE}.tar.gz" >> $GITHUB_ENV
-          fi
-
-      - name: Upload release asset
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ needs.release-please.outputs.tag_name }} "$ASSET"
-
-  publish:
-    name: Publish release
-    needs: [release-please, build]
-    if: ${{ needs.release-please.outputs.release_created }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Undraft release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release edit ${{ needs.release-please.outputs.tag_name }} \
-            --draft=false \
-            --repo ${{ github.repository }}
+          GORELEASER_CURRENT_TAG: ${{ needs.release-please.outputs.tag_name }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,43 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: dicode
+    main: ./cmd/dicode/
+    binary: dicode
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+
+archives:
+  - id: dicode
+    builds: [dicode]
+    name_template: "dicode-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+checksum:
+  name_template: "dicode-{{ .Version }}-checksums.txt"
+
+release:
+  # Upload to the GitHub release that release-please already created.
+  # GORELEASER_CURRENT_TAG is set by the workflow to the tag release-please created.
+  use_existing_draft: true
+
+changelog:
+  disable: true  # release-please manages the changelog

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,6 @@
       "package-name": "dicode"
     }
   },
-  "draft": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,


### PR DESCRIPTION
## Summary

- Replace the hand-rolled 5-job build matrix with **GoReleaser** — the standard Go release tool
- All cross-compilation still runs from a single `ubuntu-latest` runner with `CGO_ENABLED=0`
- PR artifact builds also use `goreleaser build --snapshot` so the same config drives both PR and release builds
- Fix node20 deprecation warnings + enable dependabot

## Changes

### GoReleaser
- `.goreleaser.yaml`: builds linux/darwin/windows amd64+arm64 (windows arm64 excluded), `CGO_ENABLED=0`, archives named `dicode-v0.0.2-linux-amd64.tar.gz`, checksums file, changelog disabled (release-please manages it)
- `release-please.yml`: collapsed 5-job matrix into single `goreleaser/goreleaser-action@v6` job; `GORELEASER_CURRENT_TAG` set to release-please tag so goreleaser uploads to the existing release
- `ci.yml`: PR builds use `goreleaser build --snapshot`; sticky comment via `marocchino/sticky-pull-request-comment@v2`

### Node.js 24
- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env to both workflows — stops the node20 deprecation warnings immediately, ahead of the June 2026 forced migration
- Dependabot will raise PRs when action authors publish node24-native versions

### Dependabot
- `.github/dependabot.yml`: weekly PRs on Monday for `github-actions` (grouped) and `gomod` (grouped) — one PR per ecosystem per week

## Test plan

- [ ] Open a PR → CI passes with no node20 warnings → sticky comment appears with 5 artifact links
- [ ] Merge to main → release-please creates release → goreleaser uploads archives + checksums
- [ ] Archive names: `dicode-v0.x.x-linux-amd64.tar.gz` etc.
- [ ] Next Monday → dependabot raises grouped PRs for outdated actions and Go modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)