### PR TITLE
feat(python): Python SDK shim with dicode and mcp globals

### DIFF
--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -7,10 +7,10 @@
 // # Execution model
 //
 // Each Run spawns a fresh uv subprocess connected to the same per-run Unix
-// socket server used by the Deno runtime. An embedded Python shim (sdk.py)
+// socket server used by the Deno runtime. An embedded Python shim (dicode_sdk.py)
 // provides the same globals as the Deno SDK:
 //
-//	log, params, env, kv, input, output
+//	log, params, env, kv, input, output, dicode, mcp
 //
 // To return a value from a task, assign the module-level variable `result`:
 //
@@ -49,7 +49,7 @@ import (
 	"go.uber.org/zap"
 )
 
-//go:embed sdk/sdk.py
+//go:embed sdk/dicode_sdk.py
 var sdkContent string
 
 // Runtime is the ManagedRuntime implementation for Python+uv.
@@ -71,7 +71,7 @@ func New(reg *registry.Registry, sc secrets.Chain, database db.DB, log *zap.Logg
 func (rt *Runtime) Name() string        { return "python" }
 func (rt *Runtime) DisplayName() string { return "Python (uv)" }
 func (rt *Runtime) Description() string {
-	return "Python runtime managed by uv. Supports inline dependencies via PEP 723 (# /// script blocks). Full SDK globals: log, params, env, kv, input, output."
+	return "Python runtime managed by uv. Supports inline dependencies via PEP 723 (# /// script blocks). Full SDK globals: log, params, env, kv, input, output, dicode, mcp."
 }
 func (rt *Runtime) DefaultVersion() string { return uvpkg.DefaultVersion }
 
@@ -260,7 +260,7 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 //
 //  1. PEP 723 script block (extracted from the user script, if present) — must
 //     be first so uv can parse inline dependencies.
-//  2. The dicode SDK shim (sdk.py).
+//  2. The dicode SDK shim (dicode_sdk.py).
 //  3. The user script body (script block stripped out).
 //  4. Return-capture epilogue.
 func buildWrapper(scriptBytes []byte) (string, error) {

--- a/pkg/runtime/python/sdk/dicode_sdk.py
+++ b/pkg/runtime/python/sdk/dicode_sdk.py
@@ -1,0 +1,252 @@
+# dicode SDK shim — injected before every Python task script.
+# Provides: log, params, env, kv, input, output, dicode, mcp.
+# To return a value from a task, assign: result = <value>
+#
+# Protocol: newline-delimited JSON over a single persistent Unix socket.
+#   Fire-and-forget (no id):    log, kv.set, kv.delete, output
+#   Request/response (id req):  params, input, kv.get, kv.list, return,
+#                               dicode.run_task, dicode.list_tasks,
+#                               dicode.get_runs, dicode.get_config,
+#                               mcp.list_tools, mcp.call
+import json
+import os
+import socket
+import threading
+
+_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+_sock.connect(os.environ["DICODE_SOCKET"])
+_file = _sock.makefile("rwb", buffering=0)
+
+_pending = {}       # id -> threading.Event
+_results = {}       # id -> msg
+_nid = 0
+_lock = threading.Lock()
+
+
+def _next_id():
+    global _nid
+    with _lock:
+        _nid += 1
+        return str(_nid)
+
+
+def _send(obj):
+    line = json.dumps(obj, separators=(",", ":")) + "\n"
+    with _lock:
+        _file.write(line.encode())
+        _file.flush()
+
+
+def _call(req):
+    """Send a request and block until the response arrives."""
+    rid = _next_id()
+    ev = threading.Event()
+    with _lock:
+        _pending[rid] = ev
+    _send({**req, "id": rid})
+    ev.wait()
+    msg = _results.pop(rid, {})
+    if msg.get("error"):
+        raise RuntimeError(msg["error"])
+    return msg.get("result")
+
+
+def _fire(req):
+    """Send a fire-and-forget message (no id, no response expected)."""
+    _send(req)
+
+
+def _reader():
+    """Background thread: read response lines and wake waiting _call()s."""
+    buf = b""
+    while True:
+        try:
+            chunk = _file.read(4096)
+        except Exception:
+            break
+        if not chunk:
+            break
+        buf += chunk
+        while b"\n" in buf:
+            line, buf = buf.split(b"\n", 1)
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except Exception:
+                continue
+            rid = msg.get("id")
+            if rid and rid in _pending:
+                _results[rid] = msg
+                _pending.pop(rid).set()
+
+
+_reader_thread = threading.Thread(target=_reader, daemon=True)
+_reader_thread.start()
+
+
+# ---------------------------------------------------------------------------
+# log
+# ---------------------------------------------------------------------------
+
+class _Log:
+    @staticmethod
+    def _emit(level, *args):
+        msg = " ".join(
+            json.dumps(a) if isinstance(a, (dict, list)) else str(a)
+            for a in args
+        )
+        _fire({"method": "log", "level": level, "message": msg})
+
+    def info(self, *args):   self._emit("info",  *args)
+    def warn(self, *args):   self._emit("warn",  *args)
+    def error(self, *args):  self._emit("error", *args)
+    def debug(self, *args):  self._emit("debug", *args)
+
+
+log = _Log()
+
+
+# ---------------------------------------------------------------------------
+# params (lazy-fetched, cached)
+# ---------------------------------------------------------------------------
+
+_params_cache = None
+_params_once = threading.Lock()
+
+
+def _get_params():
+    global _params_cache
+    if _params_cache is None:
+        with _params_once:
+            if _params_cache is None:
+                _params_cache = _call({"method": "params"}) or {}
+    return _params_cache
+
+
+class _Params:
+    def get(self, key, default=None):
+        return _get_params().get(key, default)
+
+    def all(self):
+        return dict(_get_params())
+
+
+params = _Params()
+
+
+# ---------------------------------------------------------------------------
+# env
+# ---------------------------------------------------------------------------
+
+class _Env:
+    def get(self, key, default=None):
+        return os.environ.get(key, default)
+
+
+env = _Env()
+
+
+# ---------------------------------------------------------------------------
+# kv
+# ---------------------------------------------------------------------------
+
+class _KV:
+    def get(self, key):
+        return _call({"method": "kv.get", "key": key})
+
+    def set(self, key, value):
+        _fire({"method": "kv.set", "key": key, "value": value})
+
+    def delete(self, key):
+        _fire({"method": "kv.delete", "key": key})
+
+    def list(self, prefix=""):
+        return _call({"method": "kv.list", "prefix": prefix}) or []
+
+
+kv = _KV()
+
+
+# ---------------------------------------------------------------------------
+# input (fetched once at import time)
+# ---------------------------------------------------------------------------
+
+input = _call({"method": "input"})
+
+
+# ---------------------------------------------------------------------------
+# output
+# ---------------------------------------------------------------------------
+
+class _Output:
+    def html(self, content, data=None):
+        _fire({"method": "output", "contentType": "text/html",
+               "content": content, "data": data})
+
+    def text(self, content):
+        _fire({"method": "output", "contentType": "text/plain",
+               "content": content})
+
+    def image(self, mime, content):
+        _fire({"method": "output", "contentType": mime or "image/png",
+               "content": content})
+
+    def file(self, name, content, mime=None):
+        _fire({"method": "output",
+               "contentType": mime or "application/octet-stream",
+               "content": content, "data": {"filename": name}})
+
+
+output = _Output()
+
+
+# ---------------------------------------------------------------------------
+# dicode — task orchestration helpers
+# ---------------------------------------------------------------------------
+
+class _Dicode:
+    def run_task(self, task_id, params=None):
+        return _call({"method": "dicode.run_task", "taskID": task_id,
+                      "params": params or {}})
+
+    def list_tasks(self):
+        return _call({"method": "dicode.list_tasks"}) or []
+
+    def get_runs(self, task_id, limit=10):
+        return _call({"method": "dicode.get_runs", "taskID": task_id,
+                      "limit": limit}) or []
+
+    def get_config(self, section):
+        return _call({"method": "dicode.get_config", "section": section})
+
+
+dicode = _Dicode()
+
+
+# ---------------------------------------------------------------------------
+# mcp — Model Context Protocol tool access
+# ---------------------------------------------------------------------------
+
+class _MCP:
+    def list_tools(self, name):
+        return _call({"method": "mcp.list_tools", "mcpName": name}) or []
+
+    def call(self, name, tool, args=None):
+        return _call({"method": "mcp.call", "mcpName": name, "tool": tool,
+                      "args": args or {}})
+
+
+mcp = _MCP()
+
+
+# ---------------------------------------------------------------------------
+# Internal: send the task return value (called by the wrapper, not user code).
+# ---------------------------------------------------------------------------
+
+def _set_return(value):
+    try:
+        _call({"method": "return", "value": value})
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary

Implements #27: create a Python SDK shim (`dicode_sdk.py`) that mirrors the Deno shim API and inject it into Python task scripts before execution.

- **New file** `pkg/runtime/python/sdk/dicode_sdk.py` — full Python SDK shim with newline-delimited JSON RPC over Unix socket (`DICODE_SOCKET`), providing: `log`, `params`, `env`, `kv`, `input`, `output`, `dicode`, `mcp`
- **`dicode` global** — `run_task`, `list_tasks`, `get_runs`, `get_config` methods for task orchestration
- **`mcp` global** — `list_tools`, `call` methods for Model Context Protocol tool access
- **`pkg/runtime/python/runtime.go`** — updated `//go:embed` directive from `sdk/sdk.py` to `sdk/dicode_sdk.py`, and updated doc comments and `Description()` to list all new globals

The Python shim follows the same protocol as the Deno `shim.js`: fire-and-forget for `log`/`kv.set`/`kv.delete`/`output`, request-response (with incrementing id) for everything else. A background daemon thread handles incoming responses and unblocks waiting `_call()` invocations.

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] `go fmt ./...` clean (verified locally)
- [ ] Write a Python task using `dicode.list_tasks()` or `mcp.call(...)` and verify the RPC messages are dispatched correctly over the socket

🤖 Generated with [Claude Code](https://claude.com/claude-code)