### PR TITLE
feat: expose concurrency metrics (active tasks, memory, CPU)

### DIFF
--- a/cmd/dicoded/main.go
+++ b/cmd/dicoded/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dicode/dicode/pkg/config"
 	"github.com/dicode/dicode/pkg/db"
 	"github.com/dicode/dicode/pkg/ipc"
+	"github.com/dicode/dicode/pkg/metrics"
 	"github.com/dicode/dicode/pkg/notify"
 	"github.com/dicode/dicode/pkg/onboarding"
 	"github.com/dicode/dicode/pkg/registry"
@@ -178,7 +179,18 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	// 9. Control socket for CLI clients.
 	socketPath := filepath.Join(dataDir, "daemon.sock")
 	tokenPath := filepath.Join(dataDir, "daemon.token")
-	ctrlSrv, err := ipc.NewControlServer(socketPath, tokenPath, reg, eng, localSecrets, version, log)
+	mp := ipc.MetricsProvider{
+		ReadDaemon: func() (float64, float64, int, *int64) {
+			dm := metrics.ReadDaemonMetrics()
+			return dm.HeapAllocMB, dm.HeapSysMB, dm.Goroutines, dm.CPUMs
+		},
+		ActivePIDs: denoruntime.ActivePIDs,
+		ReadChildren: func(pids []int, activeTasks int) (float64, *int64) {
+			cm := metrics.ReadChildMetrics(pids, activeTasks)
+			return cm.ChildRSSMB, cm.ChildCPUMs
+		},
+	}
+	ctrlSrv, err := ipc.NewControlServer(socketPath, tokenPath, reg, eng, localSecrets, mp, version, log)
 	if err != nil {
 		return fmt.Errorf("build control server: %w", err)
 	}

--- a/docs/concepts/metrics.md
+++ b/docs/concepts/metrics.md
@@ -49,6 +49,31 @@ Requires authentication when `server.auth: true` is set in `dicode.yaml`. Return
 
 Fields marked "Linux only" are sourced from `/proc/self/stat` and `/proc/<pid>/status`. On macOS, Windows, and other non-Linux platforms those fields are omitted from the JSON object (`omitempty`), so the response remains valid and parseable — the fields simply do not appear.
 
+## WebUI dashboard
+
+The webui example includes a `dc-metrics` component at the `/metrics` route that polls `GET /api/metrics` every 5 seconds and renders daemon and task cards automatically. No configuration required.
+
+## IPC control socket (`cli.metrics`)
+
+Metrics are also accessible over the daemon's Unix control socket, enabling the CLI and TUI to query live health without going through HTTP.
+
+**Request:**
+```json
+{ "id": "1", "method": "cli.metrics" }
+```
+
+**Response** (`result` field):
+```json
+{
+  "daemon": { "heap_alloc_mb": 42.3, "goroutines": 87, "cpu_ms": 1240 },
+  "tasks":  { "active_tasks": 5, "children_rss_mb": 310.5 }
+}
+```
+
+The response shape (`MetricsSnapshot`) mirrors the HTTP JSON exactly. The field set is identical to `/api/metrics`; Linux-only `/proc` fields are omitted on other platforms.
+
+Authentication uses the pre-shared CLI token written to `dataDir/daemon.token` on daemon startup — the same token used by all `cli.*` commands.
+
 ## Metrics are computed on-demand
 
 There is no background aggregation thread. Every request to `/api/metrics` reads current values synchronously:

--- a/docs/concepts/metrics.md
+++ b/docs/concepts/metrics.md
@@ -1,0 +1,62 @@
+# Metrics endpoint
+
+Dicode exposes a lightweight JSON metrics endpoint that surfaces daemon health, active task counts, and child-process resource usage. No external monitoring agent is required.
+
+## Endpoint
+
+```
+GET /api/metrics
+```
+
+Requires authentication when `server.auth: true` is set in `dicode.yaml`. Returns `401 Unauthorized` for unauthenticated requests.
+
+## Response schema
+
+```json
+{
+  "daemon": {
+    "heap_alloc_mb": 42.3,
+    "heap_sys_mb": 68.0,
+    "goroutines": 87,
+    "cpu_ms": 1240
+  },
+  "tasks": {
+    "active_tasks": 5,
+    "children_rss_mb": 310.5,
+    "children_cpu_ms": 4800
+  }
+}
+```
+
+### `daemon` object
+
+| Field | Type | Description |
+|---|---|---|
+| `heap_alloc_mb` | float | Go heap currently allocated (MB) |
+| `heap_sys_mb` | float | Go heap reserved from OS (MB) |
+| `goroutines` | int | Number of live goroutines |
+| `cpu_ms` | int | Daemon CPU time (user+sys) in milliseconds — **Linux only**, omitted otherwise |
+
+### `tasks` object
+
+| Field | Type | Description |
+|---|---|---|
+| `active_tasks` | int | Number of task runs currently in progress |
+| `children_rss_mb` | float | Aggregate RSS of all active Deno child processes (MB) — **Linux only**, omitted otherwise |
+| `children_cpu_ms` | int | Aggregate CPU time (user+sys) of all active Deno child processes (ms) — **Linux only**, omitted otherwise |
+
+## Platform notes
+
+Fields marked "Linux only" are sourced from `/proc/self/stat` and `/proc/<pid>/status`. On macOS, Windows, and other non-Linux platforms those fields are omitted from the JSON object (`omitempty`), so the response remains valid and parseable — the fields simply do not appear.
+
+## Metrics are computed on-demand
+
+There is no background aggregation thread. Every request to `/api/metrics` reads current values synchronously:
+
+- `runtime.ReadMemStats()` for Go heap figures
+- `runtime.NumGoroutine()` for goroutine count
+- `/proc/self/stat` for daemon CPU time (Linux)
+- `/proc/<pid>/status` for each active Deno child RSS (Linux)
+- The engine's `runCancels` map for active task count
+
+This means the endpoint is always fresh and adds negligible overhead.

--- a/docs/concepts/metrics.md
+++ b/docs/concepts/metrics.md
@@ -53,9 +53,10 @@ Fields marked "Linux only" are sourced from `/proc/self/stat` and `/proc/<pid>/s
 
 There is no background aggregation thread. Every request to `/api/metrics` reads current values synchronously:
 
-- `runtime.ReadMemStats()` for Go heap figures
+- `runtime/metrics.Read()` for Go heap figures (no stop-the-world pause)
 - `runtime.NumGoroutine()` for goroutine count
 - `/proc/self/stat` for daemon CPU time (Linux)
+- `/proc/<pid>/stat` for each active Deno child CPU time (Linux)
 - `/proc/<pid>/status` for each active Deno child RSS (Linux)
 - The engine's `runCancels` map for active task count
 

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -29,10 +29,11 @@ type ControlServer struct {
 	secret     []byte // HMAC key, generated on New
 	token      string // pre-issued CLI token written to tokenPath
 
-	reg     *registry.Registry
-	engine  EngineRunner
-	secrets secrets.Manager // nil if no local provider configured
-	log     *zap.Logger
+	reg             *registry.Registry
+	engine          EngineRunner
+	secrets         secrets.Manager // nil if no local provider configured
+	metricsProvider MetricsProvider
+	log             *zap.Logger
 
 	startedAt time.Time
 	version   string
@@ -46,6 +47,7 @@ func NewControlServer(
 	reg *registry.Registry,
 	engine EngineRunner,
 	secretsMgr secrets.Manager,
+	mp MetricsProvider,
 	version string,
 	log *zap.Logger,
 ) (*ControlServer, error) {
@@ -55,15 +57,16 @@ func NewControlServer(
 	}
 
 	cs := &ControlServer{
-		socketPath: socketPath,
-		tokenPath:  tokenPath,
-		secret:     secret,
-		reg:        reg,
-		engine:     engine,
-		secrets:    secretsMgr,
-		log:        log,
-		startedAt:  time.Now(),
-		version:    version,
+		socketPath:      socketPath,
+		tokenPath:       tokenPath,
+		secret:          secret,
+		reg:             reg,
+		engine:          engine,
+		secrets:         secretsMgr,
+		metricsProvider: mp,
+		log:             log,
+		startedAt:       time.Now(),
+		version:         version,
 	}
 
 	// Issue the CLI token with a long TTL — the daemon re-issues on every restart,
@@ -200,6 +203,9 @@ func (cs *ControlServer) dispatch(ctx context.Context, req Request) (any, error)
 	case "cli.secrets.delete":
 		return nil, cs.handleSecretsDelete(ctx, req)
 
+	case "cli.metrics":
+		return cs.handleMetrics(), nil
+
 	default:
 		return nil, fmt.Errorf("unknown method: %s", req.Method)
 	}
@@ -315,6 +321,43 @@ func (cs *ControlServer) handleSecretsDelete(ctx context.Context, req Request) e
 		return errors.New("key required")
 	}
 	return cs.secrets.Delete(ctx, req.Key)
+}
+
+// MetricsProvider is a pair of functions injected at startup to avoid import
+// cycles between pkg/ipc and pkg/metrics / pkg/runtime/deno.
+type MetricsProvider struct {
+	// ReadDaemon returns current daemon heap/goroutine/CPU metrics.
+	ReadDaemon func() (heapAllocMB, heapSysMB float64, goroutines int, cpuMs *int64)
+	// ActivePIDs returns the PIDs of live child (Deno) processes.
+	ActivePIDs func() []int
+	// ReadChildren returns aggregate RSS and CPU for the given PIDs.
+	ReadChildren func(pids []int, activeTasks int) (rssTotal float64, cpuTotal *int64)
+}
+
+// handleMetrics returns a MetricsSnapshot populated from the runtime/metrics
+// package and, on Linux, from /proc. It is wired to the cli.metrics command so
+// that the CLI and TUI can query live daemon health over the control socket
+// without going through the HTTP API.
+func (cs *ControlServer) handleMetrics() MetricsSnapshot {
+	var snap MetricsSnapshot
+	snap.Tasks.ActiveTasks = cs.engine.ActiveRunCount()
+
+	if cs.metricsProvider.ReadDaemon != nil {
+		heapAlloc, heapSys, goroutines, cpuMs := cs.metricsProvider.ReadDaemon()
+		snap.Daemon.HeapAllocMB = heapAlloc
+		snap.Daemon.HeapSysMB = heapSys
+		snap.Daemon.Goroutines = goroutines
+		snap.Daemon.CPUMs = cpuMs
+	}
+
+	if cs.metricsProvider.ActivePIDs != nil && cs.metricsProvider.ReadChildren != nil {
+		pids := cs.metricsProvider.ActivePIDs()
+		rss, cpu := cs.metricsProvider.ReadChildren(pids, snap.Tasks.ActiveTasks)
+		snap.Tasks.ChildRSSMB = rss
+		snap.Tasks.ChildCPUMs = cpu
+	}
+
+	return snap
 }
 
 // triggerLabel returns a human-readable trigger description for a task spec.

--- a/pkg/ipc/control_test.go
+++ b/pkg/ipc/control_test.go
@@ -1,0 +1,201 @@
+package ipc
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// controlTestEnv spins up a ControlServer listening on a temp Unix socket and
+// returns an authenticated net.Conn ready for request/response exchanges.
+func controlTestEnv(t *testing.T, mp MetricsProvider) (net.Conn, func()) {
+	t.Helper()
+
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "ctrl.sock")
+	tokenPath := filepath.Join(dir, "ctrl.token")
+
+	log := zap.NewNop()
+	eng := &mockEngine{}
+
+	cs, err := NewControlServer(socketPath, tokenPath, nil, eng, nil, mp, "test", log)
+	if err != nil {
+		t.Fatalf("NewControlServer: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = cs.Start(ctx)
+	}()
+
+	// Wait for the socket file to appear (Start is fast but runs in a goroutine).
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(socketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatal("control socket never appeared within 2s")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Read the token the server wrote.
+	tok, err := os.ReadFile(tokenPath)
+	if err != nil {
+		cancel()
+		t.Fatalf("read token: %v", err)
+	}
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		cancel()
+		t.Fatalf("dial control: %v", err)
+	}
+
+	// Handshake.
+	if err := writeMsg(conn, handshakeReq{Token: string(tok)}); err != nil {
+		conn.Close()
+		cancel()
+		t.Fatalf("handshake send: %v", err)
+	}
+	var hs struct {
+		Proto int      `json:"proto"`
+		Caps  []string `json:"caps"`
+		Error string   `json:"error"`
+	}
+	if err := readMsg(conn, &hs); err != nil {
+		conn.Close()
+		cancel()
+		t.Fatalf("handshake recv: %v", err)
+	}
+	if hs.Error != "" {
+		conn.Close()
+		cancel()
+		t.Fatalf("handshake rejected: %s", hs.Error)
+	}
+
+	cleanup := func() {
+		conn.Close()
+		cancel()
+		<-done
+	}
+	return conn, cleanup
+}
+
+func TestControl_Metrics_ReturnsSnapshot(t *testing.T) {
+	t.Parallel()
+
+	cpuMs := int64(1234)
+	mp := MetricsProvider{
+		ReadDaemon: func() (float64, float64, int, *int64) {
+			return 42.5, 64.0, 17, &cpuMs
+		},
+		ActivePIDs: func() []int { return []int{1234, 5678} },
+		ReadChildren: func(pids []int, active int) (float64, *int64) {
+			total := int64(int64(len(pids)) * 100)
+			return float64(len(pids)) * 50.0, &total
+		},
+	}
+
+	conn, cleanup := controlTestEnv(t, mp)
+	defer cleanup()
+
+	if err := writeMsg(conn, Request{ID: "m1", Method: "cli.metrics"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	var resp struct {
+		ID     string          `json:"id"`
+		Result json.RawMessage `json:"result"`
+		Error  string          `json:"error"`
+	}
+	if err := readMsg(conn, &resp); err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+
+	var snap MetricsSnapshot
+	if err := json.Unmarshal(resp.Result, &snap); err != nil {
+		t.Fatalf("unmarshal snapshot: %v", err)
+	}
+
+	if snap.Daemon.HeapAllocMB != 42.5 {
+		t.Errorf("HeapAllocMB: got %v, want 42.5", snap.Daemon.HeapAllocMB)
+	}
+	if snap.Daemon.Goroutines != 17 {
+		t.Errorf("Goroutines: got %v, want 17", snap.Daemon.Goroutines)
+	}
+	if snap.Daemon.CPUMs == nil || *snap.Daemon.CPUMs != 1234 {
+		t.Errorf("CPUMs: got %v, want &1234", snap.Daemon.CPUMs)
+	}
+	if snap.Tasks.ActiveTasks != 0 { // mockEngine returns 0
+		t.Errorf("ActiveTasks: got %v, want 0", snap.Tasks.ActiveTasks)
+	}
+	if snap.Tasks.ChildRSSMB != 100.0 {
+		t.Errorf("ChildRSSMB: got %v, want 100.0", snap.Tasks.ChildRSSMB)
+	}
+}
+
+func TestControl_Metrics_NoProvider_ReturnsZeros(t *testing.T) {
+	t.Parallel()
+
+	// Empty MetricsProvider — all function fields nil.
+	conn, cleanup := controlTestEnv(t, MetricsProvider{})
+	defer cleanup()
+
+	if err := writeMsg(conn, Request{ID: "m2", Method: "cli.metrics"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	var resp struct {
+		ID     string          `json:"id"`
+		Result json.RawMessage `json:"result"`
+		Error  string          `json:"error"`
+	}
+	if err := readMsg(conn, &resp); err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+
+	var snap MetricsSnapshot
+	if err := json.Unmarshal(resp.Result, &snap); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// All daemon fields should be zero-value; no panic.
+	if snap.Daemon.Goroutines != 0 {
+		t.Errorf("expected zero goroutines without provider, got %d", snap.Daemon.Goroutines)
+	}
+}
+
+func TestControl_UnknownMethod_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	conn, cleanup := controlTestEnv(t, MetricsProvider{})
+	defer cleanup()
+
+	if err := writeMsg(conn, Request{ID: "u1", Method: "cli.does_not_exist"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	var resp struct {
+		ID    string `json:"id"`
+		Error string `json:"error"`
+	}
+	if err := readMsg(conn, &resp); err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+	if resp.Error == "" {
+		t.Error("expected error for unknown method, got none")
+	}
+}

--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -86,11 +86,13 @@ type OutputResult struct {
 // IsSet reports whether any output was recorded.
 func (o *OutputResult) IsSet() bool { return o != nil && o.ContentType != "" }
 
-// EngineRunner allows the IPC server to fire and await task runs.
-// Implemented by the trigger engine; injected to avoid import cycles.
+// EngineRunner allows the IPC server to fire and await task runs, and to
+// query live concurrency state. Implemented by the trigger engine; injected
+// to avoid import cycles.
 type EngineRunner interface {
 	FireManual(ctx context.Context, taskID string, params map[string]string) (string, error)
 	WaitRun(ctx context.Context, runID string) (RunResult, error)
+	ActiveRunCount() int
 }
 
 // HTTPInboundRequest is a server-initiated push to a daemon task that has
@@ -137,4 +139,20 @@ type RunResult struct {
 	RunID       string `json:"runID"`
 	Status      string `json:"status"`
 	ReturnValue any    `json:"returnValue"`
+}
+
+// MetricsSnapshot is the cli.metrics response.
+// Fields sourced from /proc are omitted on non-Linux platforms.
+type MetricsSnapshot struct {
+	Daemon struct {
+		HeapAllocMB float64 `json:"heap_alloc_mb"`
+		HeapSysMB   float64 `json:"heap_sys_mb"`
+		Goroutines  int     `json:"goroutines"`
+		CPUMs       *int64  `json:"cpu_ms,omitempty"`
+	} `json:"daemon"`
+	Tasks struct {
+		ActiveTasks int     `json:"active_tasks"`
+		ChildRSSMB  float64 `json:"children_rss_mb,omitempty"`
+		ChildCPUMs  *int64  `json:"children_cpu_ms,omitempty"`
+	} `json:"tasks"`
 }

--- a/pkg/ipc/server_test.go
+++ b/pkg/ipc/server_test.go
@@ -31,6 +31,7 @@ func (m *mockEngine) FireManual(_ context.Context, _ string, _ map[string]string
 func (m *mockEngine) WaitRun(_ context.Context, _ string) (RunResult, error) {
 	return m.result, m.err
 }
+func (m *mockEngine) ActiveRunCount() int { return 0 }
 
 // sendMsg writes a length-prefixed JSON message to conn.
 func sendMsg(t *testing.T, conn net.Conn, v any) {

--- a/pkg/metrics/proc.go
+++ b/pkg/metrics/proc.go
@@ -1,0 +1,56 @@
+// Package metrics collects runtime and process metrics for the daemon.
+package metrics
+
+import "runtime"
+
+// DaemonMetrics holds Go-runtime-level metrics for the daemon process.
+type DaemonMetrics struct {
+	HeapAllocMB float64 `json:"heap_alloc_mb"`
+	HeapSysMB   float64 `json:"heap_sys_mb"`
+	Goroutines  int     `json:"goroutines"`
+	CPUMs       int64   `json:"cpu_ms,omitempty"` // Linux only
+}
+
+// ChildMetrics holds aggregate metrics across all active Deno child processes.
+type ChildMetrics struct {
+	ActiveTasks int     `json:"active_tasks"`
+	ChildRSSMB  float64 `json:"children_rss_mb,omitempty"` // Linux only
+	ChildCPUMs  int64   `json:"children_cpu_ms,omitempty"` // Linux only
+}
+
+// Metrics is the top-level response for GET /api/metrics.
+type Metrics struct {
+	Daemon DaemonMetrics `json:"daemon"`
+	Tasks  ChildMetrics  `json:"tasks"`
+}
+
+// ReadDaemonMetrics returns current daemon metrics using runtime.ReadMemStats.
+func ReadDaemonMetrics() DaemonMetrics {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	d := DaemonMetrics{
+		HeapAllocMB: float64(ms.HeapAlloc) / (1024 * 1024),
+		HeapSysMB:   float64(ms.HeapSys) / (1024 * 1024),
+		Goroutines:  runtime.NumGoroutine(),
+	}
+	d.CPUMs = readSelfCPUMs()
+	return d
+}
+
+// ReadChildMetrics returns aggregate metrics for the provided set of child PIDs.
+func ReadChildMetrics(pids []int, activeTasks int) ChildMetrics {
+	c := ChildMetrics{ActiveTasks: activeTasks}
+	var totalRSS float64
+	var totalCPU int64
+	for _, pid := range pids {
+		rss := readProcRSSMB(pid)
+		cpu := readProcCPUMs(pid)
+		totalRSS += rss
+		totalCPU += cpu
+	}
+	if len(pids) > 0 {
+		c.ChildRSSMB = totalRSS
+		c.ChildCPUMs = totalCPU
+	}
+	return c
+}

--- a/pkg/metrics/proc.go
+++ b/pkg/metrics/proc.go
@@ -1,21 +1,31 @@
 // Package metrics collects runtime and process metrics for the daemon.
 package metrics
 
-import "runtime"
+import (
+	"runtime"
+	"runtime/metrics"
+	"sync"
+	"time"
+)
 
 // DaemonMetrics holds Go-runtime-level metrics for the daemon process.
 type DaemonMetrics struct {
 	HeapAllocMB float64 `json:"heap_alloc_mb"`
 	HeapSysMB   float64 `json:"heap_sys_mb"`
 	Goroutines  int     `json:"goroutines"`
-	CPUMs       int64   `json:"cpu_ms,omitempty"` // Linux only
+	// CPUMs is the daemon's cumulative CPU time (user+sys) in milliseconds.
+	// It uses a pointer so that zero is a valid value and nil means
+	// "not available" (non-Linux). omitempty omits the field when nil.
+	CPUMs *int64 `json:"cpu_ms,omitempty"` // Linux only
 }
 
 // ChildMetrics holds aggregate metrics across all active Deno child processes.
 type ChildMetrics struct {
 	ActiveTasks int     `json:"active_tasks"`
 	ChildRSSMB  float64 `json:"children_rss_mb,omitempty"` // Linux only
-	ChildCPUMs  int64   `json:"children_cpu_ms,omitempty"` // Linux only
+	// ChildCPUMs is the aggregate CPU time of all active child processes in ms.
+	// Pointer so zero CPU is preserved and nil indicates non-Linux.
+	ChildCPUMs *int64 `json:"children_cpu_ms,omitempty"` // Linux only
 }
 
 // Metrics is the top-level response for GET /api/metrics.
@@ -24,16 +34,46 @@ type Metrics struct {
 	Tasks  ChildMetrics  `json:"tasks"`
 }
 
-// ReadDaemonMetrics returns current daemon metrics using runtime.ReadMemStats.
+// metricsCache holds a cached snapshot to avoid repeated sampling within a
+// short window. It is protected by mu.
+var (
+	mu          sync.Mutex
+	cachedAt    time.Time
+	cachedValue DaemonMetrics
+)
+
+const cacheTTL = 5 * time.Second
+
+// ReadDaemonMetrics returns current daemon metrics using the runtime/metrics
+// package (no stop-the-world GC pause). Results are cached for up to 5 seconds
+// to prevent burst abuse.
 func ReadDaemonMetrics() DaemonMetrics {
-	var ms runtime.MemStats
-	runtime.ReadMemStats(&ms)
-	d := DaemonMetrics{
-		HeapAllocMB: float64(ms.HeapAlloc) / (1024 * 1024),
-		HeapSysMB:   float64(ms.HeapSys) / (1024 * 1024),
-		Goroutines:  runtime.NumGoroutine(),
+	mu.Lock()
+	defer mu.Unlock()
+
+	if time.Since(cachedAt) < cacheTTL {
+		return cachedValue
 	}
-	d.CPUMs = readSelfCPUMs()
+
+	// runtime/metrics.Read does NOT trigger a stop-the-world pause, unlike
+	// runtime.ReadMemStats which halts all goroutines while copying MemStats.
+	samples := []metrics.Sample{
+		{Name: "/memory/classes/heap/objects:bytes"},
+		{Name: "/memory/classes/total:bytes"},
+	}
+	metrics.Read(samples)
+	heapAlloc := samples[0].Value.Uint64()
+	heapSys := samples[1].Value.Uint64()
+
+	d := DaemonMetrics{
+		HeapAllocMB: float64(heapAlloc) / (1024 * 1024),
+		HeapSysMB:   float64(heapSys) / (1024 * 1024),
+		Goroutines:  runtime.NumGoroutine(),
+		CPUMs:       selfCPUMsPtr(), // nil on non-Linux; &0 is a valid zero value
+	}
+
+	cachedValue = d
+	cachedAt = time.Now()
 	return d
 }
 
@@ -50,7 +90,7 @@ func ReadChildMetrics(pids []int, activeTasks int) ChildMetrics {
 	}
 	if len(pids) > 0 {
 		c.ChildRSSMB = totalRSS
-		c.ChildCPUMs = totalCPU
+		c.ChildCPUMs = &totalCPU
 	}
 	return c
 }

--- a/pkg/metrics/proc_linux.go
+++ b/pkg/metrics/proc_linux.go
@@ -1,0 +1,75 @@
+//go:build linux
+
+package metrics
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// clkTck is the number of clock ticks per second on Linux (usually 100).
+const clkTck = 100
+
+// readSelfCPUMs reads the daemon's own CPU time (user+sys) from /proc/self/stat
+// and returns it in milliseconds.
+func readSelfCPUMs() int64 {
+	return readProcStatCPUMs("/proc/self/stat")
+}
+
+// readProcCPUMs reads a child process's CPU time from /proc/<pid>/stat.
+func readProcCPUMs(pid int) int64 {
+	return readProcStatCPUMs(fmt.Sprintf("/proc/%d/stat", pid))
+}
+
+// readProcStatCPUMs parses a /proc/*/stat file and returns (utime+stime) in ms.
+func readProcStatCPUMs(path string) int64 {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	// The stat file has the process name in parentheses which may contain spaces.
+	// Find the closing ')' and parse fields after it.
+	line := strings.TrimSpace(string(data))
+	rp := strings.LastIndex(line, ")")
+	if rp < 0 {
+		return 0
+	}
+	fields := strings.Fields(line[rp+1:])
+	// After ')': field index 0 = state (field 3 in spec), fields 11 = utime (field 14), 12 = stime (field 15).
+	// Fields are 0-indexed from the character after ')':
+	//   0: state, 1: ppid, 2: pgrp, 3: session, 4: tty_nr, 5: tpgid,
+	//   6: flags, 7: minflt, 8: cminflt, 9: majflt, 10: cmajflt,
+	//   11: utime, 12: stime
+	if len(fields) < 13 {
+		return 0
+	}
+	utime, err1 := strconv.ParseInt(fields[11], 10, 64)
+	stime, err2 := strconv.ParseInt(fields[12], 10, 64)
+	if err1 != nil || err2 != nil {
+		return 0
+	}
+	return (utime + stime) * 1000 / clkTck
+}
+
+// readProcRSSMB reads a process's Resident Set Size from /proc/<pid>/status.
+func readProcRSSMB(pid int) float64 {
+	path := fmt.Sprintf("/proc/%d/status", pid)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "VmRSS:") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				kb, err := strconv.ParseFloat(fields[1], 64)
+				if err == nil {
+					return kb / 1024
+				}
+			}
+		}
+	}
+	return 0
+}

--- a/pkg/metrics/proc_linux.go
+++ b/pkg/metrics/proc_linux.go
@@ -3,13 +3,19 @@
 package metrics
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
 )
 
-// clkTck is the number of clock ticks per second on Linux (usually 100).
+// clkTck is the number of clock ticks per second used when converting /proc
+// stat jiffies to milliseconds. The value 100 is correct on the vast majority
+// of Linux systems (CONFIG_HZ=100) but is not universal — kernels compiled
+// with CONFIG_HZ=250 or CONFIG_HZ=1000 will produce scaled but not exact
+// values. Querying the actual value via sysconf(_SC_CLK_TCK) would require
+// cgo; the approximation is acceptable for monitoring purposes.
 const clkTck = 100
 
 // readSelfCPUMs reads the daemon's own CPU time (user+sys) from /proc/self/stat
@@ -18,15 +24,29 @@ func readSelfCPUMs() int64 {
 	return readProcStatCPUMs("/proc/self/stat")
 }
 
+// selfCPUMsPtr returns the daemon CPU time as a pointer so callers can
+// distinguish "zero CPU" from "metric not available". On Linux this is always
+// non-nil (may be zero if the process is brand new).
+func selfCPUMsPtr() *int64 {
+	v := readSelfCPUMs()
+	return &v
+}
+
 // readProcCPUMs reads a child process's CPU time from /proc/<pid>/stat.
+// If the process has exited (ENOENT or ESRCH) the function returns 0 silently.
 func readProcCPUMs(pid int) int64 {
 	return readProcStatCPUMs(fmt.Sprintf("/proc/%d/stat", pid))
 }
 
 // readProcStatCPUMs parses a /proc/*/stat file and returns (utime+stime) in ms.
+// If the file does not exist (process exited / PID recycled) it returns 0.
 func readProcStatCPUMs(path string) int64 {
 	data, err := os.ReadFile(path)
 	if err != nil {
+		// ENOENT means the process has already exited; skip silently.
+		if errors.Is(err, os.ErrNotExist) {
+			return 0
+		}
 		return 0
 	}
 	// The stat file has the process name in parentheses which may contain spaces.
@@ -54,10 +74,15 @@ func readProcStatCPUMs(path string) int64 {
 }
 
 // readProcRSSMB reads a process's Resident Set Size from /proc/<pid>/status.
+// If the process has exited (file gone) it returns 0 silently.
 func readProcRSSMB(pid int) float64 {
 	path := fmt.Sprintf("/proc/%d/status", pid)
 	data, err := os.ReadFile(path)
 	if err != nil {
+		// ENOENT: process exited between ActivePIDs() and this read — skip.
+		if errors.Is(err, os.ErrNotExist) {
+			return 0
+		}
 		return 0
 	}
 	for _, line := range strings.Split(string(data), "\n") {

--- a/pkg/metrics/proc_other.go
+++ b/pkg/metrics/proc_other.go
@@ -5,6 +5,10 @@ package metrics
 // readSelfCPUMs returns 0 on non-Linux platforms.
 func readSelfCPUMs() int64 { return 0 }
 
+// selfCPUMsPtr returns nil on non-Linux platforms to indicate the metric is
+// not available — distinguishable from a real zero-CPU value.
+func selfCPUMsPtr() *int64 { return nil }
+
 // readProcCPUMs returns 0 on non-Linux platforms.
 func readProcCPUMs(_ int) int64 { return 0 }
 

--- a/pkg/metrics/proc_other.go
+++ b/pkg/metrics/proc_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package metrics
+
+// readSelfCPUMs returns 0 on non-Linux platforms.
+func readSelfCPUMs() int64 { return 0 }
+
+// readProcCPUMs returns 0 on non-Linux platforms.
+func readProcCPUMs(_ int) int64 { return 0 }
+
+// readProcRSSMB returns 0 on non-Linux platforms.
+func readProcRSSMB(_ int) float64 { return 0 }

--- a/pkg/metrics/proc_test.go
+++ b/pkg/metrics/proc_test.go
@@ -1,0 +1,26 @@
+package metrics
+
+import "testing"
+
+func TestReadDaemonMetrics(t *testing.T) {
+	m := ReadDaemonMetrics()
+	if m.HeapAllocMB <= 0 {
+		t.Errorf("expected HeapAllocMB > 0, got %f", m.HeapAllocMB)
+	}
+	if m.HeapSysMB <= 0 {
+		t.Errorf("expected HeapSysMB > 0, got %f", m.HeapSysMB)
+	}
+	if m.Goroutines <= 0 {
+		t.Errorf("expected Goroutines > 0, got %d", m.Goroutines)
+	}
+}
+
+func TestReadChildMetrics_NoPIDs(t *testing.T) {
+	c := ReadChildMetrics(nil, 3)
+	if c.ActiveTasks != 3 {
+		t.Errorf("expected ActiveTasks=3, got %d", c.ActiveTasks)
+	}
+	if c.ChildRSSMB != 0 {
+		t.Errorf("expected ChildRSSMB=0 with no pids, got %f", c.ChildRSSMB)
+	}
+}

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -27,6 +27,19 @@ import (
 	"go.uber.org/zap"
 )
 
+// activePIDs tracks PIDs of all currently running Deno subprocesses.
+var activePIDs sync.Map // map[int]struct{}
+
+// ActivePIDs returns the PIDs of all currently running Deno subprocesses.
+func ActivePIDs() []int {
+	var pids []int
+	activePIDs.Range(func(k, _ any) bool {
+		pids = append(pids, k.(int))
+		return true
+	})
+	return pids
+}
+
 //go:embed sdk/shim.ts
 var shimContent string
 
@@ -279,6 +292,11 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		result.Error = fmt.Errorf("start deno: %w", err)
 		return result, nil
 	}
+
+	// Register PID so metrics can aggregate child process resource usage.
+	pid := cmd.Process.Pid
+	activePIDs.Store(pid, struct{}{})
+	defer activePIDs.Delete(pid)
 
 	// Stream stdout (console.log/info) as "info" and stderr (console.error +
 	// Deno runtime errors) as "error" in the run log.

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -134,6 +134,16 @@ func (e *Engine) resolveNotify(spec *task.Spec) (onSuccess, onFailure bool) {
 	return
 }
 
+// ActiveRunCount returns the number of task runs currently in progress.
+func (e *Engine) ActiveRunCount() int {
+	n := 0
+	e.runCancels.Range(func(_, _ any) bool {
+		n++
+		return true
+	})
+	return n
+}
+
 // RegisterExecutor registers an executor for the given runtime name.
 // Call this before Start to wire in Docker, subprocess, or custom runtimes.
 func (e *Engine) RegisterExecutor(rt task.Runtime, exec pkgruntime.Executor) {

--- a/pkg/webui/metrics.go
+++ b/pkg/webui/metrics.go
@@ -1,0 +1,25 @@
+package webui
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/dicode/dicode/pkg/metrics"
+	denoruntime "github.com/dicode/dicode/pkg/runtime/deno"
+)
+
+// apiMetrics handles GET /api/metrics.
+// Returns daemon heap/CPU metrics and active task/child-process metrics as JSON.
+func (s *Server) apiMetrics(w http.ResponseWriter, r *http.Request) {
+	activeTasks := s.engine.ActiveRunCount()
+	pids := denoruntime.ActivePIDs()
+
+	m := metrics.Metrics{
+		Daemon: metrics.ReadDaemonMetrics(),
+		Tasks:  metrics.ReadChildMetrics(pids, activeTasks),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(m)
+}

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -405,6 +405,9 @@ func (s *Server) Handler() http.Handler {
 			r.Patch("/sources/{name}/dev", s.apiSetDevMode)
 			r.Get("/sources/{name}/branches", s.apiListSourceBranches)
 
+			// Metrics
+			r.Get("/metrics", s.apiMetrics)
+
 			// Managed runtime lifecycle
 			r.Get("/runtimes", s.apiListRuntimes)
 			r.Post("/runtimes/{name}/install", s.apiInstallRuntime)

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -394,6 +395,61 @@ func TestAPI_Metrics_AuthRequired(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestAPI_Metrics_AuthOK(t *testing.T) {
+	// Verify that GET /api/metrics returns 200 with valid JSON when auth is
+	// enabled and a valid session token is present.
+	srv := newAuthServer(t, "hunter2")
+	token := srv.sessions.issue()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/metrics", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookie, Value: token})
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var m map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&m); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := m["daemon"]; !ok {
+		t.Error("missing 'daemon' key in metrics response")
+	}
+	if _, ok := m["tasks"]; !ok {
+		t.Error("missing 'tasks' key in metrics response")
+	}
+}
+
+func TestAPI_Metrics_Concurrent(t *testing.T) {
+	// Fire 5 concurrent GET /api/metrics requests and verify all return 200.
+	// Run with -race to detect data races in the metrics collection path.
+	srv, _ := newTestServer(t)
+	h := srv.Handler()
+
+	const n = 5
+	var wg sync.WaitGroup
+	wg.Add(n)
+	codes := make([]int, n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/api/metrics", nil)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+			codes[i] = w.Code
+		}()
+	}
+	wg.Wait()
+
+	for i, code := range codes {
+		if code != http.StatusOK {
+			t.Errorf("goroutine %d: expected 200, got %d", i, code)
+		}
 	}
 }
 

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -355,6 +355,48 @@ func TestWebhook_AuthTask_AllowsAuthenticatedSession(t *testing.T) {
 	}
 }
 
+func TestAPI_Metrics_OK(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/metrics", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	ct := w.Header().Get("Content-Type")
+	if ct == "" || ct[:16] != "application/json" {
+		t.Errorf("expected application/json content-type, got %q", ct)
+	}
+	var m map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&m); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := m["daemon"]; !ok {
+		t.Error("missing 'daemon' key in metrics response")
+	}
+	if _, ok := m["tasks"]; !ok {
+		t.Error("missing 'tasks' key in metrics response")
+	}
+}
+
+func TestAPI_Metrics_AuthRequired(t *testing.T) {
+	srv, _ := newTestServer(t)
+	// Enable auth so requireAuth rejects unauthenticated requests.
+	srv.cfg.Server.Auth = true
+
+	req := httptest.NewRequest(http.MethodGet, "/api/metrics", nil)
+	// Mark as API request so we get 401 instead of a redirect.
+	req.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
 func contains(s, sub string) bool {
 	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsStr(s, sub))
 }

--- a/tasks/buildin/webui/app/app.js
+++ b/tasks/buildin/webui/app/app.js
@@ -12,6 +12,7 @@ import './components/dc-security.js';
 import './components/dc-sources.js';
 import './components/dc-log-bar.js';
 import './components/dc-notif-panel.js';
+import './components/dc-metrics.js';
 
 // ── Auth overlay ──────────────────────────────────────────────────────────────
 // Inject a single <dc-auth-overlay> into the document body. The API client
@@ -42,6 +43,7 @@ route(/^\/config$/,    () => { app.innerHTML = '<dc-config></dc-config>'; });
 route(/^\/secrets$/,   () => { app.innerHTML = '<dc-secrets></dc-secrets>'; });
 route(/^\/security$/,  () => { app.innerHTML = '<dc-security></dc-security>'; });
 route(/^\/sources$/,   () => { app.innerHTML = '<dc-sources></dc-sources>'; });
+route(/^\/metrics$/,   () => { app.innerHTML = '<dc-metrics></dc-metrics>'; });
 route(/^\/$/,          () => { app.innerHTML = '<dc-task-list></dc-task-list>'; });
 
 // Expose navigate globally for any inline hrefs

--- a/tasks/buildin/webui/app/components/dc-metrics.js
+++ b/tasks/buildin/webui/app/components/dc-metrics.js
@@ -1,0 +1,133 @@
+import { LitElement, html } from 'https://esm.sh/lit@3';
+import { get } from '../lib/api.js';
+
+const POLL_INTERVAL_MS = 5000;
+
+class DcMetrics extends LitElement {
+  createRenderRoot() { return this; }
+
+  static properties = {
+    _data:    { state: true },
+    _error:   { state: true },
+    _loading: { state: true },
+  };
+
+  constructor() {
+    super();
+    this._data    = null;
+    this._error   = null;
+    this._loading = true;
+    this._timer   = null;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._poll();
+    this._timer = setInterval(() => this._poll(), POLL_INTERVAL_MS);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    clearInterval(this._timer);
+  }
+
+  async _poll() {
+    try {
+      this._data    = await get('/api/metrics');
+      this._error   = null;
+      this._loading = false;
+    } catch (e) {
+      this._error   = e.message;
+      this._loading = false;
+    }
+  }
+
+  _fmt(v, unit = '') {
+    if (v === null || v === undefined) return '—';
+    if (typeof v === 'number') return v.toFixed(1) + (unit ? '\u202f' + unit : '');
+    return String(v);
+  }
+
+  _fmtMB(v)  { return this._fmt(v, 'MB'); }
+  _fmtMs(v)  { return v != null ? this._fmt(v, 'ms') : '—'; }
+
+  _row(label, value) {
+    return html`
+      <tr>
+        <td class="meta" style="width:55%;padding-right:1rem">${label}</td>
+        <td style="font-variant-numeric:tabular-nums">${value}</td>
+      </tr>`;
+  }
+
+  render() {
+    if (this._loading) return html`<div class="meta">Loading…</div>`;
+    if (this._error)   return html`<p style="color:red">Error: ${this._error}</p>`;
+
+    const { daemon, tasks } = this._data;
+
+    return html`
+      <div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.25rem">
+        <h1 style="margin:0">Metrics</h1>
+        <span class="meta" style="font-size:0.8rem">auto-refreshes every ${POLL_INTERVAL_MS / 1000}s</span>
+      </div>
+
+      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem">
+
+        <!-- Tasks card -->
+        <div class="card">
+          <h3 style="margin:0 0 0.75rem">Tasks</h3>
+          <table style="width:100%">
+            <tbody>
+              ${this._row('Active runs',    tasks.active_tasks)}
+              ${tasks.queued != null
+                ? this._row('Queued (semaphore)', tasks.queued)
+                : ''}
+              ${tasks.children_rss_mb
+                ? this._row('Child RSS (Deno)', this._fmtMB(tasks.children_rss_mb))
+                : ''}
+              ${tasks.children_cpu_ms != null
+                ? this._row('Child CPU total', this._fmtMs(tasks.children_cpu_ms))
+                : ''}
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Daemon card -->
+        <div class="card">
+          <h3 style="margin:0 0 0.75rem">Daemon</h3>
+          <table style="width:100%">
+            <tbody>
+              ${this._row('Goroutines',   daemon.goroutines)}
+              ${this._row('Heap alloc',   this._fmtMB(daemon.heap_alloc_mb))}
+              ${this._row('Heap sys',     this._fmtMB(daemon.heap_sys_mb))}
+              ${daemon.cpu_ms != null
+                ? this._row('Daemon CPU', this._fmtMs(daemon.cpu_ms))
+                : ''}
+            </tbody>
+          </table>
+        </div>
+
+        <!-- DB card (optional, shown only when fields present) -->
+        ${this._data.db ? html`
+          <div class="card">
+            <h3 style="margin:0 0 0.75rem">Database</h3>
+            <table style="width:100%">
+              <tbody>
+                ${this._data.db.write_latency_p50_ms != null
+                  ? this._row('Write p50', this._fmtMs(this._data.db.write_latency_p50_ms))
+                  : ''}
+                ${this._data.db.write_latency_p99_ms != null
+                  ? this._row('Write p99', this._fmtMs(this._data.db.write_latency_p99_ms))
+                  : ''}
+                ${this._data.db.log_queue_depth != null
+                  ? this._row('Log queue depth', this._data.db.log_queue_depth)
+                  : ''}
+              </tbody>
+            </table>
+          </div>
+        ` : ''}
+      </div>`;
+  }
+}
+
+customElements.define('dc-metrics', DcMetrics);


### PR DESCRIPTION
Closes #68

## Changes

- **`pkg/metrics/`** — new package with `DaemonMetrics`, `ChildMetrics`, `Metrics` structs and collection logic
  - `proc.go` — stdlib-only: `runtime.ReadMemStats` for heap, `runtime.NumGoroutine` for goroutines
  - `proc_linux.go` — Linux-only (build tag): reads `/proc/self/stat` for daemon CPU ms, `/proc/<pid>/status` for child RSS, `/proc/<pid>/stat` for child CPU
  - `proc_other.go` — no-op stubs for non-Linux builds (all fields omitted via `omitempty`)
  - `proc_test.go` — unit tests: `HeapAllocMB > 0`, goroutines > 0, no-pid child metrics

- **`pkg/runtime/deno/runtime.go`** — package-level `sync.Map` tracks PIDs of active Deno processes; `ActivePIDs() []int` exported for aggregation; PIDs registered after `cmd.Start()` and deregistered via `defer`

- **`pkg/trigger/engine.go`** — `ActiveRunCount() int` counts entries in `runCancels` sync.Map

- **`pkg/webui/metrics.go`** — `GET /api/metrics` handler: collects and JSON-encodes a `metrics.Metrics` struct; protected by `requireAuth` middleware

- **`pkg/webui/server.go`** — route `r.Get("/metrics", s.apiMetrics)` registered inside the authenticated `r.Route("/api", ...)` group

- **`pkg/webui/server_test.go`** — `TestAPI_Metrics_OK` (200 + valid JSON) and `TestAPI_Metrics_AuthRequired` (401 when `server.auth: true`)

- **`docs/concepts/metrics.md`** — full endpoint reference with field descriptions and platform notes

## Test plan

- [ ] `go build ./...` — passes on Linux and macOS (build tags guard `/proc` reads)
- [ ] `go test ./pkg/metrics/... -v` — `TestReadDaemonMetrics`, `TestReadChildMetrics_NoPIDs` pass
- [ ] `go test ./pkg/webui/... -run TestAPI_Metrics -v` — both 200 and 401 tests pass
- [ ] `go test ./... -timeout 300s -count=1` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)