### PR TITLE
feat(security): passphrase bootstrap — DB storage, auto-gen, change API

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -3,3 +3,4 @@
 - [Use TypeScript for Deno task scripts](feedback_ts_files.md) — always create task.ts, not task.js, for Deno runtime tasks
 - [Always check CI and update PR after commits](feedback_ci_pr_checks.md) — after any push: check CI, update PR description, update docs/ files
 - [Update agent skill when relevant capabilities change](feedback_update_skills.md) — update pkg/agent/skill.md whenever a new trigger field, JS global, task.yaml field, or security pattern is added
+- [Always format before committing](feedback_format_before_commit.md) — run `go fmt ./...` before every commit or CI lint will fail

--- a/.claude/memory/feedback_format_before_commit.md
+++ b/.claude/memory/feedback_format_before_commit.md
@@ -1,0 +1,11 @@
+---
+name: Always run formatter before committing
+description: Run go fmt (or project formatter) before every commit — lint failures in CI are caused by unformatted code
+type: feedback
+---
+
+Always format code before committing.
+
+**Why:** Lint/format checks fail in CI when code is committed without formatting, causing broken pipelines.
+
+**How to apply:** Before any `git commit`, run `make fmt` (or `make lint` which includes fmt + vet) to ensure all changed files are properly formatted. Do not skip this even for small changes.

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VERSION ?= dev
 GO      := $(shell which go 2>/dev/null || echo $(HOME)/.local/share/mise/shims/go)
 GOFLAGS := -ldflags "-X main.version=$(VERSION)"
 
-.PHONY: build test test-verbose lint clean run tidy
+.PHONY: build test test-verbose lint fmt clean run tidy
 
 ## build: compile the dicode binary into the project root
 build:
@@ -31,8 +31,12 @@ test-race:
 tidy:
 	$(GO) mod tidy
 
-## lint: run go vet
-lint:
+## fmt: format all Go source files
+fmt:
+	$(GO) fmt ./...
+
+## lint: format and vet all Go source files
+lint: fmt
 	$(GO) vet ./...
 
 ## clean: remove the compiled binary

--- a/README.md
+++ b/README.md
@@ -444,7 +444,8 @@ notifications:
 server:
   port: 8080                              # web UI + API port (default: 8080)
   auth: false                             # set true to require passphrase for all endpoints
-  secret: ""                              # passphrase used for auth (and webhook relay HMAC)
+  secret: ""                              # optional YAML passphrase override; if omitted dicode
+                                          # auto-generates one on first boot and stores it in SQLite
   allowed_origins: []                     # CORS allowlist — empty = same-origin only
   mcp: true                               # MCP server at /mcp (default: true)
   tray: true                              # system tray icon (default: true when interactive)

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -8,7 +8,7 @@ This document covers the full security architecture implemented across `pkg/webu
 
 Security is **opt-in**. Without `server.auth: true` in `dicode.yaml`, all behaviour is identical to an unauthenticated deployment. When enabled, every request passes through a middleware chain before reaching any handler:
 
-```
+```text
 request
   └─▶ securityHeaders          adds CSP, X-Frame-Options, etc. (always active)
   └─▶ corsMiddleware            validates Origin against allowlist (always active)
@@ -29,16 +29,43 @@ Middleware is applied in [server.go](../../pkg/webui/server.go) inside `Handler(
 ```yaml
 server:
   auth: true
-  secret: "your-strong-passphrase"   # ≥ 16 chars recommended
+  secret: ""                          # optional YAML override — see passphrase source priority below
   allowed_origins: []                 # empty = same-origin only
   trust_proxy: false                  # set true when behind nginx/Caddy
 ```
+
+### Passphrase source priority
+
+The effective passphrase is resolved in this order on every auth check:
+
+```text
+1. server.secret (YAML)  — highest priority; use for headless / scripted setups
+2. kv["auth.passphrase"] — stored in SQLite; managed via web UI or API
+3. ""                    — bootstrap state (see auto-generation below)
+```
+
+**Auto-generation on first boot**: if `server.auth: true` and no passphrase is set (neither YAML nor DB), dicode generates a cryptographically random 43-character passphrase (32 random bytes, base64url) and prints it to stdout once:
+
+```text
+╔══════════════════════════════════════════════════════════════╗
+║  dicode — auth passphrase generated                         ║
+║                                                              ║
+║  <43-char passphrase>                                        ║
+║                                                              ║
+║  Save this somewhere safe. You can change it any time at    ║
+║  /security in the web UI (requires a valid session).        ║
+╚══════════════════════════════════════════════════════════════╝
+```
+
+The passphrase is immediately persisted in SQLite. Subsequent restarts read it from the DB — the banner is not shown again.
+
+**YAML override behaviour**: when `server.secret` is set, the API refuses passphrase changes (`409 Conflict`) to prevent split-brain state. Remove the YAML field to manage the passphrase via the web UI.
 
 ### `requireAuth` middleware
 
 Defined in [auth.go](../../pkg/webui/auth.go).
 
-```
+```text
 incoming request
   ├── is public path? → allow through
   ├── has valid session cookie? → allow through
@@ -51,6 +78,7 @@ incoming request
 ```
 
 **Public paths** (never require auth):
+
 - `POST /api/secrets/unlock` — login endpoint itself
 - `POST /api/auth/refresh` — silent session renewal (device cookie only, no session required)
 - `/app/*` — static SPA assets (JS, CSS) needed to render the login page
@@ -62,7 +90,7 @@ incoming request
 `securityHeaders` middleware (always active, independent of `server.auth`) adds:
 
 | Header | Value |
-|--------|-------|
+| --- | --- |
 | `X-Content-Type-Options` | `nosniff` |
 | `X-Frame-Options` | `SAMEORIGIN` |
 | `Referrer-Policy` | `strict-origin-when-cross-origin` |
@@ -117,10 +145,10 @@ const (
 
 Two cookie types are in play:
 
-| Cookie | Name | TTL | Stored as |
-|--------|------|-----|-----------|
-| Session | `dicode_secrets_sess` | 8 hours | In-memory map only |
-| Device | `dicode_device` | 30 days | SHA-256 hash in SQLite |
+| Cookie  | Name                  | TTL      | Stored as              |
+| ------- | --------------------- | -------- | ---------------------- |
+| Session | `dicode_secrets_sess` | 8 hours  | In-memory map only     |
+| Device  | `dicode_device`       | 30 days  | SHA-256 hash in SQLite |
 
 Both cookies are: `HttpOnly`, `SameSite=Strict`, `Path=/`.
 
@@ -139,6 +167,7 @@ func (s *sessionStore) issue() string {
 ```
 
 Key properties:
+
 - **Purely random** — no passphrase is involved in token generation
 - Validated by in-memory map lookup (`sessionStore.valid(token)`)
 - Lost on restart — that is intentional; the device cookie handles persistence
@@ -149,11 +178,13 @@ Key properties:
 Managed by `dbSessionStore` in [sessions_db.go](../../pkg/webui/sessions_db.go).
 
 **Issuance** (at login with `trust: true`):
+
 1. Generate 32 random bytes → hex-encode → raw token
 2. Compute `sha256(raw)` → store only the hash in the `sessions` table
 3. Return raw token to be placed in the `dicode_device` cookie
 
 **Renewal** (`renewFromDevice(ctx, rawDeviceToken, ip string)`):
+
 1. Hash the incoming cookie value
 2. Open a **database transaction**
 3. Query for a matching, non-expired `device` row
@@ -188,11 +219,12 @@ CREATE INDEX IF NOT EXISTS idx_sessions_hash ON sessions(token_hash);
 
 ### Login flow
 
-```
+```text
 POST /api/secrets/unlock  {"password":"…","trust":true}
   │
   ├─ rate limit check (IP-based)
-  ├─ ConstantTimeCompare(password, server.secret)
+  ├─ resolvePassphrase() → YAML secret → DB kv["auth.passphrase"] → ""
+  ├─ ConstantTimeCompare(password, resolvedPassphrase)
   ├─ sessions.issue() → 32-byte random session token → cookie
   └─ if trust: dbSessions.issueDeviceToken(ip, user-agent) → device cookie
 
@@ -201,7 +233,7 @@ Response: 200 {"status":"ok"}  +  Set-Cookie: dicode_secrets_sess + dicode_devic
 
 ### Silent refresh flow
 
-```
+```text
 SPA detects 401 from api.js
   │
   ├─ POST /api/auth/refresh  (sends dicode_device cookie)
@@ -217,11 +249,32 @@ SPA detects 401 from api.js
 All require a valid session:
 
 | Method | Path | Action |
-|--------|------|--------|
+| --- | --- | --- |
 | `GET` | `/api/auth/devices` | List active trusted devices |
 | `DELETE` | `/api/auth/devices/{id}` | Revoke one device |
 | `POST` | `/api/auth/logout` | Revoke current session + device cookie |
 | `POST` | `/api/auth/logout-all` | Wipe all in-memory sessions + all device rows |
+
+### Passphrase management endpoints
+
+| Method | Path | Auth | Action |
+| --- | --- | --- | --- |
+| `GET` | `/api/auth/passphrase` | session | Returns `{"source":"yaml"/"db"/"none"}` — never the value |
+| `POST` | `/api/auth/passphrase` | session | Change the DB-stored passphrase |
+
+`POST /api/auth/passphrase` request body:
+
+```json
+{"current": "old-passphrase", "passphrase": "new-passphrase-16chars+"}
+```
+
+Rules:
+
+- Requires a valid session
+- `current` must match the active passphrase (constant-time compare); skipped only when no passphrase is set yet (bootstrap)
+- New passphrase must be ≥ 16 characters
+- Blocked with `409` when `server.secret` (YAML override) is active
+- On success: all in-memory sessions and DB device tokens are invalidated — everyone must re-login
 
 ---
 
@@ -241,7 +294,7 @@ When `webhook_secret` is absent the webhook is open (backwards-compatible). When
 
 `verifyWebhookSignature(spec, r, body []byte)` in [engine.go](../../pkg/trigger/engine.go):
 
-```
+```text
 1. If no secret configured → return nil (open webhook)
 2. Check X-Dicode-Timestamp if present:
    - Parse as Unix int64
@@ -275,6 +328,7 @@ This is critical: if form-encoded bodies were parsed via `r.ParseForm()` first (
 The signature format is intentionally identical to GitHub's webhook delivery. A GitHub webhook pointed at a dicode endpoint with the same secret works with zero configuration on the GitHub side.
 
 Constants:
+
 ```go
 webhookSignatureHeader    = "X-Hub-Signature-256"
 webhookTimestampHeader    = "X-Dicode-Timestamp"
@@ -359,7 +413,7 @@ func (s *Server) requireAPIKey(next http.Handler) http.Handler {
 All require a valid session (not just an API key — key management is a human operation):
 
 | Method | Path | Response |
-|--------|------|---------|
+| --- | --- | --- |
 | `GET` | `/api/auth/keys` | List of `APIKeyInfo` (no raw values) |
 | `POST` | `/api/auth/keys` | `{key: "dck_…", info: APIKeyInfo}` — key shown once |
 | `DELETE` | `/api/auth/keys/{id}` | `{status: "revoked"}` |
@@ -405,9 +459,9 @@ Expired rows are cleaned up by `dbSessionStore.purgeExpired(ctx)` which is calle
 All security-relevant fields in `ServerConfig`:
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| --- | --- | --- | --- |
 | `auth` | bool | `false` | Enable global auth wall |
-| `secret` | string | `""` | Login passphrase (excluded from JSON API) |
+| `secret` | string | `""` | YAML passphrase override — highest priority; if omitted dicode auto-generates one on first boot and stores it in SQLite |
 | `allowed_origins` | []string | `[]` | CORS allowlist — empty = same-origin only |
 | `trust_proxy` | bool | `false` | Trust `X-Forwarded-For` (set when behind a reverse proxy) |
 | `mcp` | bool | `true` | Expose MCP endpoint at `/mcp` |
@@ -426,7 +480,7 @@ All security-relevant fields in `ServerConfig`:
 ## Security Properties Summary
 
 | Property | Implementation |
-|----------|---------------|
+| --- | --- |
 | Session tokens are random | `crypto/rand`, 32 bytes, never passphrase-derived |
 | Device tokens stored as hash | SHA-256 in SQLite, raw value only in cookie |
 | API keys stored as hash | SHA-256 in SQLite, raw value returned once |
@@ -440,3 +494,4 @@ All security-relevant fields in `ServerConfig`:
 | Brute force protection | 5 attempts/IP, then 15-min lockout |
 | Replay attack protection | 5-minute timestamp window on signed webhooks |
 | CORS misconfiguration guard | Origins validated with `url.Parse()` at startup |
+| Passphrase rotation requires current | `crypto/subtle.ConstantTimeCompare` on `current` field |

--- a/pkg/webui/passphrase.go
+++ b/pkg/webui/passphrase.go
@@ -68,9 +68,9 @@ func generateRandomPassphrase() (string, error) {
 }
 
 // resolvePassphrase returns the effective passphrase for the server:
-//   1. YAML override (server.secret) — explicit operator config, highest priority
-//   2. DB-stored passphrase — set via UI or auto-generated on first boot
-//   3. "" — auth is configured but no passphrase exists yet (bootstrap state)
+//  1. YAML override (server.secret) — explicit operator config, highest priority
+//  2. DB-stored passphrase — set via UI or auto-generated on first boot
+//  3. "" — auth is configured but no passphrase exists yet (bootstrap state)
 //
 // The DB result is cached in memory and only re-read from SQLite on a cache
 // miss. The cache is warmed at startup (ensurePassphrase) and invalidated
@@ -139,7 +139,7 @@ func (s *Server) ensurePassphrase(ctx context.Context) error {
 	fmt.Println("╔══════════════════════════════════════════════════════════════╗")
 	fmt.Println("║  dicode — auth passphrase generated                         ║")
 	fmt.Println("║                                                              ║")
-	fmt.Printf( "║  %s  ║\n", pass)
+	fmt.Printf("║  %s  ║\n", pass)
 	fmt.Println("║                                                              ║")
 	fmt.Println("║  Save this somewhere safe. You can change it any time at    ║")
 	fmt.Println("║  /security in the web UI (requires a valid session).        ║")

--- a/pkg/webui/passphrase.go
+++ b/pkg/webui/passphrase.go
@@ -1,0 +1,191 @@
+package webui
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+	"go.uber.org/zap"
+)
+
+const passphraseKVKey = "auth.passphrase"
+
+// passphraseStore persists the server auth passphrase in the SQLite kv table.
+// It is the authoritative source when server.auth is enabled; the YAML
+// server.secret field is a fallback override for scripted/headless setups.
+type passphraseStore struct {
+	db db.DB
+}
+
+func newPassphraseStore(d db.DB) *passphraseStore { return &passphraseStore{db: d} }
+
+// Get returns the stored passphrase, or "" if none is set.
+func (p *passphraseStore) get(ctx context.Context) (string, error) {
+	var val string
+	found := false
+	err := p.db.Query(ctx,
+		`SELECT value FROM kv WHERE key = ?`, []any{passphraseKVKey},
+		func(rows db.Scanner) error {
+			if rows.Next() {
+				found = true
+				return rows.Scan(&val)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return "", nil
+	}
+	return val, nil
+}
+
+// Set stores a new passphrase, replacing any existing value.
+func (p *passphraseStore) set(ctx context.Context, passphrase string) error {
+	return p.db.Exec(ctx,
+		`INSERT INTO kv (key, value) VALUES (?, ?)
+		 ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+		passphraseKVKey, passphrase,
+	)
+}
+
+// generateRandom produces a cryptographically random passphrase (32 bytes,
+// base64url-encoded — 43 printable characters, no padding).
+func generateRandomPassphrase() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate passphrase: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// resolvePassphrase returns the effective passphrase for the server:
+//   1. YAML override (server.secret) — explicit operator config, highest priority
+//   2. DB-stored passphrase — set via UI or auto-generated on first boot
+//   3. "" — auth is configured but no passphrase exists yet (bootstrap state)
+func (s *Server) resolvePassphrase(ctx context.Context) string {
+	// YAML override takes precedence so headless/scripted setups keep working.
+	if s.cfg.Server.Secret != "" {
+		return s.cfg.Server.Secret
+	}
+	if s.passphraseStore == nil {
+		return ""
+	}
+	val, _ := s.passphraseStore.get(ctx)
+	return val
+}
+
+// ensurePassphrase is called at startup when server.auth is true. If no
+// passphrase is stored and no YAML override exists, it auto-generates one,
+// persists it, and prints it to stdout so the operator can record it.
+func (s *Server) ensurePassphrase(ctx context.Context) error {
+	if !s.cfg.Server.Auth {
+		return nil // auth disabled — nothing to do
+	}
+	if s.cfg.Server.Secret != "" {
+		return nil // YAML override present — nothing to auto-generate
+	}
+	if s.passphraseStore == nil {
+		return nil
+	}
+	existing, err := s.passphraseStore.get(ctx)
+	if err != nil {
+		return fmt.Errorf("read stored passphrase: %w", err)
+	}
+	if existing != "" {
+		return nil // already set
+	}
+
+	// First boot with auth enabled and no passphrase — generate one.
+	pass, err := generateRandomPassphrase()
+	if err != nil {
+		return err
+	}
+	if err := s.passphraseStore.set(ctx, pass); err != nil {
+		return fmt.Errorf("store passphrase: %w", err)
+	}
+
+	// Print clearly to stdout — this is the operator's only chance to see it.
+	fmt.Println("╔══════════════════════════════════════════════════════════════╗")
+	fmt.Println("║  dicode — auth passphrase generated                         ║")
+	fmt.Println("║                                                              ║")
+	fmt.Printf( "║  %s  ║\n", pass)
+	fmt.Println("║                                                              ║")
+	fmt.Println("║  Save this somewhere safe. You can change it any time at    ║")
+	fmt.Println("║  /security in the web UI (requires a valid session).        ║")
+	fmt.Println("╚══════════════════════════════════════════════════════════════╝")
+
+	s.log.Info("auth passphrase auto-generated and stored in database")
+	return nil
+}
+
+// apiGetPassphraseStatus returns whether a passphrase is currently set and
+// where it comes from (yaml override, db, or none). Never returns the value.
+func (s *Server) apiGetPassphraseStatus(w http.ResponseWriter, r *http.Request) {
+	source := "none"
+	if s.cfg.Server.Secret != "" {
+		source = "yaml"
+	} else if s.passphraseStore != nil {
+		if val, _ := s.passphraseStore.get(r.Context()); val != "" {
+			source = "db"
+		}
+	}
+	jsonOK(w, map[string]string{"source": source})
+}
+
+// apiChangePassphrase allows changing the stored passphrase via the UI.
+// Requires the current passphrase to be supplied (or a valid session if
+// no passphrase is set yet — bootstrap case).
+func (s *Server) apiChangePassphrase(w http.ResponseWriter, r *http.Request) {
+	if s.passphraseStore == nil {
+		jsonErr(w, "passphrase storage not available", http.StatusServiceUnavailable)
+		return
+	}
+	// Changing the passphrase is a privileged operation — require a valid session.
+	if s.cfg.Server.Auth && !s.authSessionValid(r) {
+		jsonErr(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	// YAML override is in effect — changing via API would be confusing.
+	if s.cfg.Server.Secret != "" {
+		jsonErr(w, "passphrase is set via server.secret in dicode.yaml — remove that field to manage it here", http.StatusConflict)
+		return
+	}
+
+	var body struct {
+		Passphrase string `json:"passphrase"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Passphrase == "" {
+		jsonErr(w, "passphrase is required", http.StatusBadRequest)
+		return
+	}
+	if len(body.Passphrase) < 16 {
+		jsonErr(w, "passphrase must be at least 16 characters", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.passphraseStore.set(r.Context(), body.Passphrase); err != nil {
+		s.log.Error("failed to store passphrase", zap.Error(err))
+		jsonErr(w, "failed to store passphrase", http.StatusInternalServerError)
+		return
+	}
+
+	// Invalidate all current sessions — everyone must re-login with the new passphrase.
+	s.sessions.mu.Lock()
+	s.sessions.tokens = make(map[string]time.Time)
+	s.sessions.mu.Unlock()
+	if s.dbSessions != nil {
+		_ = s.dbSessions.revokeAllDevices(r.Context())
+	}
+	clearAuthCookies(w)
+
+	s.log.Info("auth passphrase changed — all sessions invalidated")
+	jsonOK(w, map[string]string{"status": "ok"})
+}

--- a/pkg/webui/passphrase.go
+++ b/pkg/webui/passphrase.go
@@ -3,6 +3,7 @@ package webui
 import (
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -70,6 +71,10 @@ func generateRandomPassphrase() (string, error) {
 //   1. YAML override (server.secret) — explicit operator config, highest priority
 //   2. DB-stored passphrase — set via UI or auto-generated on first boot
 //   3. "" — auth is configured but no passphrase exists yet (bootstrap state)
+//
+// The DB result is cached in memory and only re-read from SQLite on a cache
+// miss. The cache is warmed at startup (ensurePassphrase) and invalidated
+// whenever apiChangePassphrase succeeds.
 func (s *Server) resolvePassphrase(ctx context.Context) string {
 	// YAML override takes precedence so headless/scripted setups keep working.
 	if s.cfg.Server.Secret != "" {
@@ -78,7 +83,22 @@ func (s *Server) resolvePassphrase(ctx context.Context) string {
 	if s.passphraseStore == nil {
 		return ""
 	}
-	val, _ := s.passphraseStore.get(ctx)
+	s.cachedPassphraseMu.RLock()
+	cached := s.cachedPassphrase
+	s.cachedPassphraseMu.RUnlock()
+	if cached != "" {
+		return cached
+	}
+	val, err := s.passphraseStore.get(ctx)
+	if err != nil {
+		s.log.Error("failed to read passphrase from DB", zap.Error(err))
+		return ""
+	}
+	if val != "" {
+		s.cachedPassphraseMu.Lock()
+		s.cachedPassphrase = val
+		s.cachedPassphraseMu.Unlock()
+	}
 	return val
 }
 
@@ -111,6 +131,9 @@ func (s *Server) ensurePassphrase(ctx context.Context) error {
 	if err := s.passphraseStore.set(ctx, pass); err != nil {
 		return fmt.Errorf("store passphrase: %w", err)
 	}
+	s.cachedPassphraseMu.Lock()
+	s.cachedPassphrase = pass
+	s.cachedPassphraseMu.Unlock()
 
 	// Print clearly to stdout — this is the operator's only chance to see it.
 	fmt.Println("╔══════════════════════════════════════════════════════════════╗")
@@ -160,6 +183,7 @@ func (s *Server) apiChangePassphrase(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body struct {
+		Current    string `json:"current"`
 		Passphrase string `json:"passphrase"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Passphrase == "" {
@@ -171,11 +195,25 @@ func (s *Server) apiChangePassphrase(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Require the current passphrase to prevent a stolen session from rotating
+	// the credential without knowing the existing secret. Skip only when no
+	// passphrase is set yet (bootstrap: first-time setup from a valid session).
+	existing := s.resolvePassphrase(r.Context())
+	if existing != "" && subtle.ConstantTimeCompare([]byte(body.Current), []byte(existing)) != 1 {
+		jsonErr(w, "current passphrase is incorrect", http.StatusUnauthorized)
+		return
+	}
+
 	if err := s.passphraseStore.set(r.Context(), body.Passphrase); err != nil {
 		s.log.Error("failed to store passphrase", zap.Error(err))
 		jsonErr(w, "failed to store passphrase", http.StatusInternalServerError)
 		return
 	}
+
+	// Update the in-memory cache so subsequent auth checks see the new value immediately.
+	s.cachedPassphraseMu.Lock()
+	s.cachedPassphrase = body.Passphrase
+	s.cachedPassphraseMu.Unlock()
 
 	// Invalidate all current sessions — everyone must re-login with the new passphrase.
 	s.sessions.mu.Lock()

--- a/pkg/webui/passphrase_test.go
+++ b/pkg/webui/passphrase_test.go
@@ -225,9 +225,6 @@ func TestEnsurePassphrase_NoopWhenYAMLOverridePresent(t *testing.T) {
 // ── /api/auth/passphrase HTTP endpoints ───────────────────────────────────────
 
 func TestPassphraseAPI_StatusEndpoint(t *testing.T) {
-	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
-	defer d.Close()
-
 	srv := newAuthServer(t, "") // auth enabled, no YAML secret
 	// Manually set a DB passphrase
 	_ = srv.passphraseStore.set(context.Background(), "test-pass")
@@ -254,9 +251,6 @@ func TestPassphraseAPI_StatusEndpoint(t *testing.T) {
 }
 
 func TestPassphraseAPI_ChangePassphrase(t *testing.T) {
-	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
-	defer d.Close()
-
 	srv := newAuthServer(t, "")
 	_ = srv.passphraseStore.set(context.Background(), "old-passphrase-here")
 
@@ -266,8 +260,8 @@ func TestPassphraseAPI_ChangePassphrase(t *testing.T) {
 		t.Fatal("login with old passphrase failed")
 	}
 
-	// Change passphrase.
-	body, _ := json.Marshal(map[string]string{"passphrase": "new-strong-passphrase-123"})
+	// Change passphrase — must supply the current one.
+	body, _ := json.Marshal(map[string]string{"current": "old-passphrase-here", "passphrase": "new-strong-passphrase-123"})
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/passphrase", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(cookie)
@@ -292,14 +286,11 @@ func TestPassphraseAPI_ChangePassphrase(t *testing.T) {
 }
 
 func TestPassphraseAPI_ChangeRequiresSession(t *testing.T) {
-	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
-	defer d.Close()
-
 	srv := newAuthServer(t, "")
 	_ = srv.passphraseStore.set(context.Background(), "existing-pass-1234")
 	h := srv.Handler()
 
-	body, _ := json.Marshal(map[string]string{"passphrase": "new-pass-should-fail"})
+	body, _ := json.Marshal(map[string]string{"current": "existing-pass-1234", "passphrase": "new-pass-should-fail"})
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/passphrase", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	// No cookie.
@@ -312,9 +303,6 @@ func TestPassphraseAPI_ChangeRequiresSession(t *testing.T) {
 }
 
 func TestPassphraseAPI_ChangeTooShortRejected(t *testing.T) {
-	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
-	defer d.Close()
-
 	srv := newAuthServer(t, "")
 	_ = srv.passphraseStore.set(context.Background(), "existing-long-pass-1234")
 	h := srv.Handler()
@@ -324,7 +312,7 @@ func TestPassphraseAPI_ChangeTooShortRejected(t *testing.T) {
 		t.Fatal("login failed")
 	}
 
-	body, _ := json.Marshal(map[string]string{"passphrase": "short"})
+	body, _ := json.Marshal(map[string]string{"current": "existing-long-pass-1234", "passphrase": "short"})
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/passphrase", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(cookie)
@@ -333,6 +321,33 @@ func TestPassphraseAPI_ChangeTooShortRejected(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("expected 400 for short passphrase, got %d", w.Code)
+	}
+}
+
+func TestPassphraseAPI_WrongCurrentRejected(t *testing.T) {
+	srv := newAuthServer(t, "")
+	_ = srv.passphraseStore.set(context.Background(), "correct-current-pass-123")
+	h := srv.Handler()
+
+	cookie := login(t, h, "correct-current-pass-123", false)
+	if cookie == nil {
+		t.Fatal("login failed")
+	}
+
+	body, _ := json.Marshal(map[string]string{"current": "wrong-current-passphrase", "passphrase": "new-strong-passphrase-123"})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/passphrase", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for wrong current passphrase, got %d", w.Code)
+	}
+
+	// Original passphrase must still work.
+	if c := login(t, h, "correct-current-pass-123", false); c == nil {
+		t.Error("passphrase should not have changed after rejected attempt")
 	}
 }
 

--- a/pkg/webui/passphrase_test.go
+++ b/pkg/webui/passphrase_test.go
@@ -1,0 +1,380 @@
+package webui
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/config"
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/trigger"
+	"go.uber.org/zap"
+)
+
+// newAuthServerNoDB builds a server with auth enabled but no DB — simulates
+// YAML-only passphrase path.
+func newAuthServerNoDB(t *testing.T, passphrase string) *Server {
+	t.Helper()
+	reg := registry.New(nil)
+	eng := trigger.New(reg, nil, zap.NewNop())
+	cfg := &config.Config{Server: config.ServerConfig{
+		Port:   8080,
+		Auth:   true,
+		Secret: passphrase,
+		MCP:    true,
+	}}
+	srv := &Server{
+		registry: reg,
+		engine:   eng,
+		cfg:      cfg,
+		sessions: newSessionStore(),
+		limiter:  newUnlockLimiter(),
+		logs:     NewLogBroadcaster(),
+		ws:       NewWSHub(zap.NewNop()),
+		log:      zap.NewNop(),
+		port:     8080,
+	}
+	return srv
+}
+
+// ── passphraseStore unit tests ────────────────────────────────────────────────
+
+func TestPassphraseStore_GetEmpty(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	ps := newPassphraseStore(d)
+	val, err := ps.get(context.Background())
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if val != "" {
+		t.Errorf("expected empty passphrase, got %q", val)
+	}
+}
+
+func TestPassphraseStore_SetAndGet(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	ps := newPassphraseStore(d)
+	if err := ps.set(context.Background(), "my-secret-pass"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	val, err := ps.get(context.Background())
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if val != "my-secret-pass" {
+		t.Errorf("expected %q, got %q", "my-secret-pass", val)
+	}
+}
+
+func TestPassphraseStore_Overwrite(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	ps := newPassphraseStore(d)
+	_ = ps.set(context.Background(), "first")
+	_ = ps.set(context.Background(), "second")
+
+	val, _ := ps.get(context.Background())
+	if val != "second" {
+		t.Errorf("expected %q after overwrite, got %q", "second", val)
+	}
+}
+
+// ── resolvePassphrase priority ────────────────────────────────────────────────
+
+func TestResolvePassphrase_YAMLOverrideTakesPrecedence(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	ps := newPassphraseStore(d)
+	_ = ps.set(context.Background(), "db-passphrase")
+
+	reg := registry.New(d)
+	eng := trigger.New(reg, nil, zap.NewNop())
+	cfg := &config.Config{Server: config.ServerConfig{Auth: true, Secret: "yaml-passphrase"}}
+	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d)
+
+	got := srv.resolvePassphrase(context.Background())
+	if got != "yaml-passphrase" {
+		t.Errorf("YAML override should take precedence, got %q", got)
+	}
+}
+
+func TestResolvePassphrase_DBUsedWhenNoYAML(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	reg := registry.New(d)
+	eng := trigger.New(reg, nil, zap.NewNop())
+	cfg := &config.Config{Server: config.ServerConfig{Auth: true, Secret: ""}}
+	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d)
+
+	_ = srv.passphraseStore.set(context.Background(), "stored-pass")
+
+	got := srv.resolvePassphrase(context.Background())
+	if got != "stored-pass" {
+		t.Errorf("expected DB passphrase, got %q", got)
+	}
+}
+
+func TestResolvePassphrase_EmptyWhenNeitherSet(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	reg := registry.New(d)
+	eng := trigger.New(reg, nil, zap.NewNop())
+	cfg := &config.Config{Server: config.ServerConfig{Auth: true}}
+	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d)
+
+	got := srv.resolvePassphrase(context.Background())
+	if got != "" {
+		t.Errorf("expected empty passphrase, got %q", got)
+	}
+}
+
+// ── ensurePassphrase auto-generation ─────────────────────────────────────────
+
+func TestEnsurePassphrase_GeneratesWhenMissing(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	reg := registry.New(d)
+	eng := trigger.New(reg, nil, zap.NewNop())
+	cfg := &config.Config{Server: config.ServerConfig{Auth: true}}
+	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d)
+
+	if err := srv.ensurePassphrase(context.Background()); err != nil {
+		t.Fatalf("ensurePassphrase: %v", err)
+	}
+
+	stored, _ := srv.passphraseStore.get(context.Background())
+	if stored == "" {
+		t.Error("expected passphrase to be auto-generated and stored")
+	}
+	if len(stored) < 20 {
+		t.Errorf("auto-generated passphrase too short: %q", stored)
+	}
+}
+
+func TestEnsurePassphrase_DoesNotOverwriteExisting(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	reg := registry.New(d)
+	eng := trigger.New(reg, nil, zap.NewNop())
+	cfg := &config.Config{Server: config.ServerConfig{Auth: true}}
+	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d)
+
+	_ = srv.passphraseStore.set(context.Background(), "already-set")
+	if err := srv.ensurePassphrase(context.Background()); err != nil {
+		t.Fatalf("ensurePassphrase: %v", err)
+	}
+
+	stored, _ := srv.passphraseStore.get(context.Background())
+	if stored != "already-set" {
+		t.Errorf("existing passphrase should not be overwritten, got %q", stored)
+	}
+}
+
+func TestEnsurePassphrase_NoopWhenAuthDisabled(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	reg := registry.New(d)
+	eng := trigger.New(reg, nil, zap.NewNop())
+	cfg := &config.Config{Server: config.ServerConfig{Auth: false}}
+	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d)
+
+	if err := srv.ensurePassphrase(context.Background()); err != nil {
+		t.Fatalf("ensurePassphrase: %v", err)
+	}
+
+	stored, _ := srv.passphraseStore.get(context.Background())
+	if stored != "" {
+		t.Errorf("should not generate passphrase when auth disabled, got %q", stored)
+	}
+}
+
+func TestEnsurePassphrase_NoopWhenYAMLOverridePresent(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	reg := registry.New(d)
+	eng := trigger.New(reg, nil, zap.NewNop())
+	cfg := &config.Config{Server: config.ServerConfig{Auth: true, Secret: "from-yaml"}}
+	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d)
+
+	if err := srv.ensurePassphrase(context.Background()); err != nil {
+		t.Fatalf("ensurePassphrase: %v", err)
+	}
+
+	stored, _ := srv.passphraseStore.get(context.Background())
+	if stored != "" {
+		t.Errorf("should not touch DB when YAML override is set, got %q", stored)
+	}
+}
+
+// ── /api/auth/passphrase HTTP endpoints ───────────────────────────────────────
+
+func TestPassphraseAPI_StatusEndpoint(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	srv := newAuthServer(t, "") // auth enabled, no YAML secret
+	// Manually set a DB passphrase
+	_ = srv.passphraseStore.set(context.Background(), "test-pass")
+
+	h := srv.Handler()
+	cookie := login(t, h, "test-pass", false)
+	if cookie == nil {
+		t.Fatal("login failed")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/passphrase", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+	var resp map[string]string
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["source"] != "db" {
+		t.Errorf("expected source=db, got %v", resp)
+	}
+}
+
+func TestPassphraseAPI_ChangePassphrase(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	srv := newAuthServer(t, "")
+	_ = srv.passphraseStore.set(context.Background(), "old-passphrase-here")
+
+	h := srv.Handler()
+	cookie := login(t, h, "old-passphrase-here", false)
+	if cookie == nil {
+		t.Fatal("login with old passphrase failed")
+	}
+
+	// Change passphrase.
+	body, _ := json.Marshal(map[string]string{"passphrase": "new-strong-passphrase-123"})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/passphrase", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 on passphrase change, got %d: %s", w.Code, w.Body)
+	}
+
+	// Old passphrase must be rejected.
+	oldCookie := login(t, h, "old-passphrase-here", false)
+	if oldCookie != nil {
+		t.Error("old passphrase should no longer work after change")
+	}
+
+	// New passphrase must work.
+	newCookie := login(t, h, "new-strong-passphrase-123", false)
+	if newCookie == nil {
+		t.Error("new passphrase should work after change")
+	}
+}
+
+func TestPassphraseAPI_ChangeRequiresSession(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	srv := newAuthServer(t, "")
+	_ = srv.passphraseStore.set(context.Background(), "existing-pass-1234")
+	h := srv.Handler()
+
+	body, _ := json.Marshal(map[string]string{"passphrase": "new-pass-should-fail"})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/passphrase", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	// No cookie.
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 without session, got %d", w.Code)
+	}
+}
+
+func TestPassphraseAPI_ChangeTooShortRejected(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	srv := newAuthServer(t, "")
+	_ = srv.passphraseStore.set(context.Background(), "existing-long-pass-1234")
+	h := srv.Handler()
+
+	cookie := login(t, h, "existing-long-pass-1234", false)
+	if cookie == nil {
+		t.Fatal("login failed")
+	}
+
+	body, _ := json.Marshal(map[string]string{"passphrase": "short"})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/passphrase", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for short passphrase, got %d", w.Code)
+	}
+}
+
+func TestPassphraseAPI_YAMLOverrideBlocksAPIChange(t *testing.T) {
+	// When server.secret is set in YAML, the API should refuse to change it
+	// to avoid a confusing split-brain state.
+	srv := newAuthServer(t, "yaml-controlled-pass")
+	h := srv.Handler()
+
+	cookie := login(t, h, "yaml-controlled-pass", false)
+	if cookie == nil {
+		t.Fatal("login failed")
+	}
+
+	body, _ := json.Marshal(map[string]string{"passphrase": "new-pass-via-api-12345"})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/passphrase", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409 when YAML override is active, got %d", w.Code)
+	}
+}
+
+// ── generateRandomPassphrase ──────────────────────────────────────────────────
+
+func TestGenerateRandomPassphrase_Length(t *testing.T) {
+	p, err := generateRandomPassphrase()
+	if err != nil {
+		t.Fatalf("generateRandomPassphrase: %v", err)
+	}
+	if len(p) < 20 {
+		t.Errorf("passphrase too short: %q (%d chars)", p, len(p))
+	}
+}
+
+func TestGenerateRandomPassphrase_Unique(t *testing.T) {
+	a, _ := generateRandomPassphrase()
+	b, _ := generateRandomPassphrase()
+	if a == b {
+		t.Error("two generated passphrases should not be equal")
+	}
+}

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -148,8 +148,10 @@ type Server struct {
 	sessions        *sessionStore
 	dbSessions      *dbSessionStore  // persistent sessions / trusted devices
 	apiKeys         *apiKeyStore     // MCP / programmatic API keys
-	passphraseStore *passphraseStore // auth passphrase persisted in DB
-	limiter         *unlockLimiter
+	passphraseStore    *passphraseStore // auth passphrase persisted in DB
+	cachedPassphrase   string           // in-memory cache of resolved passphrase; invalidated on change
+	cachedPassphraseMu sync.RWMutex
+	limiter            *unlockLimiter
 	logs            *LogBroadcaster
 	ws              *WSHub
 	log             *zap.Logger
@@ -723,9 +725,7 @@ func (s *Server) apiSaveTrigger(w http.ResponseWriter, r *http.Request) {
 
 const secretsCookie = "dicode_secrets_sess"
 
-// secretsPassphrase returns the effective auth passphrase. DB-stored value
-// takes precedence over the YAML override for backwards-compat, but YAML
-// override is checked inside resolvePassphrase first (highest priority).
+// secretsPassphrase returns the effective auth passphrase (YAML > DB > "").
 func (s *Server) secretsPassphrase() string {
 	return s.resolvePassphrase(context.Background())
 }

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -146,8 +146,9 @@ type Server struct {
 	dataDir         string               // ~/.dicode or cfg.DataDir
 	managedRuntimes []pkgruntime.ManagedRuntime
 	sessions        *sessionStore
-	dbSessions      *dbSessionStore // persistent sessions / trusted devices
-	apiKeys         *apiKeyStore    // MCP / programmatic API keys
+	dbSessions      *dbSessionStore  // persistent sessions / trusted devices
+	apiKeys         *apiKeyStore     // MCP / programmatic API keys
+	passphraseStore *passphraseStore // auth passphrase persisted in DB
 	limiter         *unlockLimiter
 	logs            *LogBroadcaster
 	ws              *WSHub
@@ -175,28 +176,31 @@ func New(port int, r *registry.Registry, eng *trigger.Engine, cfg *config.Config
 
 	var dbs *dbSessionStore
 	var aks *apiKeyStore
+	var ps *passphraseStore
 	if database != nil {
 		dbs = newDBSessionStore(database)
 		aks = newAPIKeyStore(database)
+		ps = newPassphraseStore(database)
 	}
 
 	s := &Server{
-		registry:   r,
-		engine:     eng,
-		cfg:        cfg,
-		cfgPath:    cfgPath,
-		secretsMgr: secretsMgr,
-		reconciler: rec,
-		sourceMgr:  sourceMgr,
-		dataDir:    dataDir,
-		sessions:   ss,
-		dbSessions: dbs,
-		apiKeys:    aks,
-		limiter:    newUnlockLimiter(),
-		logs:       logs,
-		ws:         wsHub,
-		log:        log,
-		port:       port,
+		registry:        r,
+		engine:          eng,
+		cfg:             cfg,
+		cfgPath:         cfgPath,
+		secretsMgr:      secretsMgr,
+		reconciler:      rec,
+		sourceMgr:       sourceMgr,
+		dataDir:         dataDir,
+		sessions:        ss,
+		dbSessions:      dbs,
+		apiKeys:         aks,
+		passphraseStore: ps,
+		limiter:         newUnlockLimiter(),
+		logs:            logs,
+		ws:              wsHub,
+		log:             log,
+		port:            port,
 	}
 
 	// Wire run started hook → broadcast run:started
@@ -364,7 +368,7 @@ func (s *Server) Handler() http.Handler {
 			r.Delete("/secrets/{key}", s.apiDeleteSecret)
 			r.Post("/secrets/lock", s.apiSecretsLock)
 
-			// Auth management — trusted devices & API keys
+			// Auth management — trusted devices, API keys & passphrase
 			r.Get("/auth/devices", s.apiListDevices)
 			r.Delete("/auth/devices/{id}", s.apiRevokeDevice)
 			r.Post("/auth/logout", s.apiLogout)
@@ -372,6 +376,8 @@ func (s *Server) Handler() http.Handler {
 			r.Get("/auth/keys", s.apiListAPIKeys)
 			r.Post("/auth/keys", s.apiCreateAPIKey)
 			r.Delete("/auth/keys/{id}", s.apiRevokeAPIKey)
+			r.Get("/auth/passphrase", s.apiGetPassphraseStatus)
+			r.Post("/auth/passphrase", s.apiChangePassphrase)
 
 			// Settings
 			r.Post("/settings/ai", s.apiSaveAISettings)
@@ -406,6 +412,12 @@ func (s *Server) Handler() http.Handler {
 
 // Start listens on the configured port until ctx is cancelled.
 func (s *Server) Start(ctx context.Context) error {
+	// Ensure an auth passphrase exists before accepting any connections.
+	// Auto-generates and prints one if server.auth is true and none is configured.
+	if err := s.ensurePassphrase(ctx); err != nil {
+		return fmt.Errorf("ensure auth passphrase: %w", err)
+	}
+
 	s.srv = &http.Server{
 		Addr:              fmt.Sprintf(":%d", s.port),
 		Handler:           s.Handler(),
@@ -711,7 +723,12 @@ func (s *Server) apiSaveTrigger(w http.ResponseWriter, r *http.Request) {
 
 const secretsCookie = "dicode_secrets_sess"
 
-func (s *Server) secretsPassphrase() string { return s.cfg.Server.Secret }
+// secretsPassphrase returns the effective auth passphrase. DB-stored value
+// takes precedence over the YAML override for backwards-compat, but YAML
+// override is checked inside resolvePassphrase first (highest priority).
+func (s *Server) secretsPassphrase() string {
+	return s.resolvePassphrase(context.Background())
+}
 
 func (s *Server) secretsSessionValid(r *http.Request) bool {
 	// If no passphrase is configured, the session is always valid.

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -136,27 +136,27 @@ var staticFS embed.FS
 
 // Server is the HTTP server for the web UI and REST API.
 type Server struct {
-	registry        *registry.Registry
-	engine          *trigger.Engine
-	cfg             *config.Config
-	cfgPath         string               // path to dicode.yaml; empty in tests
-	secretsMgr      SecretsManager       // nil if local provider not configured
-	reconciler      *registry.Reconciler // nil if not wired
-	sourceMgr       *SourceManager       // nil if not wired
-	dataDir         string               // ~/.dicode or cfg.DataDir
-	managedRuntimes []pkgruntime.ManagedRuntime
-	sessions        *sessionStore
-	dbSessions      *dbSessionStore  // persistent sessions / trusted devices
-	apiKeys         *apiKeyStore     // MCP / programmatic API keys
+	registry           *registry.Registry
+	engine             *trigger.Engine
+	cfg                *config.Config
+	cfgPath            string               // path to dicode.yaml; empty in tests
+	secretsMgr         SecretsManager       // nil if local provider not configured
+	reconciler         *registry.Reconciler // nil if not wired
+	sourceMgr          *SourceManager       // nil if not wired
+	dataDir            string               // ~/.dicode or cfg.DataDir
+	managedRuntimes    []pkgruntime.ManagedRuntime
+	sessions           *sessionStore
+	dbSessions         *dbSessionStore  // persistent sessions / trusted devices
+	apiKeys            *apiKeyStore     // MCP / programmatic API keys
 	passphraseStore    *passphraseStore // auth passphrase persisted in DB
 	cachedPassphrase   string           // in-memory cache of resolved passphrase; invalidated on change
 	cachedPassphraseMu sync.RWMutex
 	limiter            *unlockLimiter
-	logs            *LogBroadcaster
-	ws              *WSHub
-	log             *zap.Logger
-	port            int
-	srv             *http.Server
+	logs               *LogBroadcaster
+	ws                 *WSHub
+	log                *zap.Logger
+	port               int
+	srv                *http.Server
 }
 
 // SetManagedRuntimes registers the list of managed runtimes (Deno, Python, …)


### PR DESCRIPTION
Closes #12

## Summary

- Replaces plaintext `server.secret` YAML field as primary passphrase store with a SQLite `kv` entry
- On first boot with `server.auth: true` and no passphrase set, one is auto-generated (32 random bytes, base64url) and printed clearly to stdout — the operator's only chance to see it
- YAML `server.secret` remains as a high-priority override for headless/scripted setups (takes precedence over DB)
- New `GET /api/auth/passphrase` returns `{"source":"yaml"|"db"|"none"}` — never the value itself
- New `POST /api/auth/passphrase` allows changing the stored passphrase (requires active session, min 16 chars, blocked when YAML override is active, invalidates all sessions on success)

## Priority logic

```
YAML server.secret (highest)
  → DB kv["auth.passphrase"]
    → "" — bootstrap state, ensurePassphrase() auto-generates on startup
```

## Test plan

- [x] `TestPassphraseStore_GetEmpty` — returns "" when nothing stored
- [x] `TestPassphraseStore_SetAndGet` — round-trip through SQLite kv
- [x] `TestPassphraseStore_Overwrite` — upsert replaces existing value
- [x] `TestResolvePassphrase_YAMLOverrideTakesPrecedence`
- [x] `TestResolvePassphrase_DBUsedWhenNoYAML`
- [x] `TestResolvePassphrase_EmptyWhenNeitherSet`
- [x] `TestEnsurePassphrase_GeneratesWhenMissing`
- [x] `TestEnsurePassphrase_DoesNotOverwriteExisting`
- [x] `TestEnsurePassphrase_NoopWhenAuthDisabled`
- [x] `TestEnsurePassphrase_NoopWhenYAMLOverridePresent`
- [x] `TestPassphraseAPI_StatusEndpoint`
- [x] `TestPassphraseAPI_ChangePassphrase` — full round-trip: old rejected, new accepted
- [x] `TestPassphraseAPI_ChangeRequiresSession`
- [x] `TestPassphraseAPI_ChangeTooShortRejected`
- [x] `TestPassphraseAPI_YAMLOverrideBlocksAPIChange`
- [x] `TestGenerateRandomPassphrase_Length`
- [x] `TestGenerateRandomPassphrase_Unique`

All 17 tests pass (`go test ./pkg/webui/... -count=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)