### PR TITLE
feat(#48): split monolith into dicoded daemon + dicode CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 dicode
 !.claude/settings.local.json
 !.claude/memory/
-.playwright-mcp/
+.playwright-mcp/dicoded

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,22 @@
-BINARY  := dicode
-CMD     := ./cmd/dicode
-VERSION ?= dev
+BINARY        := dicode
+DAEMON_BINARY := dicoded
+CMD           := ./cmd/dicode
+DAEMON_CMD    := ./cmd/dicoded
+VERSION       ?= dev
 
 GO      := $(shell which go 2>/dev/null || echo $(HOME)/.local/share/mise/shims/go)
 GOFLAGS := -ldflags "-X main.version=$(VERSION)"
 
-.PHONY: build test test-verbose lint fmt clean run tidy
+.PHONY: build test test-verbose test-race lint fmt clean run tidy help
 
-## build: compile the dicode binary into the project root
+## build: compile both dicode (CLI) and dicoded (daemon) into the project root
 build:
 	$(GO) build $(GOFLAGS) -o $(BINARY) $(CMD)
+	$(GO) build $(GOFLAGS) -o $(DAEMON_BINARY) $(DAEMON_CMD)
 
-## run: build and run dicode (Ctrl-C to stop)
+## run: build and run dicoded daemon (Ctrl-C to stop)
 run: build
-	./$(BINARY)
+	./$(DAEMON_BINARY)
 
 ## test: run all tests
 test:
@@ -39,9 +42,9 @@ fmt:
 lint: fmt
 	$(GO) vet ./...
 
-## clean: remove the compiled binary
+## clean: remove compiled binaries
 clean:
-	rm -f $(BINARY)
+	rm -f $(BINARY) $(DAEMON_BINARY)
 
 ## help: list available targets
 help:

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -1,468 +1,315 @@
+// dicode is the dicode CLI.
+//
+// It connects to a running dicoded daemon over the control socket and dispatches
+// commands. If the daemon is not running it is started automatically.
+//
+// Usage:
+//
+//	dicode [flags] <command> [args...]
+//
+// Commands:
+//
+//	run <task-id> [key=value ...]   trigger a task run and wait for the result
+//	list                            list all registered tasks
+//	logs <run-id>                   fetch log lines for a run
+//	status [task-id]                daemon health or latest run for a task
+//	secrets list                    list secret keys
+//	secrets set <key> <value>       store a secret
+//	secrets delete <key>            delete a secret
+//	version                         print version and exit
 package main
 
 import (
-	"context"
-	"flag"
+	"encoding/json"
 	"fmt"
 	"os"
-	"os/signal"
-	"sync"
-	"syscall"
-
-	"github.com/dicode/dicode/pkg/config"
-	"github.com/dicode/dicode/pkg/db"
-	"github.com/dicode/dicode/pkg/ipc"
-	"github.com/dicode/dicode/pkg/notify"
-	"github.com/dicode/dicode/pkg/onboarding"
-	"github.com/dicode/dicode/pkg/registry"
-	pkgruntime "github.com/dicode/dicode/pkg/runtime"
-	denoruntime "github.com/dicode/dicode/pkg/runtime/deno"
-	dockerruntime "github.com/dicode/dicode/pkg/runtime/docker"
-	podmanruntime "github.com/dicode/dicode/pkg/runtime/podman"
-	pythonruntime "github.com/dicode/dicode/pkg/runtime/python"
-	"github.com/dicode/dicode/pkg/secrets"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
-	"github.com/dicode/dicode/pkg/source"
-	gitSource "github.com/dicode/dicode/pkg/source/git"
-	"github.com/dicode/dicode/pkg/source/local"
-	"github.com/dicode/dicode/pkg/task"
-	"github.com/dicode/dicode/pkg/taskset"
-	"github.com/dicode/dicode/pkg/tray"
-	"github.com/dicode/dicode/pkg/trigger"
-	"github.com/dicode/dicode/pkg/webui"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"golang.org/x/sync/errgroup"
+	"github.com/dicode/dicode/pkg/ipc"
 )
 
 var version = "dev"
 
 func main() {
-	var configPath string
-	flag.StringVar(&configPath, "config", "dicode.yaml", "path to config file")
-	flag.Parse()
-
-	// Handle subcommands.
-	if flag.NArg() > 0 {
-		switch flag.Arg(0) {
-		case "task":
-			runTaskCmd(flag.Args()[1:])
-			return
-		case "version":
-			fmt.Printf("dicode %s\n", version)
-			return
-		}
-	}
-
-	// First-run onboarding: if no config exists, generate a default one.
-	if onboarding.Required(configPath) {
-		fmt.Println("Welcome to dicode! No config found — creating a local-only setup.")
-		home, _ := os.UserHomeDir()
-		content := onboarding.DefaultLocalConfig(home+"/dicode-tasks", home+"/.dicode")
-		if err := onboarding.WriteConfig(configPath, content); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to write config: %v\n", err)
-			os.Exit(1)
-		}
-		fmt.Printf("Created %s\n", configPath)
-		if err := os.MkdirAll(home+"/dicode-tasks", 0755); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to create tasks dir: %v\n", err)
-		}
-	}
-
-	cfg, err := config.Load(configPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to load config: %v\n", err)
+	if len(os.Args) < 2 {
+		usage()
 		os.Exit(1)
 	}
 
-	logBroadcaster := webui.NewLogBroadcaster()
+	if os.Args[1] == "version" {
+		fmt.Printf("dicode %s\n", version)
+		return
+	}
 
-	logger, err := buildLogger(cfg.LogLevel, logBroadcaster)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to init logger: %v\n", err)
+	dataDir := defaultDataDir()
+	socketPath := filepath.Join(dataDir, "daemon.sock")
+	tokenPath := filepath.Join(dataDir, "daemon.token")
+
+	if err := ensureDaemon(socketPath); err != nil {
+		fmt.Fprintf(os.Stderr, "dicode: could not start daemon: %v\n", err)
 		os.Exit(1)
 	}
-	defer logger.Sync()
 
-	logger.Info("dicode starting", zap.String("version", version))
+	c, err := ipc.Dial(socketPath, tokenPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dicode: connect to daemon: %v\n", err)
+		os.Exit(1)
+	}
+	defer c.Close()
 
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer cancel()
-
-	if err := run(ctx, cancel, cfg, configPath, logBroadcaster, logger); err != nil {
-		logger.Fatal("dicode exited with error", zap.Error(err))
+	if err := dispatch(c, os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "dicode: %v\n", err)
+		os.Exit(1)
 	}
 }
 
-func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, configPath string, logBroadcaster *webui.LogBroadcaster, log *zap.Logger) error {
-	// 1. Open database.
-	database, err := db.Open(db.Config{
-		Type:   cfg.Database.Type,
-		Path:   cfg.Database.Path,
-		URLEnv: cfg.Database.URLEnv,
-	})
-	if err != nil {
-		return fmt.Errorf("open database: %w", err)
+func dispatch(c *ipc.ControlClient, args []string) error {
+	switch args[0] {
+	case "list":
+		return cmdList(c)
+	case "run":
+		if len(args) < 2 {
+			return fmt.Errorf("usage: dicode run <task-id> [key=value ...]")
+		}
+		return cmdRun(c, args[1], args[2:])
+	case "logs":
+		if len(args) < 2 {
+			return fmt.Errorf("usage: dicode logs <run-id>")
+		}
+		return cmdLogs(c, args[1])
+	case "status":
+		taskID := ""
+		if len(args) >= 2 {
+			taskID = args[1]
+		}
+		return cmdStatus(c, taskID)
+	case "secrets":
+		if len(args) < 2 {
+			return fmt.Errorf("usage: dicode secrets <list|set|delete> [args...]")
+		}
+		return cmdSecrets(c, args[1:])
+	default:
+		return fmt.Errorf("unknown command %q — run 'dicode' for usage", args[0])
 	}
-	defer database.Close()
+}
 
-	// 2. Build secrets chain.
-	secretsChain, localSecrets := buildSecretsChain(cfg, database, log)
-
-	// 3. Task registry + startup cleanup.
-	// Remove orphaned containers first (before marking runs cancelled)
-	// so the DB status reflects what actually happened to each container.
-	dockerruntime.CleanupOrphanedContainers(ctx, log)
-	podmanruntime.CleanupOrphanedContainers(ctx, log)
-
-	reg := registry.New(database)
-	if stale, err := reg.CleanupStaleRuns(ctx); err != nil {
-		log.Warn("stale run cleanup failed", zap.Error(err))
-	} else if len(stale) > 0 {
-		log.Info("cancelled stale runs from previous session", zap.Strings("tasks", stale))
-	}
-
-	// 4. HTTP gateway — created early so runtimes can propagate it to IPC servers.
-	gateway := ipc.NewGateway()
-
-	// 5. Build managed runtimes (deno is always available; others depend on config).
-	managedRuntimes, eng, err := buildRuntimes(ctx, cfg, reg, secretsChain, database, log, gateway)
+func cmdList(c *ipc.ControlClient) error {
+	resp, err := c.Send(ipc.Request{Method: "cli.list"})
 	if err != nil {
 		return err
 	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	var tasks []ipc.TaskSummary
+	if err := remarshal(resp.Result, &tasks); err != nil {
+		return err
+	}
+	if len(tasks) == 0 {
+		fmt.Println("no tasks registered")
+		return nil
+	}
+	fmt.Printf("%-30s %-12s %-10s %s\n", "ID", "TRIGGER", "LAST STATUS", "NAME")
+	for _, t := range tasks {
+		fmt.Printf("%-30s %-12s %-10s %s\n", t.ID, t.Trigger, orDash(t.LastStatus), t.Name)
+	}
+	return nil
+}
 
-	// 6. Sources + reconciler.
-	// Auto-register webhook tasks in the gateway so HTTP traffic is routed to them.
-	sources, sourceMgr, err := buildSources(cfg, log)
+func cmdRun(c *ipc.ControlClient, taskID string, kvArgs []string) error {
+	params := map[string]string{}
+	for _, kv := range kvArgs {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid param %q — expected key=value", kv)
+		}
+		params[parts[0]] = parts[1]
+	}
+	paramsJSON, _ := json.Marshal(params)
+	resp, err := c.Send(ipc.Request{
+		Method: "cli.run",
+		TaskID: taskID,
+		Params: paramsJSON,
+	})
 	if err != nil {
-		return fmt.Errorf("build sources: %w", err)
+		return err
 	}
-	rec := registry.NewReconciler(reg, sources, log)
-	// Capture the webhook handler once — it is a singleton backed by the engine.
-	webhookH := eng.WebhookHandler()
-	// Track webhook paths locally so OnUnregister doesn't need to call reg.Get,
-	// which would race with a concurrent re-registration of the same task ID.
-	var webhookMu sync.Mutex
-	webhookPaths := make(map[string]string) // taskID → registered path
-	rec.OnRegister = func(spec *task.Spec) {
-		eng.Register(spec)
-		if spec.Trigger.Webhook != "" {
-			gateway.Register(spec.Trigger.Webhook, webhookH)
-			webhookMu.Lock()
-			webhookPaths[spec.ID] = spec.Trigger.Webhook
-			webhookMu.Unlock()
-		}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
 	}
-	rec.OnUnregister = func(id string) {
-		webhookMu.Lock()
-		path := webhookPaths[id]
-		delete(webhookPaths, id)
-		webhookMu.Unlock()
-		if path != "" {
-			gateway.Unregister(path)
-		}
-		eng.Unregister(id)
+	var result ipc.RunResult
+	if err := remarshal(resp.Result, &result); err != nil {
+		return err
 	}
+	fmt.Printf("run %s: %s\n", result.RunID, result.Status)
+	if result.ReturnValue != nil {
+		out, _ := json.MarshalIndent(result.ReturnValue, "", "  ")
+		fmt.Println(string(out))
+	}
+	return nil
+}
 
-	// 7. Web UI.
-	port := cfg.Server.Port
-	if port == 0 {
-		port = 8080
-	}
-	dataDir := cfg.DataDir
-	if dataDir == "" {
-		home, _ := os.UserHomeDir()
-		dataDir = home + "/.dicode"
-	}
-	srv, err := webui.New(port, reg, eng, cfg, configPath, localSecrets, rec, sourceMgr, dataDir, logBroadcaster, log, database, gateway)
+func cmdLogs(c *ipc.ControlClient, runID string) error {
+	resp, err := c.Send(ipc.Request{Method: "cli.logs", RunID: runID})
 	if err != nil {
-		return fmt.Errorf("build webui: %w", err)
+		return err
 	}
-	srv.SetManagedRuntimes(managedRuntimes)
-
-	// 7. Run everything concurrently.
-	g, ctx := errgroup.WithContext(ctx)
-	g.Go(func() error { return rec.Run(ctx) })
-	g.Go(func() error { return eng.Start(ctx) })
-	g.Go(func() error { return srv.Start(ctx) })
-
-	// 8. System tray (optional).
-	trayEnabled := cfg.Server.Tray == nil || *cfg.Server.Tray // nil = auto = enabled
-	if trayEnabled {
-		g.Go(func() error {
-			tray.Run(ctx, cancel, port, log)
-			return nil
-		})
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
 	}
-
-	return g.Wait()
+	var entries []ipc.LogEntry
+	if err := remarshal(resp.Result, &entries); err != nil {
+		return err
+	}
+	for _, e := range entries {
+		fmt.Printf("%s [%s] %s\n", e.Timestamp, e.Level, e.Message)
+	}
+	return nil
 }
 
-// buildRuntimes initialises all managed runtimes, registers them in the trigger
-// engine, and returns the managed-runtime list (for the Config UI).
-func buildRuntimes(
-	_ context.Context,
-	cfg *config.Config,
-	reg *registry.Registry,
-	secretsChain secrets.Chain,
-	database db.DB,
-	log *zap.Logger,
-	gateway *ipc.Gateway,
-) ([]pkgruntime.ManagedRuntime, *trigger.Engine, error) {
-	// --- Deno (always-on default executor) ---
-	denoRT, err := denoruntime.New(reg, secretsChain, database, log)
+func cmdStatus(c *ipc.ControlClient, taskID string) error {
+	resp, err := c.Send(ipc.Request{Method: "cli.status", TaskID: taskID})
 	if err != nil {
-		return nil, nil, fmt.Errorf("init deno runtime: %w", err)
+		return err
 	}
-	eng := trigger.New(reg, denoRT, log)
-	// Wire the engine into the Deno runtime so tasks can orchestrate other tasks.
-	denoRT.SetEngine(eng)
-	denoRT.SetGateway(gateway)
-	// Wire AI config so tasks can call dicode.get_config("ai").
-	aiAPIKey := cfg.AI.APIKey
-	if aiAPIKey == "" && cfg.AI.APIKeyEnv != "" {
-		aiAPIKey = os.Getenv(cfg.AI.APIKeyEnv)
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
 	}
-	denoRT.SetAIConfig(cfg.AI.BaseURL, cfg.AI.Model, aiAPIKey)
-	// Wire config-level on_failure_chain default.
-	if cfg.Defaults.OnFailureChain != "" {
-		eng.SetDefaultsOnFailureChain(cfg.Defaults.OnFailureChain)
-	}
-	// Wire notification provider and global defaults.
-	if p := cfg.Notifications.Provider; p != nil {
-		eng.SetNotifier(notify.NewNotifier(p.Type, p.URL, p.Topic, p.TokenEnv))
-	}
-	eng.SetNotifyDefaults(cfg.Notifications.NotifyOnSuccess(), cfg.Notifications.NotifyOnFailure())
-
-	var managed []pkgruntime.ManagedRuntime
-	managed = append(managed, denoRT) // *denoruntime.Runtime implements ManagedRuntime
-
-	// Allow overriding the deno version at startup (unusual but supported).
-	if rc, ok := cfg.Runtimes["deno"]; ok && rc.Version != "" {
-		if denoRT.IsInstalled(rc.Version) {
-			if p, err := denoRT.BinaryPath(rc.Version); err == nil {
-				eng.RegisterExecutor(task.RuntimeDeno, denoRT.NewExecutor(p))
-			}
-		}
-	}
-
-	// --- Docker ---
-	eng.RegisterExecutor(task.RuntimeDocker, dockerruntime.New(reg, log))
-
-	// --- Podman — registered as ManagedRuntime; executor added only if binary found ---
-	podmanMgr := podmanruntime.New(reg, log)
-	managed = append(managed, podmanMgr)
-	if podmanMgr.IsInstalled("") {
-		if p, err := podmanMgr.BinaryPath(""); err == nil {
-			eng.RegisterExecutor(task.RuntimePodman, podmanMgr.NewExecutor(p))
-			log.Info("podman runtime registered", zap.String("path", p))
-		}
-	}
-
-	// --- Python (uv) — register only if configured + installed ---
-	pythonMgr, err := pythonruntime.New(reg, secretsChain, database, log)
-	if err != nil {
-		log.Fatal("python runtime init", zap.Error(err))
-	}
-	pythonMgr.SetGateway(gateway)
-	managed = append(managed, pythonMgr)
-
-	if rc, ok := cfg.Runtimes["python"]; ok && !rc.Disabled {
-		version := rc.Version
-		if version == "" {
-			version = pythonMgr.DefaultVersion()
-		}
-		if pythonMgr.IsInstalled(version) {
-			if p, err := pythonMgr.BinaryPath(version); err == nil {
-				eng.RegisterExecutor(task.Runtime("python"), pythonMgr.NewExecutor(p))
-				log.Info("python runtime registered", zap.String("version", version))
-			}
-		} else {
-			log.Info("python runtime configured but not installed — run install from Config UI",
-				zap.String("version", version))
-		}
-	}
-
-	return managed, eng, nil
+	out, _ := json.MarshalIndent(resp.Result, "", "  ")
+	fmt.Println(string(out))
+	return nil
 }
 
-func buildSecretsChain(cfg *config.Config, database db.DB, log *zap.Logger) (secrets.Chain, webui.SecretsManager) {
-	var chain secrets.Chain
-	var localProvider webui.SecretsManager
-	home, _ := os.UserHomeDir()
-	dataDir := cfg.DataDir
-	if dataDir == "" {
-		dataDir = home + "/.dicode"
-	}
-
-	for _, p := range cfg.Secrets.Providers {
-		switch p.Type {
-		case "local":
-			sdb := secrets.NewSQLiteSecretDB(database)
-			lp, err := secrets.NewLocalProvider(dataDir, sdb)
-			if err != nil {
-				log.Warn("local secrets provider init failed", zap.Error(err))
-				continue
-			}
-			chain = append(chain, lp)
-			if localProvider == nil {
-				localProvider = lp
-			}
-		case "env", "":
-			chain = append(chain, secrets.NewEnvProvider())
-		}
-	}
-	// Default: local + env if no providers configured.
-	if len(chain) == 0 {
-		sdb := secrets.NewSQLiteSecretDB(database)
-		if lp, err := secrets.NewLocalProvider(dataDir, sdb); err == nil {
-			chain = append(chain, lp)
-			localProvider = lp
-		}
-		chain = append(chain, secrets.NewEnvProvider())
-	}
-	return chain, localProvider
-}
-
-func buildSources(cfg *config.Config, log *zap.Logger) ([]source.Source, *webui.SourceManager, error) {
-	dataDir := cfg.DataDir
-	if dataDir == "" {
-		home, _ := os.UserHomeDir()
-		dataDir = home + "/.dicode"
-	}
-
-	tasksetSources := make(map[string]*taskset.Source)
-	var sources []source.Source
-
-	for _, sc := range cfg.Sources {
-		// Use taskset.Source when the new model is indicated (Name or EntryPath set).
-		if sc.Name != "" || sc.EntryPath != "" {
-			ts, err := buildTaskSetSource(sc, dataDir, log)
-			if err != nil {
-				return nil, nil, err
-			}
-			sources = append(sources, ts)
-			name := sourceNameFor(sc)
-			tasksetSources[name] = ts
-			continue
-		}
-
-		switch sc.Type {
-		case config.SourceTypeLocal:
-			s, err := local.New(sc.Path, sc.Path, log)
-			if err != nil {
-				return nil, nil, fmt.Errorf("local source %q: %w", sc.Path, err)
-			}
-			sources = append(sources, s)
-		case config.SourceTypeGit:
-			gs, err := gitSource.New(dataDir, sc.URL, sc.Branch, sc.PollInterval, sc.Auth.TokenEnv, sc.Auth.SSHKey, log)
-			if err != nil {
-				return nil, nil, fmt.Errorf("git source %q: %w", sc.URL, err)
-			}
-			sources = append(sources, gs)
-		default:
-			return nil, nil, fmt.Errorf("unknown source type %q", sc.Type)
-		}
-	}
-
-	sourceMgr := webui.NewSourceManager(cfg, tasksetSources, dataDir, log)
-	return sources, sourceMgr, nil
-}
-
-// sourceNameFor derives the canonical name for a SourceConfig.
-// Must stay in sync with webui.sourceName.
-func sourceNameFor(sc config.SourceConfig) string {
-	if sc.Name != "" {
-		return sc.Name
-	}
-	base := sc.URL
-	if base == "" {
-		base = sc.Path
-	}
-	base = strings.TrimRight(base, "/")
-	name := filepath.Base(base)
-	if ext := filepath.Ext(name); ext == ".yaml" || ext == ".yml" {
-		name = strings.TrimSuffix(name, ext)
-	}
-	return name
-}
-
-// buildTaskSetSource creates a taskset.Source for a SourceConfig using the new model.
-func buildTaskSetSource(sc config.SourceConfig, dataDir string, log *zap.Logger) (*taskset.Source, error) {
-	// Derive namespace from Name, falling back to last segment of URL or Path.
-	namespace := sc.Name
-	if namespace == "" {
-		base := sc.URL
-		if base == "" {
-			base = sc.Path
-		}
-		// Strip trailing slashes and take the last path segment.
-		base = strings.TrimRight(base, "/")
-		namespace = filepath.Base(base)
-		// Strip common extensions from local paths.
-		if ext := filepath.Ext(namespace); ext == ".yaml" || ext == ".yml" {
-			namespace = strings.TrimSuffix(namespace, ext)
-		}
-	}
-
-	var rootRef *taskset.Ref
-	if sc.URL != "" {
-		entryPath := sc.EntryPath
-		if entryPath == "" {
-			entryPath = "taskset.yaml"
-		}
-		rootRef = &taskset.Ref{
-			URL:          sc.URL,
-			Branch:       sc.Branch,
-			Path:         entryPath,
-			PollInterval: sc.PollInterval,
-			Auth:         taskset.RefAuth{TokenEnv: sc.Auth.TokenEnv, SSHKey: sc.Auth.SSHKey},
-		}
-	} else {
-		// Local source: Path points to the taskset.yaml file.
-		entryPath := sc.Path
-		if sc.EntryPath != "" {
-			entryPath = sc.EntryPath
-		}
-		rootRef = &taskset.Ref{Path: entryPath}
-	}
-
-	id := sc.URL
-	if id == "" {
-		id = sc.Path
-	}
-
-	src := taskset.NewSource(id, namespace, rootRef, sc.ConfigPath, dataDir, false, sc.PollInterval, log)
-	return src, nil
-}
-
-func runTaskCmd(args []string) {
-	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: dicode task <install|list> [args...]")
-		os.Exit(1)
-	}
+func cmdSecrets(c *ipc.ControlClient, args []string) error {
 	switch args[0] {
-	case "install":
-		fmt.Println("task install: not yet implemented")
 	case "list":
-		fmt.Println("task list: not yet implemented")
+		resp, err := c.Send(ipc.Request{Method: "cli.secrets.list"})
+		if err != nil {
+			return err
+		}
+		if resp.Error != "" {
+			return fmt.Errorf("%s", resp.Error)
+		}
+		var keys []string
+		if err := remarshal(resp.Result, &keys); err != nil {
+			return err
+		}
+		for _, k := range keys {
+			fmt.Println(k)
+		}
+	case "set":
+		if len(args) < 3 {
+			return fmt.Errorf("usage: dicode secrets set <key> <value>")
+		}
+		resp, err := c.Send(ipc.Request{Method: "cli.secrets.set", Key: args[1], StringValue: args[2]})
+		if err != nil {
+			return err
+		}
+		if resp.Error != "" {
+			return fmt.Errorf("%s", resp.Error)
+		}
+		fmt.Printf("secret %q set\n", args[1])
+	case "delete":
+		if len(args) < 2 {
+			return fmt.Errorf("usage: dicode secrets delete <key>")
+		}
+		resp, err := c.Send(ipc.Request{Method: "cli.secrets.delete", Key: args[1]})
+		if err != nil {
+			return err
+		}
+		if resp.Error != "" {
+			return fmt.Errorf("%s", resp.Error)
+		}
+		fmt.Printf("secret %q deleted\n", args[1])
 	default:
-		fmt.Fprintf(os.Stderr, "unknown task subcommand: %s\n", args[0])
-		os.Exit(1)
+		return fmt.Errorf("unknown secrets subcommand %q", args[0])
 	}
+	return nil
 }
 
-func buildLogger(level string, broadcast *webui.LogBroadcaster) (*zap.Logger, error) {
-	zapLevel := zapcore.InfoLevel
-	if level == "debug" {
-		zapLevel = zapcore.DebugLevel
+// ensureDaemon starts dicoded in the background if the socket is not reachable.
+func ensureDaemon(socketPath string) error {
+	if isDaemonRunning(socketPath) {
+		return nil
 	}
-	enc := zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
-	core := zapcore.NewTee(
-		zapcore.NewCore(enc, zapcore.AddSync(os.Stderr), zapLevel),
-		zapcore.NewCore(enc, zapcore.AddSync(broadcast), zapLevel),
-	)
-	return zap.New(core, zap.AddCaller()), nil
+
+	// Locate the dicoded binary next to the dicode binary.
+	self, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	dicoded := filepath.Join(filepath.Dir(self), "dicoded")
+	if _, err := os.Stat(dicoded); err != nil {
+		// Fall back to PATH.
+		dicoded, err = exec.LookPath("dicoded")
+		if err != nil {
+			return fmt.Errorf("dicoded binary not found; start the daemon manually")
+		}
+	}
+
+	cmd := exec.Command(dicoded)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	cmd.Stdin = nil
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start dicoded: %w", err)
+	}
+	// Detach from the child process.
+	go func() { _ = cmd.Wait() }()
+
+	// Poll until the socket appears (up to 8 seconds).
+	deadline := time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		if isDaemonRunning(socketPath) {
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return fmt.Errorf("daemon did not start within 8 seconds")
+}
+
+func isDaemonRunning(socketPath string) bool {
+	_, err := os.Stat(socketPath)
+	return err == nil
+}
+
+func defaultDataDir() string {
+	if d := os.Getenv("DICODE_DATA_DIR"); d != "" {
+		return d
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".dicode")
+}
+
+func remarshal(v any, dst any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, dst)
+}
+
+func orDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `Usage: dicode <command> [args...]
+
+Commands:
+  run <task-id> [key=value ...]   trigger a task and wait for the result
+  list                            list registered tasks
+  logs <run-id>                   show logs for a run
+  status [task-id]                daemon health or task's latest run
+  secrets list                    list secret keys
+  secrets set <key> <value>       store a secret
+  secrets delete <key>            delete a secret
+  version                         print version
+`)
 }

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -22,6 +22,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -235,6 +236,8 @@ func ensureDaemon(socketPath string) error {
 	if isDaemonRunning(socketPath) {
 		return nil
 	}
+	// Remove a stale socket file so the new daemon can bind cleanly.
+	_ = os.Remove(socketPath)
 
 	// Locate the dicoded binary next to the dicode binary.
 	self, err := os.Executable()
@@ -250,17 +253,30 @@ func ensureDaemon(socketPath string) error {
 		}
 	}
 
+	// Log daemon stderr to dataDir/daemon.log so startup failures are diagnosable.
+	logPath := filepath.Join(filepath.Dir(socketPath), "daemon.log")
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		logFile = nil // non-fatal: proceed without log capture
+	}
+
 	cmd := exec.Command(dicoded)
-	cmd.Stdout = nil
-	cmd.Stderr = nil
 	cmd.Stdin = nil
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
 	if err := cmd.Start(); err != nil {
+		if logFile != nil {
+			logFile.Close()
+		}
 		return fmt.Errorf("start dicoded: %w", err)
 	}
-	// Detach from the child process.
-	go func() { _ = cmd.Wait() }()
+	if logFile != nil {
+		go func() { _ = cmd.Wait(); logFile.Close() }()
+	} else {
+		go func() { _ = cmd.Wait() }()
+	}
 
-	// Poll until the socket appears (up to 8 seconds).
+	// Poll until the socket is live (up to 8 seconds).
 	deadline := time.Now().Add(8 * time.Second)
 	for time.Now().Before(deadline) {
 		if isDaemonRunning(socketPath) {
@@ -268,19 +284,28 @@ func ensureDaemon(socketPath string) error {
 		}
 		time.Sleep(200 * time.Millisecond)
 	}
-	return fmt.Errorf("daemon did not start within 8 seconds")
+	return fmt.Errorf("daemon did not start within 8 seconds (check %s)", logPath)
 }
 
+// isDaemonRunning returns true if the socket exists and accepts connections.
 func isDaemonRunning(socketPath string) bool {
-	_, err := os.Stat(socketPath)
-	return err == nil
+	conn, err := net.DialTimeout("unix", socketPath, 200*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
 }
 
 func defaultDataDir() string {
 	if d := os.Getenv("DICODE_DATA_DIR"); d != "" {
 		return d
 	}
-	home, _ := os.UserHomeDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dicode: cannot determine home directory: %v\n", err)
+		os.Exit(1)
+	}
 	return filepath.Join(home, ".dicode")
 }
 

--- a/cmd/dicoded/main.go
+++ b/cmd/dicoded/main.go
@@ -105,7 +105,10 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	// 2. Resolve data directory.
 	dataDir := cfg.DataDir
 	if dataDir == "" {
-		home, _ := os.UserHomeDir()
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("cannot determine home directory: %w", err)
+		}
 		dataDir = home + "/.dicode"
 	}
 

--- a/cmd/dicoded/main.go
+++ b/cmd/dicoded/main.go
@@ -1,0 +1,415 @@
+// dicoded is the dicode daemon process.
+//
+// It runs the task engine, reconciler, runtimes, HTTP gateway, web UI, and
+// the control socket that the dicode CLI connects to.
+//
+// Usage:
+//
+//	dicoded [-config dicode.yaml]
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/dicode/dicode/pkg/config"
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/ipc"
+	"github.com/dicode/dicode/pkg/notify"
+	"github.com/dicode/dicode/pkg/onboarding"
+	"github.com/dicode/dicode/pkg/registry"
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+	denoruntime "github.com/dicode/dicode/pkg/runtime/deno"
+	dockerruntime "github.com/dicode/dicode/pkg/runtime/docker"
+	podmanruntime "github.com/dicode/dicode/pkg/runtime/podman"
+	pythonruntime "github.com/dicode/dicode/pkg/runtime/python"
+	"github.com/dicode/dicode/pkg/secrets"
+	"github.com/dicode/dicode/pkg/source"
+	gitSource "github.com/dicode/dicode/pkg/source/git"
+	"github.com/dicode/dicode/pkg/source/local"
+	"github.com/dicode/dicode/pkg/task"
+	"github.com/dicode/dicode/pkg/taskset"
+	"github.com/dicode/dicode/pkg/tray"
+	"github.com/dicode/dicode/pkg/trigger"
+	"github.com/dicode/dicode/pkg/webui"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"golang.org/x/sync/errgroup"
+)
+
+var version = "dev"
+
+func main() {
+	var configPath string
+	flag.StringVar(&configPath, "config", "dicode.yaml", "path to config file")
+	flag.Parse()
+
+	// First-run onboarding: if no config exists, generate a default one.
+	if onboarding.Required(configPath) {
+		fmt.Println("Welcome to dicode! No config found — creating a local-only setup.")
+		home, _ := os.UserHomeDir()
+		content := onboarding.DefaultLocalConfig(home+"/dicode-tasks", home+"/.dicode")
+		if err := onboarding.WriteConfig(configPath, content); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to write config: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Created %s\n", configPath)
+		if err := os.MkdirAll(home+"/dicode-tasks", 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to create tasks dir: %v\n", err)
+		}
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to load config: %v\n", err)
+		os.Exit(1)
+	}
+
+	logBroadcaster := webui.NewLogBroadcaster()
+	logger, err := buildLogger(cfg.LogLevel, logBroadcaster)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to init logger: %v\n", err)
+		os.Exit(1)
+	}
+	defer logger.Sync()
+
+	logger.Info("dicoded starting", zap.String("version", version))
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	if err := run(ctx, cancel, cfg, configPath, logBroadcaster, logger); err != nil {
+		logger.Fatal("dicoded exited with error", zap.Error(err))
+	}
+}
+
+func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, configPath string, logBroadcaster *webui.LogBroadcaster, log *zap.Logger) error {
+	// 1. Open database.
+	database, err := db.Open(db.Config{
+		Type:   cfg.Database.Type,
+		Path:   cfg.Database.Path,
+		URLEnv: cfg.Database.URLEnv,
+	})
+	if err != nil {
+		return fmt.Errorf("open database: %w", err)
+	}
+	defer database.Close()
+
+	// 2. Resolve data directory.
+	dataDir := cfg.DataDir
+	if dataDir == "" {
+		home, _ := os.UserHomeDir()
+		dataDir = home + "/.dicode"
+	}
+
+	// 3. Build secrets chain.
+	secretsChain, localSecrets := buildSecretsChain(cfg, dataDir, database, log)
+
+	// 4. Task registry + startup cleanup.
+	dockerruntime.CleanupOrphanedContainers(ctx, log)
+	podmanruntime.CleanupOrphanedContainers(ctx, log)
+
+	reg := registry.New(database)
+	if stale, err := reg.CleanupStaleRuns(ctx); err != nil {
+		log.Warn("stale run cleanup failed", zap.Error(err))
+	} else if len(stale) > 0 {
+		log.Info("cancelled stale runs from previous session", zap.Strings("tasks", stale))
+	}
+
+	// 5. HTTP gateway.
+	gateway := ipc.NewGateway()
+
+	// 6. Managed runtimes + trigger engine.
+	managedRuntimes, eng, err := buildRuntimes(ctx, cfg, reg, secretsChain, database, log, gateway)
+	if err != nil {
+		return err
+	}
+
+	// 7. Sources + reconciler.
+	sources, sourceMgr, err := buildSources(cfg, dataDir, log)
+	if err != nil {
+		return fmt.Errorf("build sources: %w", err)
+	}
+	rec := registry.NewReconciler(reg, sources, log)
+	webhookH := eng.WebhookHandler()
+	var webhookMu sync.Mutex
+	webhookPaths := make(map[string]string)
+	rec.OnRegister = func(spec *task.Spec) {
+		eng.Register(spec)
+		if spec.Trigger.Webhook != "" {
+			gateway.Register(spec.Trigger.Webhook, webhookH)
+			webhookMu.Lock()
+			webhookPaths[spec.ID] = spec.Trigger.Webhook
+			webhookMu.Unlock()
+		}
+	}
+	rec.OnUnregister = func(id string) {
+		webhookMu.Lock()
+		path := webhookPaths[id]
+		delete(webhookPaths, id)
+		webhookMu.Unlock()
+		if path != "" {
+			gateway.Unregister(path)
+		}
+		eng.Unregister(id)
+	}
+
+	// 8. Web UI.
+	port := cfg.Server.Port
+	if port == 0 {
+		port = 8080
+	}
+	srv, err := webui.New(port, reg, eng, cfg, configPath, localSecrets, rec, sourceMgr, dataDir, logBroadcaster, log, database, gateway)
+	if err != nil {
+		return fmt.Errorf("build webui: %w", err)
+	}
+	srv.SetManagedRuntimes(managedRuntimes)
+
+	// 9. Control socket for CLI clients.
+	socketPath := filepath.Join(dataDir, "daemon.sock")
+	tokenPath := filepath.Join(dataDir, "daemon.token")
+	ctrlSrv, err := ipc.NewControlServer(socketPath, tokenPath, reg, eng, localSecrets, version, log)
+	if err != nil {
+		return fmt.Errorf("build control server: %w", err)
+	}
+
+	// 10. Run everything concurrently.
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error { return rec.Run(ctx) })
+	g.Go(func() error { return eng.Start(ctx) })
+	g.Go(func() error { return srv.Start(ctx) })
+	g.Go(func() error { return ctrlSrv.Start(ctx) })
+
+	// 11. System tray (optional).
+	trayEnabled := cfg.Server.Tray == nil || *cfg.Server.Tray
+	if trayEnabled {
+		g.Go(func() error {
+			tray.Run(ctx, cancel, port, log)
+			return nil
+		})
+	}
+
+	return g.Wait()
+}
+
+func buildRuntimes(
+	_ context.Context,
+	cfg *config.Config,
+	reg *registry.Registry,
+	secretsChain secrets.Chain,
+	database db.DB,
+	log *zap.Logger,
+	gateway *ipc.Gateway,
+) ([]pkgruntime.ManagedRuntime, *trigger.Engine, error) {
+	denoRT, err := denoruntime.New(reg, secretsChain, database, log)
+	if err != nil {
+		return nil, nil, fmt.Errorf("init deno runtime: %w", err)
+	}
+	eng := trigger.New(reg, denoRT, log)
+	denoRT.SetEngine(eng)
+	denoRT.SetGateway(gateway)
+	aiAPIKey := cfg.AI.APIKey
+	if aiAPIKey == "" && cfg.AI.APIKeyEnv != "" {
+		aiAPIKey = os.Getenv(cfg.AI.APIKeyEnv)
+	}
+	denoRT.SetAIConfig(cfg.AI.BaseURL, cfg.AI.Model, aiAPIKey)
+	if cfg.Defaults.OnFailureChain != "" {
+		eng.SetDefaultsOnFailureChain(cfg.Defaults.OnFailureChain)
+	}
+	if p := cfg.Notifications.Provider; p != nil {
+		eng.SetNotifier(notify.NewNotifier(p.Type, p.URL, p.Topic, p.TokenEnv))
+	}
+	eng.SetNotifyDefaults(cfg.Notifications.NotifyOnSuccess(), cfg.Notifications.NotifyOnFailure())
+
+	var managed []pkgruntime.ManagedRuntime
+	managed = append(managed, denoRT)
+
+	if rc, ok := cfg.Runtimes["deno"]; ok && rc.Version != "" {
+		if denoRT.IsInstalled(rc.Version) {
+			if p, err := denoRT.BinaryPath(rc.Version); err == nil {
+				eng.RegisterExecutor(task.RuntimeDeno, denoRT.NewExecutor(p))
+			}
+		}
+	}
+
+	eng.RegisterExecutor(task.RuntimeDocker, dockerruntime.New(reg, log))
+
+	podmanMgr := podmanruntime.New(reg, log)
+	managed = append(managed, podmanMgr)
+	if podmanMgr.IsInstalled("") {
+		if p, err := podmanMgr.BinaryPath(""); err == nil {
+			eng.RegisterExecutor(task.RuntimePodman, podmanMgr.NewExecutor(p))
+			log.Info("podman runtime registered", zap.String("path", p))
+		}
+	}
+
+	pythonMgr, err := pythonruntime.New(reg, secretsChain, database, log)
+	if err != nil {
+		log.Fatal("python runtime init", zap.Error(err))
+	}
+	pythonMgr.SetGateway(gateway)
+	managed = append(managed, pythonMgr)
+
+	if rc, ok := cfg.Runtimes["python"]; ok && !rc.Disabled {
+		ver := rc.Version
+		if ver == "" {
+			ver = pythonMgr.DefaultVersion()
+		}
+		if pythonMgr.IsInstalled(ver) {
+			if p, err := pythonMgr.BinaryPath(ver); err == nil {
+				eng.RegisterExecutor(task.Runtime("python"), pythonMgr.NewExecutor(p))
+				log.Info("python runtime registered", zap.String("version", ver))
+			}
+		} else {
+			log.Info("python runtime configured but not installed", zap.String("version", ver))
+		}
+	}
+
+	return managed, eng, nil
+}
+
+func buildSecretsChain(cfg *config.Config, dataDir string, database db.DB, log *zap.Logger) (secrets.Chain, secrets.Manager) {
+	var chain secrets.Chain
+	var localProvider secrets.Manager
+
+	for _, p := range cfg.Secrets.Providers {
+		switch p.Type {
+		case "local":
+			sdb := secrets.NewSQLiteSecretDB(database)
+			lp, err := secrets.NewLocalProvider(dataDir, sdb)
+			if err != nil {
+				log.Warn("local secrets provider init failed", zap.Error(err))
+				continue
+			}
+			chain = append(chain, lp)
+			if localProvider == nil {
+				localProvider = lp
+			}
+		case "env", "":
+			chain = append(chain, secrets.NewEnvProvider())
+		}
+	}
+	if len(chain) == 0 {
+		sdb := secrets.NewSQLiteSecretDB(database)
+		if lp, err := secrets.NewLocalProvider(dataDir, sdb); err == nil {
+			chain = append(chain, lp)
+			localProvider = lp
+		}
+		chain = append(chain, secrets.NewEnvProvider())
+	}
+	return chain, localProvider
+}
+
+func buildSources(cfg *config.Config, dataDir string, log *zap.Logger) ([]source.Source, *webui.SourceManager, error) {
+	tasksetSources := make(map[string]*taskset.Source)
+	var sources []source.Source
+
+	for _, sc := range cfg.Sources {
+		if sc.Name != "" || sc.EntryPath != "" {
+			ts, err := buildTaskSetSource(sc, dataDir, log)
+			if err != nil {
+				return nil, nil, err
+			}
+			sources = append(sources, ts)
+			tasksetSources[sourceNameFor(sc)] = ts
+			continue
+		}
+		switch sc.Type {
+		case config.SourceTypeLocal:
+			s, err := local.New(sc.Path, sc.Path, log)
+			if err != nil {
+				return nil, nil, fmt.Errorf("local source %q: %w", sc.Path, err)
+			}
+			sources = append(sources, s)
+		case config.SourceTypeGit:
+			gs, err := gitSource.New(dataDir, sc.URL, sc.Branch, sc.PollInterval, sc.Auth.TokenEnv, sc.Auth.SSHKey, log)
+			if err != nil {
+				return nil, nil, fmt.Errorf("git source %q: %w", sc.URL, err)
+			}
+			sources = append(sources, gs)
+		default:
+			return nil, nil, fmt.Errorf("unknown source type %q", sc.Type)
+		}
+	}
+
+	sourceMgr := webui.NewSourceManager(cfg, tasksetSources, dataDir, log)
+	return sources, sourceMgr, nil
+}
+
+func sourceNameFor(sc config.SourceConfig) string {
+	if sc.Name != "" {
+		return sc.Name
+	}
+	base := sc.URL
+	if base == "" {
+		base = sc.Path
+	}
+	base = strings.TrimRight(base, "/")
+	name := filepath.Base(base)
+	if ext := filepath.Ext(name); ext == ".yaml" || ext == ".yml" {
+		name = strings.TrimSuffix(name, ext)
+	}
+	return name
+}
+
+func buildTaskSetSource(sc config.SourceConfig, dataDir string, log *zap.Logger) (*taskset.Source, error) {
+	namespace := sc.Name
+	if namespace == "" {
+		base := sc.URL
+		if base == "" {
+			base = sc.Path
+		}
+		base = strings.TrimRight(base, "/")
+		namespace = filepath.Base(base)
+		if ext := filepath.Ext(namespace); ext == ".yaml" || ext == ".yml" {
+			namespace = strings.TrimSuffix(namespace, ext)
+		}
+	}
+
+	var rootRef *taskset.Ref
+	if sc.URL != "" {
+		entryPath := sc.EntryPath
+		if entryPath == "" {
+			entryPath = "taskset.yaml"
+		}
+		rootRef = &taskset.Ref{
+			URL:          sc.URL,
+			Branch:       sc.Branch,
+			Path:         entryPath,
+			PollInterval: sc.PollInterval,
+			Auth:         taskset.RefAuth{TokenEnv: sc.Auth.TokenEnv, SSHKey: sc.Auth.SSHKey},
+		}
+	} else {
+		entryPath := sc.Path
+		if sc.EntryPath != "" {
+			entryPath = sc.EntryPath
+		}
+		rootRef = &taskset.Ref{Path: entryPath}
+	}
+
+	id := sc.URL
+	if id == "" {
+		id = sc.Path
+	}
+	return taskset.NewSource(id, namespace, rootRef, sc.ConfigPath, dataDir, false, sc.PollInterval, log), nil
+}
+
+func buildLogger(level string, broadcast *webui.LogBroadcaster) (*zap.Logger, error) {
+	zapLevel := zapcore.InfoLevel
+	if level == "debug" {
+		zapLevel = zapcore.DebugLevel
+	}
+	enc := zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
+	core := zapcore.NewTee(
+		zapcore.NewCore(enc, zapcore.AddSync(os.Stderr), zapLevel),
+		zapcore.NewCore(enc, zapcore.AddSync(broadcast), zapLevel),
+	)
+	return zap.New(core, zap.AddCaller()), nil
+}

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -1,6 +1,6 @@
 # Current State
 
-> Last updated: 2026-04-01 — Agent globals (`dicode`, `mcp`) added to Deno + Python shims; `SecurityConfig` + `MCPPort` + `OnFailureChain` in `task.Spec`; `EngineRunner` interface for cross-package orchestration; `pkg/mcp/client` HTTP JSON-RPC 2.0 client; `defaults.on_failure_chain` in config; Python `dicode_sdk.py` shim; example tasks: `ai-agent`, `task-creator`, `failure-monitor`
+> Last updated: 2026-04-03 — Daemon/CLI split: `cmd/dicoded` (daemon) + `cmd/dicode` (CLI); `pkg/ipc` gains `ControlServer` + `ControlClient` (persistent control socket at `~/.dicode/daemon.sock`); `pkg/relay` deleted; `pkg/secrets.Manager` interface; `make run` now starts `dicoded`
 
 This document describes exactly what exists in the codebase today — what is fully implemented, what is stubbed with interfaces and TODOs, and what exists only as documentation.
 
@@ -53,7 +53,7 @@ Full configuration loading. All structs defined and validated:
 
 ### `pkg/secrets/` ✅
 
-- `provider.go` — `Provider` interface, `Chain`, `ResolveAll()`, `NotFoundError`
+- `provider.go` — `Provider` interface, `Chain`, `ResolveAll()`, `NotFoundError`; **`Manager` interface** (`List`, `Set`, `Delete`) — satisfied by `*LocalProvider`, used by `ControlServer` and `pkg/webui` (`SecretsManager = secrets.Manager` type alias)
 - `env.go` — `EnvProvider` (reads host env vars)
 - `local.go` — `LocalProvider` — ChaCha20-Poly1305 + Argon2id, master key management
 - `localdb.go` — `SQLiteSecretDB` — sqlite-backed Set/Get/Delete/List
@@ -92,10 +92,9 @@ Full TaskSet architecture — hierarchical task composition inspired by ArgoCD A
 - `skill.go` — `//go:embed skill.md` + exported `Skill` string
 - `skill.md` — complete agent skill document (workflow, rules, globals reference, test format, common mistakes)
 
-### `pkg/relay/` 🟡
+### `pkg/relay/` ❌ deleted
 
-- `relay.go` — `Client` struct, `Start()`, `WebhookURL()`, `WebhookHandler` type
-- WebSocket tunnel logic — **not yet implemented**
+Removed in PR #56. The HTTP gateway in `pkg/ipc/` replaced all relay functionality.
 
 ### `pkg/service/` 🟡
 
@@ -191,18 +190,25 @@ Full TaskSet architecture — hierarchical task composition inspired by ArgoCD A
 
 ### `pkg/ipc/` ✅
 
-Unified IPC protocol replacing the old per-runtime `pkg/runtime/deno/server/`.
+Unified IPC protocol replacing the old per-runtime `pkg/runtime/deno/server/`. Two socket types:
 
-- **Wire format**: 4-byte little-endian length prefix + JSON payload (replaces newline-delimited JSON — correctly handles multi-line messages)
+**Task shim sockets** (per-run, temporary):
+
+- **Wire format**: 4-byte little-endian length prefix + JSON payload
 - **Handshake**: client sends `{"token":"<DICODE_TOKEN>"}`, server validates HMAC-signed token and replies `{"proto":1,"caps":[...]}`
-- **Capability tokens**: HMAC-SHA256 signed, scoped to a specific run ID. Task shims get `log`, `params.read`, `input.read`, `kv.read`, `kv.write`, `output.write`, `return`, `tasks.list`, `runs.list`, `config.read`; additionally `tasks.trigger` if `security.allowed_tasks` is set; `mcp.call` if `security.allowed_mcp` is set
+- **Capability tokens**: HMAC-SHA256 signed, scoped to a specific run ID. Task shims get `log`, `params.read`, `input.read`, `kv.read`, `kv.write`, `output.write`, `return`, `tasks.list`, `runs.list`, `config.read`; additionally `tasks.trigger` / `mcp.call` based on security config; `http.register` for daemon tasks
 - `server.go` — `Server` struct; `Start()` returns `(socketPath, token, error)`. Dispatcher enforces capability checks before every handler
-- `token.go` — `IssueToken` / `VerifyToken` (HMAC-SHA256); `NewSecret()` generates per-runtime random secret
-- `conn.go` — `readMsg` / `writeMsg` (length-prefix framing)
-- `capability.go` — capability constants; `defaultTaskCaps()`
-- `message.go` — `Request`, `Response`, `OutputResult`, `EngineRunner`, `RunResult` types (moved from `pkg/runtime/deno/server/`)
-- Methods: all 15 from the old server plus structured capability enforcement on each
-- `EngineRunner` interface lives here (breaks trigger ↔ runtime import cycle)
+- `gateway.go` — `Gateway` HTTP dispatch layer: priority-ordered pattern routing (longest-prefix wins). Two handler types: Go handlers (webhook tasks) and IPC handlers (daemon tasks via `http.register`). `ipcHandler` bridges HTTP requests to open IPC connections via `HTTPInboundRequest` push + `http.respond` reply
+- `token.go` — `IssueToken` / `IssueTokenWithTTL` / `VerifyToken` (HMAC-SHA256); `NewSecret()`
+- `conn.go` — `readMsg` / `writeMsg` (length-prefix framing) with outbound size guard (8 MiB)
+- `capability.go` — capability constants; `defaultTaskCaps()`; **`CapCLI*` constants** + `cliCaps()` for control socket clients
+- `message.go` — `Request`, `Response`, `OutputResult`, `EngineRunner`, `RunResult`, `HTTPInboundRequest`, **`TaskSummary`**, **`LogEntry`**, **`DaemonStatus`** types
+
+**Control socket** (persistent, daemon-lifetime):
+
+- `control.go` — **`ControlServer`**: listens at `~/.dicode/daemon.sock` (mode 0600). On startup writes a pre-issued CLI token to `~/.dicode/daemon.token` (mode 0600, atomic write). Handles `cli.ping`, `cli.list`, `cli.run`, `cli.logs`, `cli.status`, `cli.secrets.{list,set,delete}`. Context-aware: per-connection context cancels in-flight `cli.run` on client disconnect. CLI tokens use `tokenCLITTL` (~10 years) — daemon restart re-issues anyway
+- `control_client.go` — **`ControlClient`**: `Dial(socketPath, tokenPath)` → `Send(req)` → `Close()`. Handshake decodes a union struct covering both success (`proto`) and error (`error`) envelopes
+
 - `pkg/runtime/deno/server/` **deleted** — both Deno and Python runtimes now import `pkg/ipc`
 
 ### `pkg/runtime/deno/sdk/shim.js` ✅
@@ -222,17 +228,24 @@ Injected before every Python task script via `buildWrapper()`. Updated for unifi
 - `kv.get_async`, `kv.set_async`, `kv.list_async` variants for async task bodies
 - Globals: `log`, `params`, `env`, `kv`, `input`, `output`, **`dicode`**, **`mcp`**
 
-### `cmd/dicode/main.go` ✅
+### `cmd/dicoded/main.go` ✅ (daemon binary)
 
-- Full component wiring: db → secrets → registry → Deno runtime → Docker/Podman/Python runtimes → trigger engine → reconciler → webui → tray
-- `denoRT.SetEngine(eng)` — wires the trigger engine into the Deno runtime for `dicode.run_task` support
-- `denoRT.SetAIConfig(baseURL, model, apiKey)` — resolves `ai.api_key_env` and passes config to socket server for `dicode.get_config("ai")`
-- `pythonRT` receives the same engine + AI config wiring via `SetEngine` / `SetAIConfig`
-- `eng.SetDefaultsOnFailureChain(id)` — set when `defaults.on_failure_chain` is present in config
-- `buildSources()` returns `([]source.Source, *webui.SourceManager, error)` — builds both the source slice and the `SourceManager` for dev mode control
-- `buildTaskSetSource()` returns `*taskset.Source` so it can be stored in the source map for runtime dev mode control
-- Startup sequence: `CleanupOrphanedContainers` → `CleanupStaleRuns` → register tasks → `engine.Start`
-- `db.DB` passed to `webui.New()` for persistent sessions and API key storage
+The full daemon process — extracted from the old monolith. Starts all long-running components:
+
+- Full component wiring: db → secrets → registry → Deno runtime → Docker/Podman/Python runtimes → trigger engine → reconciler → HTTP gateway → webui → control socket → tray
+- `NewControlServer(socketPath, tokenPath, ...)` — creates the CLI control socket and writes `daemon.token`
+- `buildSecretsChain(cfg, dataDir, database, log)` returns `(secrets.Chain, secrets.Manager)` — the `Manager` is passed to both `webui.New()` and `NewControlServer()`
+- Startup sequence: `CleanupOrphanedContainers` → `CleanupStaleRuns` → build runtimes → build sources → build webui → build control socket → run errgroup (reconciler + engine + webui + control socket + tray)
+- `make run` builds and starts this binary
+
+### `cmd/dicode/main.go` ✅ (CLI binary)
+
+Thin command dispatcher — no runtime or database initialisation:
+
+- Subcommands: `run <task-id> [key=value ...]`, `list`, `logs <run-id>`, `status [task-id]`, `secrets {list,set,delete}`, `version`
+- **Auto-start**: if `~/.dicode/daemon.sock` is not connectable, locates `dicoded` (next to `dicode` binary, then `$PATH`), starts it in the background, redirects stderr to `~/.dicode/daemon.log`, polls for the socket (8 second timeout)
+- Reads `~/.dicode/daemon.token` and calls `ipc.Dial()` to connect
+- `DICODE_DATA_DIR` env var overrides the default data directory
 
 ### `examples/` ✅
 
@@ -287,8 +300,20 @@ Injected before every Python task script via `buildWrapper()`. Updated for unifi
 
 ---
 
+## Build
+
+```bash
+make build   # compiles both ./dicode (CLI) and ./dicoded (daemon)
+make run     # builds and starts dicoded — web UI on :8080, control socket at ~/.dicode/daemon.sock
+make test    # go test ./...
+make lint    # go fmt + go vet
+make clean   # removes both binaries
+```
+
+---
+
 ## Test coverage
 
-94+ tests across: db, secrets, source/local, registry, runtime/js, trigger (including HMAC), taskset, and webui (including auth) packages.
+94+ tests across: db, secrets, source/local, registry, runtime/js, trigger (including HMAC), taskset, ipc (including gateway + control socket), and webui (including auth) packages.
 
-All packages compile with `go test -race ./...` as of 2026-03-30.
+All packages compile with `go test -race ./...` as of 2026-04-03.

--- a/pkg/ipc/capability.go
+++ b/pkg/ipc/capability.go
@@ -43,7 +43,25 @@ const (
 	CapHTTPRegister  = "http.register" // register HTTP handler routes (issue #54)
 	CapSourcesManage = "sources.manage"
 	CapSecretsWrite  = "secrets.write"
+
+	// CLI capabilities — granted to dicode CLI clients on the control socket.
+	CapCLIRun     = "cli.run"     // trigger a task run and stream its output
+	CapCLIList    = "cli.list"    // list tasks and their last-run status
+	CapCLILogs    = "cli.logs"    // fetch log entries for a run
+	CapCLIStatus  = "cli.status"  // daemon health and uptime
+	CapCLISecrets = "cli.secrets" // list / set / delete secrets
 )
+
+// cliCaps is the full capability set granted to every CLI client.
+func cliCaps() []string {
+	return []string{
+		CapCLIRun,
+		CapCLIList,
+		CapCLILogs,
+		CapCLIStatus,
+		CapCLISecrets,
+	}
+}
 
 // defaultTaskCaps returns the base capability set granted to every task shim token.
 func defaultTaskCaps() []string {

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/dicode/dicode/pkg/registry"
@@ -37,10 +36,6 @@ type ControlServer struct {
 
 	startedAt time.Time
 	version   string
-
-	listener net.Listener
-	mu       sync.Mutex
-	done     chan struct{}
 }
 
 // NewControlServer creates a ControlServer. Call Start to begin accepting
@@ -69,11 +64,11 @@ func NewControlServer(
 		log:        log,
 		startedAt:  time.Now(),
 		version:    version,
-		done:       make(chan struct{}),
 	}
 
-	// Issue the CLI token and write it atomically.
-	tok, err := IssueToken(secret, "cli", "cli", cliCaps())
+	// Issue the CLI token with a long TTL — the daemon re-issues on every restart,
+	// so expiry is not the right protection mechanism here.
+	tok, err := IssueTokenWithTTL(secret, "cli", "cli", cliCaps(), tokenCLITTL)
 	if err != nil {
 		return nil, fmt.Errorf("control: issue token: %w", err)
 	}
@@ -112,16 +107,11 @@ func (cs *ControlServer) Start(ctx context.Context) error {
 		ln.Close()
 		return fmt.Errorf("control: chmod socket: %w", err)
 	}
-	cs.mu.Lock()
-	cs.listener = ln
-	cs.mu.Unlock()
-
 	cs.log.Info("control socket ready", zap.String("path", cs.socketPath))
 
 	go func() {
 		<-ctx.Done()
 		ln.Close()
-		close(cs.done)
 		_ = os.Remove(cs.socketPath)
 		_ = os.Remove(cs.tokenPath)
 	}()
@@ -129,20 +119,18 @@ func (cs *ControlServer) Start(ctx context.Context) error {
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
-			select {
-			case <-cs.done:
-				return nil
-			default:
-				cs.log.Warn("control: accept error", zap.Error(err))
-				continue
+			if ctx.Err() != nil {
+				return nil // clean shutdown
 			}
+			cs.log.Warn("control: accept error", zap.Error(err))
+			continue
 		}
-		go cs.handleConn(conn)
+		go cs.handleConn(ctx, conn)
 	}
 }
 
 // handleConn runs the handshake and then the request loop for one CLI client.
-func (cs *ControlServer) handleConn(conn net.Conn) {
+func (cs *ControlServer) handleConn(ctx context.Context, conn net.Conn) {
 	defer conn.Close()
 
 	// Handshake — 5-second deadline.
@@ -159,6 +147,11 @@ func (cs *ControlServer) handleConn(conn net.Conn) {
 	_ = writeMsg(conn, handshakeResp{Proto: 1, Caps: claims.Caps})
 	_ = conn.SetDeadline(time.Time{})
 
+	// Derive a per-connection context so that when the client disconnects,
+	// in-flight requests (e.g. cli.run) can be cancelled.
+	connCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	// Request loop.
 	for {
 		var req Request
@@ -168,7 +161,7 @@ func (cs *ControlServer) handleConn(conn net.Conn) {
 		if req.ID == "" {
 			continue // fire-and-forget not used on control socket
 		}
-		result, rerr := cs.dispatch(req)
+		result, rerr := cs.dispatch(connCtx, req)
 		resp := Response{ID: req.ID}
 		if rerr != nil {
 			resp.Error = rerr.Error()
@@ -181,8 +174,7 @@ func (cs *ControlServer) handleConn(conn net.Conn) {
 	}
 }
 
-func (cs *ControlServer) dispatch(req Request) (any, error) {
-	ctx := context.Background()
+func (cs *ControlServer) dispatch(ctx context.Context, req Request) (any, error) {
 	switch req.Method {
 	case "cli.ping":
 		return cs.handlePing(), nil
@@ -223,6 +215,7 @@ func (cs *ControlServer) handlePing() DaemonStatus {
 }
 
 func (cs *ControlServer) handleList() ([]TaskSummary, error) {
+	ctx := context.Background()
 	specs := cs.reg.All()
 	out := make([]TaskSummary, 0, len(specs))
 	for _, s := range specs {
@@ -231,6 +224,14 @@ func (cs *ControlServer) handleList() ([]TaskSummary, error) {
 			Name:        s.Name,
 			Description: s.Description,
 			Trigger:     triggerLabel(s),
+		}
+		if runs, err := cs.reg.ListRuns(ctx, s.ID, 1); err == nil && len(runs) > 0 {
+			r := runs[0]
+			summary.LastStatus = r.Status
+			summary.LastRunID = r.ID
+			if !r.StartedAt.IsZero() {
+				summary.LastRunAt = r.StartedAt.UTC().Format(time.RFC3339)
+			}
 		}
 		out = append(out, summary)
 	}

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -1,0 +1,332 @@
+package ipc
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/secrets"
+	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
+)
+
+// ControlServer is the daemon's persistent control socket. It listens at a
+// fixed path (dataDir/daemon.sock) and accepts connections from the dicode CLI.
+//
+// Each CLI client authenticates with a pre-shared token that the daemon writes
+// to dataDir/daemon.token on startup. The token is signed with a per-run secret
+// (same HMAC machinery as task shim tokens) and grants the full cliCaps() set.
+type ControlServer struct {
+	socketPath string
+	tokenPath  string
+	secret     []byte // HMAC key, generated on New
+	token      string // pre-issued CLI token written to tokenPath
+
+	reg     *registry.Registry
+	engine  EngineRunner
+	secrets secrets.Manager // nil if no local provider configured
+	log     *zap.Logger
+
+	startedAt time.Time
+	version   string
+
+	listener net.Listener
+	mu       sync.Mutex
+	done     chan struct{}
+}
+
+// NewControlServer creates a ControlServer. Call Start to begin accepting
+// connections. socketPath is the Unix socket path; tokenPath is where the CLI
+// token is written.
+func NewControlServer(
+	socketPath, tokenPath string,
+	reg *registry.Registry,
+	engine EngineRunner,
+	secretsMgr secrets.Manager,
+	version string,
+	log *zap.Logger,
+) (*ControlServer, error) {
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		return nil, fmt.Errorf("control: generate secret: %w", err)
+	}
+
+	cs := &ControlServer{
+		socketPath: socketPath,
+		tokenPath:  tokenPath,
+		secret:     secret,
+		reg:        reg,
+		engine:     engine,
+		secrets:    secretsMgr,
+		log:        log,
+		startedAt:  time.Now(),
+		version:    version,
+		done:       make(chan struct{}),
+	}
+
+	// Issue the CLI token and write it atomically.
+	tok, err := IssueToken(secret, "cli", "cli", cliCaps())
+	if err != nil {
+		return nil, fmt.Errorf("control: issue token: %w", err)
+	}
+	cs.token = tok
+	if err := writeTokenFile(tokenPath, tok); err != nil {
+		return nil, fmt.Errorf("control: write token file: %w", err)
+	}
+	return cs, nil
+}
+
+// writeTokenFile writes the token to path atomically (tmp + rename, mode 0600).
+func writeTokenFile(path, token string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(token), 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// Start begins accepting connections. It removes any stale socket file first.
+// Run blocks until ctx is cancelled.
+func (cs *ControlServer) Start(ctx context.Context) error {
+	_ = os.Remove(cs.socketPath)
+	if err := os.MkdirAll(filepath.Dir(cs.socketPath), 0700); err != nil {
+		return fmt.Errorf("control: mkdir: %w", err)
+	}
+
+	ln, err := net.Listen("unix", cs.socketPath)
+	if err != nil {
+		return fmt.Errorf("control: listen: %w", err)
+	}
+	if err := os.Chmod(cs.socketPath, 0600); err != nil {
+		ln.Close()
+		return fmt.Errorf("control: chmod socket: %w", err)
+	}
+	cs.mu.Lock()
+	cs.listener = ln
+	cs.mu.Unlock()
+
+	cs.log.Info("control socket ready", zap.String("path", cs.socketPath))
+
+	go func() {
+		<-ctx.Done()
+		ln.Close()
+		close(cs.done)
+		_ = os.Remove(cs.socketPath)
+		_ = os.Remove(cs.tokenPath)
+	}()
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			select {
+			case <-cs.done:
+				return nil
+			default:
+				cs.log.Warn("control: accept error", zap.Error(err))
+				continue
+			}
+		}
+		go cs.handleConn(conn)
+	}
+}
+
+// handleConn runs the handshake and then the request loop for one CLI client.
+func (cs *ControlServer) handleConn(conn net.Conn) {
+	defer conn.Close()
+
+	// Handshake — 5-second deadline.
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+	var hs handshakeReq
+	if err := readMsg(conn, &hs); err != nil {
+		return
+	}
+	claims, err := VerifyToken(cs.secret, hs.Token)
+	if err != nil || claims.Identity != "cli" {
+		_ = writeMsg(conn, handshakeErr{Error: "invalid token"})
+		return
+	}
+	_ = writeMsg(conn, handshakeResp{Proto: 1, Caps: claims.Caps})
+	_ = conn.SetDeadline(time.Time{})
+
+	// Request loop.
+	for {
+		var req Request
+		if err := readMsg(conn, &req); err != nil {
+			return
+		}
+		if req.ID == "" {
+			continue // fire-and-forget not used on control socket
+		}
+		result, rerr := cs.dispatch(req)
+		resp := Response{ID: req.ID}
+		if rerr != nil {
+			resp.Error = rerr.Error()
+		} else {
+			resp.Result = result
+		}
+		if err := writeMsg(conn, resp); err != nil {
+			return
+		}
+	}
+}
+
+func (cs *ControlServer) dispatch(req Request) (any, error) {
+	ctx := context.Background()
+	switch req.Method {
+	case "cli.ping":
+		return cs.handlePing(), nil
+
+	case "cli.list":
+		return cs.handleList()
+
+	case "cli.run":
+		return cs.handleRun(ctx, req)
+
+	case "cli.logs":
+		return cs.handleLogs(ctx, req)
+
+	case "cli.status":
+		return cs.handleStatus(ctx, req)
+
+	case "cli.secrets.list":
+		return cs.handleSecretsList(ctx)
+
+	case "cli.secrets.set":
+		return nil, cs.handleSecretsSet(ctx, req)
+
+	case "cli.secrets.delete":
+		return nil, cs.handleSecretsDelete(ctx, req)
+
+	default:
+		return nil, fmt.Errorf("unknown method: %s", req.Method)
+	}
+}
+
+func (cs *ControlServer) handlePing() DaemonStatus {
+	all := cs.reg.All()
+	return DaemonStatus{
+		Version:   cs.version,
+		UptimeSec: int64(time.Since(cs.startedAt).Seconds()),
+		TaskCount: len(all),
+	}
+}
+
+func (cs *ControlServer) handleList() ([]TaskSummary, error) {
+	specs := cs.reg.All()
+	out := make([]TaskSummary, 0, len(specs))
+	for _, s := range specs {
+		summary := TaskSummary{
+			ID:          s.ID,
+			Name:        s.Name,
+			Description: s.Description,
+			Trigger:     triggerLabel(s),
+		}
+		out = append(out, summary)
+	}
+	return out, nil
+}
+
+func (cs *ControlServer) handleRun(ctx context.Context, req Request) (RunResult, error) {
+	if req.TaskID == "" {
+		return RunResult{}, errors.New("taskID required")
+	}
+	var params map[string]string
+	if req.Params != nil {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return RunResult{}, fmt.Errorf("params: %w", err)
+		}
+	}
+	runID, err := cs.engine.FireManual(ctx, req.TaskID, params)
+	if err != nil {
+		return RunResult{}, err
+	}
+	return cs.engine.WaitRun(ctx, runID)
+}
+
+func (cs *ControlServer) handleLogs(ctx context.Context, req Request) ([]LogEntry, error) {
+	if req.RunID == "" {
+		return nil, errors.New("runID required")
+	}
+	entries, err := cs.reg.GetRunLogs(ctx, req.RunID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]LogEntry, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, LogEntry{
+			RunID:     e.RunID,
+			Timestamp: e.Ts.UTC().Format(time.RFC3339),
+			Level:     e.Level,
+			Message:   e.Message,
+		})
+	}
+	return out, nil
+}
+
+func (cs *ControlServer) handleStatus(ctx context.Context, req Request) (any, error) {
+	if req.TaskID == "" {
+		return cs.handlePing(), nil
+	}
+	// Return the latest run for the given task.
+	runs, err := cs.reg.ListRuns(ctx, req.TaskID, 1)
+	if err != nil {
+		return nil, err
+	}
+	if len(runs) == 0 {
+		return nil, fmt.Errorf("no runs found for task %q", req.TaskID)
+	}
+	return runs[0], nil
+}
+
+func (cs *ControlServer) handleSecretsList(ctx context.Context) ([]string, error) {
+	if cs.secrets == nil {
+		return nil, errors.New("no secrets provider configured")
+	}
+	return cs.secrets.List(ctx)
+}
+
+func (cs *ControlServer) handleSecretsSet(ctx context.Context, req Request) error {
+	if cs.secrets == nil {
+		return errors.New("no secrets provider configured")
+	}
+	if req.Key == "" {
+		return errors.New("key required")
+	}
+	return cs.secrets.Set(ctx, req.Key, req.StringValue)
+}
+
+func (cs *ControlServer) handleSecretsDelete(ctx context.Context, req Request) error {
+	if cs.secrets == nil {
+		return errors.New("no secrets provider configured")
+	}
+	if req.Key == "" {
+		return errors.New("key required")
+	}
+	return cs.secrets.Delete(ctx, req.Key)
+}
+
+// triggerLabel returns a human-readable trigger description for a task spec.
+func triggerLabel(s *task.Spec) string {
+	t := s.Trigger
+	switch {
+	case t.Cron != "":
+		return "cron:" + t.Cron
+	case t.Webhook != "":
+		return "webhook:" + t.Webhook
+	case t.Daemon:
+		return "daemon"
+	default:
+		return "manual"
+	}
+}

--- a/pkg/ipc/control_client.go
+++ b/pkg/ipc/control_client.go
@@ -1,0 +1,80 @@
+package ipc
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"time"
+)
+
+// ControlClient is a synchronous client for the daemon's control socket.
+// It connects, performs the handshake, and exposes a Send method for CLI
+// command dispatch. Each CLI invocation creates one client, sends one
+// request, and closes.
+type ControlClient struct {
+	conn net.Conn
+	caps []string
+}
+
+// Dial connects to the daemon control socket at socketPath and authenticates
+// using the token stored in tokenPath. Returns a ready-to-use ControlClient.
+func Dial(socketPath, tokenPath string) (*ControlClient, error) {
+	tok, err := os.ReadFile(tokenPath)
+	if err != nil {
+		return nil, fmt.Errorf("read token file %s: %w", tokenPath, err)
+	}
+
+	conn, err := net.DialTimeout("unix", socketPath, 5*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("connect to daemon at %s: %w", socketPath, err)
+	}
+
+	c := &ControlClient{conn: conn}
+	if err := c.handshake(string(tok)); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return c, nil
+}
+
+func (c *ControlClient) handshake(token string) error {
+	_ = c.conn.SetDeadline(time.Now().Add(5 * time.Second))
+	defer func() { _ = c.conn.SetDeadline(time.Time{}) }()
+
+	if err := writeMsg(c.conn, handshakeReq{Token: token}); err != nil {
+		return fmt.Errorf("handshake send: %w", err)
+	}
+
+	// Try success response first; fall back to error envelope.
+	var resp handshakeResp
+	if err := readMsg(c.conn, &resp); err != nil {
+		return fmt.Errorf("handshake recv: %w", err)
+	}
+	if resp.Proto == 0 {
+		// Server sent an error — re-read as handshakeErr.
+		// (We already consumed the bytes, so check via the zero Proto.)
+		return fmt.Errorf("handshake rejected by daemon")
+	}
+	c.caps = resp.Caps
+	return nil
+}
+
+// Send sends a single request to the daemon and returns the response.
+// The request ID is set automatically.
+func (c *ControlClient) Send(req Request) (Response, error) {
+	req.ID = "1"
+	if err := writeMsg(c.conn, req); err != nil {
+		return Response{}, fmt.Errorf("send: %w", err)
+	}
+	var resp Response
+	if err := readMsg(c.conn, &resp); err != nil {
+		return Response{}, fmt.Errorf("recv: %w", err)
+	}
+	return resp, nil
+}
+
+// Close closes the underlying connection.
+func (c *ControlClient) Close() error { return c.conn.Close() }
+
+// Caps returns the capability list granted by the daemon during handshake.
+func (c *ControlClient) Caps() []string { return c.caps }

--- a/pkg/ipc/control_client.go
+++ b/pkg/ipc/control_client.go
@@ -45,17 +45,23 @@ func (c *ControlClient) handshake(token string) error {
 		return fmt.Errorf("handshake send: %w", err)
 	}
 
-	// Try success response first; fall back to error envelope.
-	var resp handshakeResp
-	if err := readMsg(c.conn, &resp); err != nil {
+	// Decode into a struct that covers both the success and error envelopes.
+	// The server sends either {"proto":1,"caps":[...]} or {"error":"..."}.
+	var raw struct {
+		Proto int      `json:"proto"`
+		Caps  []string `json:"caps"`
+		Error string   `json:"error"`
+	}
+	if err := readMsg(c.conn, &raw); err != nil {
 		return fmt.Errorf("handshake recv: %w", err)
 	}
-	if resp.Proto == 0 {
-		// Server sent an error — re-read as handshakeErr.
-		// (We already consumed the bytes, so check via the zero Proto.)
-		return fmt.Errorf("handshake rejected by daemon")
+	if raw.Error != "" {
+		return fmt.Errorf("handshake rejected: %s", raw.Error)
 	}
-	c.caps = resp.Caps
+	if raw.Proto == 0 {
+		return fmt.Errorf("handshake: unexpected response from daemon (proto=0)")
+	}
+	c.caps = raw.Caps
 	return nil
 }
 

--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -62,6 +62,11 @@ type Request struct {
 	Status      int               `json:"status,omitempty"`
 	RespHeaders map[string]string `json:"respHeaders,omitempty"`
 	RespBody    []byte            `json:"respBody,omitempty"` // base64-encoded in JSON
+
+	// cli.* (control socket — CLI client commands)
+	RunID       string `json:"runID,omitempty"`
+	StringValue string `json:"stringValue,omitempty"` // cli.secrets.set value
+	Follow      bool   `json:"follow,omitempty"`      // cli.logs — reserved for streaming
 }
 
 // Response is an outbound message to a connected client.
@@ -98,6 +103,33 @@ type HTTPInboundRequest struct {
 	Query      string            `json:"query,omitempty"`
 	ReqHeaders map[string]string `json:"reqHeaders,omitempty"`
 	ReqBody    []byte            `json:"reqBody,omitempty"` // base64-encoded in JSON
+}
+
+// TaskSummary is a single row in the cli.list response.
+type TaskSummary struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Trigger     string `json:"trigger"`    // "manual" | "cron:..." | "webhook:..." | "daemon"
+	LastStatus  string `json:"lastStatus"` // "success" | "failure" | "running" | ""
+	LastRunID   string `json:"lastRunID"`  // "" if never run
+	LastRunAt   string `json:"lastRunAt"`  // RFC3339 or ""
+}
+
+// LogEntry is one log line returned by cli.logs.
+type LogEntry struct {
+	RunID     string `json:"runID"`
+	Timestamp string `json:"timestamp"` // RFC3339
+	Level     string `json:"level"`
+	Message   string `json:"message"`
+}
+
+// DaemonStatus is the cli.status response.
+type DaemonStatus struct {
+	Version   string `json:"version"`
+	UptimeSec int64  `json:"uptimeSec"`
+	TaskCount int    `json:"taskCount"`
+	RunCount  int    `json:"runCount"` // runs in the last 24h
 }
 
 // RunResult is returned by EngineRunner.WaitRun.

--- a/pkg/ipc/token.go
+++ b/pkg/ipc/token.go
@@ -12,7 +12,10 @@ import (
 	"time"
 )
 
-const tokenTTL = 24 * time.Hour
+const (
+	tokenTTL    = 24 * time.Hour
+	tokenCLITTL = 10 * 365 * 24 * time.Hour // CLI tokens are valid for ~10 years; daemon restart re-issues anyway
+)
 
 // tokenClaims is the payload embedded in a capability token.
 type tokenClaims struct {
@@ -25,11 +28,20 @@ type tokenClaims struct {
 // IssueToken creates a signed capability token for the given identity and caps.
 // secret is a per-daemon random secret; runID ties the token to a specific run.
 func IssueToken(secret []byte, identity, runID string, caps []string) (string, error) {
+	return issueToken(secret, identity, runID, caps, tokenTTL)
+}
+
+// IssueTokenWithTTL is like IssueToken but with an explicit TTL.
+func IssueTokenWithTTL(secret []byte, identity, runID string, caps []string, ttl time.Duration) (string, error) {
+	return issueToken(secret, identity, runID, caps, ttl)
+}
+
+func issueToken(secret []byte, identity, runID string, caps []string, ttl time.Duration) (string, error) {
 	claims := tokenClaims{
 		Identity: identity,
 		RunID:    runID,
 		Caps:     caps,
-		Exp:      time.Now().Add(tokenTTL).Unix(),
+		Exp:      time.Now().Add(ttl).Unix(),
 	}
 	payload, err := json.Marshal(claims)
 	if err != nil {

--- a/pkg/secrets/provider.go
+++ b/pkg/secrets/provider.go
@@ -58,6 +58,14 @@ func (c Chain) ResolveAll(ctx context.Context, keys []string) (map[string]string
 	return out, nil
 }
 
+// Manager is implemented by secret stores that support full CRUD operations
+// (list, set, delete). Satisfied by *LocalProvider.
+type Manager interface {
+	List(ctx context.Context) ([]string, error)
+	Set(ctx context.Context, key, value string) error
+	Delete(ctx context.Context, key string) error
+}
+
 // NotFoundError is returned when no provider in the chain has the requested key.
 type NotFoundError struct {
 	Key string

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dicode/dicode/pkg/mcp"
 	"github.com/dicode/dicode/pkg/registry"
 	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+	"github.com/dicode/dicode/pkg/secrets"
 	gitSource "github.com/dicode/dicode/pkg/source/git"
 	"github.com/dicode/dicode/pkg/source/local"
 	"github.com/dicode/dicode/pkg/task"
@@ -34,12 +35,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// SecretsManager is the interface the secrets UI uses — satisfied by *secrets.LocalProvider.
-type SecretsManager interface {
-	List(ctx context.Context) ([]string, error)
-	Set(ctx context.Context, key, value string) error
-	Delete(ctx context.Context, key string) error
-}
+// SecretsManager is an alias for secrets.Manager kept for call-site clarity.
+type SecretsManager = secrets.Manager
 
 // sessionStore holds in-memory session tokens for the secrets page.
 type sessionStore struct {


### PR DESCRIPTION
## Summary

- **** — new daemon binary; extracted from the monolith. Runs the task engine, reconciler, runtimes, HTTP gateway, web UI server, and the persistent control socket at `~/.dicode/daemon.sock`
- **** — stripped to a thin CLI. Subcommands: `run`, `list`, `logs`, `status`, `secrets {list,set,delete}`, `version`. Auto-starts `dicoded` in the background if the socket is absent
- **`pkg/ipc/control.go`** — `ControlServer`: persistent Unix socket, HMAC handshake, dispatches `cli.*` methods
- **`pkg/ipc/control_client.go`** — `ControlClient`: `Dial(socketPath, tokenPath)` → `Send(req)` → `Close()`
- **`pkg/ipc/capability.go`** — `CapCLI*` constants and `cliCaps()` helper
- **`pkg/ipc/message.go`** — `TaskSummary`, `LogEntry`, `DaemonStatus` response types; `RunID`, `StringValue`, `Follow` fields on `Request`
- **`pkg/secrets/provider.go`** — `Manager` interface moved here from `pkg/webui` to avoid an import cycle (`webui → ipc → secrets`)
- **`pkg/webui/server.go`** — `SecretsManager = secrets.Manager` type alias; no behaviour change

## What's deferred

- Streaming logs over the control socket (`cli.logs` returns a snapshot; `Follow` field reserved)
- `pkg/service/` platform implementations (systemd, LaunchAgent, Windows Service)
- WebUI migration away from `pkg/webui/` (stays embedded in `dicoded` for now)

## Test plan

- [x] `go build ./cmd/dicoded ./cmd/dicode` — both binaries compile
- [x] `go test ./...` — all existing tests pass
- [x] `dicoded` writes `daemon.sock` + `daemon.token` to `~/.dicode/`
- [x] `dicode list` connects and returns the task list
- [x] `dicode run <task>` fires a run and prints the result
- [x] `dicode` with no running daemon auto-starts `dicoded`

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)