### PR TITLE
feat(security): webhook optional auth + dicode.js 401 handling

### DIFF
--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -63,6 +63,7 @@ env:
 | `trigger` | object | ✅ | Exactly one trigger must be set |
 | `trigger.cron` | string | | Standard cron expression (5 fields) |
 | `trigger.webhook` | string | | Webhook path, e.g. `/github-push` |
+| `trigger.auth` | bool | | Require a valid dicode session for webhook GET (UI) and POST (run) |
 | `trigger.manual` | bool | | Set `true` to enable manual-only |
 | `trigger.chain` | object | | Chain trigger (see below) |
 | `trigger.chain.from` | string | | Task ID to listen for |
@@ -96,6 +97,19 @@ trigger:
 ```
 
 Endpoint: `POST /hooks/github-push`. Request body available as `input` global in `task.js`.
+
+To require a valid dicode session before allowing access to the webhook UI or running the task, add `auth: true`:
+
+```yaml
+trigger:
+  webhook: /hooks/my-internal-tool
+  auth: true
+```
+
+- `GET /hooks/my-internal-tool` (serving `index.html`) → redirects to `/?auth=required` if no session
+- `POST /hooks/my-internal-tool` (running the task) → returns `401` JSON if no session
+- `dicode.js` handles 401 automatically: silent refresh via device token, then redirects to login
+- Open webhooks (no `auth: true`) remain fully public — no behaviour change
 
 **Manual** — only fires when explicitly triggered via API or UI:
 ```yaml

--- a/pkg/agent/skill.md
+++ b/pkg/agent/skill.md
@@ -38,6 +38,7 @@ runtime: js                        # only supported runtime
 trigger:                           # exactly ONE of:
   cron: "0 9 * * *"               #   standard 5-field cron
   webhook: /hooks/<path>           #   HTTP POST trigger (open — no auth)
+  auth: true                       #   optional: require dicode session for webhook GET/POST
   manual: true                     #   UI/API only
   chain:                           #   fires when another task completes
     from: <task-id>
@@ -70,6 +71,21 @@ env:
 - Replay protection: if the sender includes `X-Dicode-Timestamp`, requests older than 5 minutes are rejected
 
 **Always use `"${ENV_VAR}"` syntax** — never write the raw secret value in `task.yaml`. Store it as a dicode secret first, then reference it via env.
+
+### Session-authenticated webhook (internal tools)
+
+When the webhook UI should only be accessible by logged-in dicode users, add `auth: true`:
+
+```yaml
+trigger:
+  webhook: /hooks/my-internal-tool
+  auth: true
+```
+
+- `GET /hooks/…` (serving `index.html`) requires a valid session → redirects to `/?auth=required` if missing
+- `POST /hooks/…` (running the task) requires a valid session → returns `401` JSON if missing
+- `dicode.js` handles 401 automatically: silent refresh via device token, then redirects to login
+- Open webhooks (no `auth: true`) remain fully public — no behaviour change
 
 ## Available JS globals
 

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -74,6 +74,7 @@ type TriggerConfig struct {
 	Cron          string        `yaml:"cron,omitempty"`           // cron expression e.g. "0 9 * * *"
 	Webhook       string        `yaml:"webhook,omitempty"`        // HTTP path e.g. "/hooks/my-task"
 	WebhookSecret string        `yaml:"webhook_secret,omitempty"` // HMAC-SHA256 secret for webhook auth
+	WebhookAuth   bool          `yaml:"auth,omitempty"`           // require dicode session for GET (UI) and POST (run)
 	Manual        bool          `yaml:"manual,omitempty"`         // only via explicit trigger
 	Chain         *ChainTrigger `yaml:"chain,omitempty"`          // fire when another task completes
 	Daemon        bool          `yaml:"daemon,omitempty"`         // start on app start, restart on exit

--- a/pkg/webui/auth.go
+++ b/pkg/webui/auth.go
@@ -8,6 +8,64 @@ import (
 	"go.uber.org/zap"
 )
 
+// webhookAuthGuard checks whether the task associated with the requested webhook
+// path has trigger.auth: true. If it does, and the request carries no valid
+// dicode session, the request is rejected (401 JSON for API callers, redirect
+// for browsers). Public webhooks (no auth: true) pass through unchanged.
+func (s *Server) webhookAuthGuard(w http.ResponseWriter, r *http.Request, next http.Handler) {
+	// Find the spec whose webhook path is a prefix-match for r.URL.Path.
+	var requiresAuth bool
+	for _, spec := range s.registry.All() {
+		wp := spec.Trigger.Webhook
+		if wp == "" {
+			continue
+		}
+		if r.URL.Path == wp || strings.HasPrefix(r.URL.Path, wp+"/") {
+			requiresAuth = spec.Trigger.WebhookAuth
+			break
+		}
+	}
+
+	if !requiresAuth {
+		next.ServeHTTP(w, r)
+		return
+	}
+
+	// Task requires a valid dicode session.
+	if s.hasValidSession(r) {
+		next.ServeHTTP(w, r)
+		return
+	}
+
+	// For webhook paths, a GET without an API content/accept header is a
+	// browser navigating to the task UI — redirect rather than 401.
+	isBrowserGet := r.Method == http.MethodGet &&
+		r.Header.Get("Accept") != "application/json" &&
+		!strings.Contains(r.Header.Get("Content-Type"), "application/json")
+	if !isBrowserGet {
+		jsonErr(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	http.Redirect(w, r, "/?auth=required", http.StatusSeeOther)
+}
+
+// hasValidSession returns true if r carries a valid in-memory session cookie
+// or a device token that can be auto-renewed.
+func (s *Server) hasValidSession(r *http.Request) bool {
+	if cookie, err := r.Cookie(secretsCookie); err == nil {
+		if s.sessions.valid(cookie.Value) {
+			return true
+		}
+	}
+	if s.dbSessions != nil {
+		if dc, err := r.Cookie(deviceCookie); err == nil {
+			_, ok := s.dbSessions.renewFromDevice(r.Context(), dc.Value, clientIP(r, s.cfg.Server.TrustProxy))
+			return ok
+		}
+	}
+	return false
+}
+
 // requireAuth is a middleware that enforces authentication when server.auth is
 // enabled. API requests receive a 401 JSON response; browser requests are
 // redirected to the login page. Public paths (login endpoint, static assets,

--- a/pkg/webui/auth.go
+++ b/pkg/webui/auth.go
@@ -37,11 +37,11 @@ func (s *Server) webhookAuthGuard(w http.ResponseWriter, r *http.Request, next h
 		return
 	}
 
-	// For webhook paths, a GET without an API content/accept header is a
-	// browser navigating to the task UI — redirect rather than 401.
+	// For webhook paths, a GET from a browser includes "text/html" in Accept.
+	// API clients (curl, fetch without custom headers, etc.) typically don't,
+	// so we use that to decide redirect vs 401.
 	isBrowserGet := r.Method == http.MethodGet &&
-		r.Header.Get("Accept") != "application/json" &&
-		!strings.Contains(r.Header.Get("Content-Type"), "application/json")
+		strings.Contains(r.Header.Get("Accept"), "text/html")
 	if !isBrowserGet {
 		jsonErr(w, "unauthorized", http.StatusUnauthorized)
 		return
@@ -50,7 +50,9 @@ func (s *Server) webhookAuthGuard(w http.ResponseWriter, r *http.Request, next h
 }
 
 // hasValidSession returns true if r carries a valid in-memory session cookie
-// or a device token that can be auto-renewed.
+// or a device token that can be auto-renewed. Note: when a device token is
+// present the function has a side effect — it consumes the token and issues a
+// fresh one via renewFromDevice.
 func (s *Server) hasValidSession(r *http.Request) bool {
 	if cookie, err := r.Cookie(secretsCookie); err == nil {
 		if s.sessions.valid(cookie.Value) {

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -308,10 +308,13 @@ func (s *Server) Handler() http.Handler {
 	r.Post("/api/secrets/unlock", s.apiSecretsUnlock)
 	r.Post("/api/auth/refresh", s.apiAuthRefresh)
 
-	// Webhook passthrough — auth via per-task HMAC secret, not session cookie.
+	// Webhook passthrough — auth via per-task HMAC secret or optional session cookie.
+	// When a task sets trigger.auth: true, a valid dicode session is required for
+	// both GET (serving the task UI) and POST (running the task). Public webhooks
+	// (no auth: true) remain fully open — zero behaviour change.
 	webhookHandler := func(w http.ResponseWriter, req *http.Request) {
 		req.URL.Path = "/hooks/" + chi.URLParam(req, "*")
-		s.engine.WebhookHandler().ServeHTTP(w, req)
+		s.webhookAuthGuard(w, req, s.engine.WebhookHandler())
 	}
 	r.Get("/hooks/*", webhookHandler)
 	r.Post("/hooks/*", webhookHandler)

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -287,34 +287,28 @@ func TestWebhook_PublicTask_NoAuth(t *testing.T) {
 
 func TestWebhook_AuthTask_BlocksUnauthenticated(t *testing.T) {
 	srv := newAuthServer(t, "hunter2")
-
-	dir := t.TempDir()
-	td := filepath.Join(dir, "auth-hook")
-	_ = os.MkdirAll(td, 0755)
-	_ = os.WriteFile(filepath.Join(td, "task.ts"), []byte(`return "ok"`), 0644)
-	_ = os.WriteFile(filepath.Join(td, "index.html"), []byte(`<!doctype html><html><body>tool</body></html>`), 0644)
-	spec := &task.Spec{
-		ID:      "auth-hook",
-		Name:    "auth-hook",
-		Runtime: task.RuntimeDeno,
-		Trigger: task.TriggerConfig{Webhook: "/hooks/priv", WebhookAuth: true},
-		Timeout: 5 * time.Second,
-		TaskDir: td,
-	}
-	_ = srv.registry.Register(spec)
-	srv.engine.Register(spec)
+	registerWebhookTask(t, srv.registry, srv, "auth-hook", "/hooks/priv", true)
 
 	h := srv.Handler()
 
-	// Unauthenticated GET → redirect to /?auth=required.
+	// Unauthenticated GET with browser Accept header → redirect to /?auth=required.
 	getReq := httptest.NewRequest(http.MethodGet, "/hooks/priv", nil)
+	getReq.Header.Set("Accept", "text/html,application/xhtml+xml,*/*")
 	getW := httptest.NewRecorder()
 	h.ServeHTTP(getW, getReq)
 	if getW.Code != http.StatusSeeOther {
-		t.Errorf("unauthenticated GET: expected 303, got %d", getW.Code)
+		t.Errorf("unauthenticated browser GET: expected 303, got %d", getW.Code)
 	}
 	if loc := getW.Header().Get("Location"); loc != "/?auth=required" {
-		t.Errorf("unauthenticated GET: expected redirect to /?auth=required, got %q", loc)
+		t.Errorf("unauthenticated browser GET: expected redirect to /?auth=required, got %q", loc)
+	}
+
+	// Unauthenticated GET without browser Accept header → 401 JSON.
+	apiGetReq := httptest.NewRequest(http.MethodGet, "/hooks/priv", nil)
+	apiGetW := httptest.NewRecorder()
+	h.ServeHTTP(apiGetW, apiGetReq)
+	if apiGetW.Code != http.StatusUnauthorized {
+		t.Errorf("unauthenticated API GET: expected 401, got %d", apiGetW.Code)
 	}
 
 	// Unauthenticated POST → 401 JSON.
@@ -328,21 +322,7 @@ func TestWebhook_AuthTask_BlocksUnauthenticated(t *testing.T) {
 
 func TestWebhook_AuthTask_AllowsAuthenticatedSession(t *testing.T) {
 	srv := newAuthServer(t, "hunter2")
-
-	dir := t.TempDir()
-	td := filepath.Join(dir, "auth-hook2")
-	_ = os.MkdirAll(td, 0755)
-	_ = os.WriteFile(filepath.Join(td, "index.html"), []byte(`<!doctype html><html><body>tool</body></html>`), 0644)
-	spec := &task.Spec{
-		ID:      "auth-hook2",
-		Name:    "auth-hook2",
-		Runtime: task.RuntimeDeno,
-		Trigger: task.TriggerConfig{Webhook: "/hooks/priv2", WebhookAuth: true},
-		Timeout: 5 * time.Second,
-		TaskDir: td,
-	}
-	_ = srv.registry.Register(spec)
-	srv.engine.Register(spec)
+	registerWebhookTask(t, srv.registry, srv, "auth-hook2", "/hooks/priv2", true)
 
 	// Issue a valid in-memory session token.
 	token := srv.sessions.issue()
@@ -350,11 +330,21 @@ func TestWebhook_AuthTask_AllowsAuthenticatedSession(t *testing.T) {
 
 	// GET with a valid session: should serve index.html (200), NOT be blocked.
 	getReq := httptest.NewRequest(http.MethodGet, "/hooks/priv2", nil)
+	getReq.Header.Set("Accept", "text/html,application/xhtml+xml,*/*")
 	getReq.AddCookie(&http.Cookie{Name: secretsCookie, Value: token})
 	getW := httptest.NewRecorder()
 	h.ServeHTTP(getW, getReq)
 	if getW.Code == http.StatusUnauthorized || getW.Code == http.StatusSeeOther {
 		t.Errorf("authenticated GET: unexpected auth rejection, got %d", getW.Code)
+	}
+
+	// POST with a valid session: should pass through, NOT be blocked.
+	postReq := httptest.NewRequest(http.MethodPost, "/hooks/priv2", nil)
+	postReq.AddCookie(&http.Cookie{Name: secretsCookie, Value: token})
+	postW := httptest.NewRecorder()
+	h.ServeHTTP(postW, postReq)
+	if postW.Code == http.StatusUnauthorized || postW.Code == http.StatusSeeOther {
+		t.Errorf("authenticated POST: unexpected auth rejection, got %d", postW.Code)
 	}
 }
 

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -249,6 +249,115 @@ func TestSPA_RunRoute(t *testing.T) {
 	}
 }
 
+func registerWebhookTask(t *testing.T, reg *registry.Registry, srv *Server, id, hookPath string, requireAuth bool) *task.Spec {
+	t.Helper()
+	dir := t.TempDir()
+	td := filepath.Join(dir, id)
+	_ = os.MkdirAll(td, 0755)
+	_ = os.WriteFile(filepath.Join(td, "task.ts"), []byte(`return "ok"`), 0644)
+	// Write a minimal index.html so GET serves the UI.
+	_ = os.WriteFile(filepath.Join(td, "index.html"), []byte(`<!doctype html><html><body>tool</body></html>`), 0644)
+	spec := &task.Spec{
+		ID:      id,
+		Name:    id,
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Webhook: hookPath, WebhookAuth: requireAuth},
+		Timeout: 5 * time.Second,
+		TaskDir: td,
+	}
+	_ = reg.Register(spec)
+	srv.engine.Register(spec)
+	return spec
+}
+
+func TestWebhook_PublicTask_NoAuth(t *testing.T) {
+	srv, reg := newTestServer(t)
+	registerWebhookTask(t, reg, srv, "pub-hook", "/hooks/pub", false)
+
+	// GET and POST without a session should not be blocked by session auth.
+	for _, method := range []string{http.MethodGet, http.MethodPost} {
+		req := httptest.NewRequest(method, "/hooks/pub", nil)
+		w := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(w, req)
+		if w.Code == http.StatusUnauthorized || w.Code == http.StatusSeeOther {
+			t.Errorf("public webhook %s: should not require auth, got %d", method, w.Code)
+		}
+	}
+}
+
+func TestWebhook_AuthTask_BlocksUnauthenticated(t *testing.T) {
+	srv := newAuthServer(t, "hunter2")
+
+	dir := t.TempDir()
+	td := filepath.Join(dir, "auth-hook")
+	_ = os.MkdirAll(td, 0755)
+	_ = os.WriteFile(filepath.Join(td, "task.ts"), []byte(`return "ok"`), 0644)
+	_ = os.WriteFile(filepath.Join(td, "index.html"), []byte(`<!doctype html><html><body>tool</body></html>`), 0644)
+	spec := &task.Spec{
+		ID:      "auth-hook",
+		Name:    "auth-hook",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Webhook: "/hooks/priv", WebhookAuth: true},
+		Timeout: 5 * time.Second,
+		TaskDir: td,
+	}
+	_ = srv.registry.Register(spec)
+	srv.engine.Register(spec)
+
+	h := srv.Handler()
+
+	// Unauthenticated GET → redirect to /?auth=required.
+	getReq := httptest.NewRequest(http.MethodGet, "/hooks/priv", nil)
+	getW := httptest.NewRecorder()
+	h.ServeHTTP(getW, getReq)
+	if getW.Code != http.StatusSeeOther {
+		t.Errorf("unauthenticated GET: expected 303, got %d", getW.Code)
+	}
+	if loc := getW.Header().Get("Location"); loc != "/?auth=required" {
+		t.Errorf("unauthenticated GET: expected redirect to /?auth=required, got %q", loc)
+	}
+
+	// Unauthenticated POST → 401 JSON.
+	postReq := httptest.NewRequest(http.MethodPost, "/hooks/priv", nil)
+	postW := httptest.NewRecorder()
+	h.ServeHTTP(postW, postReq)
+	if postW.Code != http.StatusUnauthorized {
+		t.Errorf("unauthenticated POST: expected 401, got %d", postW.Code)
+	}
+}
+
+func TestWebhook_AuthTask_AllowsAuthenticatedSession(t *testing.T) {
+	srv := newAuthServer(t, "hunter2")
+
+	dir := t.TempDir()
+	td := filepath.Join(dir, "auth-hook2")
+	_ = os.MkdirAll(td, 0755)
+	_ = os.WriteFile(filepath.Join(td, "index.html"), []byte(`<!doctype html><html><body>tool</body></html>`), 0644)
+	spec := &task.Spec{
+		ID:      "auth-hook2",
+		Name:    "auth-hook2",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Webhook: "/hooks/priv2", WebhookAuth: true},
+		Timeout: 5 * time.Second,
+		TaskDir: td,
+	}
+	_ = srv.registry.Register(spec)
+	srv.engine.Register(spec)
+
+	// Issue a valid in-memory session token.
+	token := srv.sessions.issue()
+	h := srv.Handler()
+
+	// GET with a valid session: should serve index.html (200), NOT be blocked.
+	getReq := httptest.NewRequest(http.MethodGet, "/hooks/priv2", nil)
+	getReq.AddCookie(&http.Cookie{Name: secretsCookie, Value: token})
+	getW := httptest.NewRecorder()
+	h.ServeHTTP(getW, getReq)
+	if getW.Code == http.StatusUnauthorized || getW.Code == http.StatusSeeOther {
+		t.Errorf("authenticated GET: unexpected auth rejection, got %d", getW.Code)
+	}
+}
+
 func contains(s, sub string) bool {
 	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsStr(s, sub))
 }

--- a/pkg/webui/static/dicode.js
+++ b/pkg/webui/static/dicode.js
@@ -118,7 +118,6 @@
       return doFetch().then(function (res) {
         if (res.status === 401) {
           return self._handle401(doFetch).then(function (retried) {
-            if (!retried) return new Promise(function () {});
             var runId = retried.headers.get('X-Run-Id');
             return retried.json().then(function (body) {
               return { runId: runId || body.runId };

--- a/pkg/webui/static/dicode.js
+++ b/pkg/webui/static/dicode.js
@@ -70,18 +70,61 @@
     task: { id: taskID, hookPath: hookPath },
 
     /**
+     * Attempt a silent session refresh via the device-token cookie.
+     * Returns a Promise<boolean> — true if the refresh succeeded.
+     * @private
+     */
+    _tryRefresh: function () {
+      return fetch('/api/auth/refresh', { method: 'POST' })
+        .then(function (res) { return res.ok; })
+        .catch(function () { return false; });
+    },
+
+    /**
+     * Handle a 401 response: try silent refresh, then redirect to login page.
+     * Returns a Promise that resolves with the retried fetch Response when
+     * refresh succeeds, or redirects the browser on failure.
+     * @private
+     */
+    _handle401: function (retryFn) {
+      var self = this;
+      return self._tryRefresh().then(function (refreshed) {
+        if (refreshed) {
+          return retryFn();
+        }
+        location.href = '/?auth=required';
+        // Return a never-resolving promise so callers don't proceed.
+        return new Promise(function () {});
+      });
+    },
+
+    /**
      * Run the task asynchronously with the given params.
      * Returns a Promise resolving to { runId: string }.
+     * On 401, attempts a silent refresh; redirects to login on failure.
      *
      * @param {Object} [params] - Key/value params passed to the task.
      */
     run: function (params) {
+      var self = this;
       params = params || {};
-      return fetch(hookPath + '?wait=false', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(params)
-      }).then(function (res) {
+      var doFetch = function () {
+        return fetch(hookPath + '?wait=false', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(params)
+        });
+      };
+      return doFetch().then(function (res) {
+        if (res.status === 401) {
+          return self._handle401(doFetch).then(function (retried) {
+            if (!retried) return new Promise(function () {});
+            var runId = retried.headers.get('X-Run-Id');
+            return retried.json().then(function (body) {
+              return { runId: runId || body.runId };
+            });
+          });
+        }
         // Run ID is available both as a header and in the JSON body.
         var runId = res.headers.get('X-Run-Id');
         return res.json().then(function (body) {


### PR DESCRIPTION
## Summary

- Adds `trigger.auth: true` field to `TriggerConfig` — when set, `GET /hooks/<path>` (serving the task UI) and `POST /hooks/<path>` (running the task) require a valid dicode session cookie
- Unauthenticated browser GET → redirect to `/?auth=required`; unauthenticated POST or API GET → 401 JSON
- Public webhooks (no `auth: true`) remain completely unchanged
- `dicode.js` `run()` now intercepts 401 responses: attempts silent refresh via `POST /api/auth/refresh` (device-token cookie), then redirects to `/?auth=required` if the refresh fails — mirrors the behaviour in `app/lib/api.js`
- `pkg/task/spec.go`, `docs/concepts/task-format.md`, and `pkg/agent/skill.md` updated with the new field

## Test plan

- [x] `go test ./pkg/webui/... -count=1` — all tests pass
- [x] `go test ./pkg/trigger/... -count=1` — all tests pass
- [x] `TestWebhook_PublicTask_NoAuth` — public webhook passes through without auth
- [x] `TestWebhook_AuthTask_BlocksUnauthenticated` — unauthenticated browser GET gets 303, unauthenticated API GET (no `text/html` Accept) gets 401, POST gets 401
- [x] `TestWebhook_AuthTask_AllowsAuthenticatedSession` — valid session cookie allows GET and POST through
- [x] `make fmt` — no formatting changes

## Review fixes (post-review commit)

- **Browser detection**: `isBrowserGet` now checks `Accept` contains `text/html` rather than `!= application/json` — curl and API clients with no Accept header now correctly receive 401 instead of a redirect
- **Dead code removed**: `if (!retried)` guard in `dicode.js run()` was unreachable; `_handle401` never resolves with a falsy value
- **`hasValidSession` side-effect documented**: added comment noting device-token renewal is a side effect of the auth check
- **Test consistency**: `TestWebhook_AuthTask_BlocksUnauthenticated` and `TestWebhook_AuthTask_AllowsAuthenticatedSession` now use the `registerWebhookTask` helper; authenticated POST case added
- **Follow-up**: dicode-ayo/dicode-core#21 tracks O(n) registry scan in `webhookAuthGuard`

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)