### PR TITLE
feat: mcp_port field + mcp shim for agent tasks

### DIFF
--- a/pkg/mcp/client/client.go
+++ b/pkg/mcp/client/client.go
@@ -1,0 +1,104 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Tool describes an MCP tool.
+type Tool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"inputSchema,omitempty"`
+}
+
+// Client is a minimal HTTP MCP client (JSON-RPC 2.0).
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// New creates a client for an MCP server running on the given port.
+func New(port int) *Client {
+	return &Client{
+		baseURL:    fmt.Sprintf("http://localhost:%d", port),
+		httpClient: &http.Client{},
+	}
+}
+
+type rpcRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      int         `json:"id"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (c *Client) call(ctx context.Context, method string, params interface{}) (json.RawMessage, error) {
+	req := rpcRequest{JSONRPC: "2.0", ID: 1, Method: method, Params: params}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/rpc", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("mcp request: %w", err)
+	}
+	defer resp.Body.Close()
+	var rpcResp rpcResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		return nil, fmt.Errorf("decode mcp response: %w", err)
+	}
+	if rpcResp.Error != nil {
+		return nil, fmt.Errorf("mcp error %d: %s", rpcResp.Error.Code, rpcResp.Error.Message)
+	}
+	return rpcResp.Result, nil
+}
+
+// ListTools returns the tools available on the MCP server.
+func (c *Client) ListTools(ctx context.Context) ([]Tool, error) {
+	raw, err := c.call(ctx, "tools/list", nil)
+	if err != nil {
+		return nil, err
+	}
+	var result struct {
+		Tools []Tool `json:"tools"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return result.Tools, nil
+}
+
+// Call invokes a tool on the MCP server with the given arguments.
+func (c *Client) Call(ctx context.Context, tool string, args map[string]any) (any, error) {
+	raw, err := c.call(ctx, "tools/call", map[string]any{
+		"name":      tool,
+		"arguments": args,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var result any
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -116,7 +116,7 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 
 	mergedParams := mergeParams(spec.Params, opts.Params)
 
-	srv := denoserver.New(runID, spec.ID, rt.registry, rt.db, mergedParams, opts.Input, rt.log)
+	srv := denoserver.New(runID, spec.ID, rt.registry, rt.db, mergedParams, opts.Input, rt.log, spec)
 	socketPath, err := srv.Start(execCtx)
 	if err != nil {
 		status = registry.StatusFailure

--- a/pkg/runtime/deno/sdk/shim.js
+++ b/pkg/runtime/deno/sdk/shim.js
@@ -128,3 +128,9 @@ const output = {
 async function __setReturn__(val) {
   await __call__({ method: "return", value: val ?? null });
 }
+
+// --- mcp ---
+const mcp = {
+  list_tools: (name)             => __call__({ method: "mcp.list_tools", mcpName: name }),
+  call:       (name, tool, args) => __call__({ method: "mcp.call", mcpName: name, tool, args: args ?? {} }),
+};

--- a/pkg/runtime/deno/server/server.go
+++ b/pkg/runtime/deno/server/server.go
@@ -27,7 +27,9 @@ import (
 	"sync"
 
 	"github.com/dicode/dicode/pkg/db"
+	mcpclient "github.com/dicode/dicode/pkg/mcp/client"
 	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
 	"go.uber.org/zap"
 )
 
@@ -56,6 +58,7 @@ type Server struct {
 	returnCh     chan interface{}
 	mu           sync.Mutex
 	outputResult *OutputResult
+	spec         *task.Spec
 }
 
 // request is an inbound message from the Deno subprocess.
@@ -77,6 +80,11 @@ type request struct {
 	ContentType string          `json:"contentType,omitempty"`
 	Content     string          `json:"content,omitempty"`
 	Data        json.RawMessage `json:"data,omitempty"`
+
+	// mcp.*
+	MCPName string          `json:"mcpName,omitempty"`
+	Tool    string          `json:"tool,omitempty"`
+	Args    json.RawMessage `json:"args,omitempty"`
 }
 
 // response is an outbound message to the Deno subprocess.
@@ -94,6 +102,7 @@ func New(
 	params map[string]string,
 	input interface{},
 	log *zap.Logger,
+	spec *task.Spec,
 ) *Server {
 	return &Server{
 		runID:    runID,
@@ -104,6 +113,7 @@ func New(
 		input:    input,
 		log:      log,
 		returnCh: make(chan interface{}, 1),
+		spec:     spec,
 	}
 }
 
@@ -307,6 +317,71 @@ func (s *Server) handleConn(conn net.Conn) {
 			default:
 			}
 			reply(req.ID, true, "")
+
+		case "mcp.list_tools":
+			if !s.mcpAllowed(req.MCPName) {
+				reply(req.ID, nil, fmt.Sprintf("task %q is not in allowed_mcp", req.MCPName))
+				continue
+			}
+			port, err := s.getMCPPort(req.MCPName)
+			if err != nil {
+				reply(req.ID, nil, err.Error())
+				continue
+			}
+			c := mcpclient.New(port)
+			tools, err := c.ListTools(context.Background())
+			if err != nil {
+				reply(req.ID, nil, err.Error())
+				continue
+			}
+			reply(req.ID, tools, "")
+
+		case "mcp.call":
+			if !s.mcpAllowed(req.MCPName) {
+				reply(req.ID, nil, fmt.Sprintf("task %q is not in allowed_mcp", req.MCPName))
+				continue
+			}
+			port, err := s.getMCPPort(req.MCPName)
+			if err != nil {
+				reply(req.ID, nil, err.Error())
+				continue
+			}
+			var args map[string]any
+			if len(req.Args) > 0 {
+				_ = json.Unmarshal(req.Args, &args)
+			}
+			c := mcpclient.New(port)
+			result, err := c.Call(context.Background(), req.Tool, args)
+			if err != nil {
+				reply(req.ID, nil, err.Error())
+				continue
+			}
+			reply(req.ID, result, "")
 		}
 	}
+}
+
+// mcpAllowed reports whether the calling task is permitted to access the named MCP server.
+func (s *Server) mcpAllowed(name string) bool {
+	if s.spec == nil || s.spec.Security == nil {
+		return false
+	}
+	for _, allowed := range s.spec.Security.AllowedMCP {
+		if allowed == "*" || allowed == name {
+			return true
+		}
+	}
+	return false
+}
+
+// getMCPPort looks up the mcp_port declared by the named task.
+func (s *Server) getMCPPort(taskID string) (int, error) {
+	spec, ok := s.registry.Get(taskID)
+	if !ok {
+		return 0, fmt.Errorf("task %q not found", taskID)
+	}
+	if spec.MCPPort == 0 {
+		return 0, fmt.Errorf("task %q does not declare mcp_port", taskID)
+	}
+	return spec.MCPPort, nil
 }

--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -162,7 +162,7 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 
 	mergedParams := mergeParams(spec.Params, opts.Params)
 
-	srv := denoserver.New(runID, spec.ID, e.reg, e.db, mergedParams, opts.Input, e.log)
+	srv := denoserver.New(runID, spec.ID, e.reg, e.db, mergedParams, opts.Input, e.log, spec)
 	socketPath, err := srv.Start(execCtx)
 	if err != nil {
 		status = registry.StatusFailure

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -96,6 +96,12 @@ type FSEntry struct {
 	Permission string `yaml:"permission"` // "r" | "w" | "rw"
 }
 
+// SecurityConfig controls inter-task access permissions.
+type SecurityConfig struct {
+	AllowedTasks []string `yaml:"allowed_tasks,omitempty"`
+	AllowedMCP   []string `yaml:"allowed_mcp,omitempty"`
+}
+
 // NotifyConfig controls when dicode sends push notifications for a task.
 // Nil fields inherit from the parent TaskSet defaults or the global config.
 type NotifyConfig struct {
@@ -105,18 +111,20 @@ type NotifyConfig struct {
 
 // Spec is parsed from task.yaml.
 type Spec struct {
-	Name        string        `yaml:"name"        json:"name"`
-	Description string        `yaml:"description" json:"description"`
-	Version     string        `yaml:"version"     json:"version"`
-	Author      string        `yaml:"author,omitempty" json:"author,omitempty"`
-	Runtime     Runtime       `yaml:"runtime"     json:"runtime"`
-	Docker      *DockerConfig `yaml:"docker,omitempty" json:"docker,omitempty"`
-	Trigger     TriggerConfig `yaml:"trigger"     json:"trigger"`
-	Params      []Param       `yaml:"params,omitempty" json:"params,omitempty"`
-	Env         []string      `yaml:"env,omitempty" json:"env,omitempty"`
-	FS          []FSEntry     `yaml:"fs,omitempty"  json:"fs,omitempty"`
-	Timeout     time.Duration `yaml:"timeout"     json:"timeout"`
-	Notify      *NotifyConfig `yaml:"notify,omitempty" json:"notify,omitempty"`
+	Name        string          `yaml:"name"        json:"name"`
+	Description string          `yaml:"description" json:"description"`
+	Version     string          `yaml:"version"     json:"version"`
+	Author      string          `yaml:"author,omitempty" json:"author,omitempty"`
+	Runtime     Runtime         `yaml:"runtime"     json:"runtime"`
+	Docker      *DockerConfig   `yaml:"docker,omitempty" json:"docker,omitempty"`
+	Trigger     TriggerConfig   `yaml:"trigger"     json:"trigger"`
+	Params      []Param         `yaml:"params,omitempty" json:"params,omitempty"`
+	Env         []string        `yaml:"env,omitempty" json:"env,omitempty"`
+	FS          []FSEntry       `yaml:"fs,omitempty"  json:"fs,omitempty"`
+	Timeout     time.Duration   `yaml:"timeout"     json:"timeout"`
+	Notify      *NotifyConfig   `yaml:"notify,omitempty" json:"notify,omitempty"`
+	Security    *SecurityConfig `yaml:"security,omitempty" json:"security,omitempty"`
+	MCPPort     int             `yaml:"mcp_port,omitempty" json:"mcp_port,omitempty"`
 
 	// TaskDir is the directory path of the task in the repo (not stored in YAML).
 	TaskDir string `yaml:"-" json:"-"`


### PR DESCRIPTION
## Summary

Implements issue #26 — allows tasks to declare `mcp_port` to expose themselves as MCP servers, and gives agent tasks a `mcp` shim global to call tools on those servers.

- **`pkg/task/spec.go`**: Added `MCPPort int` to `Spec` and new `SecurityConfig` struct with `AllowedTasks` + `AllowedMCP` fields; `Spec.Security *SecurityConfig` controls inter-task MCP access
- **`pkg/mcp/client/client.go`** (new): Minimal HTTP JSON-RPC 2.0 MCP client with `ListTools` and `Call` methods
- **`pkg/runtime/deno/server/server.go`**: Added `mcp.list_tools` and `mcp.call` socket handler cases; security enforced via `allowed_mcp` list; `spec *task.Spec` field added and threaded through `New()`
- **`pkg/runtime/deno/sdk/shim.js`**: Added `mcp` global exposing `list_tools(name)` and `call(name, tool, args)`
- **`pkg/runtime/deno/runtime.go`** + **`pkg/runtime/python/runtime.go`**: Updated `server.New()` call sites to pass `spec`

## Test plan

- [ ] Create a task with `mcp_port: 9000` and verify the field is parsed from `task.yaml`
- [ ] Create an agent task with `security.allowed_mcp: ["my-mcp-task"]` and call `await mcp.list_tools("my-mcp-task")` — verify it proxies to `http://localhost:9000/rpc`
- [ ] Verify that calling `mcp.list_tools` for a task not in `allowed_mcp` returns an error
- [ ] Verify that calling `mcp.list_tools` for a task with no `mcp_port` returns an error
- [ ] Run `go build ./...` — no errors

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)