### PR TITLE
feat: webhook task UIs — serve index.html + dicode.js client SDK

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,3 +1,4 @@
 # Memory Index
 
 - [Use TypeScript for Deno task scripts](feedback_ts_files.md) — always create task.ts, not task.js, for Deno runtime tasks
+- [Always check CI and update PR after commits](feedback_ci_pr_checks.md) — after any push: check CI, update PR description, update docs/ files

--- a/.claude/memory/feedback_ci_pr_checks.md
+++ b/.claude/memory/feedback_ci_pr_checks.md
@@ -1,0 +1,14 @@
+---
+name: Always check CI and update PR after commits
+description: After every commit or push, check CI status and PR description; also update docs/ files to reflect completed features
+type: feedback
+---
+
+After any commit to a feature branch, always:
+1. Check CI task status (e.g. `gh pr checks`) and fix any failures before moving on
+2. Review and update the PR description to reflect the latest state of the work
+3. Update relevant docs/ files: `docs/current-state.md`, `docs/implementation-plan.md`, and `docs/README.md` if the feature is documented there
+
+**Why:** This was a repeated pattern in the webhook UI feature — lint CI failed after the work was "done", and the PR description was outdated. Keeping docs and PR descriptions current prevents confusion about what's actually shipped.
+
+**How to apply:** Treat CI checks and doc updates as part of the definition of done for any feature work, not as optional follow-up. Run `gh pr checks` after pushing and don't declare the task complete until CI is green and docs are updated.

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -1,6 +1,6 @@
 # Current State
 
-> Last updated: 2026-03-29 — TaskSet architecture, MCP server, Sources web UI
+> Last updated: 2026-03-29 — TaskSet architecture, MCP server, Sources web UI, Webhook Task UIs
 
 This document describes exactly what exists in the codebase today — what is fully implemented, what is stubbed with interfaces and TODOs, and what exists only as documentation.
 
@@ -137,7 +137,11 @@ Full TaskSet architecture — hierarchical task composition inspired by ArgoCD A
   - Daemon: `startDaemon`, `onDaemonRunFinished` with restart policy (always/on-failure/never)
   - Shutdown: kills all active daemon runs via `shutdownCtx`
   - Audit logs: run started (task, run, trigger source, runtime), run finished (status, duration), kill requested, manual trigger, chain trigger (from/to/on), webhook trigger (path/task), task registered/unregistered, daemon restart lifecycle events
-- 8 tests passing
+  - **Webhook Task UIs**: `WebhookHandler()` detects tasks with an `index.html` file; on browser GET it serves the page with SDK injection; on POST it either runs the task (JSON/API) or redirects browser form submissions to `/runs/{id}/result`
+  - `injectDicodeSDK(html, hookPath, taskID)` — injects `<base href>` + meta tags + `<script src="/dicode.js">` after `<head>` open tag
+  - `serveTaskAsset()` — sandboxed static asset serving with extension allowlist (`.html/.css/.js/.json/.svg/.png/.jpg/.ico/.woff/.woff2`) and path-traversal guard
+  - `flatStringMap()` — converts JSON POST body `map[string]interface{}` to `map[string]string` for `RunOptions.Params`
+- 16 tests passing
 
 ### `pkg/webui/` ✅
 
@@ -148,12 +152,15 @@ Full TaskSet architecture — hierarchical task composition inspired by ArgoCD A
 - WebSocket hub (`/ws`) — real-time fan-out for log lines, run status changes, task events; ring buffer (recent logs replayed on connect)
 - Session store, secrets manager UI (unlock/lock with passphrase), AI chat, config editor
 - SPA routing: `/app/*` serves static assets; `/*` catch-all serves `index.html`
+- `GET /dicode.js` — serves the standalone webhook task UI SDK (embedded from `static/dicode.js`)
 - Audit logs: run requested via API, kill requested via API
 - Task table sorted stably (registry.All() sorts by ID); namespace headers rendered when namespaced IDs present
+- Webhook trigger labels rendered as clickable links (using `t.trigger?.Webhook` — capital W matches Go's JSON marshalling of untagged struct fields)
 - **Frontend** — Lit/LitElement SPA with ESM modules (no build step):
   - `static/app/app.js` — entry point, client-side router, WebSocket boot
-  - `static/app/lib/` — `ws.js` (WebSocket client + auto-reconnect), `router.js`, `api.js` (get/post/patch), `styles.js`, `utils.js`
-  - `static/app/components/` — `dc-task-list` (namespace-grouped), `dc-task-detail`, `dc-run-detail`, `dc-config`, `dc-secrets`, `dc-sources` (dev mode toggle, branch picker), `dc-log-bar`, `dc-notif-panel`
+  - `static/app/lib/` — `ws.js` (WebSocket client + auto-reconnect), `router.js`, `api.js` (get/post/patch), `styles.js`, `utils.js`, `ansi.js` (ansi-to-html wrapper, Catppuccin Mocha palette)
+  - `static/app/components/` — `dc-task-list` (namespace-grouped, webhook links), `dc-task-detail`, `dc-run-detail` (ANSI log rendering via `unsafeHTML(ansiToHtml(...))`), `dc-config`, `dc-secrets`, `dc-sources` (dev mode toggle, branch picker), `dc-log-bar`, `dc-notif-panel`
+  - `static/dicode.js` — standalone IIFE SDK for webhook task UIs; exposes `window.dicode` with `run()`, `stream()`, `execute()`, `result()`, `ansiToHtml()`; auto-enhances `<form data-dicode>` elements
 - 11 tests passing
 
 ### `pkg/tray/` ✅

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -14,6 +14,8 @@ This document is the ordered build roadmap. Each milestone produces something ru
 
 **TaskSet Architecture ✅ Complete.** Hierarchical task composition (`kind:TaskSet`, `kind:Config`, `kind:Task`), namespace-scoped IDs (`infra/backend/deploy`), 6-level override precedence, dev mode API (`PATCH /api/sources/:name/dev`), MCP server with `list_tasks`/`get_task`/`run_task`/`list_sources`/`switch_dev_mode` tools, Sources web UI page, task list namespace grouping, examples updated to TaskSet model.
 
+**Webhook Task UIs ✅ Complete.** Webhook tasks can include an `index.html` to serve a custom browser UI. The `dicode.js` SDK is auto-injected (with `<base href>` + meta tags), providing three complexity levels: zero-JS plain forms, auto-enhanced `<form data-dicode>` with log streaming, and full `dicode.execute()` API. Assets (CSS, JS, images) served sandboxed from the task directory. ANSI escape codes rendered in the SPA run detail view via `ansi-to-html`. Two examples ship: `webhook-form` (text transformer, Level 2) and `webhook-dashboard` (system info, Level 3).
+
 ---
 
 ## Milestone 0 — Environment setup ✅

--- a/examples/taskset.yaml
+++ b/examples/taskset.yaml
@@ -43,3 +43,11 @@ spec:
     nginx-start:
       ref:
         path: /home/dr14/dicode/examples/nginx-start/task.yaml
+
+    webhook-form:
+      ref:
+        path: /home/dr14/dicode/examples/webhook-form/task.yaml
+
+    webhook-dashboard:
+      ref:
+        path: /home/dr14/dicode/examples/webhook-dashboard/task.yaml

--- a/examples/webhook-dashboard/index.html
+++ b/examples/webhook-dashboard/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>System Dashboard</title>
+  <link rel="stylesheet" href="style.css">
+  <!--
+    dicode.js is automatically injected here by dicode when serving this page.
+    This example uses dicode.execute() directly (Level 3) for full control:
+    live log streaming into a status bar + custom tile rendering from the
+    task's JSON return value.
+  -->
+</head>
+<body>
+<header>
+  <div>
+    <h1>System Dashboard</h1>
+    <p class="subtitle">Live data from your local dicode runtime</p>
+  </div>
+  <button id="refresh-btn">Refresh</button>
+</header>
+
+<pre id="log-stream"></pre>
+<div class="grid" id="grid"></div>
+<p id="status"></p>
+
+<script>
+  var logEl    = document.getElementById('log-stream');
+  var gridEl   = document.getElementById('grid');
+  var statusEl = document.getElementById('status');
+  var btn      = document.getElementById('refresh-btn');
+
+  function fmt(bytes) {
+    return (bytes / 1024 / 1024).toFixed(1) + ' MB';
+  }
+
+  function renderTiles(data) {
+    var tiles = [
+      { label: 'Deno',       value: data.deno },
+      { label: 'TypeScript', value: data.typescript },
+      { label: 'V8',         value: data.v8 },
+      { label: 'OS',         value: data.os + ' / ' + data.arch },
+      { label: 'PID',        value: data.pid },
+      { label: 'Heap used',  value: fmt(data.memory.heapUsed) },
+      { label: 'Heap total', value: fmt(data.memory.heapTotal) },
+      { label: 'RSS',        value: fmt(data.memory.rss) },
+    ];
+
+    gridEl.innerHTML = tiles.map(function(t) {
+      return '<div class="tile"><div class="label">' + t.label +
+             '</div><div class="value">' + t.value + '</div></div>';
+    }).join('');
+  }
+
+  function refresh() {
+    btn.disabled = true;
+    logEl.textContent = '';
+    logEl.classList.add('active');
+    gridEl.innerHTML = '';
+    statusEl.textContent = '';
+
+    // Level 3 — full programmatic API.
+    // dicode.execute() fires the task asynchronously, streams logs via
+    // WebSocket, and resolves with the RunFinishedData payload containing
+    // the task's JSON return value.
+    dicode.execute({}, {
+      onLog: function(line) {
+        logEl.textContent += line + '\n';
+      },
+      onFinish: function(data) {
+        btn.disabled = false;
+        logEl.classList.remove('active');
+        logEl.textContent = '';
+
+        if (data.status !== 'success') {
+          statusEl.textContent = 'Run failed: ' + data.status;
+          return;
+        }
+
+        // returnValue is the JSON-serialised task return value.
+        var info;
+        try { info = JSON.parse(data.returnValue); } catch (e) {
+          statusEl.textContent = 'Could not parse result';
+          return;
+        }
+        renderTiles(info);
+        statusEl.textContent = 'Last refreshed ' + new Date().toLocaleTimeString();
+      }
+    }).catch(function() {
+      btn.disabled = false;
+      statusEl.textContent = 'Connection error — is dicode running?';
+    });
+  }
+
+  btn.addEventListener('click', refresh);
+
+  // Auto-refresh on page load once dicode.js is ready.
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', refresh);
+  } else {
+    refresh();
+  }
+</script>
+</body>
+</html>

--- a/examples/webhook-dashboard/style.css
+++ b/examples/webhook-dashboard/style.css
@@ -1,0 +1,88 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #1e1e2e;
+  color: #cdd6f4;
+  min-height: 100vh;
+  padding: 2rem 1rem;
+}
+
+header {
+  max-width: 720px;
+  margin: 0 auto 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+h1 { font-size: 1.25rem; font-weight: 600; }
+.subtitle { color: #6c7086; font-size: .875rem; }
+
+#refresh-btn {
+  background: #89b4fa;
+  color: #1e1e2e;
+  border: none;
+  border-radius: 8px;
+  padding: .5rem 1.25rem;
+  font-size: .875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity .15s;
+  white-space: nowrap;
+}
+#refresh-btn:hover    { opacity: .9; }
+#refresh-btn:disabled { opacity: .5; cursor: not-allowed; }
+
+#log-stream {
+  max-width: 720px;
+  margin: 0 auto 1.5rem;
+  background: #11111b;
+  border: 1px solid #313244;
+  border-radius: 8px;
+  padding: .75rem 1rem;
+  font-family: monospace;
+  font-size: .8125rem;
+  color: #a6e3a1;
+  min-height: 2.5rem;
+  white-space: pre-wrap;
+  display: none;
+}
+#log-stream.active { display: block; }
+
+.grid {
+  max-width: 720px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.tile {
+  background: #181825;
+  border: 1px solid #313244;
+  border-radius: 10px;
+  padding: 1.25rem;
+}
+.tile .label {
+  font-size: .75rem;
+  color: #6c7086;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  margin-bottom: .375rem;
+}
+.tile .value {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #cba6f7;
+  word-break: break-all;
+}
+
+#status {
+  max-width: 720px;
+  margin: 1.5rem auto 0;
+  font-size: .8125rem;
+  color: #6c7086;
+  text-align: right;
+}

--- a/examples/webhook-dashboard/task.ts
+++ b/examples/webhook-dashboard/task.ts
@@ -1,0 +1,25 @@
+await log.info("Collecting system info…");
+
+const mem = Deno.memoryUsage();
+
+const info = {
+  deno:     Deno.version.deno,
+  typescript: Deno.version.typescript,
+  v8:       Deno.version.v8,
+  os:       Deno.build.os,
+  arch:     Deno.build.arch,
+  memory: {
+    rss:        mem.rss,
+    heapTotal:  mem.heapTotal,
+    heapUsed:   mem.heapUsed,
+    external:   mem.external,
+  },
+  pid: Deno.pid,
+  uptime: performance.now(),
+};
+
+await log.info(`OS: ${info.os} / ${info.arch}`);
+await log.info(`Deno: ${info.deno}`);
+await log.info(`Heap used: ${Math.round(mem.heapUsed / 1024 / 1024)} MB`);
+
+return info;

--- a/examples/webhook-dashboard/task.yaml
+++ b/examples/webhook-dashboard/task.yaml
@@ -1,0 +1,14 @@
+apiVersion: dicode/v1
+kind: Task
+name: System Dashboard
+description: |
+  Returns a JSON snapshot of system info (Deno version, platform, memory,
+  environment variables). Demonstrates a webhook task with a custom UI that
+  uses the dicode.execute() JavaScript API for full control over rendering —
+  no page reload required.
+runtime: deno
+
+trigger:
+  webhook: /hooks/system-dashboard
+
+timeout: 15s

--- a/examples/webhook-form/index.html
+++ b/examples/webhook-form/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Text Transformer</title>
+  <link rel="stylesheet" href="style.css">
+  <!--
+    dicode.js is automatically injected here by dicode when serving this page.
+    It provides window.dicode with run(), execute(), stream(), and result() methods,
+    and auto-enhances any <form data-dicode> element.
+  -->
+</head>
+<body>
+<div class="card">
+  <h1>Text Transformer</h1>
+  <p class="subtitle">Transform text using a dicode task running on your machine.</p>
+
+  <!--
+    Level 2 — auto-enhanced form.
+    dicode.js intercepts submit, POSTs JSON to the webhook, streams
+    logs into #output, and re-enables the button on finish.
+
+    For a zero-JS fallback just remove data-dicode / data-output and add
+    method="POST" — the server will redirect to the run result page.
+  -->
+  <form data-dicode data-output="#output">
+    <label for="text">Input text</label>
+    <textarea id="text" name="text" placeholder="Type something…" required></textarea>
+
+    <label for="op">Operation</label>
+    <select id="op" name="op">
+      <option value="uppercase">UPPERCASE</option>
+      <option value="lowercase">lowercase</option>
+      <option value="reverse">Reverse</option>
+      <option value="wordcount">Word count</option>
+    </select>
+
+    <button type="submit">Transform</button>
+  </form>
+
+  <pre id="output"></pre>
+</div>
+</body>
+</html>

--- a/examples/webhook-form/style.css
+++ b/examples/webhook-form/style.css
@@ -1,0 +1,86 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #1e1e2e;
+  color: #cdd6f4;
+  min-height: 100vh;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 3rem 1rem;
+}
+
+.card {
+  background: #181825;
+  border: 1px solid #313244;
+  border-radius: 12px;
+  padding: 2rem;
+  width: 100%;
+  max-width: 540px;
+}
+
+h1 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: .25rem;
+}
+
+.subtitle {
+  color: #6c7086;
+  font-size: .875rem;
+  margin-bottom: 1.5rem;
+}
+
+label {
+  display: block;
+  font-size: .875rem;
+  color: #a6adc8;
+  margin-bottom: .375rem;
+}
+
+textarea, select {
+  width: 100%;
+  background: #313244;
+  border: 1px solid #45475a;
+  border-radius: 8px;
+  color: #cdd6f4;
+  padding: .625rem .75rem;
+  font-size: .9375rem;
+  font-family: inherit;
+  outline: none;
+  transition: border-color .15s;
+  margin-bottom: 1rem;
+}
+textarea { resize: vertical; min-height: 100px; }
+textarea:focus, select:focus { border-color: #89b4fa; }
+
+button[type="submit"] {
+  width: 100%;
+  background: #89b4fa;
+  color: #1e1e2e;
+  border: none;
+  border-radius: 8px;
+  padding: .625rem;
+  font-size: .9375rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity .15s;
+}
+button[type="submit"]:hover   { opacity: .9; }
+button[type="submit"]:disabled { opacity: .5; cursor: not-allowed; }
+
+#output {
+  margin-top: 1.25rem;
+  background: #11111b;
+  border: 1px solid #313244;
+  border-radius: 8px;
+  padding: .75rem 1rem;
+  font-family: monospace;
+  font-size: .875rem;
+  color: #a6e3a1;
+  white-space: pre-wrap;
+  min-height: 3rem;
+  display: none;
+}
+#output:not(:empty) { display: block; }

--- a/examples/webhook-form/task.ts
+++ b/examples/webhook-form/task.ts
@@ -1,0 +1,39 @@
+const text = String(await params.get("text") ?? "");
+const op   = String(await params.get("op")   ?? "uppercase");
+
+if (!text) throw new Error("text param is required");
+
+await log.info(`Running "${op}" on ${text.length} character(s)…`);
+
+let result: string;
+switch (op) {
+  case "uppercase":
+    result = text.toUpperCase();
+    break;
+  case "lowercase":
+    result = text.toLowerCase();
+    break;
+  case "reverse":
+    result = [...text].reverse().join("");
+    break;
+  case "wordcount": {
+    const words = text.trim().split(/\s+/).filter(Boolean);
+    result = `${words.length} word(s), ${text.length} character(s)`;
+    break;
+  }
+  default:
+    throw new Error(`Unknown operation: ${op}`);
+}
+
+await log.info(`Result: ${result}`);
+
+return output.html(`
+<div style="font-family:system-ui,sans-serif;max-width:640px;padding:1.5rem">
+  <h2 style="margin:0 0 .5rem">Result</h2>
+  <p style="color:#888;font-size:.875rem">Operation: <strong>${op}</strong></p>
+  <pre style="background:#1e1e2e;color:#cdd6f4;padding:1rem;border-radius:8px;
+              white-space:pre-wrap;word-break:break-all">${result}</pre>
+  <a href="/hooks/text-transform"
+     style="color:#89b4fa;font-size:.875rem">← Transform another</a>
+</div>
+`);

--- a/examples/webhook-form/task.yaml
+++ b/examples/webhook-form/task.yaml
@@ -1,0 +1,23 @@
+apiVersion: dicode/v1
+kind: Task
+name: Text Transformer
+description: |
+  Transforms text using one of several operations (uppercase, lowercase,
+  reverse, word-count). Demonstrates a webhook task with an HTML form UI:
+  open the webhook URL in a browser to see the form; submit it to run the task.
+runtime: deno
+
+trigger:
+  webhook: /hooks/text-transform
+
+params:
+  - name: text
+    type: string
+    description: The input text to transform
+    required: true
+  - name: op
+    type: string
+    description: "Operation: uppercase | lowercase | reverse | wordcount"
+    default: uppercase
+
+timeout: 10s

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,7 +59,7 @@ type SecretProviderConfig struct {
 
 type NotificationsConfig struct {
 	// OnFailure sends a notification when a task run fails. Defaults to true.
-	OnFailure *bool                 `yaml:"on_failure,omitempty"`
+	OnFailure *bool `yaml:"on_failure,omitempty"`
 	// OnSuccess sends a notification when a task run succeeds. Defaults to false.
 	OnSuccess *bool                 `yaml:"on_success,omitempty"`
 	Provider  *NotifyProviderConfig `yaml:"provider,omitempty"`

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -4,6 +4,7 @@ package registry
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
 	"sync"
 	"time"
@@ -12,6 +13,10 @@ import (
 	"github.com/dicode/dicode/pkg/task"
 	"github.com/google/uuid"
 )
+
+// ansiEscape matches ANSI/VT100 escape sequences (colours, cursor movement, etc.).
+// Stripped from log messages before storage so the UI does not render raw codes.
+var ansiEscape = regexp.MustCompile(`\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])`)
 
 // RunStatus values.
 const (
@@ -143,6 +148,7 @@ func (r *Registry) SetLogHook(fn func(runID, level, msg string, ts int64)) {
 
 // AppendLog adds a log entry for a run.
 func (r *Registry) AppendLog(ctx context.Context, runID, level, msg string) error {
+	msg = ansiEscape.ReplaceAllString(msg, "")
 	now := time.Now().UnixMilli()
 	if err := r.db.Exec(ctx,
 		`INSERT INTO run_logs (run_id, ts, level, message) VALUES (?, ?, ?, ?)`,

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -4,7 +4,6 @@ package registry
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"sort"
 	"sync"
 	"time"
@@ -13,10 +12,6 @@ import (
 	"github.com/dicode/dicode/pkg/task"
 	"github.com/google/uuid"
 )
-
-// ansiEscape matches ANSI/VT100 escape sequences (colours, cursor movement, etc.).
-// Stripped from log messages before storage so the UI does not render raw codes.
-var ansiEscape = regexp.MustCompile(`\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])`)
 
 // RunStatus values.
 const (
@@ -148,7 +143,6 @@ func (r *Registry) SetLogHook(fn func(runID, level, msg string, ts int64)) {
 
 // AppendLog adds a log entry for a run.
 func (r *Registry) AppendLog(ctx context.Context, runID, level, msg string) error {
-	msg = ansiEscape.ReplaceAllString(msg, "")
 	now := time.Now().UnixMilli()
 	if err := r.db.Exec(ctx,
 		`INSERT INTO run_logs (run_id, ts, level, message) VALUES (?, ?, ?, ?)`,

--- a/pkg/taskset/source.go
+++ b/pkg/taskset/source.go
@@ -37,7 +37,7 @@ type Source struct {
 	snapshot    map[string]taskSnap // namespaced taskID → snapshot
 	ch          chan source.Event   // live channel set by Start; nil before Start
 	devRootPath string              // non-empty overrides rootRef.Path in dev mode
-	watchRoot   string             // directory watched by fsnotify; set in Start
+	watchRoot   string              // directory watched by fsnotify; set in Start
 }
 
 type taskSnap struct {

--- a/pkg/taskset/spec.go
+++ b/pkg/taskset/spec.go
@@ -49,11 +49,11 @@ func (r *Ref) effectivePoll() time.Duration {
 // Defaults are applied to all entries in a TaskSet before per-entry overrides.
 // They sit at levels 2–4 in the six-level precedence stack.
 type Defaults struct {
-	Timeout time.Duration    `yaml:"timeout,omitempty"`
-	Retry   *RetryConfig     `yaml:"retry,omitempty"`
-	Env     []string         `yaml:"env,omitempty"`
+	Timeout time.Duration `yaml:"timeout,omitempty"`
+	Retry   *RetryConfig  `yaml:"retry,omitempty"`
+	Env     []string      `yaml:"env,omitempty"`
 	// Trigger sets a fallback trigger for any entry that has none.
-	Trigger *TriggerPatch    `yaml:"trigger,omitempty"`
+	Trigger *TriggerPatch      `yaml:"trigger,omitempty"`
 	Notify  *task.NotifyConfig `yaml:"notify,omitempty"`
 }
 

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -537,8 +537,14 @@ func flatStringMap(v interface{}) map[string]string {
 
 // injectDicodeSDK injects the dicode client SDK script and context meta tags
 // into an HTML page's <head>, allowing the page to use window.dicode.
+//
+// A <base> tag with a trailing slash is also injected so that relative URLs
+// in the task's HTML (e.g. href="style.css") resolve to the correct sub-path
+// (e.g. /hooks/my-task/style.css) regardless of the page having no trailing
+// slash in its URL.
 func injectDicodeSDK(html, hookPath, taskID string) string {
-	injection := `<meta name="dicode-task" content="` + taskID + `">` +
+	injection := `<base href="` + hookPath + `/">` +
+		`<meta name="dicode-task" content="` + taskID + `">` +
 		`<meta name="dicode-hook" content="` + hookPath + `">` +
 		`<script src="/dicode.js"></script>`
 	if i := strings.Index(html, "</head>"); i != -1 {

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -8,6 +8,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -353,12 +356,34 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runStatus strin
 }
 
 // WebhookHandler returns an HTTP handler that dispatches webhook-triggered tasks.
+//
+// Behaviour by request type:
+//   - GET  /{hookPath}            — if the task directory contains index.html, serve
+//     it with the dicode client SDK injected; otherwise run the task with query params.
+//   - GET  /{hookPath}/{asset}    — serve a static asset (CSS/JS/image) from the task
+//     directory, sandboxed so path traversal is impossible.
+//   - POST /{hookPath}            — run the task. JSON body or form-encoded body are
+//     both accepted. Browser form submissions (Content-Type: form) redirect to the run
+//     result page; API callers receive the usual JSON envelope.
 func (e *Engine) WebhookHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 
+		// Exact match — normal webhook execution path.
 		e.mu.Lock()
 		taskID, ok := e.webhooks[path]
+		var assetPath string
+		if !ok {
+			// Prefix match — request is for a static asset belonging to a webhook UI.
+			for hookPath, tid := range e.webhooks {
+				if strings.HasPrefix(path, hookPath+"/") {
+					taskID = tid
+					assetPath = path[len(hookPath)+1:]
+					ok = true
+					break
+				}
+			}
+		}
 		e.mu.Unlock()
 
 		if !ok {
@@ -372,9 +397,29 @@ func (e *Engine) WebhookHandler() http.Handler {
 			return
 		}
 
+		// Serve a static asset from the task directory (CSS, JS, images, …).
+		if assetPath != "" {
+			e.serveTaskAsset(w, r, spec.TaskDir, assetPath)
+			return
+		}
+
+		// On GET, serve the task's index.html UI when one is present.
+		if r.Method == http.MethodGet {
+			indexFile := filepath.Join(spec.TaskDir, "index.html")
+			if data, err := os.ReadFile(indexFile); err == nil {
+				e.log.Info("webhook UI served", zap.String("path", path), zap.String("task", taskID))
+				html := injectDicodeSDK(string(data), path, taskID)
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				_, _ = w.Write([]byte(html))
+				return
+			}
+		}
+
 		e.log.Info("webhook trigger", zap.String("path", path), zap.String("task", taskID))
 
 		var input interface{}
+		isFormSubmit := false
+
 		if r.Method == http.MethodGet {
 			if q := r.URL.Query(); len(q) > 0 {
 				m := make(map[string]interface{}, len(q))
@@ -386,6 +431,20 @@ func (e *Engine) WebhookHandler() http.Handler {
 					}
 				}
 				input = m
+			}
+		} else if strings.Contains(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
+			// Browser form submission — parse form fields as task input.
+			if err := r.ParseForm(); err == nil {
+				m := make(map[string]interface{}, len(r.Form))
+				for k, v := range r.Form {
+					if len(v) == 1 {
+						m[k] = v[0]
+					} else {
+						m[k] = v
+					}
+				}
+				input = m
+				isFormSubmit = true
 			}
 		} else if r.Body != nil {
 			body, err := io.ReadAll(r.Body)
@@ -404,6 +463,7 @@ func (e *Engine) WebhookHandler() http.Handler {
 				http.Error(w, "task failed to start", http.StatusInternalServerError)
 				return
 			}
+			w.Header().Set("X-Run-Id", runID)
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]string{"runId": runID})
 			return
@@ -412,6 +472,12 @@ func (e *Engine) WebhookHandler() http.Handler {
 		runID, result, err := e.fireSync(spec, pkgruntime.RunOptions{Input: input}, "webhook")
 		if err != nil {
 			http.Error(w, "task failed to start", http.StatusInternalServerError)
+			return
+		}
+
+		// Browser form submissions redirect to the run result page.
+		if isFormSubmit {
+			http.Redirect(w, r, "/runs/"+runID+"/result", http.StatusSeeOther)
 			return
 		}
 
@@ -448,6 +514,70 @@ func (e *Engine) WebhookHandler() http.Handler {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]string{"runId": runID, "status": status})
 	})
+}
+
+// injectDicodeSDK injects the dicode client SDK script and context meta tags
+// into an HTML page's <head>, allowing the page to use window.dicode.
+func injectDicodeSDK(html, hookPath, taskID string) string {
+	injection := `<meta name="dicode-task" content="` + taskID + `">` +
+		`<meta name="dicode-hook" content="` + hookPath + `">` +
+		`<script src="/dicode.js"></script>`
+	if i := strings.Index(html, "</head>"); i != -1 {
+		return html[:i] + injection + "\n" + html[i:]
+	}
+	return injection + "\n" + html
+}
+
+// allowedAssetTypes maps file extensions to their Content-Type for webhook UI assets.
+var allowedAssetTypes = map[string]string{
+	".html":  "text/html; charset=utf-8",
+	".css":   "text/css; charset=utf-8",
+	".js":    "application/javascript; charset=utf-8",
+	".json":  "application/json; charset=utf-8",
+	".svg":   "image/svg+xml",
+	".png":   "image/png",
+	".jpg":   "image/jpeg",
+	".jpeg":  "image/jpeg",
+	".ico":   "image/x-icon",
+	".woff":  "font/woff",
+	".woff2": "font/woff2",
+}
+
+// serveTaskAsset serves a static asset file from a webhook task's directory.
+// Access is sandboxed: only known file types are served and path traversal is blocked.
+func (e *Engine) serveTaskAsset(w http.ResponseWriter, r *http.Request, taskDir, assetPath string) {
+	// Block path traversal before filepath.Clean can resolve it.
+	if strings.Contains(assetPath, "..") {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	clean := filepath.Clean(assetPath)
+	if filepath.IsAbs(clean) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	ct, allowed := allowedAssetTypes[strings.ToLower(filepath.Ext(clean))]
+	if !allowed {
+		http.Error(w, "file type not allowed", http.StatusForbidden)
+		return
+	}
+
+	fullPath := filepath.Join(taskDir, clean)
+	// Double-check the resolved path is still inside taskDir.
+	if !strings.HasPrefix(fullPath, filepath.Clean(taskDir)+string(filepath.Separator)) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	data, err := os.ReadFile(fullPath)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", ct)
+	_, _ = w.Write(data)
 }
 
 // startRun creates the DB record, stores the cancel func, fires the started

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -547,9 +547,13 @@ func injectDicodeSDK(html, hookPath, taskID string) string {
 		`<meta name="dicode-task" content="` + taskID + `">` +
 		`<meta name="dicode-hook" content="` + hookPath + `">` +
 		`<script src="/dicode.js"></script>`
-	if i := strings.Index(html, "</head>"); i != -1 {
-		return html[:i] + injection + "\n" + html[i:]
+	// Inject immediately after <head> so <base> precedes every other element
+	// (stylesheets, scripts, images) that carries a relative URL.
+	if i := strings.Index(html, "<head>"); i != -1 {
+		after := i + len("<head>")
+		return html[:after] + "\n" + injection + html[after:]
 	}
+	// Fallback for pages without a <head> tag.
 	return injection + "\n" + html
 }
 

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -453,12 +453,17 @@ func (e *Engine) WebhookHandler() http.Handler {
 			}
 		}
 
+		// Extract a flat string map from the input so it is accessible via
+		// params.get() in task scripts (RunOptions.Params), in addition to the
+		// raw input being available as the `input` global (RunOptions.Input).
+		params := flatStringMap(input)
+
 		// Default: wait for the run to finish and return the result inline.
 		// Pass ?wait=false to fire-and-forget (returns runId immediately).
 		async := r.URL.Query().Get("wait") == "false"
 
 		if async {
-			runID, err := e.fireAsync(r.Context(), spec, pkgruntime.RunOptions{Input: input}, "webhook")
+			runID, err := e.fireAsync(r.Context(), spec, pkgruntime.RunOptions{Input: input, Params: params}, "webhook")
 			if err != nil {
 				http.Error(w, "task failed to start", http.StatusInternalServerError)
 				return
@@ -469,7 +474,7 @@ func (e *Engine) WebhookHandler() http.Handler {
 			return
 		}
 
-		runID, result, err := e.fireSync(spec, pkgruntime.RunOptions{Input: input}, "webhook")
+		runID, result, err := e.fireSync(spec, pkgruntime.RunOptions{Input: input, Params: params}, "webhook")
 		if err != nil {
 			http.Error(w, "task failed to start", http.StatusInternalServerError)
 			return
@@ -514,6 +519,20 @@ func (e *Engine) WebhookHandler() http.Handler {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]string{"runId": runID, "status": status})
 	})
+}
+
+// flatStringMap converts a map[string]interface{} into a map[string]string by
+// formatting each value with %v. Returns nil if input is not a flat map.
+func flatStringMap(v interface{}) map[string]string {
+	m, ok := v.(map[string]interface{})
+	if !ok || len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, val := range m {
+		out[k] = fmt.Sprintf("%v", val)
+	}
+	return out
 }
 
 // injectDicodeSDK injects the dicode client SDK script and context meta tags

--- a/pkg/trigger/engine_test.go
+++ b/pkg/trigger/engine_test.go
@@ -253,3 +253,219 @@ func TestEngine_Cron_Register(t *testing.T) {
 		t.Fatal("cron entry should be removed")
 	}
 }
+
+// newMinimalEngine creates an Engine without a real executor, suitable for
+// tests that only exercise HTTP serving (UI pages, assets) without task execution.
+func newMinimalEngine(t *testing.T) (*Engine, *registry.Registry) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+	eng := New(reg, nil, zap.NewNop())
+	return eng, reg
+}
+
+// writeUITask creates a task directory with a task.yaml, optional task.ts,
+// and optional extra files (filename → content).
+func writeUITask(t *testing.T, dir, id string, trigger task.TriggerConfig, extraFiles map[string]string) *task.Spec {
+	t.Helper()
+	td := filepath.Join(dir, id)
+	_ = os.MkdirAll(td, 0755)
+	yaml := "name: " + id + "\nruntime: deno\n"
+	_ = os.WriteFile(filepath.Join(td, "task.yaml"), []byte(yaml), 0644)
+	for name, content := range extraFiles {
+		_ = os.WriteFile(filepath.Join(td, name), []byte(content), 0644)
+	}
+	return &task.Spec{
+		ID:      id,
+		Name:    id,
+		Runtime: task.RuntimeDeno,
+		Trigger: trigger,
+		TaskDir: td,
+	}
+}
+
+func TestEngine_WebhookHandler_ServesIndexHTML(t *testing.T) {
+	dir := t.TempDir()
+	eng, reg := newMinimalEngine(t)
+
+	const indexContent = `<html><head><title>My UI</title></head><body>Hello</body></html>`
+	spec := writeUITask(t, dir, "ui-task", task.TriggerConfig{Webhook: "/hooks/ui-task"}, map[string]string{
+		"index.html": indexContent,
+	})
+	_ = reg.Register(spec)
+	eng.Register(spec)
+
+	handler := eng.WebhookHandler()
+	req := httptest.NewRequest(http.MethodGet, "/hooks/ui-task", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(w.Header().Get("Content-Type"), "text/html") {
+		t.Errorf("expected text/html content type, got %s", w.Header().Get("Content-Type"))
+	}
+	if !strings.Contains(body, "/dicode.js") {
+		t.Errorf("expected dicode.js injection, got: %s", body)
+	}
+	if !strings.Contains(body, `content="ui-task"`) {
+		t.Errorf("expected dicode-task meta tag, got: %s", body)
+	}
+	if !strings.Contains(body, "Hello") {
+		t.Errorf("expected original HTML content, got: %s", body)
+	}
+}
+
+func TestEngine_WebhookHandler_NoIndexHTML_RunsTask(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+	spec := writeTask(t, dir, "plain-hook", `return "ran"`, task.TriggerConfig{Webhook: "/hooks/plain-hook"})
+	_ = e.reg.Register(spec)
+	e.engine.Register(spec)
+
+	handler := e.engine.WebhookHandler()
+	req := httptest.NewRequest(http.MethodGet, "/hooks/plain-hook", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "ran") {
+		t.Errorf("expected task output, got: %s", w.Body.String())
+	}
+}
+
+func TestEngine_WebhookHandler_ServesAsset(t *testing.T) {
+	dir := t.TempDir()
+	eng, reg := newMinimalEngine(t)
+
+	const cssContent = `body { color: red; }`
+	spec := writeUITask(t, dir, "asset-task", task.TriggerConfig{Webhook: "/hooks/asset-task"}, map[string]string{
+		"index.html": `<html><head></head><body></body></html>`,
+		"style.css":  cssContent,
+	})
+	_ = reg.Register(spec)
+	eng.Register(spec)
+
+	handler := eng.WebhookHandler()
+	req := httptest.NewRequest(http.MethodGet, "/hooks/asset-task/style.css", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Header().Get("Content-Type"), "text/css") {
+		t.Errorf("expected text/css, got %s", w.Header().Get("Content-Type"))
+	}
+	if w.Body.String() != cssContent {
+		t.Errorf("expected CSS content, got: %s", w.Body.String())
+	}
+}
+
+func TestEngine_WebhookHandler_AssetTraversalBlocked(t *testing.T) {
+	dir := t.TempDir()
+	eng, reg := newMinimalEngine(t)
+
+	spec := writeUITask(t, dir, "traversal-task", task.TriggerConfig{Webhook: "/hooks/traversal-task"}, map[string]string{
+		"index.html": `<html><head></head><body></body></html>`,
+	})
+	_ = reg.Register(spec)
+	eng.Register(spec)
+
+	handler := eng.WebhookHandler()
+
+	for _, dangerous := range []string{
+		"/hooks/traversal-task/../../../etc/passwd",
+		"/hooks/traversal-task/%2e%2e/secret",
+	} {
+		req := httptest.NewRequest(http.MethodGet, dangerous, nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code == http.StatusOK {
+			t.Errorf("path traversal not blocked for %q: got 200", dangerous)
+		}
+	}
+}
+
+func TestEngine_WebhookHandler_AssetUnknownTypeBlocked(t *testing.T) {
+	dir := t.TempDir()
+	eng, reg := newMinimalEngine(t)
+
+	spec := writeUITask(t, dir, "blocked-task", task.TriggerConfig{Webhook: "/hooks/blocked-task"}, map[string]string{
+		"index.html": `<html><head></head><body></body></html>`,
+		"task.ts":    `return 1`,
+	})
+	_ = reg.Register(spec)
+	eng.Register(spec)
+
+	handler := eng.WebhookHandler()
+	req := httptest.NewRequest(http.MethodGet, "/hooks/blocked-task/task.ts", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for .ts file, got %d", w.Code)
+	}
+}
+
+func TestEngine_WebhookHandler_FormPOST(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+	spec := writeTask(t, dir, "form-task", `return params.get("name")`, task.TriggerConfig{Webhook: "/hooks/form-task"})
+	_ = e.reg.Register(spec)
+	e.engine.Register(spec)
+
+	handler := e.engine.WebhookHandler()
+
+	req := httptest.NewRequest(http.MethodPost, "/hooks/form-task",
+		strings.NewReader("name=Alice"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// Form POST should redirect to /runs/{id}/result.
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("expected 303 redirect, got %d: %s", w.Code, w.Body.String())
+	}
+	loc := w.Header().Get("Location")
+	if !strings.HasPrefix(loc, "/runs/") {
+		t.Errorf("expected redirect to /runs/..., got %q", loc)
+	}
+}
+
+func TestInjectDicodeSDK(t *testing.T) {
+	html := `<html><head><title>Test</title></head><body></body></html>`
+	result := injectDicodeSDK(html, "/hooks/my-task", "my-task")
+
+	if !strings.Contains(result, `<script src="/dicode.js"></script>`) {
+		t.Error("dicode.js script tag not injected")
+	}
+	if !strings.Contains(result, `content="my-task"`) {
+		t.Error("dicode-task meta not injected")
+	}
+	if !strings.Contains(result, `content="/hooks/my-task"`) {
+		t.Error("dicode-hook meta not injected")
+	}
+	// Injection must appear before </head>, not after.
+	injIdx := strings.Index(result, "dicode.js")
+	headIdx := strings.Index(result, "</head>")
+	if injIdx > headIdx {
+		t.Error("injection appeared after </head>")
+	}
+}
+
+func TestInjectDicodeSDK_NoHead(t *testing.T) {
+	html := `<body>No head tag</body>`
+	result := injectDicodeSDK(html, "/hooks/x", "x")
+	if !strings.Contains(result, "dicode.js") {
+		t.Error("dicode.js not injected when no </head> present")
+	}
+}

--- a/pkg/trigger/engine_test.go
+++ b/pkg/trigger/engine_test.go
@@ -457,11 +457,11 @@ func TestInjectDicodeSDK(t *testing.T) {
 	if !strings.Contains(result, `content="/hooks/my-task"`) {
 		t.Error("dicode-hook meta not injected")
 	}
-	// Injection must appear before </head>, not after.
-	injIdx := strings.Index(result, "dicode.js")
-	headIdx := strings.Index(result, "</head>")
-	if injIdx > headIdx {
-		t.Error("injection appeared after </head>")
+	// <base> must appear before any other head element (i.e. right after <head>).
+	baseIdx := strings.Index(result, "<base ")
+	linkIdx := strings.Index(result, "<title>")
+	if baseIdx > linkIdx {
+		t.Error("<base> tag must appear before other <head> elements")
 	}
 }
 

--- a/pkg/trigger/engine_test.go
+++ b/pkg/trigger/engine_test.go
@@ -445,6 +445,9 @@ func TestInjectDicodeSDK(t *testing.T) {
 	html := `<html><head><title>Test</title></head><body></body></html>`
 	result := injectDicodeSDK(html, "/hooks/my-task", "my-task")
 
+	if !strings.Contains(result, `<base href="/hooks/my-task/">`) {
+		t.Error("base tag not injected")
+	}
 	if !strings.Contains(result, `<script src="/dicode.js"></script>`) {
 		t.Error("dicode.js script tag not injected")
 	}

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -15,9 +15,9 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
-	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -351,13 +351,25 @@ func (s *Server) Handler() http.Handler {
 		r.Mount("/mcp", mcpSrv.Handler())
 	}
 
-	// Webhook passthrough — POST accepts a JSON body; GET accepts query params.
+	// Webhook passthrough — POST accepts JSON or form body; GET accepts query params
+	// or serves the task's index.html UI when one is present.
 	webhookHandler := func(w http.ResponseWriter, req *http.Request) {
 		req.URL.Path = "/hooks/" + chi.URLParam(req, "*")
 		s.engine.WebhookHandler().ServeHTTP(w, req)
 	}
 	r.Get("/hooks/*", webhookHandler)
 	r.Post("/hooks/*", webhookHandler)
+
+	// dicode.js — client SDK injected into webhook task UIs.
+	r.Get("/dicode.js", func(w http.ResponseWriter, req *http.Request) {
+		b, err := staticFS.ReadFile("static/dicode.js")
+		if err != nil {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
+		_, _ = w.Write(b)
+	})
 
 	// Static SPA assets (/app/app.js, etc.)
 	appFS, _ := fs.Sub(staticFS, "static")
@@ -531,6 +543,8 @@ var allowedFiles = map[string]bool{
 	"task.js": true, "task.ts": true, "task.py": true,
 	"task.test.js": true, "task.test.ts": true,
 	"Dockerfile": true,
+	// Webhook UI files — editable via the built-in code editor.
+	"index.html": true, "style.css": true, "script.js": true,
 }
 
 func (s *Server) apiGetFile(w http.ResponseWriter, r *http.Request) {

--- a/pkg/webui/static/app/components/dc-run-detail.js
+++ b/pkg/webui/static/app/components/dc-run-detail.js
@@ -1,8 +1,10 @@
 import { LitElement, html } from 'https://esm.sh/lit@3';
+import { unsafeHTML } from 'https://esm.sh/lit@3/directives/unsafe-html.js';
 import { get, post } from '../lib/api.js';
 import { wsOn } from '../lib/ws.js';
 import { navigate } from '../lib/router.js';
 import { fmtTime, fmtDuration } from '../lib/utils.js';
+import { ansiToHtml } from '../lib/ansi.js';
 
 class DcRunDetail extends LitElement {
   createRenderRoot() { return this; }
@@ -161,7 +163,7 @@ class DcRunDetail extends LitElement {
         </div>` : ''}
 
       <h2>Logs</h2>
-      <pre id="log-output" style="max-height:600px;overflow-y:auto">${this._logs.map(l => html`<span>[${l.level}] ${l.time} ${l.message}\n</span>`)}</pre>`;
+      <pre id="log-output" style="max-height:600px;overflow-y:auto">${this._logs.map(l => html`<span>[${l.level}] ${l.time} ${unsafeHTML(ansiToHtml(l.message))}\n</span>`)}</pre>`;
   }
 }
 

--- a/pkg/webui/static/app/components/dc-task-list.js
+++ b/pkg/webui/static/app/components/dc-task-list.js
@@ -79,8 +79,8 @@ class DcTaskList extends LitElement {
       <tr>
         <td><a href="/tasks/${t.id}" @click=${e => { e.preventDefault(); navigate('/tasks/' + t.id); }}>${t.id}</a></td>
         <td>${t.name}</td>
-        <td>${t.trigger?.webhook
-          ? html`<a href="${t.trigger.webhook}" target="_blank" class="meta">${t.trigger_label}</a>`
+        <td>${t.trigger?.Webhook
+          ? html`<a href="${t.trigger.Webhook}" target="_blank" class="meta">${t.trigger_label}</a>`
           : html`<span class="meta">${t.trigger_label || 'manual'}</span>`}</td>
         <td>${t.last_run_id
           ? html`<a href="/runs/${t.last_run_id}" @click=${e => { e.preventDefault(); navigate('/runs/' + t.last_run_id); }}>${t.last_run_id.slice(0, 8)}</a>`

--- a/pkg/webui/static/app/components/dc-task-list.js
+++ b/pkg/webui/static/app/components/dc-task-list.js
@@ -79,7 +79,9 @@ class DcTaskList extends LitElement {
       <tr>
         <td><a href="/tasks/${t.id}" @click=${e => { e.preventDefault(); navigate('/tasks/' + t.id); }}>${t.id}</a></td>
         <td>${t.name}</td>
-        <td><span class="meta">${t.trigger_label || 'manual'}</span></td>
+        <td>${t.trigger?.webhook
+          ? html`<a href="${t.trigger.webhook}" target="_blank" class="meta">${t.trigger_label}</a>`
+          : html`<span class="meta">${t.trigger_label || 'manual'}</span>`}</td>
         <td>${t.last_run_id
           ? html`<a href="/runs/${t.last_run_id}" @click=${e => { e.preventDefault(); navigate('/runs/' + t.last_run_id); }}>${t.last_run_id.slice(0, 8)}</a>`
           : '—'}</td>

--- a/pkg/webui/static/app/lib/ansi.js
+++ b/pkg/webui/static/app/lib/ansi.js
@@ -1,78 +1,45 @@
 /**
- * ansi.js — convert ANSI SGR escape sequences to HTML spans.
+ * ansi.js — thin wrapper around the ansi-to-html package.
+ * Re-exports a pre-configured convert() function ready for use with
+ * unsafeHTML() in Lit components.
  *
- * Colours are mapped to the Catppuccin Mocha palette used throughout the UI.
- * Text content is always HTML-escaped, so the output is safe to set as innerHTML.
+ * ansi-to-html: https://github.com/rburns/ansi-to-html
  */
+import Convert from 'https://esm.sh/ansi-to-html@0.7.2';
 
-// Foreground colour map: ANSI code → Catppuccin Mocha hex.
-const FG = {
-  30: '#585b70', // black   → surface2
-  31: '#f38ba8', // red
-  32: '#a6e3a1', // green
-  33: '#f9e2af', // yellow
-  34: '#89b4fa', // blue
-  35: '#cba6f7', // magenta
-  36: '#89dceb', // cyan
-  37: '#cdd6f4', // white
-  90: '#6c7086', // bright black → overlay0
-  91: '#f38ba8', // bright red
-  92: '#a6e3a1', // bright green
-  93: '#f9e2af', // bright yellow
-  94: '#89b4fa', // bright blue
-  95: '#cba6f7', // bright magenta
-  96: '#89dceb', // bright cyan
-  97: '#cdd6f4', // bright white
-};
-
-function escHtml(s) {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}
+// Catppuccin Mocha palette mapped to the 16 ANSI colour slots.
+const convert = new Convert({
+  fg:      '#cdd6f4',
+  bg:      '#1e1e2e',
+  newline: false,
+  escapeXML: true,
+  colors: {
+    0:  '#585b70', // black   → surface2
+    1:  '#f38ba8', // red
+    2:  '#a6e3a1', // green
+    3:  '#f9e2af', // yellow
+    4:  '#89b4fa', // blue
+    5:  '#cba6f7', // magenta
+    6:  '#89dceb', // cyan
+    7:  '#cdd6f4', // white
+    8:  '#6c7086', // bright black → overlay0
+    9:  '#f38ba8', // bright red
+    10: '#a6e3a1', // bright green
+    11: '#f9e2af', // bright yellow
+    12: '#89b4fa', // bright blue
+    13: '#cba6f7', // bright magenta
+    14: '#89dceb', // bright cyan
+    15: '#cdd6f4', // bright white
+  },
+});
 
 /**
- * Convert a string that may contain ANSI SGR escape sequences into an HTML
- * string with equivalent <span style="…"> elements.
+ * Convert a string containing ANSI escape sequences to an HTML string.
+ * Text is HTML-escaped by ansi-to-html; safe for unsafeHTML / innerHTML.
  *
- * Handles: reset (0), bold (1), italic (3), colour codes (30–37, 90–97).
- *
- * @param {string} text  Raw string, possibly containing \x1b[…m sequences.
- * @returns {string}     HTML-safe string ready for innerHTML / unsafeHTML.
+ * @param {string} text
+ * @returns {string}
  */
 export function ansiToHtml(text) {
-  // Split into alternating text segments and SGR sequences.
-  const parts = text.split(/(\x1b\[[0-9;]*m)/);
-  let out    = '';
-  let bold   = false;
-  let italic = false;
-  let color  = '';
-
-  for (const part of parts) {
-    if (part.startsWith('\x1b[') && part.endsWith('m')) {
-      // Parse each semicolon-separated code in the sequence.
-      const seq   = part.slice(2, -1);
-      const codes = seq === '' ? [0] : seq.split(';').map(Number);
-      for (const c of codes) {
-        if      (c === 0)              { bold = false; italic = false; color = ''; }
-        else if (c === 1)              { bold   = true;  }
-        else if (c === 3)              { italic = true;  }
-        else if (c === 22)             { bold   = false; }
-        else if (c === 23)             { italic = false; }
-        else if (c === 39)             { color  = '';    }
-        else if (FG[c] !== undefined)  { color  = FG[c]; }
-      }
-    } else if (part !== '') {
-      const escaped = escHtml(part);
-      if (bold || italic || color) {
-        const styles = [];
-        if (bold)   styles.push('font-weight:bold');
-        if (italic) styles.push('font-style:italic');
-        if (color)  styles.push('color:' + color);
-        out += '<span style="' + styles.join(';') + '">' + escaped + '</span>';
-      } else {
-        out += escaped;
-      }
-    }
-  }
-
-  return out;
+  return convert.toHtml(text);
 }

--- a/pkg/webui/static/app/lib/ansi.js
+++ b/pkg/webui/static/app/lib/ansi.js
@@ -1,0 +1,78 @@
+/**
+ * ansi.js — convert ANSI SGR escape sequences to HTML spans.
+ *
+ * Colours are mapped to the Catppuccin Mocha palette used throughout the UI.
+ * Text content is always HTML-escaped, so the output is safe to set as innerHTML.
+ */
+
+// Foreground colour map: ANSI code → Catppuccin Mocha hex.
+const FG = {
+  30: '#585b70', // black   → surface2
+  31: '#f38ba8', // red
+  32: '#a6e3a1', // green
+  33: '#f9e2af', // yellow
+  34: '#89b4fa', // blue
+  35: '#cba6f7', // magenta
+  36: '#89dceb', // cyan
+  37: '#cdd6f4', // white
+  90: '#6c7086', // bright black → overlay0
+  91: '#f38ba8', // bright red
+  92: '#a6e3a1', // bright green
+  93: '#f9e2af', // bright yellow
+  94: '#89b4fa', // bright blue
+  95: '#cba6f7', // bright magenta
+  96: '#89dceb', // bright cyan
+  97: '#cdd6f4', // bright white
+};
+
+function escHtml(s) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Convert a string that may contain ANSI SGR escape sequences into an HTML
+ * string with equivalent <span style="…"> elements.
+ *
+ * Handles: reset (0), bold (1), italic (3), colour codes (30–37, 90–97).
+ *
+ * @param {string} text  Raw string, possibly containing \x1b[…m sequences.
+ * @returns {string}     HTML-safe string ready for innerHTML / unsafeHTML.
+ */
+export function ansiToHtml(text) {
+  // Split into alternating text segments and SGR sequences.
+  const parts = text.split(/(\x1b\[[0-9;]*m)/);
+  let out    = '';
+  let bold   = false;
+  let italic = false;
+  let color  = '';
+
+  for (const part of parts) {
+    if (part.startsWith('\x1b[') && part.endsWith('m')) {
+      // Parse each semicolon-separated code in the sequence.
+      const seq   = part.slice(2, -1);
+      const codes = seq === '' ? [0] : seq.split(';').map(Number);
+      for (const c of codes) {
+        if      (c === 0)              { bold = false; italic = false; color = ''; }
+        else if (c === 1)              { bold   = true;  }
+        else if (c === 3)              { italic = true;  }
+        else if (c === 22)             { bold   = false; }
+        else if (c === 23)             { italic = false; }
+        else if (c === 39)             { color  = '';    }
+        else if (FG[c] !== undefined)  { color  = FG[c]; }
+      }
+    } else if (part !== '') {
+      const escaped = escHtml(part);
+      if (bold || italic || color) {
+        const styles = [];
+        if (bold)   styles.push('font-weight:bold');
+        if (italic) styles.push('font-style:italic');
+        if (color)  styles.push('color:' + color);
+        out += '<span style="' + styles.join(';') + '">' + escaped + '</span>';
+      } else {
+        out += escaped;
+      }
+    }
+  }
+
+  return out;
+}

--- a/pkg/webui/static/dicode.js
+++ b/pkg/webui/static/dicode.js
@@ -31,6 +31,63 @@
     return new WebSocket(proto + '//' + location.host + '/ws');
   }
 
+  // ── ANSI → HTML ──────────────────────────────────────────────────────────
+  // Catppuccin Mocha palette mapped to standard ANSI foreground colour codes.
+  var ANSI_FG = {
+    30: '#585b70', 31: '#f38ba8', 32: '#a6e3a1', 33: '#f9e2af',
+    34: '#89b4fa', 35: '#cba6f7', 36: '#89dceb', 37: '#cdd6f4',
+    90: '#6c7086', 91: '#f38ba8', 92: '#a6e3a1', 93: '#f9e2af',
+    94: '#89b4fa', 95: '#cba6f7', 96: '#89dceb', 97: '#cdd6f4'
+  };
+
+  function escHtml(s) {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  /**
+   * Convert a string containing ANSI SGR escape sequences to an HTML string.
+   * Text content is HTML-escaped; styles become inline <span> elements.
+   * Safe to set as innerHTML / insertAdjacentHTML.
+   *
+   * @param {string} text
+   * @returns {string}
+   */
+  function ansiToHtml(text) {
+    var parts  = text.split(/(\x1b\[[0-9;]*m)/);
+    var out    = '';
+    var bold   = false, italic = false, color = '';
+
+    for (var i = 0; i < parts.length; i++) {
+      var part = parts[i];
+      if (part.charAt(0) === '\x1b' && part.charAt(part.length - 1) === 'm') {
+        var seq   = part.slice(2, -1);
+        var codes = seq === '' ? [0] : seq.split(';');
+        for (var j = 0; j < codes.length; j++) {
+          var c = parseInt(codes[j], 10) || 0;
+          if      (c === 0)  { bold = false; italic = false; color = ''; }
+          else if (c === 1)  { bold   = true;  }
+          else if (c === 3)  { italic = true;  }
+          else if (c === 22) { bold   = false; }
+          else if (c === 23) { italic = false; }
+          else if (c === 39) { color  = '';    }
+          else if (ANSI_FG[c]) { color = ANSI_FG[c]; }
+        }
+      } else if (part !== '') {
+        var escaped = escHtml(part);
+        if (bold || italic || color) {
+          var styles = [];
+          if (bold)   styles.push('font-weight:bold');
+          if (italic) styles.push('font-style:italic');
+          if (color)  styles.push('color:' + color);
+          out += '<span style="' + styles.join(';') + '">' + escaped + '</span>';
+        } else {
+          out += escaped;
+        }
+      }
+    }
+    return out;
+  }
+
   var dicode = {
     /** Context for the current task UI page. */
     task: { id: taskID, hookPath: hookPath },
@@ -122,7 +179,15 @@
      */
     result: function (runId) {
       return fetch('/api/runs/' + runId).then(function (r) { return r.json(); });
-    }
+    },
+
+    /**
+     * Convert a string containing ANSI escape sequences to an HTML string.
+     * Safe to use with innerHTML / insertAdjacentHTML.
+     * @param {string} text
+     * @returns {string}
+     */
+    ansiToHtml: ansiToHtml
   };
 
   // ── Auto-enhanced forms ───────────────────────────────────────────────────
@@ -146,18 +211,18 @@
           var btn = form.querySelector('[type="submit"]') ||
                     form.querySelector('button:not([type])');
           if (btn) { btn.disabled = true; }
-          if (output) { output.textContent = ''; }
+          if (output) { output.innerHTML = ''; }
 
           dicode.execute(params, {
             onLog: function (line) {
-              if (output) { output.textContent += line + '\n'; }
+              if (output) { output.insertAdjacentHTML('beforeend', ansiToHtml(line) + '\n'); }
             },
             onFinish: function () {
               if (btn) { btn.disabled = false; }
             },
             onError: function () {
               if (btn) { btn.disabled = false; }
-              if (output) { output.textContent += '\nConnection error.'; }
+              if (output) { output.insertAdjacentHTML('beforeend', '\nConnection error.'); }
             }
           }).catch(function () {
             if (btn) { btn.disabled = false; }

--- a/pkg/webui/static/dicode.js
+++ b/pkg/webui/static/dicode.js
@@ -1,0 +1,177 @@
+/*!
+ * dicode.js — client SDK for webhook task UIs.
+ *
+ * Automatically injected by dicode when serving a task's index.html.
+ * Exposes window.dicode with methods to run tasks, stream logs, and
+ * auto-enhance HTML forms.
+ *
+ * Complexity levels for task UI authors:
+ *
+ *   Level 1 — Zero JS: plain <form method="POST"> works out of the box.
+ *     The server parses the form body and redirects to /runs/{id}/result.
+ *
+ *   Level 2 — Auto-enhanced: add data-dicode to any <form>.
+ *     dicode.js intercepts submission, streams logs into data-output target.
+ *
+ *   Level 3 — Full API: use dicode.execute(params, { onLog, onFinish }).
+ *     Full control over rendering and error handling.
+ */
+(function () {
+  'use strict';
+
+  // Context injected by the server into <head>.
+  var hookMeta = document.querySelector('meta[name="dicode-hook"]');
+  var taskMeta = document.querySelector('meta[name="dicode-task"]');
+  var hookPath = hookMeta ? hookMeta.content : window.location.pathname;
+  var taskID   = taskMeta ? taskMeta.content : '';
+
+  /** Open a WebSocket to the dicode hub. */
+  function openWS() {
+    var proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    return new WebSocket(proto + '//' + location.host + '/ws');
+  }
+
+  var dicode = {
+    /** Context for the current task UI page. */
+    task: { id: taskID, hookPath: hookPath },
+
+    /**
+     * Run the task asynchronously with the given params.
+     * Returns a Promise resolving to { runId: string }.
+     *
+     * @param {Object} [params] - Key/value params passed to the task.
+     */
+    run: function (params) {
+      params = params || {};
+      return fetch(hookPath + '?wait=false', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(params)
+      }).then(function (res) {
+        // Run ID is available both as a header and in the JSON body.
+        var runId = res.headers.get('X-Run-Id');
+        return res.json().then(function (body) {
+          return { runId: runId || body.runId };
+        });
+      });
+    },
+
+    /**
+     * Stream logs and completion events for a run via WebSocket.
+     * Returns an unsubscribe function that closes the connection.
+     *
+     * @param {string} runId
+     * @param {{ onLog?: (msg, data) => void, onFinish?: (data) => void, onError?: (e) => void }} handlers
+     */
+    stream: function (runId, handlers) {
+      handlers = handlers || {};
+      var ws = openWS();
+
+      ws.onmessage = function (evt) {
+        var msg;
+        try { msg = JSON.parse(evt.data); } catch (e) { return; }
+        var d = msg.data;
+        if (!d || d.runID !== runId) return;
+
+        if (msg.type === 'run:log' && handlers.onLog) {
+          handlers.onLog(d.message, d);
+        }
+        if (msg.type === 'run:finished') {
+          if (handlers.onFinish) handlers.onFinish(d);
+          ws.close();
+        }
+      };
+
+      ws.onerror = function (e) {
+        if (handlers.onError) handlers.onError(e);
+      };
+
+      return function unsubscribe() { ws.close(); };
+    },
+
+    /**
+     * Run the task and stream results in one call.
+     * Returns a Promise resolving to the RunFinishedData payload.
+     *
+     * @param {Object} [params]
+     * @param {{ onLog?: (msg, data) => void, onFinish?: (data) => void, onError?: (e) => void }} [handlers]
+     */
+    execute: function (params, handlers) {
+      var self = this;
+      handlers = handlers || {};
+      return self.run(params).then(function (res) {
+        return new Promise(function (resolve, reject) {
+          self.stream(res.runId, {
+            onLog: handlers.onLog,
+            onFinish: function (data) {
+              if (handlers.onFinish) handlers.onFinish(data);
+              resolve(data);
+            },
+            onError: function (e) {
+              if (handlers.onError) handlers.onError(e);
+              reject(e);
+            }
+          });
+        });
+      });
+    },
+
+    /**
+     * Fetch the stored result for a completed run from the REST API.
+     * @param {string} runId
+     */
+    result: function (runId) {
+      return fetch('/api/runs/' + runId).then(function (r) { return r.json(); });
+    }
+  };
+
+  // ── Auto-enhanced forms ───────────────────────────────────────────────────
+  // Any <form data-dicode> is intercepted on submit. Logs are streamed into
+  // the element matching the data-output CSS selector (if provided).
+
+  function enhanceForms() {
+    var forms = document.querySelectorAll('form[data-dicode]');
+    for (var i = 0; i < forms.length; i++) {
+      (function (form) {
+        var outputSel = form.getAttribute('data-output');
+        var output    = outputSel ? document.querySelector(outputSel) : null;
+
+        form.addEventListener('submit', function (e) {
+          e.preventDefault();
+
+          var fd     = new FormData(form);
+          var params = {};
+          fd.forEach(function (val, key) { params[key] = val; });
+
+          var btn = form.querySelector('[type="submit"]') ||
+                    form.querySelector('button:not([type])');
+          if (btn) { btn.disabled = true; }
+          if (output) { output.textContent = ''; }
+
+          dicode.execute(params, {
+            onLog: function (line) {
+              if (output) { output.textContent += line + '\n'; }
+            },
+            onFinish: function () {
+              if (btn) { btn.disabled = false; }
+            },
+            onError: function () {
+              if (btn) { btn.disabled = false; }
+              if (output) { output.textContent += '\nConnection error.'; }
+            }
+          }).catch(function () {
+            if (btn) { btn.disabled = false; }
+          });
+        });
+      })(forms[i]);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', enhanceForms);
+  } else {
+    enhanceForms();
+  }
+
+  window.dicode = dicode;
+})();

--- a/pkg/webui/static/dicode.js
+++ b/pkg/webui/static/dicode.js
@@ -32,60 +32,37 @@
   }
 
   // ── ANSI → HTML ──────────────────────────────────────────────────────────
-  // Catppuccin Mocha palette mapped to standard ANSI foreground colour codes.
-  var ANSI_FG = {
-    30: '#585b70', 31: '#f38ba8', 32: '#a6e3a1', 33: '#f9e2af',
-    34: '#89b4fa', 35: '#cba6f7', 36: '#89dceb', 37: '#cdd6f4',
-    90: '#6c7086', 91: '#f38ba8', 92: '#a6e3a1', 93: '#f9e2af',
-    94: '#89b4fa', 95: '#cba6f7', 96: '#89dceb', 97: '#cdd6f4'
-  };
+  // Use ansi-to-html from esm.sh (same package as the main UI uses).
+  // Dynamic import so this standalone script doesn't need to be a module.
+  // Until the package loads, ansiToHtml falls back to HTML-escaping only.
+
+  var _convert = null;
+  import('https://esm.sh/ansi-to-html@0.7.2').then(function (m) {
+    _convert = new m.default({
+      fg: '#cdd6f4', bg: '#1e1e2e', newline: false, escapeXML: true,
+      colors: {
+        0:  '#585b70', 1:  '#f38ba8', 2:  '#a6e3a1', 3:  '#f9e2af',
+        4:  '#89b4fa', 5:  '#cba6f7', 6:  '#89dceb', 7:  '#cdd6f4',
+        8:  '#6c7086', 9:  '#f38ba8', 10: '#a6e3a1', 11: '#f9e2af',
+        12: '#89b4fa', 13: '#cba6f7', 14: '#89dceb', 15: '#cdd6f4',
+      },
+    });
+  });
 
   function escHtml(s) {
     return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
   }
 
   /**
-   * Convert a string containing ANSI SGR escape sequences to an HTML string.
-   * Text content is HTML-escaped; styles become inline <span> elements.
-   * Safe to set as innerHTML / insertAdjacentHTML.
+   * Convert a string containing ANSI escape sequences to an HTML string.
+   * Falls back to plain HTML-escaping until ansi-to-html finishes loading.
+   * Safe for innerHTML / insertAdjacentHTML.
    *
    * @param {string} text
    * @returns {string}
    */
   function ansiToHtml(text) {
-    var parts  = text.split(/(\x1b\[[0-9;]*m)/);
-    var out    = '';
-    var bold   = false, italic = false, color = '';
-
-    for (var i = 0; i < parts.length; i++) {
-      var part = parts[i];
-      if (part.charAt(0) === '\x1b' && part.charAt(part.length - 1) === 'm') {
-        var seq   = part.slice(2, -1);
-        var codes = seq === '' ? [0] : seq.split(';');
-        for (var j = 0; j < codes.length; j++) {
-          var c = parseInt(codes[j], 10) || 0;
-          if      (c === 0)  { bold = false; italic = false; color = ''; }
-          else if (c === 1)  { bold   = true;  }
-          else if (c === 3)  { italic = true;  }
-          else if (c === 22) { bold   = false; }
-          else if (c === 23) { italic = false; }
-          else if (c === 39) { color  = '';    }
-          else if (ANSI_FG[c]) { color = ANSI_FG[c]; }
-        }
-      } else if (part !== '') {
-        var escaped = escHtml(part);
-        if (bold || italic || color) {
-          var styles = [];
-          if (bold)   styles.push('font-weight:bold');
-          if (italic) styles.push('font-style:italic');
-          if (color)  styles.push('color:' + color);
-          out += '<span style="' + styles.join(';') + '">' + escaped + '</span>';
-        } else {
-          out += escaped;
-        }
-      }
-    }
-    return out;
+    return _convert ? _convert.toHtml(text) : escHtml(text);
   }
 
   var dicode = {


### PR DESCRIPTION
## Summary

- **Webhook task UIs** — a webhook task can now include an `index.html` alongside its script. Opening the webhook URL in a browser serves the HTML page with the `dicode.js` client SDK automatically injected, turning any webhook into a self-contained interactive UI
- **Static asset serving** — sub-paths (`/hooks/my-task/style.css`, `script.js`, images) are served from the task directory, sandboxed with a file-type allowlist and path-traversal guard
- **`dicode.js` client SDK** — always available at `/dicode.js`; exposes `window.dicode` with `run()`, `stream()`, `execute()`, `result()`, and `ansiToHtml()`
- **Form POST support** — `application/x-www-form-urlencoded` bodies are parsed as task params; browser form submissions redirect to `/runs/{id}/result`
- **ANSI colour rendering** — run log messages render ANSI escape sequences as styled HTML using `ansi-to-html` (Catppuccin Mocha palette), instead of showing raw codes
- **Clickable webhook links** — webhook trigger labels in the task list are rendered as `<a target="_blank">` links
- **Editor API** — `index.html`, `style.css`, `script.js` added to the `allowedFiles` whitelist

## Three complexity levels for task UI authors

| Level | What the author writes | What they get |
|---|---|---|
| 1 — Zero JS | `<form method="POST">` | Redirect to `/runs/{id}/result` on submit |
| 2 — Auto-enhanced | `<form data-dicode data-output="#logs">` | Async submit + live ANSI-rendered log streaming |
| 3 — Full API | `dicode.execute(params, { onLog, onFinish })` | Full control — custom rendering, progress bars |

## New examples

- **`examples/webhook-form/`** — Text Transformer: uppercase / lowercase / reverse / word-count via a Level 2 auto-enhanced form with live log output
- **`examples/webhook-dashboard/`** — System Dashboard: returns Deno runtime info as JSON; uses Level 3 `dicode.execute()` to render live tiles without page reload

## Bug fixes included

- `params.get()` now works in webhook tasks — POST body and query params are mapped to `RunOptions.Params` (not only `Input`) so task scripts can read them via `params.get("key")`
- `<base href="…/">` injected as first element of `<head>` so relative asset URLs (`style.css`, `script.js`) resolve correctly
- ANSI escape codes no longer appear as raw text in log output

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean (also fixed pre-existing formatting issues in `pkg/config` and `pkg/taskset`)
- [x] `go test -race ./...` — all pass, including 8 new tests in `pkg/trigger`:
  - `TestEngine_WebhookHandler_ServesIndexHTML`
  - `TestEngine_WebhookHandler_NoIndexHTML_RunsTask`
  - `TestEngine_WebhookHandler_ServesAsset`
  - `TestEngine_WebhookHandler_AssetTraversalBlocked`
  - `TestEngine_WebhookHandler_AssetUnknownTypeBlocked`
  - `TestEngine_WebhookHandler_FormPOST`
  - `TestInjectDicodeSDK`
  - `TestInjectDicodeSDK_NoHead`

🤖 Generated with [Claude Code](https://claude.com/claude-code)