### PR TITLE
feat: add max concurrent tasks semaphore in fireAsync()

### DIFF
--- a/cmd/dicoded/main.go
+++ b/cmd/dicoded/main.go
@@ -236,7 +236,11 @@ func buildRuntimes(
 	eng.SetDB(database)
 	if v := os.Getenv("DICODE_MAX_CONCURRENT_TASKS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
+			// Negative values and overflow are handled inside SetMaxConcurrentTasks.
 			eng.SetMaxConcurrentTasks(n)
+		} else {
+			log.Warn("DICODE_MAX_CONCURRENT_TASKS: invalid integer value — ignoring",
+				zap.String("value", v), zap.Error(err))
 		}
 	}
 	denoRT.SetEngine(eng)

--- a/cmd/dicoded/main.go
+++ b/cmd/dicoded/main.go
@@ -234,14 +234,19 @@ func buildRuntimes(
 	}
 	eng := trigger.New(reg, denoRT, log)
 	eng.SetDB(database)
+	// Config value first, env var overrides it. 0 = unlimited.
+	maxConcurrent := cfg.Execution.MaxConcurrentTasks
 	if v := os.Getenv("DICODE_MAX_CONCURRENT_TASKS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
-			// Negative values and overflow are handled inside SetMaxConcurrentTasks.
-			eng.SetMaxConcurrentTasks(n)
+			maxConcurrent = n
 		} else {
 			log.Warn("DICODE_MAX_CONCURRENT_TASKS: invalid integer value — ignoring",
 				zap.String("value", v), zap.Error(err))
 		}
+	}
+	if maxConcurrent != 0 {
+		// Negative values and overflow are handled inside SetMaxConcurrentTasks.
+		eng.SetMaxConcurrentTasks(maxConcurrent)
 	}
 	denoRT.SetEngine(eng)
 	denoRT.SetGateway(gateway)

--- a/cmd/dicoded/main.go
+++ b/cmd/dicoded/main.go
@@ -234,20 +234,28 @@ func buildRuntimes(
 	}
 	eng := trigger.New(reg, denoRT, log)
 	eng.SetDB(database)
-	// Config value first, env var overrides it. 0 = unlimited.
+	// Config value first, env var overrides when set. 0 = unlimited. Always
+	// call SetMaxConcurrentTasks so an env override of "0" correctly clears
+	// a config-set cap, and so operators get observable confirmation of
+	// which source (config vs env) won.
 	maxConcurrent := cfg.Execution.MaxConcurrentTasks
+	source := "config"
 	if v := os.Getenv("DICODE_MAX_CONCURRENT_TASKS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			maxConcurrent = n
+			source = "env"
 		} else {
-			log.Warn("DICODE_MAX_CONCURRENT_TASKS: invalid integer value — ignoring",
-				zap.String("value", v), zap.Error(err))
+			log.Error("DICODE_MAX_CONCURRENT_TASKS: invalid integer value — falling back to config",
+				zap.String("value", v),
+				zap.Int("using_config_value", maxConcurrent),
+				zap.Error(err))
 		}
 	}
-	if maxConcurrent != 0 {
-		// Negative values and overflow are handled inside SetMaxConcurrentTasks.
-		eng.SetMaxConcurrentTasks(maxConcurrent)
-	}
+	// Negative values and overflow are handled inside SetMaxConcurrentTasks.
+	eng.SetMaxConcurrentTasks(maxConcurrent)
+	log.Info("task concurrency configured",
+		zap.Int("max_concurrent_tasks", maxConcurrent),
+		zap.String("source", source))
 	denoRT.SetEngine(eng)
 	denoRT.SetGateway(gateway)
 	denoRT.SetSecretsManager(secretsMgr)

--- a/cmd/dicoded/main.go
+++ b/cmd/dicoded/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -233,6 +234,11 @@ func buildRuntimes(
 	}
 	eng := trigger.New(reg, denoRT, log)
 	eng.SetDB(database)
+	if v := os.Getenv("DICODE_MAX_CONCURRENT_TASKS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			eng.SetMaxConcurrentTasks(n)
+		}
+	}
 	denoRT.SetEngine(eng)
 	denoRT.SetGateway(gateway)
 	denoRT.SetSecretsManager(secretsMgr)

--- a/docs/concepts/metrics.md
+++ b/docs/concepts/metrics.md
@@ -23,7 +23,10 @@ Requires authentication when `server.auth: true` is set in `dicode.yaml`. Return
   "tasks": {
     "active_tasks": 5,
     "children_rss_mb": 310.5,
-    "children_cpu_ms": 4800
+    "children_cpu_ms": 4800,
+    "max_concurrent_tasks": 8,
+    "active_task_slots": 5,
+    "waiting_tasks": 0
   }
 }
 ```
@@ -44,6 +47,9 @@ Requires authentication when `server.auth: true` is set in `dicode.yaml`. Return
 | `active_tasks` | int | Number of task runs currently in progress |
 | `children_rss_mb` | float | Aggregate RSS of all active Deno child processes (MB) — **Linux only**, omitted otherwise |
 | `children_cpu_ms` | int | Aggregate CPU time (user+sys) of all active Deno child processes (ms) — **Linux only**, omitted otherwise |
+| `max_concurrent_tasks` | int | Configured concurrency cap (`execution.max_concurrent_tasks`). `0` means unlimited |
+| `active_task_slots` | int | Semaphore slots currently held by running task goroutines. `0` when no cap is configured |
+| `waiting_tasks` | int | Task goroutines parked waiting for a free semaphore slot. Non-zero values indicate backpressure — consider raising `max_concurrent_tasks` |
 
 ## Platform notes
 

--- a/docs/concepts/metrics.md
+++ b/docs/concepts/metrics.md
@@ -44,7 +44,7 @@ Requires authentication when `server.auth: true` is set in `dicode.yaml`. Return
 
 | Field | Type | Description |
 |---|---|---|
-| `active_tasks` | int | Number of task runs currently in progress |
+| `active_tasks` | int | Number of task runs currently in progress. **Includes runs queued on the concurrency semaphore** — subtract `waiting_tasks` to get the count of runs actually executing |
 | `children_rss_mb` | float | Aggregate RSS of all active Deno child processes (MB) — **Linux only**, omitted otherwise |
 | `children_cpu_ms` | int | Aggregate CPU time (user+sys) of all active Deno child processes (ms) — **Linux only**, omitted otherwise |
 | `max_concurrent_tasks` | int | Configured concurrency cap (`execution.max_concurrent_tasks`). `0` means unlimited |

--- a/docs/concepts/triggers.md
+++ b/docs/concepts/triggers.md
@@ -191,6 +191,22 @@ A 2-second back-off is applied between restarts to prevent tight loops on immedi
 
 ---
 
+## Concurrency limit
+
+By default dicode spawns a goroutine for every task invocation with no upper bound. Under sustained load this can cause goroutine storms and amplified SQLite write contention.
+
+Set `DICODE_MAX_CONCURRENT_TASKS` to cap how many task goroutines run in parallel:
+
+```bash
+DICODE_MAX_CONCURRENT_TASKS=8 dicoded
+```
+
+- `0` (default) — unlimited, backwards-compatible behaviour.
+- `N > 0` — at most N tasks execute concurrently. Additional invocations queue inside the daemon and run as slots become free.
+- **Shutdown safety:** queued goroutines are unblocked immediately when the daemon shuts down, so a full slot queue never causes a hang on `SIGTERM`.
+
+---
+
 ## Trigger constraints
 
 - Exactly one trigger per task. Multiple triggers are not supported (use `dicode.trigger()` from a task for complex dispatch logic).

--- a/docs/concepts/triggers.md
+++ b/docs/concepts/triggers.md
@@ -195,7 +195,14 @@ A 2-second back-off is applied between restarts to prevent tight loops on immedi
 
 By default dicode spawns a goroutine for every task invocation with no upper bound. Under sustained load this can cause goroutine storms and amplified SQLite write contention.
 
-Set `DICODE_MAX_CONCURRENT_TASKS` to cap how many task goroutines run in parallel:
+Cap how many task goroutines run in parallel via config:
+
+```yaml
+execution:
+  max_concurrent_tasks: 8
+```
+
+…or via env var (overrides the config value):
 
 ```bash
 DICODE_MAX_CONCURRENT_TASKS=8 dicoded
@@ -203,7 +210,12 @@ DICODE_MAX_CONCURRENT_TASKS=8 dicoded
 
 - `0` (default) — unlimited, backwards-compatible behaviour.
 - `N > 0` — at most N tasks execute concurrently. Additional invocations queue inside the daemon and run as slots become free.
+- **Daemon tasks bypass the cap** so long-running daemons don't starve webhook/cron tasks.
 - **Shutdown safety:** queued goroutines are unblocked when the semaphore releases or the daemon shuts down, so a full slot queue never causes a hang on `SIGTERM`.
+
+Runtime visibility of the cap is exposed via [GET /api/metrics](metrics.md) —
+the `tasks` object includes `max_concurrent_tasks`, `active_task_slots`, and
+`waiting_tasks`.
 
 ---
 

--- a/docs/concepts/triggers.md
+++ b/docs/concepts/triggers.md
@@ -211,7 +211,9 @@ DICODE_MAX_CONCURRENT_TASKS=8 dicoded
 - `0` (default) — unlimited, backwards-compatible behaviour.
 - `N > 0` — at most N tasks execute concurrently. Additional invocations queue inside the daemon and run as slots become free.
 - **Daemon tasks bypass the cap** so long-running daemons don't starve webhook/cron tasks.
-- **Shutdown safety:** queued goroutines are unblocked when the semaphore releases or the daemon shuts down, so a full slot queue never causes a hang on `SIGTERM`.
+- **Synchronous webhook responses bypass the cap** — tasks fired via `fireSync` (webhooks that return a response to the HTTP caller) are not subject to the semaphore, so sync clients can never deadlock waiting for a slot. Only async triggers (cron, async webhooks, chained `dicode.trigger()` calls) count against the limit.
+- **Killing a queued run** — cancelling a run that is still waiting on a slot honors the kill immediately; the run is finalized as `cancelled` and the websocket `run:finished` event fires so the UI stays in sync.
+- **Shutdown safety:** queued goroutines are unblocked when the daemon shuts down, finalized as `cancelled`, and their DB rows updated under a bounded timeout, so a full slot queue never causes a hang on `SIGTERM`.
 
 Runtime visibility of the cap is exposed via [GET /api/metrics](metrics.md) —
 the `tasks` object includes `max_concurrent_tasks`, `active_task_slots`, and

--- a/docs/concepts/triggers.md
+++ b/docs/concepts/triggers.md
@@ -203,7 +203,7 @@ DICODE_MAX_CONCURRENT_TASKS=8 dicoded
 
 - `0` (default) — unlimited, backwards-compatible behaviour.
 - `N > 0` — at most N tasks execute concurrently. Additional invocations queue inside the daemon and run as slots become free.
-- **Shutdown safety:** queued goroutines are unblocked immediately when the daemon shuts down, so a full slot queue never causes a hang on `SIGTERM`.
+- **Shutdown safety:** queued goroutines are unblocked when the semaphore releases or the daemon shuts down, so a full slot queue never causes a hang on `SIGTERM`.
 
 ---
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,6 +29,16 @@ type DefaultsConfig struct {
 	OnFailureChain string `yaml:"on_failure_chain,omitempty"`
 }
 
+// ExecutionConfig tunes how task runs are dispatched by the trigger engine.
+type ExecutionConfig struct {
+	// MaxConcurrentTasks caps how many task goroutines run in parallel.
+	// 0 (default) = unlimited. Extra invocations queue inside the daemon
+	// and run as slots free. Daemon-trigger tasks bypass the limit so
+	// long-runners can't starve webhook/cron tasks.
+	// The DICODE_MAX_CONCURRENT_TASKS env var overrides this value when set.
+	MaxConcurrentTasks int `yaml:"max_concurrent_tasks,omitempty"`
+}
+
 // RelayConfig configures the WebSocket relay client.
 // The relay allows a local dicode instance to receive webhooks from external
 // services (GitHub, Slack, etc.) without port forwarding.
@@ -46,6 +56,7 @@ type Config struct {
 	AI            AIConfig                 `yaml:"ai"`
 	Defaults      DefaultsConfig           `yaml:"defaults"`
 	Runtimes      map[string]RuntimeConfig `yaml:"runtimes,omitempty"`
+	Execution     ExecutionConfig          `yaml:"execution,omitempty"`
 	Relay         RelayConfig              `yaml:"relay,omitempty"`
 	LogLevel      string                   `yaml:"log_level"`
 	DataDir       string                   `yaml:"data_dir"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -70,3 +70,26 @@ database:
 		t.Errorf("database.path = %q, want %q", cfg.Database.Path, wantDB)
 	}
 }
+
+func TestLoadExecutionMaxConcurrentTasks(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+
+	content := `
+sources:
+  - type: local
+    path: ${CONFIGDIR}/tasks
+execution:
+  max_concurrent_tasks: 8
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Execution.MaxConcurrentTasks != 8 {
+		t.Errorf("Execution.MaxConcurrentTasks = %d, want 8", cfg.Execution.MaxConcurrentTasks)
+	}
+}

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -341,6 +341,9 @@ type MetricsProvider struct {
 func (cs *ControlServer) handleMetrics() MetricsSnapshot {
 	var snap MetricsSnapshot
 	snap.Tasks.ActiveTasks = cs.engine.ActiveRunCount()
+	snap.Tasks.ActiveTaskSlots = cs.engine.ActiveTaskSlots()
+	snap.Tasks.MaxConcurrentTasks = cs.engine.MaxConcurrentTasks()
+	snap.Tasks.WaitingTasks = cs.engine.WaitingTasks()
 
 	if cs.metricsProvider.ReadDaemon != nil {
 		heapAlloc, heapSys, goroutines, cpuMs := cs.metricsProvider.ReadDaemon()

--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -105,6 +105,9 @@ type EngineRunner interface {
 	FireManual(ctx context.Context, taskID string, params map[string]string) (string, error)
 	WaitRun(ctx context.Context, runID string) (RunResult, error)
 	ActiveRunCount() int
+	ActiveTaskSlots() int
+	MaxConcurrentTasks() int
+	WaitingTasks() int
 }
 
 // HTTPInboundRequest is a server-initiated push to a daemon task that has
@@ -163,8 +166,11 @@ type MetricsSnapshot struct {
 		CPUMs       *int64  `json:"cpu_ms,omitempty"`
 	} `json:"daemon"`
 	Tasks struct {
-		ActiveTasks int     `json:"active_tasks"`
-		ChildRSSMB  float64 `json:"children_rss_mb,omitempty"`
-		ChildCPUMs  *int64  `json:"children_cpu_ms,omitempty"`
+		ActiveTasks        int     `json:"active_tasks"`
+		ChildRSSMB         float64 `json:"children_rss_mb,omitempty"`
+		ChildCPUMs         *int64  `json:"children_cpu_ms,omitempty"`
+		ActiveTaskSlots    int     `json:"active_task_slots"`
+		MaxConcurrentTasks int     `json:"max_concurrent_tasks"`
+		WaitingTasks       int     `json:"waiting_tasks"`
 	} `json:"tasks"`
 }

--- a/pkg/ipc/server_test.go
+++ b/pkg/ipc/server_test.go
@@ -31,7 +31,10 @@ func (m *mockEngine) FireManual(_ context.Context, _ string, _ map[string]string
 func (m *mockEngine) WaitRun(_ context.Context, _ string) (RunResult, error) {
 	return m.result, m.err
 }
-func (m *mockEngine) ActiveRunCount() int { return 0 }
+func (m *mockEngine) ActiveRunCount() int     { return 0 }
+func (m *mockEngine) ActiveTaskSlots() int    { return 0 }
+func (m *mockEngine) MaxConcurrentTasks() int { return 0 }
+func (m *mockEngine) WaitingTasks() int       { return 0 }
 
 // sendMsg writes a length-prefixed JSON message to conn.
 func sendMsg(t *testing.T, conn net.Conn, v any) {

--- a/pkg/metrics/proc.go
+++ b/pkg/metrics/proc.go
@@ -26,6 +26,15 @@ type ChildMetrics struct {
 	// ChildCPUMs is the aggregate CPU time of all active child processes in ms.
 	// Pointer so zero CPU is preserved and nil indicates non-Linux.
 	ChildCPUMs *int64 `json:"children_cpu_ms,omitempty"` // Linux only
+
+	// ActiveTaskSlots is the number of semaphore slots currently held by
+	// running task goroutines. 0 when no concurrency cap is configured.
+	ActiveTaskSlots int `json:"active_task_slots"`
+	// MaxConcurrentTasks is the configured concurrency cap. 0 = unlimited.
+	MaxConcurrentTasks int `json:"max_concurrent_tasks"`
+	// WaitingTasks is the number of task goroutines parked waiting for a
+	// free semaphore slot. Always 0 when no cap is configured.
+	WaitingTasks int `json:"waiting_tasks"`
 }
 
 // Metrics is the top-level response for GET /api/metrics.

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -1203,6 +1203,30 @@ func (e *Engine) runTask(runCtx context.Context, spec *task.Spec, opts pkgruntim
 	return status, result
 }
 
+// finalizeCancelled closes out a run that was cancelled before ever executing
+// — e.g. user killed it while queued on the concurrency semaphore, or the
+// daemon is shutting down. It updates the registry row and fires the finished
+// hook so websocket subscribers see a matching started/finished pair.
+// Safe to call even on the hot shutdown path: the DB write is bounded by a
+// short timeout so a stuck SQLite connection cannot block the goroutine.
+func (e *Engine) finalizeCancelled(spec *task.Spec, opts pkgruntime.RunOptions, source string) {
+	finishCtx, finishCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer finishCancel()
+	if err := e.registry.FinishRun(finishCtx, opts.RunID, registry.StatusCancelled); err != nil {
+		e.log.Error("failed to finalize cancelled queued run",
+			zap.String("run", opts.RunID),
+			zap.String("task", spec.ID),
+			zap.Error(err))
+	}
+	if h := e.runFinishedHook; h != nil {
+		// Duration is 0 — the run never executed. The notifier (wired via
+		// a separate path in runTask) only fires on Success/Failure, so
+		// cancelled runs do not send spurious notifications.
+		notifyOnSuccess, notifyOnFailure := e.resolveNotify(spec)
+		h(spec.ID, opts.RunID, registry.StatusCancelled, source, 0, notifyOnSuccess, notifyOnFailure)
+	}
+}
+
 // fireAsync pre-creates the run record, starts execution in a goroutine,
 // and returns the run ID immediately.
 //
@@ -1231,16 +1255,29 @@ func (e *Engine) fireAsync(ctx context.Context, spec *task.Spec, opts pkgruntime
 				shutDone = shutCtx.Done()
 			}
 
+			// Increment the "parked waiting for a slot" counter. Each select
+			// case below must decrement exactly once: "waiting" ends when
+			// either the slot is acquired or the goroutine aborts — NOT
+			// when the run itself finishes. A single deferred decrement
+			// here would wrongly keep the counter inflated for the entire
+			// lifetime of successfully-acquired runs.
 			e.taskWaiting.Add(1)
 			select {
 			case e.taskSem <- struct{}{}:
+				e.taskWaiting.Add(-1)
 				// Slot acquired; release when done.
-				e.taskWaiting.Add(-1)
 				defer func() { <-e.taskSem }()
-			case <-shutDone:
+			case <-runCtx.Done():
+				// User killed (or gave up on) the queued run before a slot
+				// freed. Finalize it as cancelled so the websocket finished
+				// event fires and the DB row doesn't stay stuck in `running`.
 				e.taskWaiting.Add(-1)
-				// Engine is shutting down; mark the run as cancelled and abort.
-				_ = e.registry.FinishRun(context.Background(), opts.RunID, registry.StatusCancelled)
+				e.finalizeCancelled(spec, opts, source)
+				return
+			case <-shutDone:
+				// Engine is shutting down; finalize as cancelled and abort.
+				e.taskWaiting.Add(-1)
+				e.finalizeCancelled(spec, opts, source)
 				return
 			}
 		}

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -66,8 +66,9 @@ type Engine struct {
 
 	db db.DB // optional — enables cron-job persistence and missed-run catchup
 
-	taskSem chan struct{} // nil = unlimited; capacity = MaxConcurrentTasks
-	started atomic.Bool   // set to true by Start(); guards SetMaxConcurrentTasks
+	taskSem     chan struct{} // nil = unlimited; capacity = MaxConcurrentTasks
+	taskWaiting atomic.Int64  // goroutines parked waiting for a semaphore slot
+	started     atomic.Bool   // set to true by Start(); guards SetMaxConcurrentTasks
 
 	runFinishedHook func(taskID, runID, status, triggerSource string, durationMs int64, notifyOnSuccess, notifyOnFailure bool)
 	runStartedHook  func(taskID, runID, triggerSource string)
@@ -119,6 +120,29 @@ func (e *Engine) SetMaxConcurrentTasks(n int) {
 	} else {
 		e.taskSem = nil
 	}
+}
+
+// MaxConcurrentTasks returns the configured concurrency cap, or 0 if unlimited.
+func (e *Engine) MaxConcurrentTasks() int {
+	if e.taskSem == nil {
+		return 0
+	}
+	return cap(e.taskSem)
+}
+
+// ActiveTaskSlots returns the number of semaphore slots currently held by
+// running task goroutines. Returns 0 when no cap is configured.
+func (e *Engine) ActiveTaskSlots() int {
+	if e.taskSem == nil {
+		return 0
+	}
+	return len(e.taskSem)
+}
+
+// WaitingTasks returns the number of task goroutines currently parked waiting
+// for a semaphore slot to free. Always 0 when no cap is configured.
+func (e *Engine) WaitingTasks() int {
+	return int(e.taskWaiting.Load())
 }
 
 // SetRunStartedHook registers a callback invoked when a run starts.
@@ -1207,11 +1231,14 @@ func (e *Engine) fireAsync(ctx context.Context, spec *task.Spec, opts pkgruntime
 				shutDone = shutCtx.Done()
 			}
 
+			e.taskWaiting.Add(1)
 			select {
 			case e.taskSem <- struct{}{}:
 				// Slot acquired; release when done.
+				e.taskWaiting.Add(-1)
 				defer func() { <-e.taskSem }()
 			case <-shutDone:
+				e.taskWaiting.Add(-1)
 				// Engine is shutting down; mark the run as cancelled and abort.
 				_ = e.registry.FinishRun(context.Background(), opts.RunID, registry.StatusCancelled)
 				return

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -65,6 +65,8 @@ type Engine struct {
 
 	db db.DB // optional — enables cron-job persistence and missed-run catchup
 
+	taskSem chan struct{} // nil = unlimited; capacity = MaxConcurrentTasks
+
 	runFinishedHook func(taskID, runID, status, triggerSource string, durationMs int64, notifyOnSuccess, notifyOnFailure bool)
 	runStartedHook  func(taskID, runID, triggerSource string)
 }
@@ -90,6 +92,17 @@ func New(r *registry.Registry, defaultExec pkgruntime.Executor, log *zap.Logger)
 // detects missed runs on startup (e.g. after a process restart).
 func (e *Engine) SetDB(d db.DB) {
 	e.db = d
+}
+
+// SetMaxConcurrentTasks configures a semaphore that limits how many task
+// goroutines run concurrently. n == 0 (the default) means unlimited.
+// Must be called before Start().
+func (e *Engine) SetMaxConcurrentTasks(n int) {
+	if n > 0 {
+		e.taskSem = make(chan struct{}, n)
+	} else {
+		e.taskSem = nil
+	}
 }
 
 // SetRunStartedHook registers a callback invoked when a run starts.
@@ -1151,6 +1164,10 @@ func (e *Engine) runTask(runCtx context.Context, spec *task.Spec, opts pkgruntim
 
 // fireAsync pre-creates the run record, starts execution in a goroutine,
 // and returns the run ID immediately.
+//
+// When a MaxConcurrentTasks semaphore is configured, the goroutine blocks
+// until a slot is available or the shutdown context is cancelled — ensuring
+// shutdown never deadlocks waiting tasks.
 func (e *Engine) fireAsync(ctx context.Context, spec *task.Spec, opts pkgruntime.RunOptions, source string) (string, error) {
 	opts.RunID = uuid.New().String()
 
@@ -1161,6 +1178,23 @@ func (e *Engine) fireAsync(ctx context.Context, spec *task.Spec, opts pkgruntime
 
 	go func() {
 		defer cleanup()
+
+		if e.taskSem != nil {
+			// Obtain shutdown context snapshot so we can select on it.
+			e.shutdownMu.RLock()
+			shutCtx := e.shutdownCtx
+			e.shutdownMu.RUnlock()
+
+			select {
+			case e.taskSem <- struct{}{}:
+				// Slot acquired; release when done.
+				defer func() { <-e.taskSem }()
+			case <-shutCtx.Done():
+				// Daemon is shutting down; abort without running.
+				return
+			}
+		}
+
 		e.runTask(runCtx, spec, opts, source)
 	}()
 

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/dicode/dicode/pkg/db"
@@ -66,6 +67,7 @@ type Engine struct {
 	db db.DB // optional — enables cron-job persistence and missed-run catchup
 
 	taskSem chan struct{} // nil = unlimited; capacity = MaxConcurrentTasks
+	started atomic.Bool   // set to true by Start(); guards SetMaxConcurrentTasks
 
 	runFinishedHook func(taskID, runID, status, triggerSource string, durationMs int64, notifyOnSuccess, notifyOnFailure bool)
 	runStartedHook  func(taskID, runID, triggerSource string)
@@ -96,8 +98,22 @@ func (e *Engine) SetDB(d db.DB) {
 
 // SetMaxConcurrentTasks configures a semaphore that limits how many task
 // goroutines run concurrently. n == 0 (the default) means unlimited.
-// Must be called before Start().
+// Must be called before Start(); calls after Start() are ignored with a warning.
 func (e *Engine) SetMaxConcurrentTasks(n int) {
+	if e.started.Load() {
+		e.log.Warn("SetMaxConcurrentTasks called after Start — ignoring; configure before Start()")
+		return
+	}
+	if n < 0 {
+		e.log.Warn("SetMaxConcurrentTasks: negative value treated as unlimited", zap.Int("n", n))
+		n = 0
+	}
+	const maxConcurrentTasksLimit = 10000
+	if n > maxConcurrentTasksLimit {
+		e.log.Warn("SetMaxConcurrentTasks: value exceeds maximum, capping",
+			zap.Int("requested", n), zap.Int("cap", maxConcurrentTasksLimit))
+		n = maxConcurrentTasksLimit
+	}
 	if n > 0 {
 		e.taskSem = make(chan struct{}, n)
 	} else {
@@ -172,6 +188,7 @@ func (e *Engine) RegisterExecutor(rt task.Runtime, exec pkgruntime.Executor) {
 
 // Start begins scheduling and runs until ctx is cancelled.
 func (e *Engine) Start(ctx context.Context) error {
+	e.started.Store(true)
 	e.shutdownMu.Lock()
 	e.shutdownCtx = ctx
 	e.shutdownMu.Unlock()
@@ -1179,18 +1196,24 @@ func (e *Engine) fireAsync(ctx context.Context, spec *task.Spec, opts pkgruntime
 	go func() {
 		defer cleanup()
 
-		if e.taskSem != nil {
-			// Obtain shutdown context snapshot so we can select on it.
-			e.shutdownMu.RLock()
-			shutCtx := e.shutdownCtx
-			e.shutdownMu.RUnlock()
+		// Daemon tasks are long-running; they must not consume semaphore slots
+		// or they would permanently starve webhook/cron tasks.
+		if e.taskSem != nil && !spec.Trigger.Daemon {
+			// Build a done channel that is nil (blocks forever) when the engine
+			// has not yet started — nil channels never select, which is safe.
+			var shutDone <-chan struct{}
+			shutCtx := e.getShutdownCtx()
+			if shutCtx != nil {
+				shutDone = shutCtx.Done()
+			}
 
 			select {
 			case e.taskSem <- struct{}{}:
 				// Slot acquired; release when done.
 				defer func() { <-e.taskSem }()
-			case <-shutCtx.Done():
-				// Daemon is shutting down; abort without running.
+			case <-shutDone:
+				// Engine is shutting down; mark the run as cancelled and abort.
+				_ = e.registry.FinishRun(context.Background(), opts.RunID, registry.StatusCancelled)
 				return
 			}
 		}

--- a/pkg/trigger/engine_test.go
+++ b/pkg/trigger/engine_test.go
@@ -2,11 +2,14 @@ package trigger
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -873,4 +876,220 @@ func TestWaitRun_ContextCancellation(t *testing.T) {
 	if elapsed > 500*time.Millisecond {
 		t.Errorf("WaitRun did not respect context timeout: elapsed %v", elapsed)
 	}
+}
+
+// TestSetMaxConcurrentTasks_Unlimited verifies that the default (0) semaphore
+// setting leaves taskSem nil, preserving backwards-compatible unlimited behaviour.
+func TestSetMaxConcurrentTasks_Unlimited(t *testing.T) {
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+	reg := registry.New(d)
+	eng := New(reg, nil, zap.NewNop())
+
+	// Default: no semaphore.
+	if eng.taskSem != nil {
+		t.Fatal("expected taskSem to be nil by default (unlimited)")
+	}
+
+	// Explicitly set to 0 → still nil.
+	eng.SetMaxConcurrentTasks(0)
+	if eng.taskSem != nil {
+		t.Fatal("expected taskSem to be nil after SetMaxConcurrentTasks(0)")
+	}
+}
+
+// TestSetMaxConcurrentTasks_SetAndReset verifies that SetMaxConcurrentTasks
+// correctly sets and clears the semaphore channel.
+func TestSetMaxConcurrentTasks_SetAndReset(t *testing.T) {
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+	reg := registry.New(d)
+	eng := New(reg, nil, zap.NewNop())
+
+	eng.SetMaxConcurrentTasks(3)
+	if eng.taskSem == nil {
+		t.Fatal("expected taskSem to be non-nil after SetMaxConcurrentTasks(3)")
+	}
+	if cap(eng.taskSem) != 3 {
+		t.Fatalf("expected semaphore capacity 3, got %d", cap(eng.taskSem))
+	}
+
+	// Resetting to 0 clears the semaphore.
+	eng.SetMaxConcurrentTasks(0)
+	if eng.taskSem != nil {
+		t.Fatal("expected taskSem to be nil after SetMaxConcurrentTasks(0)")
+	}
+}
+
+// TestFireAsync_ConcurrencyLimit verifies that with MaxConcurrentTasks=2 at
+// most 2 task goroutines execute simultaneously.
+func TestFireAsync_ConcurrencyLimit(t *testing.T) {
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+	reg := registry.New(d)
+
+	const limit = 2
+	const total = 5
+
+	// inflight tracks how many tasks are running concurrently.
+	var inflight atomic.Int32
+	var maxSeen atomic.Int32
+
+	// blockCh gates each task: send a value to unblock one goroutine.
+	blockCh := make(chan struct{}, total)
+
+	// Build a fake executor that records concurrency.
+	fakeExec := &fakeExecutor{
+		fn: func() {
+			cur := inflight.Add(1)
+			defer inflight.Add(-1)
+			// Record the peak.
+			for {
+				old := maxSeen.Load()
+				if cur <= old || maxSeen.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+			// Block until the test unblocks us.
+			<-blockCh
+		},
+	}
+
+	eng := New(reg, fakeExec, zap.NewNop())
+	eng.SetMaxConcurrentTasks(limit)
+
+	// Provide a shutdown context so fireAsync can select on it.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	eng.shutdownMu.Lock()
+	eng.shutdownCtx = ctx
+	eng.shutdownMu.Unlock()
+
+	dir := t.TempDir()
+	var specs []*task.Spec
+	for i := range total {
+		id := fmt.Sprintf("sem-task-%d", i)
+		specs = append(specs, writeTask(t, dir, id, `return 1`, task.TriggerConfig{Manual: true}))
+		if err := reg.Register(specs[i]); err != nil {
+			t.Fatalf("Register: %v", err)
+		}
+	}
+
+	// Fire all tasks asynchronously.
+	for i := range total {
+		if _, err := eng.fireAsync(ctx, specs[i], pkgruntime.RunOptions{}, "test"); err != nil {
+			t.Fatalf("fireAsync %d: %v", i, err)
+		}
+	}
+
+	// Give goroutines time to start and fill the semaphore.
+	time.Sleep(100 * time.Millisecond)
+
+	// Unblock all tasks.
+	for range total {
+		blockCh <- struct{}{}
+	}
+
+	// Wait for all goroutines to drain.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if inflight.Load() == 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if maxSeen.Load() > int32(limit) {
+		t.Errorf("concurrency limit exceeded: saw %d concurrent tasks (limit %d)", maxSeen.Load(), limit)
+	}
+}
+
+// TestFireAsync_ShutdownUnblocksWaiting verifies that cancelling the shutdown
+// context releases goroutines that are blocked waiting for a semaphore slot.
+func TestFireAsync_ShutdownUnblocksWaiting(t *testing.T) {
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+	reg := registry.New(d)
+
+	holdCh := make(chan struct{})
+	fakeExec := &fakeExecutor{
+		fn: func() {
+			// Block until test releases.
+			<-holdCh
+		},
+	}
+
+	eng := New(reg, fakeExec, zap.NewNop())
+	eng.SetMaxConcurrentTasks(1) // Only 1 slot.
+
+	ctx, cancel := context.WithCancel(context.Background())
+	eng.shutdownMu.Lock()
+	eng.shutdownCtx = ctx
+	eng.shutdownMu.Unlock()
+
+	dir := t.TempDir()
+	spec1 := writeTask(t, dir, "shutdown-task-1", `return 1`, task.TriggerConfig{Manual: true})
+	spec2 := writeTask(t, dir, "shutdown-task-2", `return 1`, task.TriggerConfig{Manual: true})
+	_ = reg.Register(spec1)
+	_ = reg.Register(spec2)
+
+	// Fire task 1 — it will occupy the sole semaphore slot.
+	if _, err := eng.fireAsync(ctx, spec1, pkgruntime.RunOptions{}, "test"); err != nil {
+		t.Fatalf("fireAsync 1: %v", err)
+	}
+
+	// Give task 1 time to acquire the semaphore.
+	time.Sleep(50 * time.Millisecond)
+
+	// Fire task 2 — it will block waiting for a slot.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = eng.fireAsync(ctx, spec2, pkgruntime.RunOptions{}, "test")
+	}()
+
+	// Cancel the shutdown context — task 2's goroutine should unblock.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good: shutdown unblocked the waiting goroutine.
+	case <-time.After(3 * time.Second):
+		t.Fatal("shutdown did not unblock the waiting task goroutine")
+	}
+
+	// Unblock task 1 so the goroutine can exit cleanly.
+	close(holdCh)
+}
+
+// fakeExecutor is a minimal pkgruntime.Executor for testing.
+type fakeExecutor struct {
+	fn func()
+}
+
+func (f *fakeExecutor) Execute(_ context.Context, _ *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
+	if f.fn != nil {
+		f.fn()
+	}
+	return &pkgruntime.RunResult{}, nil
 }

--- a/pkg/trigger/engine_test.go
+++ b/pkg/trigger/engine_test.go
@@ -947,6 +947,11 @@ func TestFireAsync_ConcurrencyLimit(t *testing.T) {
 	// blockCh gates each task: send a value to unblock one goroutine.
 	blockCh := make(chan struct{}, total)
 
+	// atLimitCh is closed when inflight first reaches the concurrency limit,
+	// giving the test a reliable signal without sleeping.
+	atLimitCh := make(chan struct{})
+	var atLimitOnce sync.Once
+
 	// Build a fake executor that records concurrency.
 	fakeExec := &fakeExecutor{
 		fn: func() {
@@ -958,6 +963,10 @@ func TestFireAsync_ConcurrencyLimit(t *testing.T) {
 				if cur <= old || maxSeen.CompareAndSwap(old, cur) {
 					break
 				}
+			}
+			// Signal the test once we have reached the semaphore limit.
+			if cur >= int32(limit) {
+				atLimitOnce.Do(func() { close(atLimitCh) })
 			}
 			// Block until the test unblocks us.
 			<-blockCh
@@ -991,8 +1000,12 @@ func TestFireAsync_ConcurrencyLimit(t *testing.T) {
 		}
 	}
 
-	// Give goroutines time to start and fill the semaphore.
-	time.Sleep(100 * time.Millisecond)
+	// Wait until the semaphore is full before unblocking tasks.
+	select {
+	case <-atLimitCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for inflight tasks to reach concurrency limit")
+	}
 
 	// Unblock all tasks.
 	for range total {
@@ -1024,8 +1037,15 @@ func TestFireAsync_ShutdownUnblocksWaiting(t *testing.T) {
 	reg := registry.New(d)
 
 	holdCh := make(chan struct{})
+	// acquiredCh is closed by the first task once it has acquired the semaphore
+	// slot, giving the test a reliable signal without sleeping.
+	acquiredCh := make(chan struct{})
+	var acquiredOnce sync.Once
+
 	fakeExec := &fakeExecutor{
 		fn: func() {
+			// Signal that the semaphore slot has been acquired.
+			acquiredOnce.Do(func() { close(acquiredCh) })
 			// Block until test releases.
 			<-holdCh
 		},
@@ -1050,8 +1070,12 @@ func TestFireAsync_ShutdownUnblocksWaiting(t *testing.T) {
 		t.Fatalf("fireAsync 1: %v", err)
 	}
 
-	// Give task 1 time to acquire the semaphore.
-	time.Sleep(50 * time.Millisecond)
+	// Wait until task 1 has acquired the semaphore before firing task 2.
+	select {
+	case <-acquiredCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for task 1 to acquire semaphore")
+	}
 
 	// Fire task 2 — it will block waiting for a slot.
 	var wg sync.WaitGroup
@@ -1062,7 +1086,6 @@ func TestFireAsync_ShutdownUnblocksWaiting(t *testing.T) {
 	}()
 
 	// Cancel the shutdown context — task 2's goroutine should unblock.
-	time.Sleep(50 * time.Millisecond)
 	cancel()
 
 	done := make(chan struct{})

--- a/pkg/trigger/engine_test.go
+++ b/pkg/trigger/engine_test.go
@@ -1143,6 +1143,128 @@ func TestFireAsync_ShutdownUnblocksWaiting(t *testing.T) {
 	close(holdCh)
 }
 
+// TestFireAsync_KillQueuedRun verifies that killing a run while it is parked
+// on the concurrency semaphore honors the kill immediately: the run is
+// finalized as `cancelled` in the registry and the runFinishedHook fires so
+// websocket subscribers see a matching started/finished pair.
+func TestFireAsync_KillQueuedRun(t *testing.T) {
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+	reg := registry.New(d)
+
+	holdCh := make(chan struct{})
+	acquiredCh := make(chan struct{})
+	var acquiredOnce sync.Once
+	fakeExec := &fakeExecutor{
+		fn: func() {
+			acquiredOnce.Do(func() { close(acquiredCh) })
+			<-holdCh
+		},
+	}
+
+	eng := New(reg, fakeExec, zap.NewNop())
+	eng.SetMaxConcurrentTasks(1)
+
+	// Record finished-hook invocations so we can assert a matching
+	// started/finished pair fired for the cancelled run.
+	type finishRecord struct {
+		runID, status string
+	}
+	finishedCh := make(chan finishRecord, 2)
+	eng.SetRunFinishedHook(func(_, runID, status, _ string, _ int64, _, _ bool) {
+		finishedCh <- finishRecord{runID: runID, status: status}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	eng.shutdownMu.Lock()
+	eng.shutdownCtx = ctx
+	eng.shutdownMu.Unlock()
+
+	dir := t.TempDir()
+	spec1 := writeTask(t, dir, "kill-task-1", `return 1`, task.TriggerConfig{Manual: true})
+	spec2 := writeTask(t, dir, "kill-task-2", `return 1`, task.TriggerConfig{Manual: true})
+	_ = reg.Register(spec1)
+	_ = reg.Register(spec2)
+
+	// Task 1 occupies the sole semaphore slot.
+	run1ID, err := eng.fireAsync(ctx, spec1, pkgruntime.RunOptions{}, "test")
+	if err != nil {
+		t.Fatalf("fireAsync 1: %v", err)
+	}
+	select {
+	case <-acquiredCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for task 1 to acquire semaphore")
+	}
+
+	// Task 2 parks on the semaphore waiting.
+	run2ID, err := eng.fireAsync(ctx, spec2, pkgruntime.RunOptions{}, "test")
+	if err != nil {
+		t.Fatalf("fireAsync 2: %v", err)
+	}
+
+	// Poll until task 2 shows up as waiting.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && eng.WaitingTasks() == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if eng.WaitingTasks() != 1 {
+		t.Fatalf("expected WaitingTasks=1 after fireAsync 2, got %d", eng.WaitingTasks())
+	}
+
+	// Kill the queued run. The kill must be honored immediately.
+	if !eng.KillRun(run2ID) {
+		t.Fatal("KillRun returned false — run2 not found in runCancels")
+	}
+
+	// The finished hook for run2 should fire with status=cancelled.
+	var sawRun2 bool
+	deadline = time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && !sawRun2 {
+		select {
+		case rec := <-finishedCh:
+			if rec.runID == run2ID {
+				if rec.status != registry.StatusCancelled {
+					t.Errorf("run2 finished hook status = %q, want %q", rec.status, registry.StatusCancelled)
+				}
+				sawRun2 = true
+			}
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	if !sawRun2 {
+		t.Fatal("runFinishedHook did not fire for the killed queued run")
+	}
+
+	// Registry row for run2 must be persisted as cancelled.
+	run2, err := reg.GetRun(context.Background(), run2ID)
+	if err != nil {
+		t.Fatalf("GetRun run2: %v", err)
+	}
+	if run2.Status != registry.StatusCancelled {
+		t.Errorf("run2.Status = %q, want %q", run2.Status, registry.StatusCancelled)
+	}
+
+	// Waiter counter drops to 0 via the deferred decrement when the goroutine
+	// actually returns — that happens after finalizeCancelled fires the hook,
+	// so poll briefly rather than asserting immediately.
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && eng.WaitingTasks() != 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if eng.WaitingTasks() != 0 {
+		t.Errorf("WaitingTasks after kill = %d, want 0", eng.WaitingTasks())
+	}
+
+	// Cleanup: let run 1 finish.
+	close(holdCh)
+	_ = run1ID
+}
+
 // fakeExecutor is a minimal pkgruntime.Executor for testing.
 type fakeExecutor struct {
 	fn func()

--- a/pkg/trigger/engine_test.go
+++ b/pkg/trigger/engine_test.go
@@ -927,6 +927,44 @@ func TestSetMaxConcurrentTasks_SetAndReset(t *testing.T) {
 	}
 }
 
+// TestConcurrencyGetters verifies the public accessors used by /api/metrics
+// report consistent values for unlimited, configured-but-idle, and reset states.
+func TestConcurrencyGetters(t *testing.T) {
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+	reg := registry.New(d)
+	eng := New(reg, nil, zap.NewNop())
+
+	// Unlimited defaults.
+	if got := eng.MaxConcurrentTasks(); got != 0 {
+		t.Errorf("MaxConcurrentTasks() default = %d, want 0", got)
+	}
+	if got := eng.ActiveTaskSlots(); got != 0 {
+		t.Errorf("ActiveTaskSlots() default = %d, want 0", got)
+	}
+	if got := eng.WaitingTasks(); got != 0 {
+		t.Errorf("WaitingTasks() default = %d, want 0", got)
+	}
+
+	// Configured but idle.
+	eng.SetMaxConcurrentTasks(5)
+	if got := eng.MaxConcurrentTasks(); got != 5 {
+		t.Errorf("MaxConcurrentTasks() = %d, want 5", got)
+	}
+	if got := eng.ActiveTaskSlots(); got != 0 {
+		t.Errorf("ActiveTaskSlots() idle = %d, want 0", got)
+	}
+
+	// Reset clears cap.
+	eng.SetMaxConcurrentTasks(0)
+	if got := eng.MaxConcurrentTasks(); got != 0 {
+		t.Errorf("MaxConcurrentTasks() after reset = %d, want 0", got)
+	}
+}
+
 // TestFireAsync_ConcurrencyLimit verifies that with MaxConcurrentTasks=2 at
 // most 2 task goroutines execute simultaneously.
 func TestFireAsync_ConcurrencyLimit(t *testing.T) {

--- a/pkg/webui/metrics.go
+++ b/pkg/webui/metrics.go
@@ -14,9 +14,14 @@ func (s *Server) apiMetrics(w http.ResponseWriter, r *http.Request) {
 	activeTasks := s.engine.ActiveRunCount()
 	pids := denoruntime.ActivePIDs()
 
+	tasks := metrics.ReadChildMetrics(pids, activeTasks)
+	tasks.ActiveTaskSlots = s.engine.ActiveTaskSlots()
+	tasks.MaxConcurrentTasks = s.engine.MaxConcurrentTasks()
+	tasks.WaitingTasks = s.engine.WaitingTasks()
+
 	m := metrics.Metrics{
 		Daemon: metrics.ReadDaemonMetrics(),
-		Tasks:  metrics.ReadChildMetrics(pids, activeTasks),
+		Tasks:  tasks,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -377,8 +377,14 @@ func TestAPI_Metrics_OK(t *testing.T) {
 	if _, ok := m["daemon"]; !ok {
 		t.Error("missing 'daemon' key in metrics response")
 	}
-	if _, ok := m["tasks"]; !ok {
-		t.Error("missing 'tasks' key in metrics response")
+	tasks, ok := m["tasks"].(map[string]interface{})
+	if !ok {
+		t.Fatal("missing or non-object 'tasks' key in metrics response")
+	}
+	for _, key := range []string{"active_task_slots", "max_concurrent_tasks", "waiting_tasks"} {
+		if _, ok := tasks[key]; !ok {
+			t.Errorf("missing %q in tasks metrics response", key)
+		}
 	}
 }
 

--- a/tasks/buildin/webui/app/components/dc-metrics.js
+++ b/tasks/buildin/webui/app/components/dc-metrics.js
@@ -94,8 +94,14 @@ class DcMetrics extends LitElement {
           <table style="width:100%">
             <tbody>
               ${this._row('Active runs',    tasks.active_tasks)}
-              ${tasks.queued != null
-                ? this._row('Queued (semaphore)', tasks.queued)
+              ${tasks.max_concurrent_tasks > 0
+                ? this._row(
+                    'Concurrency slots',
+                    `${tasks.active_task_slots} / ${tasks.max_concurrent_tasks}`,
+                  )
+                : this._row('Concurrency cap', 'unlimited')}
+              ${tasks.waiting_tasks > 0
+                ? this._row('Waiting for slot', tasks.waiting_tasks)
                 : ''}
               ${tasks.children_rss_mb
                 ? this._row('Child RSS (Deno)', this._fmtMB(tasks.children_rss_mb))


### PR DESCRIPTION
Closes #64

## Changes

- **`pkg/trigger/engine.go`**: Added `taskSem chan struct{}` field to `Engine` struct and a new `SetMaxConcurrentTasks(n int)` method. Modified `fireAsync()` to acquire the semaphore before running a task goroutine and release it on exit. A `select` on both the semaphore and the shutdown context ensures the daemon never deadlocks on `SIGTERM` when slots are full.
- **`cmd/dicoded/main.go`**: Reads `DICODE_MAX_CONCURRENT_TASKS` env var on startup and calls `eng.SetMaxConcurrentTasks(n)` when set.
- **`pkg/trigger/engine_test.go`**: Four new unit tests — unlimited default, set/reset semaphore, concurrency cap observed at runtime, and shutdown unblocking waiting goroutines.
- **`docs/concepts/triggers.md`**: Added "Concurrency limit" section documenting `DICODE_MAX_CONCURRENT_TASKS`.

## Behaviour

| `DICODE_MAX_CONCURRENT_TASKS` | Effect |
|---|---|
| `0` (default) | Unlimited — no behaviour change |
| `N` | At most N task goroutines run concurrently; extras queue and run as slots free |

Shutdown (`SIGTERM`) unblocks all queued goroutines immediately via context cancellation.

## Test plan

- [x] `TestSetMaxConcurrentTasks_Unlimited` — default is nil semaphore
- [x] `TestSetMaxConcurrentTasks_SetAndReset` — correct channel capacity, clears to nil on 0
- [x] `TestFireAsync_ConcurrencyLimit` — peak concurrency never exceeds configured limit
- [x] `TestFireAsync_ShutdownUnblocksWaiting` — cancel context releases blocked goroutine within 3s
- [x] Full `go test ./... -timeout 300s -count=1` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)