### PR TITLE
fix: persist cron next-run time to detect missed jobs on restart

### DIFF
--- a/cmd/dicoded/main.go
+++ b/cmd/dicoded/main.go
@@ -216,6 +216,7 @@ func buildRuntimes(
 		return nil, nil, fmt.Errorf("init deno runtime: %w", err)
 	}
 	eng := trigger.New(reg, denoRT, log)
+	eng.SetDB(database)
 	denoRT.SetEngine(eng)
 	denoRT.SetGateway(gateway)
 	aiAPIKey := cfg.AI.APIKey

--- a/docs/concepts/triggers.md
+++ b/docs/concepts/triggers.md
@@ -40,6 +40,10 @@ Schedule is evaluated in the dicode process's local timezone. Set the `TZ` envir
 
 **Implementation:** `robfig/cron` v3. The cron scheduler is managed by the trigger engine — when a task is added or updated, the engine cancels any existing cron registration and creates a new one. When a task is removed, the registration is cancelled.
 
+**Missed-run catchup:** dicode persists each cron task's next scheduled time in the database (`cron_jobs` table). On startup, any task whose recorded `next_run_at` is in the past (but within the last 24 hours) is fired immediately with `trigger_source = "cron-catchup"`. This prevents silent skips when dicode restarts mid-schedule (e.g. after an OS reboot or deploy).
+
+**Fire-once semantics:** at most one catchup run is fired per task per restart, regardless of how many intervals were missed. For example, if a task runs every 5 minutes and the daemon was offline for 2 hours, one catchup run fires — not 24. This avoids bulk-firing high-frequency tasks after long outages. Runs missed more than 24 hours ago are skipped with a `Warn` log. Tasks deleted between sessions are pruned from the `cron_jobs` table on startup.
+
 ---
 
 ## Webhook

--- a/pkg/db/sqlite.go
+++ b/pkg/db/sqlite.go
@@ -86,6 +86,13 @@ func (s *SQLiteDB) migrate() error {
 			ciphertext BLOB NOT NULL,
 			nonce      BLOB NOT NULL
 		);
+
+		CREATE TABLE IF NOT EXISTS cron_jobs (
+			task_id     TEXT PRIMARY KEY,
+			cron_expr   TEXT NOT NULL,
+			last_run_at INTEGER,
+			next_run_at INTEGER NOT NULL
+		);
 	`)
 	if err != nil {
 		return err

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -212,7 +212,10 @@ func (e *Engine) Unregister(id string) {
 	e.mu.Unlock()
 
 	if hadCron && e.db != nil {
-		_ = e.db.Exec(context.Background(), `DELETE FROM cron_jobs WHERE task_id=?`, id)
+		if dbErr := e.db.Exec(context.Background(), `DELETE FROM cron_jobs WHERE task_id=?`, id); dbErr != nil {
+			e.log.Warn("cron: failed to delete cron_jobs row on unregister",
+				zap.String("task", id), zap.Error(dbErr))
+		}
 	}
 
 	e.daemonMu.Lock()
@@ -243,7 +246,10 @@ func (e *Engine) registerCron(spec *task.Spec) {
 		if !ok {
 			return
 		}
-		if e.db != nil {
+		// Advance next_run_at AFTER fireAsync so that a failed dispatch does not
+		// silently advance the schedule and cause the missed run to be invisible
+		// on the next restart.
+		if _, ferr := e.fireAsync(context.Background(), s, pkgruntime.RunOptions{}, "cron"); ferr == nil && e.db != nil {
 			if next, nerr := cronNextRun(spec.Trigger.Cron); nerr == nil {
 				if dbErr := e.db.Exec(context.Background(),
 					`UPDATE cron_jobs SET last_run_at=?, next_run_at=? WHERE task_id=?`,
@@ -254,7 +260,6 @@ func (e *Engine) registerCron(spec *task.Spec) {
 				}
 			}
 		}
-		e.fireAsync(context.Background(), s, pkgruntime.RunOptions{}, "cron") //nolint:errcheck
 	})
 	if err != nil {
 		e.log.Error("invalid cron expression",
@@ -284,6 +289,11 @@ func (e *Engine) registerCron(spec *task.Spec) {
 
 // catchupMissedCronRuns fires any cron tasks whose next_run_at is in the past,
 // up to a 24-hour cutoff. Called at startup before tasks are re-registered.
+//
+// Fire-once semantics: at most one catchup run is fired per task per restart,
+// regardless of how many intervals were missed. This prevents bulk-firing a
+// high-frequency task after a long outage. Operators can see the skipped count
+// in the Warn log entries for rows older than 24h.
 func (e *Engine) catchupMissedCronRuns(ctx context.Context) {
 	now := time.Now().Unix()
 	cutoff := time.Now().Add(-24 * time.Hour).Unix()
@@ -315,7 +325,7 @@ func (e *Engine) catchupMissedCronRuns(ctx context.Context) {
 	}
 	var missed, tooOld []missedRow
 
-	_ = e.db.Query(ctx,
+	if queryErr := e.db.Query(ctx,
 		`SELECT task_id, next_run_at FROM cron_jobs WHERE next_run_at < ?`,
 		[]any{now},
 		func(rows db.Scanner) error {
@@ -331,7 +341,10 @@ func (e *Engine) catchupMissedCronRuns(ctx context.Context) {
 			}
 			return nil
 		},
-	)
+	); queryErr != nil {
+		e.log.Warn("cron catchup: failed to query missed runs", zap.Error(queryErr))
+		return
+	}
 
 	for _, m := range tooOld {
 		e.log.Warn("cron catchup: missed run is older than 24h — skipping",

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dicode/dicode/pkg/db"
 	"github.com/dicode/dicode/pkg/ipc"
 	"github.com/dicode/dicode/pkg/notify"
 	"github.com/dicode/dicode/pkg/registry"
@@ -55,6 +56,8 @@ type Engine struct {
 
 	defaultsOnFailureChain string // from config.Defaults.OnFailureChain
 
+	db db.DB // optional — enables cron-job persistence and missed-run catchup
+
 	runFinishedHook func(taskID, runID, status, triggerSource string, durationMs int64, notifyOnSuccess, notifyOnFailure bool)
 	runStartedHook  func(taskID, runID, triggerSource string)
 }
@@ -73,6 +76,13 @@ func New(r *registry.Registry, defaultExec pkgruntime.Executor, log *zap.Logger)
 	}
 	e.executors[task.RuntimeDeno] = defaultExec
 	return e
+}
+
+// SetDB wires a database into the engine for cron-job persistence.
+// When set, the engine persists each cron task's next scheduled time and
+// detects missed runs on startup (e.g. after a process restart).
+func (e *Engine) SetDB(d db.DB) {
+	e.db = d
 }
 
 // SetRunStartedHook registers a callback invoked when a run starts.
@@ -136,6 +146,13 @@ func (e *Engine) Start(ctx context.Context) error {
 	e.shutdownCtx = ctx
 	e.shutdownMu.Unlock()
 
+	// Check for missed cron runs BEFORE registering tasks: registration overwrites
+	// next_run_at with a fresh future value, so the catchup must read the prior
+	// session's persisted next_run_at first.
+	if e.db != nil {
+		e.catchupMissedCronRuns(ctx)
+	}
+
 	for _, spec := range e.registry.All() {
 		e.Register(spec)
 	}
@@ -181,9 +198,11 @@ func (e *Engine) Register(spec *task.Spec) {
 // Unregister removes all trigger registrations for a task ID.
 func (e *Engine) Unregister(id string) {
 	e.mu.Lock()
+	hadCron := false
 	if entryID, ok := e.cronEntries[id]; ok {
 		e.cron.Remove(entryID)
 		delete(e.cronEntries, id)
+		hadCron = true
 	}
 	for path, tid := range e.webhooks {
 		if tid == id {
@@ -191,6 +210,10 @@ func (e *Engine) Unregister(id string) {
 		}
 	}
 	e.mu.Unlock()
+
+	if hadCron && e.db != nil {
+		_ = e.db.Exec(context.Background(), `DELETE FROM cron_jobs WHERE task_id=?`, id)
+	}
 
 	e.daemonMu.Lock()
 	delete(e.daemonSpecs, id)
@@ -205,11 +228,31 @@ func (e *Engine) Unregister(id string) {
 	e.log.Info("task unregistered", zap.String("task", id))
 }
 
+// cronNextRun parses expr and returns the next scheduled time after now.
+func cronNextRun(expr string) (time.Time, error) {
+	sched, err := cron.ParseStandard(expr)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return sched.Next(time.Now()), nil
+}
+
 func (e *Engine) registerCron(spec *task.Spec) {
 	id, err := e.cron.AddFunc(spec.Trigger.Cron, func() {
 		s, ok := e.registry.Get(spec.ID)
 		if !ok {
 			return
+		}
+		if e.db != nil {
+			if next, nerr := cronNextRun(spec.Trigger.Cron); nerr == nil {
+				if dbErr := e.db.Exec(context.Background(),
+					`UPDATE cron_jobs SET last_run_at=?, next_run_at=? WHERE task_id=?`,
+					time.Now().Unix(), next.Unix(), spec.ID,
+				); dbErr != nil {
+					e.log.Warn("cron: failed to persist next_run_at",
+						zap.String("task", spec.ID), zap.Error(dbErr))
+				}
+			}
 		}
 		e.fireAsync(context.Background(), s, pkgruntime.RunOptions{}, "cron") //nolint:errcheck
 	})
@@ -224,6 +267,93 @@ func (e *Engine) registerCron(spec *task.Spec) {
 	e.mu.Lock()
 	e.cronEntries[spec.ID] = id
 	e.mu.Unlock()
+
+	if e.db != nil {
+		if next, nerr := cronNextRun(spec.Trigger.Cron); nerr == nil {
+			if dbErr := e.db.Exec(context.Background(),
+				`INSERT INTO cron_jobs(task_id,cron_expr,next_run_at) VALUES(?,?,?)
+				 ON CONFLICT(task_id) DO UPDATE SET cron_expr=excluded.cron_expr, next_run_at=excluded.next_run_at`,
+				spec.ID, spec.Trigger.Cron, next.Unix(),
+			); dbErr != nil {
+				e.log.Warn("cron: failed to persist cron_jobs row",
+					zap.String("task", spec.ID), zap.Error(dbErr))
+			}
+		}
+	}
+}
+
+// catchupMissedCronRuns fires any cron tasks whose next_run_at is in the past,
+// up to a 24-hour cutoff. Called at startup before tasks are re-registered.
+func (e *Engine) catchupMissedCronRuns(ctx context.Context) {
+	now := time.Now().Unix()
+	cutoff := time.Now().Add(-24 * time.Hour).Unix()
+
+	// Remove rows for tasks no longer in the registry (deleted while daemon was offline).
+	allSpecs := e.registry.All()
+	knownIDs := make([]any, 0, len(allSpecs))
+	for _, s := range allSpecs {
+		knownIDs = append(knownIDs, s.ID)
+	}
+	if len(knownIDs) > 0 {
+		placeholders := strings.Repeat("?,", len(knownIDs))
+		placeholders = placeholders[:len(placeholders)-1]
+		if dbErr := e.db.Exec(ctx,
+			`DELETE FROM cron_jobs WHERE task_id NOT IN (`+placeholders+`)`,
+			knownIDs...,
+		); dbErr != nil {
+			e.log.Warn("cron catchup: failed to prune orphaned rows", zap.Error(dbErr))
+		}
+	} else {
+		if dbErr := e.db.Exec(ctx, `DELETE FROM cron_jobs`); dbErr != nil {
+			e.log.Warn("cron catchup: failed to prune orphaned rows", zap.Error(dbErr))
+		}
+	}
+
+	type missedRow struct {
+		taskID string
+		nextAt int64
+	}
+	var missed, tooOld []missedRow
+
+	_ = e.db.Query(ctx,
+		`SELECT task_id, next_run_at FROM cron_jobs WHERE next_run_at < ?`,
+		[]any{now},
+		func(rows db.Scanner) error {
+			for rows.Next() {
+				var r missedRow
+				if err := rows.Scan(&r.taskID, &r.nextAt); err == nil {
+					if r.nextAt > cutoff {
+						missed = append(missed, r)
+					} else {
+						tooOld = append(tooOld, r)
+					}
+				}
+			}
+			return nil
+		},
+	)
+
+	for _, m := range tooOld {
+		e.log.Warn("cron catchup: missed run is older than 24h — skipping",
+			zap.String("task", m.taskID),
+			zap.Time("was_due", time.Unix(m.nextAt, 0)),
+		)
+	}
+	for _, m := range missed {
+		spec, ok := e.registry.Get(m.taskID)
+		if !ok {
+			e.log.Warn("cron catchup: task no longer registered, skipping",
+				zap.String("task", m.taskID),
+				zap.Time("was_due", time.Unix(m.nextAt, 0)),
+			)
+			continue
+		}
+		e.log.Info("cron catchup: firing missed run",
+			zap.String("task", m.taskID),
+			zap.Time("was_due", time.Unix(m.nextAt, 0)),
+		)
+		e.fireAsync(ctx, spec, pkgruntime.RunOptions{}, "cron-catchup") //nolint:errcheck
+	}
 }
 
 func (e *Engine) registerWebhook(spec *task.Spec) {
@@ -894,7 +1024,7 @@ func (e *Engine) dispatch(ctx context.Context, spec *task.Spec, opts pkgruntime.
 	exec, ok := e.executors[spec.Runtime]
 	e.mu.Unlock()
 
-	if !ok {
+	if !ok || exec == nil {
 		e.log.Error("no executor for runtime",
 			zap.String("task", spec.ID),
 			zap.String("runtime", string(spec.Runtime)),

--- a/pkg/trigger/engine_test.go
+++ b/pkg/trigger/engine_test.go
@@ -441,6 +441,137 @@ func TestEngine_WebhookHandler_FormPOST(t *testing.T) {
 	}
 }
 
+// TestCronCatchup verifies that cron tasks whose next_run_at is in the past
+// are fired with trigger_source="cron-catchup".
+// Calls catchupMissedCronRuns directly (same package) to avoid the goroutine
+// race that would arise from calling Start() and then polling.
+func TestCronCatchup(t *testing.T) {
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+
+	reg := registry.New(d)
+
+	dir := t.TempDir()
+	spec := writeTask(t, dir, "catchup-task", `return 1`, task.TriggerConfig{Cron: "0 9 * * *"})
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("reg.Register: %v", err)
+	}
+
+	// Seed a stale cron_jobs row simulating the previous session.
+	missedAt := time.Now().Add(-5 * time.Minute).Unix()
+	if err := d.Exec(context.Background(),
+		`INSERT INTO cron_jobs(task_id,cron_expr,next_run_at) VALUES(?,?,?)`,
+		"catchup-task", "0 9 * * *", missedAt,
+	); err != nil {
+		t.Fatalf("seed cron_jobs: %v", err)
+	}
+
+	eng := New(reg, nil, zap.NewNop()) // nil executor — dispatch fails but run record is created
+	eng.SetDB(d)
+
+	// Call directly — synchronous, no goroutine scheduling race.
+	// fireAsync creates the run record before launching its goroutine, so
+	// ListRuns is reliable immediately after this returns.
+	eng.catchupMissedCronRuns(context.Background())
+
+	runs, err := reg.ListRuns(context.Background(), "catchup-task", 5)
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	var found bool
+	for _, r := range runs {
+		if r.TriggerSource == "cron-catchup" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected a cron-catchup run to be created")
+	}
+}
+
+// TestCronCatchup_OrphanRow verifies that a task deleted between sessions
+// produces a warning log and does not panic.
+func TestCronCatchup_OrphanRow(t *testing.T) {
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+
+	reg := registry.New(d)
+
+	// Seed a cron_jobs row for a task that is NOT in the registry.
+	missedAt := time.Now().Add(-5 * time.Minute).Unix()
+	if err := d.Exec(context.Background(),
+		`INSERT INTO cron_jobs(task_id,cron_expr,next_run_at) VALUES(?,?,?)`,
+		"deleted-task", "* * * * *", missedAt,
+	); err != nil {
+		t.Fatalf("seed cron_jobs: %v", err)
+	}
+
+	eng := New(reg, nil, zap.NewNop())
+	eng.SetDB(d)
+
+	// Should not panic; orphan row is skipped with a warning.
+	eng.catchupMissedCronRuns(context.Background())
+
+	runs, _ := reg.ListRuns(context.Background(), "deleted-task", 5)
+	if len(runs) != 0 {
+		t.Errorf("expected no runs for deleted task, got %d", len(runs))
+	}
+}
+
+// TestCronPersistence verifies that registering a cron task writes a cron_jobs
+// row and unregistering it removes the row.
+func TestCronPersistence(t *testing.T) {
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+
+	reg := registry.New(d)
+	eng := New(reg, nil, zap.NewNop())
+	eng.SetDB(d)
+
+	dir := t.TempDir()
+	spec := writeTask(t, dir, "persist-cron", `return 1`, task.TriggerConfig{Cron: "* * * * *"})
+	_ = reg.Register(spec)
+	eng.Register(spec)
+
+	// Row must exist after Register.
+	var count int
+	_ = d.Query(context.Background(),
+		`SELECT COUNT(*) FROM cron_jobs WHERE task_id=?`, []any{"persist-cron"},
+		func(rows db.Scanner) error {
+			rows.Next()
+			return rows.Scan(&count)
+		},
+	)
+	if count != 1 {
+		t.Errorf("expected 1 cron_jobs row after Register, got %d", count)
+	}
+
+	eng.Unregister("persist-cron")
+
+	// Row must be gone after Unregister.
+	count = 0
+	_ = d.Query(context.Background(),
+		`SELECT COUNT(*) FROM cron_jobs WHERE task_id=?`, []any{"persist-cron"},
+		func(rows db.Scanner) error {
+			rows.Next()
+			return rows.Scan(&count)
+		},
+	)
+	if count != 0 {
+		t.Errorf("expected 0 cron_jobs rows after Unregister, got %d", count)
+	}
+}
+
 func TestInjectDicodeSDK(t *testing.T) {
 	html := `<html><head><title>Test</title></head><body></body></html>`
 	result := injectDicodeSDK(html, "/hooks/my-task", "my-task")

--- a/pkg/trigger/engine_test.go
+++ b/pkg/trigger/engine_test.go
@@ -525,6 +525,43 @@ func TestCronCatchup_OrphanRow(t *testing.T) {
 	}
 }
 
+// TestCronCatchup_TooOld verifies that a missed run older than 24h is skipped
+// (not fired) and produces a Warn log, not a catchup run.
+func TestCronCatchup_TooOld(t *testing.T) {
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+
+	reg := registry.New(d)
+
+	dir := t.TempDir()
+	spec := writeTask(t, dir, "old-cron", `return 1`, task.TriggerConfig{Cron: "* * * * *"})
+	_ = reg.Register(spec)
+
+	// Seed a next_run_at more than 24h in the past.
+	tooOldAt := time.Now().Add(-25 * time.Hour).Unix()
+	if err := d.Exec(context.Background(),
+		`INSERT INTO cron_jobs(task_id,cron_expr,next_run_at) VALUES(?,?,?)`,
+		"old-cron", "* * * * *", tooOldAt,
+	); err != nil {
+		t.Fatalf("seed cron_jobs: %v", err)
+	}
+
+	eng := New(reg, nil, zap.NewNop())
+	eng.SetDB(d)
+	eng.catchupMissedCronRuns(context.Background())
+
+	// No run should be created — the row is too old.
+	runs, _ := reg.ListRuns(context.Background(), "old-cron", 5)
+	for _, r := range runs {
+		if r.TriggerSource == "cron-catchup" {
+			t.Error("expected no cron-catchup run for a >24h old missed run")
+		}
+	}
+}
+
 // TestCronPersistence verifies that registering a cron task writes a cron_jobs
 // row and unregistering it removes the row.
 func TestCronPersistence(t *testing.T) {


### PR DESCRIPTION
Closes #41

## Problem

The cron scheduler (`robfig/cron`) is entirely in-memory. If dicode restarts at 09:01 after a task was scheduled for 09:00, that run is silently missed — no log, no error, no catchup.

## Solution

Persist each cron task's `next_run_at` to a new `cron_jobs` SQLite table. On startup, `catchupMissedCronRuns` is called before task re-registration, fires any overdue runs (up to 24h back), and then registration overwrites `next_run_at` with the next future time.

**New `cron_jobs` table** (`pkg/db/sqlite.go`):
```sql
CREATE TABLE IF NOT EXISTS cron_jobs (
    task_id     TEXT PRIMARY KEY,
    cron_expr   TEXT NOT NULL,
    last_run_at INTEGER,
    next_run_at INTEGER NOT NULL
);
```

**`trigger.Engine` changes** (`pkg/trigger/engine.go`):
- `SetDB(d db.DB)` — opt-in DB wiring (preserves existing `New()` signature)
- `registerCron` — `INSERT OR REPLACE` on register, `UPDATE` on each fire, `DELETE` on unregister
- `catchupMissedCronRuns` — queries past rows, fires with `trigger_source="cron-catchup"`; warns on >24h skips; prunes orphaned rows for tasks deleted while daemon was offline
- Nil-executor guard in `dispatch` (latent panic fix included)

**`cmd/dicoded/main.go`**: `eng.SetDB(database)` wired in `buildRuntimes`.

## Behaviour

| Scenario | Before | After |
| --- | --- | --- |
| Daemon restarted within 24h of missed run | Silent skip | Fires with `cron-catchup`, logged |
| Missed run > 24h ago | Silent skip | Skipped with `Warn` log |
| Task deleted while daemon offline | Stale DB row forever | Row pruned on next startup |
| Persistence error (full disk, etc.) | Silent failure | `Warn` log, operation continues |

## Test plan

- [x] `TestCronCatchup_MissedRun` — seeds a past `next_run_at`, calls `catchupMissedCronRuns`, verifies a `cron-catchup` run appears in registry
- [x] `TestCronCatchup_OrphanRow` — seeds a row for a deleted task, verifies no run is created and no panic
- [x] `TestCronPersistence` — registers a cron task, verifies row exists; unregisters, verifies row is deleted
- [x] All existing tests pass (`go test ./...`)