### PR TITLE
feat: relay client with cryptographic identity

### DIFF
--- a/cmd/dicoded/main.go
+++ b/cmd/dicoded/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dicode/dicode/pkg/notify"
 	"github.com/dicode/dicode/pkg/onboarding"
 	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/relay"
 	pkgruntime "github.com/dicode/dicode/pkg/runtime"
 	denoruntime "github.com/dicode/dicode/pkg/runtime/deno"
 	dockerruntime "github.com/dicode/dicode/pkg/runtime/docker"
@@ -188,6 +189,17 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	g.Go(func() error { return eng.Start(ctx) })
 	g.Go(func() error { return srv.Start(ctx) })
 	g.Go(func() error { return ctrlSrv.Start(ctx) })
+
+	// 11. Relay client — optional, enabled via config.
+	if cfg.Relay.Enabled && cfg.Relay.ServerURL != "" {
+		id, err := relay.LoadOrGenerateIdentity(ctx, database)
+		if err != nil {
+			log.Warn("relay: identity init failed, relay disabled", zap.Error(err))
+		} else {
+			rc := relay.NewClient(cfg.Relay.ServerURL, id, eng.WebhookHandler(), log)
+			g.Go(func() error { return rc.Run(ctx) })
+		}
+	}
 
 	return g.Wait()
 }

--- a/docs/design/relay.md
+++ b/docs/design/relay.md
@@ -1,0 +1,188 @@
+# Relay Client Design
+
+## Problem
+
+dicode instances running on developer laptops or behind corporate NAT/firewall
+cannot receive incoming webhooks from external services (GitHub, Slack, Stripe,
+etc.). The conventional solutions — ngrok, Cloudflare Tunnel, port forwarding —
+require separate tooling, accounts, or network configuration that adds friction
+and is not reproducible across machines.
+
+The relay solves this by maintaining a persistent outbound WebSocket connection
+from the local dicode daemon to a publicly reachable relay server. The relay
+server receives inbound HTTP requests and forwards them over the WebSocket. The
+local daemon reconstructs the HTTP request, runs it through the existing webhook
+handler, and sends the HTTP response back over the same WebSocket.
+
+The architecture requires no inbound ports, no NAT traversal, and no third-party
+accounts for self-hosters.
+
+---
+
+## Architecture
+
+```
+GitHub / Slack / Stripe
+        │
+        │ POST /u/<uuid>/hooks/my-task
+        ▼
+┌──────────────────┐
+│   Relay Server   │  (relay.dicode.app or self-hosted)
+│                  │
+│ /u/<uuid>/hooks/* ──── WebSocket ────────────────┐
+└──────────────────┘                               │
+                                                   │
+                                        ┌──────────▼─────────┐
+                                        │  dicode daemon     │
+                                        │  (local machine)   │
+                                        │                    │
+                                        │  relay.Client      │
+                                        │       │            │
+                                        │  trigger.Engine    │
+                                        │  WebhookHandler    │
+                                        └────────────────────┘
+```
+
+The relay server proxies `POST /u/<uuid>/hooks/my-task` to the local daemon as
+a WebSocket `request` message. The daemon runs the webhook handler against a
+synthetic `*http.Request`, captures the response with `httptest.ResponseRecorder`,
+and sends back a `response` message. The relay server translates that back into
+an HTTP response to the original caller.
+
+---
+
+## Cryptographic Identity
+
+### Key generation (first run)
+
+1. Generate an ECDSA P-256 keypair using `crypto/rand`.
+2. Store the PEM-encoded private key in the `kv` SQLite table (key:
+   `relay.private_key`). The `kv` table already exists in the schema.
+3. Derive the UUID: `hex(sha256(uncompressed P-256 public key bytes))` — 64
+   lowercase hex characters. The uncompressed form is the 65-byte encoding
+   `0x04 || X || Y`.
+
+### Reconnection (stable identity)
+
+On every subsequent start the daemon loads the private key from SQLite, derives
+the same UUID, and presents the same stable public webhook URL. The URL never
+changes as long as the database file is preserved.
+
+### UUID derivation rationale
+
+Using SHA-256 of the uncompressed public key as the identifier means:
+- The relay server can verify `hex(sha256(presented_pubkey)) == claimed_uuid`
+  without any server-side user database.
+- The identifier is collision-resistant (SHA-256 preimage resistance).
+- Clients cannot choose an arbitrary UUID; they must control the corresponding
+  private key.
+
+---
+
+## Protocol Specification
+
+All messages are JSON objects sent over a single WebSocket connection (text
+frames). The connection is always initiated by the client (dicode daemon).
+
+### Handshake
+
+```
+Server → Client  {"type":"challenge","nonce":"<64 hex chars>"}
+Client → Server  {"type":"hello","uuid":"<64 hex>","pubkey":"<base64>","sig":"<base64>","timestamp":<unix>}
+Server → Client  {"type":"welcome","url":"https://relay.example.com/u/<uuid>/hooks/"}
+                 or
+                 {"type":"error","message":"<reason>"}
+```
+
+**Challenge**: 32 random bytes encoded as 64 lowercase hex characters.
+
+**Hello fields**:
+- `uuid`: 64 hex chars derived as `hex(sha256(uncompressed_pubkey))`.
+- `pubkey`: base64 (standard encoding) of the 65-byte uncompressed P-256 public
+  key.
+- `sig`: base64 ECDSA signature over `sha256(nonce_bytes || big-endian uint64
+  timestamp)` using the private key. ASN.1 DER encoding.
+- `timestamp`: Unix seconds at signing time.
+
+**Verification steps** (server):
+1. Decode `pubkey` from base64; reject if not 65 bytes starting with `0x04`.
+2. Verify `hex(sha256(pubkey_bytes)) == uuid`; reject if mismatch.
+3. Verify `timestamp` is within ±30 seconds of server clock; reject if outside.
+4. Verify nonce has not been seen in the last 60 seconds; reject if replayed.
+5. Verify ECDSA signature over `sha256(nonce_bytes || timestamp_be_uint64)`.
+
+### Webhook forwarding
+
+```
+Server → Client  {
+  "type":    "request",
+  "id":      "<uuid>",
+  "method":  "POST",
+  "path":    "/hooks/my-task",
+  "headers": {"X-Hub-Signature-256": ["sha256=..."]},
+  "body":    "<base64>"
+}
+
+Client → Server  {
+  "type":    "response",
+  "id":      "<uuid>",
+  "status":  200,
+  "headers": {"Content-Type": ["application/json"]},
+  "body":    "<base64>"
+}
+```
+
+The `id` field correlates requests and responses. The relay server may
+send multiple requests concurrently; the client handles each in a separate
+goroutine and sends responses as they complete.
+
+### Keepalive
+
+Standard WebSocket ping/pong frames are used. The client sends a ping every
+30 seconds. The relay server closes the connection if no pong is received
+within 10 seconds of a ping.
+
+---
+
+## Threat Model
+
+### Prevented
+
+| Attack | Mitigation |
+|---|---|
+| UUID squatting | Server verifies `hex(sha256(pubkey)) == uuid`; you must hold the private key |
+| Challenge replay | Timestamp must be within ±30 s; nonce is single-use (60 s TTL) |
+| Signature forgery | ECDSA P-256; only the holder of the private key can sign |
+| Connection hijacking | TLS (WSS) in production; MitM cannot read or inject frames |
+| Enumeration of UUIDs | UUIDs are SHA-256 hashes; not guessable from the public URL |
+
+### Not prevented
+
+- **Relay server compromise**: The relay server sees plaintext request bodies and
+  response bodies. A compromised relay server can read all webhook payloads and
+  forge requests to the client. Mitigate by self-hosting the relay server on
+  infrastructure you control.
+- **Client key compromise**: An attacker who extracts the SQLite database gains
+  the private key and can impersonate the client. Encrypt your disk or use the
+  dicode secrets encryption layer.
+- **Denial of service**: The relay server can drop connections or refuse to
+  forward requests. The client reconnects automatically but cannot force the
+  server to cooperate.
+- **Traffic analysis**: An observer watching the WebSocket connection can infer
+  that webhooks are being delivered (timing, sizes) even without reading content.
+
+---
+
+## Self-hosting vs Hosted Relay
+
+| | Hosted (`relay.dicode.app`) | Self-hosted |
+|---|---|---|
+| Setup | Enable in config, done | Deploy relay server binary |
+| Trust | Must trust dicode.app | You control the server |
+| Availability | Managed, SLA | Your responsibility |
+| Cost | May require paid plan | Free, infrastructure costs |
+| Privacy | Relay sees plaintext payloads | You see your own payloads |
+
+For high-security environments, self-host the relay server inside your network
+perimeter. The relay server implementation (`pkg/relay/server.go`) is designed
+to run standalone.

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -1,0 +1,117 @@
+# Relay
+
+The dicode relay lets a local dicode instance receive webhooks from GitHub,
+Slack, Stripe, and other external services without port forwarding, ngrok, or
+any inbound firewall rules. The daemon makes a single outbound WebSocket
+connection to a relay server; the relay server forwards incoming HTTP requests
+over that connection, and the daemon sends back HTTP responses. Your local
+webhook tasks work exactly as they do in production — the relay is transparent.
+
+---
+
+## Quick start
+
+**1. Enable relay in `dicode.yaml`:**
+
+```yaml
+relay:
+  enabled: true
+  server_url: wss://relay.dicode.app
+```
+
+**2. Start the daemon:**
+
+```
+dicoded -config dicode.yaml
+```
+
+On first start the daemon generates a P-256 keypair, stores it in the local
+SQLite database, and logs the public webhook URL:
+
+```
+{"level":"info","msg":"relay connected","url":"https://relay.dicode.app/u/4a7b3c.../hooks/"}
+```
+
+**3. Copy the URL to your webhook provider:**
+
+In GitHub → Settings → Webhooks, set the Payload URL to:
+
+```
+https://relay.dicode.app/u/<your-uuid>/hooks/github-push
+```
+
+That's it. The URL is stable across restarts as long as you keep your database.
+
+---
+
+## Config reference
+
+```yaml
+relay:
+  enabled: true          # default: false
+  server_url: wss://...  # relay WebSocket endpoint
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | `false` | Enable the relay client |
+| `server_url` | string | — | WebSocket URL of the relay server (must start with `wss://` in production) |
+
+---
+
+## Stable URL
+
+The webhook URL is derived from a cryptographic keypair, not from your IP
+address or hostname. As long as the dicode SQLite database is intact:
+
+- Restarts do not change your URL.
+- Changing networks does not change your URL.
+- The relay reconnects automatically after network interruptions.
+
+The URL has the form:
+
+```
+https://<relay-host>/u/<64-hex-chars>/hooks/
+```
+
+The 64-hex identifier is `sha256(public_key)`. It is stable, collision-resistant,
+and cannot be guessed or squatted by another party.
+
+---
+
+## Exporting and backing up the relay key
+
+The relay private key is stored in the SQLite database under the key
+`relay.private_key` in the `kv` table. To back it up:
+
+```sh
+sqlite3 ~/.dicode/data.db "SELECT value FROM kv WHERE key = 'relay.private_key';"
+```
+
+To restore it on another machine, insert the same row into the `kv` table
+before starting the daemon:
+
+```sh
+sqlite3 ~/.dicode/data.db "INSERT OR REPLACE INTO kv (key, value) VALUES ('relay.private_key', '<pem>');"
+```
+
+Keep this value secret. Anyone with the private key can impersonate your relay
+client.
+
+---
+
+## Self-hosting the relay server
+
+The relay server is included in the dicode repository (`pkg/relay/server.go`).
+To run a standalone relay server, build and run the `relay-server` binary
+(coming soon as a separate `cmd/relay-server`). Configure clients to point at
+your server:
+
+```yaml
+relay:
+  enabled: true
+  server_url: wss://relay.example.com
+```
+
+The relay server requires no database; nonce state is kept in memory.
+TLS termination should be handled by a reverse proxy (nginx, Caddy, etc.).

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -88,11 +88,17 @@ The relay private key is stored in the SQLite database under the key
 sqlite3 ~/.dicode/data.db "SELECT value FROM kv WHERE key = 'relay.private_key';"
 ```
 
-To restore it on another machine, insert the same row into the `kv` table
-before starting the daemon:
+To restore it on another machine, write the PEM to a temp file first, then
+insert it — this avoids storing the raw key in your shell history:
 
 ```sh
-sqlite3 ~/.dicode/data.db "INSERT OR REPLACE INTO kv (key, value) VALUES ('relay.private_key', '<pem>');"
+# Export from source machine
+sqlite3 ~/.dicode/data.db "SELECT value FROM kv WHERE key = 'relay.private_key';" > /tmp/relay_key.pem
+
+# On the destination machine, import via a file variable (not an inline string)
+PEM=$(cat /tmp/relay_key.pem)
+sqlite3 ~/.dicode/data.db "INSERT OR REPLACE INTO kv (key, value) VALUES ('relay.private_key', '$PEM');"
+rm /tmp/relay_key.pem
 ```
 
 Keep this value secret. Anyone with the private key can impersonate your relay

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,14 @@ type DefaultsConfig struct {
 	OnFailureChain string `yaml:"on_failure_chain,omitempty"`
 }
 
+// RelayConfig configures the WebSocket relay client.
+// The relay allows a local dicode instance to receive webhooks from external
+// services (GitHub, Slack, etc.) without port forwarding.
+type RelayConfig struct {
+	Enabled   bool   `yaml:"enabled"`
+	ServerURL string `yaml:"server_url"` // wss://relay.dicode.app
+}
+
 type Config struct {
 	Sources       []SourceConfig           `yaml:"sources"`
 	Database      DatabaseConfig           `yaml:"database"`
@@ -36,6 +44,7 @@ type Config struct {
 	AI            AIConfig                 `yaml:"ai"`
 	Defaults      DefaultsConfig           `yaml:"defaults"`
 	Runtimes      map[string]RuntimeConfig `yaml:"runtimes,omitempty"`
+	Relay         RelayConfig              `yaml:"relay,omitempty"`
 	LogLevel      string                   `yaml:"log_level"`
 	DataDir       string                   `yaml:"data_dir"`
 }

--- a/pkg/relay/client.go
+++ b/pkg/relay/client.go
@@ -13,15 +13,30 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	mathrand "math/rand/v2"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/coder/websocket"
 	"go.uber.org/zap"
+)
+
+const (
+	// maxBodySize is the maximum request body size accepted by the relay (5 MB).
+	maxBodySize = 5 * 1024 * 1024
+
+	// dialTimeout is the maximum time allowed for the WebSocket dial + handshake.
+	dialTimeout = 15 * time.Second
+
+	// stableConnectionThreshold is the minimum time a connection must stay up
+	// before the backoff resets on the next reconnect.
+	stableConnectionThreshold = 10 * time.Second
 )
 
 // Client maintains a persistent WebSocket connection to a relay server and
@@ -33,8 +48,15 @@ type Client struct {
 	log       *zap.Logger
 }
 
-// NewClient creates a relay client. serverURL must be a ws:// or wss:// URL.
+// NewClient creates a relay client. serverURL must be a wss:// URL.
+// In test/dev environments ws:// is accepted but a warning is logged.
 func NewClient(serverURL string, identity *Identity, handler http.Handler, log *zap.Logger) *Client {
+	if !strings.HasPrefix(serverURL, "wss://") && !strings.HasPrefix(serverURL, "ws://") {
+		log.Error("relay: serverURL must start with wss:// or ws://", zap.String("url", serverURL))
+	} else if strings.HasPrefix(serverURL, "ws://") {
+		log.Warn("relay: using unencrypted ws:// connection — use wss:// in production",
+			zap.String("url", serverURL))
+	}
 	return &Client{
 		serverURL: serverURL,
 		identity:  identity,
@@ -50,6 +72,7 @@ func (c *Client) Run(ctx context.Context) error {
 	const maxBackoff = 60 * time.Second
 
 	for {
+		connectedAt := time.Now()
 		if err := c.runOnce(ctx); err != nil {
 			if ctx.Err() != nil {
 				return nil
@@ -57,10 +80,17 @@ func (c *Client) Run(ctx context.Context) error {
 			c.log.Warn("relay disconnected, reconnecting", zap.Error(err), zap.Duration("backoff", backoff))
 		}
 
+		// Reset backoff if the connection was stable long enough.
+		if time.Since(connectedAt) >= stableConnectionThreshold {
+			backoff = time.Second
+		}
+
+		t := time.NewTimer(jitter(backoff))
 		select {
 		case <-ctx.Done():
+			t.Stop()
 			return nil
-		case <-time.After(jitter(backoff)):
+		case <-t.C:
 		}
 
 		backoff = time.Duration(math.Min(float64(backoff*2), float64(maxBackoff)))
@@ -76,20 +106,28 @@ func jitter(d time.Duration) time.Duration {
 }
 
 func (c *Client) runOnce(ctx context.Context) error {
-	conn, _, err := websocket.Dial(ctx, c.serverURL, nil)
+	// Apply a timeout to the dial + handshake phase.
+	dialCtx, cancel := context.WithTimeout(ctx, dialTimeout)
+	defer cancel()
+
+	conn, _, err := websocket.Dial(dialCtx, c.serverURL, nil)
 	if err != nil {
 		return fmt.Errorf("dial relay: %w", err)
 	}
 	defer conn.CloseNow()
 
-	if err := c.handshake(ctx, conn); err != nil {
+	// sendMu serializes all writes to this connection (required by coder/websocket).
+	var sendMu sync.Mutex
+
+	if err := c.handshake(dialCtx, conn, &sendMu); err != nil {
 		return fmt.Errorf("handshake: %w", err)
 	}
+	cancel() // handshake done — release the dial timeout
 
-	return c.serve(ctx, conn)
+	return c.serve(ctx, conn, &sendMu)
 }
 
-func (c *Client) handshake(ctx context.Context, conn *websocket.Conn) error {
+func (c *Client) handshake(ctx context.Context, conn *websocket.Conn, sendMu *sync.Mutex) error {
 	_, data, err := conn.Read(ctx)
 	if err != nil {
 		return fmt.Errorf("read challenge: %w", err)
@@ -126,7 +164,10 @@ func (c *Client) handshake(ctx context.Context, conn *websocket.Conn) error {
 		return fmt.Errorf("encode hello: %w", err)
 	}
 
-	if err := conn.Write(ctx, websocket.MessageText, hello); err != nil {
+	sendMu.Lock()
+	err = conn.Write(ctx, websocket.MessageText, hello)
+	sendMu.Unlock()
+	if err != nil {
 		return fmt.Errorf("send hello: %w", err)
 	}
 
@@ -152,7 +193,7 @@ func (c *Client) handshake(ctx context.Context, conn *websocket.Conn) error {
 	}
 }
 
-func (c *Client) serve(ctx context.Context, conn *websocket.Conn) error {
+func (c *Client) serve(ctx context.Context, conn *websocket.Conn, sendMu *sync.Mutex) error {
 	for {
 		_, data, err := conn.Read(ctx)
 		if err != nil {
@@ -173,18 +214,21 @@ func (c *Client) serve(ctx context.Context, conn *websocket.Conn) error {
 			continue
 		}
 
-		go c.handleRequest(ctx, conn, req)
+		go c.handleRequest(ctx, conn, sendMu, req)
 	}
 }
 
-func (c *Client) handleRequest(ctx context.Context, conn *websocket.Conn, req requestMsg) {
+func (c *Client) handleRequest(ctx context.Context, conn *websocket.Conn, sendMu *sync.Mutex, req requestMsg) {
 	resp := c.dispatchRequest(req)
 	out, err := encodeMsg(resp)
 	if err != nil {
 		c.log.Error("relay: encode response", zap.Error(err))
 		return
 	}
-	if err := conn.Write(ctx, websocket.MessageText, out); err != nil {
+	sendMu.Lock()
+	err = conn.Write(ctx, websocket.MessageText, out)
+	sendMu.Unlock()
+	if err != nil {
 		c.log.Warn("relay: send response", zap.Error(err))
 	}
 }
@@ -192,19 +236,27 @@ func (c *Client) handleRequest(ctx context.Context, conn *websocket.Conn, req re
 func (c *Client) dispatchRequest(req requestMsg) responseMsg {
 	var body []byte
 	if req.Body != "" {
-		var err error
-		body, err = base64.StdEncoding.DecodeString(req.Body)
+		// Limit base64-decoded body to maxBodySize to avoid memory exhaustion.
+		// The base64 string itself can be at most ~4/3 * maxBodySize.
+		maxB64 := int64(maxBodySize * 4 / 3)
+		limited := io.LimitReader(strings.NewReader(req.Body), maxB64+1)
+		b64Data, err := io.ReadAll(limited)
+		if err != nil || int64(len(b64Data)) > maxB64 {
+			return errorResponse(req.ID, http.StatusRequestEntityTooLarge)
+		}
+		body, err = base64.StdEncoding.DecodeString(string(b64Data))
 		if err != nil {
 			return errorResponse(req.ID, http.StatusBadRequest)
 		}
+		if len(body) > maxBodySize {
+			return errorResponse(req.ID, http.StatusRequestEntityTooLarge)
+		}
 	}
 
-	httpReq, err := http.NewRequest(req.Method, req.Path, bytes.NewReader(body))
+	u := &url.URL{Scheme: "http", Host: "relay", Path: req.Path}
+	httpReq, err := http.NewRequestWithContext(context.Background(), req.Method, u.String(), bytes.NewReader(body))
 	if err != nil {
 		return errorResponse(req.ID, http.StatusBadRequest)
-	}
-	if !strings.HasPrefix(req.Path, "http") {
-		httpReq.RequestURI = req.Path
 	}
 	for k, vals := range req.Headers {
 		for _, v := range vals {
@@ -224,10 +276,7 @@ func (c *Client) dispatchRequest(req requestMsg) responseMsg {
 		respBody = buf.Bytes()
 	}
 
-	headers := make(map[string][]string)
-	for k, vals := range result.Header {
-		headers[k] = vals
-	}
+	headers := filterResponseHeaders(result.Header)
 
 	return responseMsg{
 		Type:    msgResponse,
@@ -236,6 +285,33 @@ func (c *Client) dispatchRequest(req requestMsg) responseMsg {
 		Headers: headers,
 		Body:    base64.StdEncoding.EncodeToString(respBody),
 	}
+}
+
+// hopByHopHeaders are headers that must not be forwarded per HTTP/1.1.
+var hopByHopHeaders = map[string]bool{
+	"Connection":          true,
+	"Keep-Alive":          true,
+	"Proxy-Authenticate":  true,
+	"Proxy-Authorization": true,
+	"Te":                  true,
+	"Trailers":            true,
+	"Transfer-Encoding":   true,
+	"Upgrade":             true,
+	// Sensitive headers that should not leak to the inbound caller.
+	"Set-Cookie": true,
+}
+
+// filterResponseHeaders strips hop-by-hop and sensitive headers before
+// forwarding the response back to the inbound webhook caller.
+func filterResponseHeaders(h http.Header) map[string][]string {
+	out := make(map[string][]string, len(h))
+	for k, vals := range h {
+		if hopByHopHeaders[k] {
+			continue
+		}
+		out[k] = vals
+	}
+	return out
 }
 
 func errorResponse(id string, status int) responseMsg {

--- a/pkg/relay/client.go
+++ b/pkg/relay/client.go
@@ -1,0 +1,262 @@
+// Package relay implements a WebSocket relay client that lets a local dicode
+// instance receive webhooks from external services without port forwarding.
+package relay
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	mathrand "math/rand/v2"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	"github.com/coder/websocket"
+	"go.uber.org/zap"
+)
+
+// Client maintains a persistent WebSocket connection to a relay server and
+// forwards incoming webhook requests through a local http.Handler.
+type Client struct {
+	serverURL string
+	identity  *Identity
+	handler   http.Handler
+	log       *zap.Logger
+}
+
+// NewClient creates a relay client. serverURL must be a ws:// or wss:// URL.
+func NewClient(serverURL string, identity *Identity, handler http.Handler, log *zap.Logger) *Client {
+	return &Client{
+		serverURL: serverURL,
+		identity:  identity,
+		handler:   handler,
+		log:       log,
+	}
+}
+
+// Run connects to the relay server and maintains the connection until ctx is
+// cancelled. Reconnects with exponential backoff on disconnect.
+func (c *Client) Run(ctx context.Context) error {
+	backoff := time.Second
+	const maxBackoff = 60 * time.Second
+
+	for {
+		if err := c.runOnce(ctx); err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			c.log.Warn("relay disconnected, reconnecting", zap.Error(err), zap.Duration("backoff", backoff))
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(jitter(backoff)):
+		}
+
+		backoff = time.Duration(math.Min(float64(backoff*2), float64(maxBackoff)))
+	}
+}
+
+// jitter returns d ±20%.
+func jitter(d time.Duration) time.Duration {
+	f := float64(d)
+	delta := f * 0.2
+	offset := (mathrand.Float64()*2 - 1) * delta
+	return time.Duration(f + offset)
+}
+
+func (c *Client) runOnce(ctx context.Context) error {
+	conn, _, err := websocket.Dial(ctx, c.serverURL, nil)
+	if err != nil {
+		return fmt.Errorf("dial relay: %w", err)
+	}
+	defer conn.CloseNow()
+
+	if err := c.handshake(ctx, conn); err != nil {
+		return fmt.Errorf("handshake: %w", err)
+	}
+
+	return c.serve(ctx, conn)
+}
+
+func (c *Client) handshake(ctx context.Context, conn *websocket.Conn) error {
+	_, data, err := conn.Read(ctx)
+	if err != nil {
+		return fmt.Errorf("read challenge: %w", err)
+	}
+	if msgType(data) != msgChallenge {
+		return fmt.Errorf("expected challenge, got %q", msgType(data))
+	}
+	var ch challengeMsg
+	if err := json.Unmarshal(data, &ch); err != nil {
+		return fmt.Errorf("parse challenge: %w", err)
+	}
+
+	nonceBytes, err := hex.DecodeString(ch.Nonce)
+	if err != nil || len(nonceBytes) != 32 {
+		return fmt.Errorf("invalid nonce")
+	}
+
+	ts := time.Now().Unix()
+	sig, err := signChallenge(c.identity.PrivateKey, nonceBytes, ts)
+	if err != nil {
+		return fmt.Errorf("sign challenge: %w", err)
+	}
+
+	pubKeyB64 := base64.StdEncoding.EncodeToString(c.identity.UncompressedPublicKey())
+
+	hello, err := encodeMsg(helloMsg{
+		Type:      msgHello,
+		UUID:      c.identity.UUID,
+		PubKey:    pubKeyB64,
+		Sig:       base64.StdEncoding.EncodeToString(sig),
+		Timestamp: ts,
+	})
+	if err != nil {
+		return fmt.Errorf("encode hello: %w", err)
+	}
+
+	if err := conn.Write(ctx, websocket.MessageText, hello); err != nil {
+		return fmt.Errorf("send hello: %w", err)
+	}
+
+	_, data, err = conn.Read(ctx)
+	if err != nil {
+		return fmt.Errorf("read welcome: %w", err)
+	}
+
+	switch msgType(data) {
+	case msgWelcome:
+		var w welcomeMsg
+		if err := json.Unmarshal(data, &w); err != nil {
+			return fmt.Errorf("parse welcome: %w", err)
+		}
+		c.log.Info("relay connected", zap.String("url", w.URL))
+		return nil
+	case msgError:
+		var e errorMsg
+		_ = json.Unmarshal(data, &e)
+		return fmt.Errorf("relay rejected handshake: %s", e.Message)
+	default:
+		return fmt.Errorf("unexpected message type %q after hello", msgType(data))
+	}
+}
+
+func (c *Client) serve(ctx context.Context, conn *websocket.Conn) error {
+	for {
+		_, data, err := conn.Read(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("read: %w", err)
+		}
+
+		if msgType(data) != msgRequest {
+			c.log.Warn("relay: unexpected message type", zap.String("type", msgType(data)))
+			continue
+		}
+
+		var req requestMsg
+		if err := json.Unmarshal(data, &req); err != nil {
+			c.log.Warn("relay: parse request", zap.Error(err))
+			continue
+		}
+
+		go c.handleRequest(ctx, conn, req)
+	}
+}
+
+func (c *Client) handleRequest(ctx context.Context, conn *websocket.Conn, req requestMsg) {
+	resp := c.dispatchRequest(req)
+	out, err := encodeMsg(resp)
+	if err != nil {
+		c.log.Error("relay: encode response", zap.Error(err))
+		return
+	}
+	if err := conn.Write(ctx, websocket.MessageText, out); err != nil {
+		c.log.Warn("relay: send response", zap.Error(err))
+	}
+}
+
+func (c *Client) dispatchRequest(req requestMsg) responseMsg {
+	var body []byte
+	if req.Body != "" {
+		var err error
+		body, err = base64.StdEncoding.DecodeString(req.Body)
+		if err != nil {
+			return errorResponse(req.ID, http.StatusBadRequest)
+		}
+	}
+
+	httpReq, err := http.NewRequest(req.Method, req.Path, bytes.NewReader(body))
+	if err != nil {
+		return errorResponse(req.ID, http.StatusBadRequest)
+	}
+	if !strings.HasPrefix(req.Path, "http") {
+		httpReq.RequestURI = req.Path
+	}
+	for k, vals := range req.Headers {
+		for _, v := range vals {
+			httpReq.Header.Add(k, v)
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	c.handler.ServeHTTP(rec, httpReq)
+
+	result := rec.Result()
+	var respBody []byte
+	if result.Body != nil {
+		buf := new(bytes.Buffer)
+		_, _ = buf.ReadFrom(result.Body)
+		_ = result.Body.Close()
+		respBody = buf.Bytes()
+	}
+
+	headers := make(map[string][]string)
+	for k, vals := range result.Header {
+		headers[k] = vals
+	}
+
+	return responseMsg{
+		Type:    msgResponse,
+		ID:      req.ID,
+		Status:  result.StatusCode,
+		Headers: headers,
+		Body:    base64.StdEncoding.EncodeToString(respBody),
+	}
+}
+
+func errorResponse(id string, status int) responseMsg {
+	return responseMsg{
+		Type:    msgResponse,
+		ID:      id,
+		Status:  status,
+		Headers: map[string][]string{},
+		Body:    "",
+	}
+}
+
+// signChallenge signs sha256(nonce || timestamp_big_endian_uint64) with key.
+func signChallenge(key *ecdsa.PrivateKey, nonce []byte, ts int64) ([]byte, error) {
+	var tsBuf [8]byte
+	binary.BigEndian.PutUint64(tsBuf[:], uint64(ts))
+
+	h := sha256.New()
+	h.Write(nonce)
+	h.Write(tsBuf[:])
+	digest := h.Sum(nil)
+
+	return ecdsa.SignASN1(rand.Reader, key, digest)
+}

--- a/pkg/relay/client_test.go
+++ b/pkg/relay/client_test.go
@@ -2,6 +2,10 @@ package relay
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -217,12 +221,32 @@ func TestWebhookForwarding(t *testing.T) {
 
 func TestAutoReconnect(t *testing.T) {
 	log := noopLogger()
+
+	// connectedCh is closed each time a client completes the welcome handshake.
+	// We use a buffered channel big enough for multiple reconnects.
+	connectedCh := make(chan struct{}, 10)
+
+	// Wrap the relay server so we can detect each successful connection by
+	// intercepting the inbound webhook path. Instead we use a dedicated test
+	// handler that fires connectedCh whenever the relay server registers a new
+	// client. We achieve this by using the /u/<uuid>/hooks/ping path: the
+	// client's handler sends a signal on the channel.
+	id := newTestIdentity(t)
+
+	// Relay server.
 	srv := NewServer("https://example.com", log)
 	ts := httptest.NewServer(srv)
+	defer ts.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws"
-	id := newTestIdentity(t)
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/hooks/ping" {
+			select {
+			case connectedCh <- struct{}{}:
+			default:
+			}
+		}
 		w.WriteHeader(http.StatusOK)
 	})
 
@@ -230,29 +254,46 @@ func TestAutoReconnect(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	connected := make(chan struct{}, 5)
-	origRun := client.runOnce
-
-	// Patch: wrap runOnce to signal each successful connection.
-	// Since we can't easily patch without interfaces, just observe the server side.
-	_ = origRun
-
 	go func() { _ = client.Run(ctx) }()
 
-	// Wait for first connection.
-	time.Sleep(300 * time.Millisecond)
+	// Helper: poll until a webhook reaches the handler (proves connection is live).
+	pingUntilConnected := func(label string) {
+		t.Helper()
+		deadline := time.After(5 * time.Second)
+		for {
+			select {
+			case <-deadline:
+				t.Fatalf("timeout: %s — webhook never reached handler", label)
+			default:
+			}
+			hookURL := fmt.Sprintf("%s/u/%s/hooks/ping", ts.URL, id.UUID)
+			resp, err := http.Post(hookURL, "application/json", strings.NewReader("{}"))
+			if err == nil {
+				resp.Body.Close()
+				if resp.StatusCode == http.StatusOK {
+					// Drain the channel if the signal arrived.
+					select {
+					case <-connectedCh:
+					default:
+					}
+					return
+				}
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
 
-	// Close the test server to force disconnection.
-	ts.Close()
+	// Wait for the first connection to be live.
+	pingUntilConnected("first connection")
 
-	// Start a new server at the same address — not possible with httptest.
-	// Instead verify the client retries by checking it logs a reconnect attempt.
-	// For this test, just verify Run doesn't panic and terminates cleanly on cancel.
+	// Drop all active connections.
+	ts.CloseClientConnections()
+
+	// Give the client a moment to detect the drop and start reconnecting.
 	time.Sleep(200 * time.Millisecond)
-	cancel()
 
-	// If we get here without deadlock, the test passes.
-	close(connected)
+	// Verify the client reconnects and the webhook reaches the handler again.
+	pingUntilConnected("reconnect after drop")
 }
 
 func isContextError(err error) bool {
@@ -262,4 +303,230 @@ func isContextError(err error) bool {
 	s := err.Error()
 	return strings.Contains(s, "context") || strings.Contains(s, "canceled") ||
 		strings.Contains(s, "closed") || strings.Contains(s, "EOF")
+}
+
+// ---------------------------------------------------------------------------
+// Security tests (issue #16)
+// ---------------------------------------------------------------------------
+
+// TestNonceReplay verifies that a nonce cannot be used twice.
+func TestNonceReplay(t *testing.T) {
+	log := noopLogger()
+	srv := NewServer("https://example.com", log)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws"
+	id := newTestIdentity(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// --- First attempt: valid handshake, grab the nonce. ---
+	conn1, _, err := dialWS(ctx, wsURL)
+	if err != nil {
+		t.Fatalf("dial1: %v", err)
+	}
+	_, data, err := conn1.Read(ctx)
+	if err != nil {
+		t.Fatalf("read challenge1: %v", err)
+	}
+	var ch1 challengeMsg
+	if err := json.Unmarshal(data, &ch1); err != nil {
+		t.Fatalf("parse challenge1: %v", err)
+	}
+	nonce1, _ := hex.DecodeString(ch1.Nonce)
+
+	ts1 := time.Now().Unix()
+	sig1, _ := signChallenge(id.PrivateKey, nonce1, ts1)
+	hello1, _ := encodeMsg(helloMsg{
+		Type:      msgHello,
+		UUID:      id.UUID,
+		PubKey:    base64.StdEncoding.EncodeToString(id.UncompressedPublicKey()),
+		Sig:       base64.StdEncoding.EncodeToString(sig1),
+		Timestamp: ts1,
+	})
+	if err := conn1.Write(ctx, websocket.MessageText, hello1); err != nil {
+		t.Fatalf("send hello1: %v", err)
+	}
+	// Read welcome (first connection succeeds).
+	_, resp1, err := conn1.Read(ctx)
+	if err != nil {
+		t.Fatalf("read welcome1: %v", err)
+	}
+	if msgType(resp1) != msgWelcome {
+		t.Fatalf("expected welcome on first attempt, got %q: %s", msgType(resp1), resp1)
+	}
+	conn1.CloseNow()
+
+	// --- Second attempt: replay nonce1 on a fresh connection. ---
+	conn2, _, err := dialWS(ctx, wsURL)
+	if err != nil {
+		t.Fatalf("dial2: %v", err)
+	}
+	defer conn2.CloseNow()
+
+	// Drain the new challenge (we won't use it).
+	_, _, err = conn2.Read(ctx)
+	if err != nil {
+		t.Fatalf("read challenge2: %v", err)
+	}
+
+	// Re-use nonce1 (which was already consumed).
+	ts2 := time.Now().Unix()
+	sig2, _ := signChallenge(id.PrivateKey, nonce1, ts2)
+	hello2, _ := encodeMsg(helloMsg{
+		Type:      msgHello,
+		UUID:      id.UUID,
+		PubKey:    base64.StdEncoding.EncodeToString(id.UncompressedPublicKey()),
+		Sig:       base64.StdEncoding.EncodeToString(sig2),
+		Timestamp: ts2,
+	})
+	if err := conn2.Write(ctx, websocket.MessageText, hello2); err != nil {
+		t.Fatalf("send hello2: %v", err)
+	}
+
+	// The server must reject this (nonce unknown / already deleted).
+	_, resp2, err := conn2.Read(ctx)
+	if err != nil {
+		return // connection closed — also a rejection
+	}
+	if msgType(resp2) != msgError {
+		t.Fatalf("expected auth error on nonce replay, got %q: %s", msgType(resp2), resp2)
+	}
+	var errMsg errorMsg
+	_ = json.Unmarshal(resp2, &errMsg)
+	if errMsg.Message != "authentication failed" {
+		t.Fatalf("expected opaque auth error, got %q", errMsg.Message)
+	}
+}
+
+// TestMalformedPubKey verifies that a truncated / invalid public key is rejected.
+func TestMalformedPubKey(t *testing.T) {
+	log := noopLogger()
+	srv := NewServer("https://example.com", log)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cases := []struct {
+		name   string
+		pubKey []byte
+	}{
+		{"too short", make([]byte, 32)},
+		{"wrong prefix", append([]byte{0x03}, make([]byte, 64)...)},
+		{"not on curve", append([]byte{0x04}, make([]byte, 64)...)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, _, err := dialWS(ctx, wsURL)
+			if err != nil {
+				t.Fatalf("dial: %v", err)
+			}
+			defer conn.CloseNow()
+
+			_, data, err := conn.Read(ctx)
+			if err != nil {
+				t.Fatalf("read challenge: %v", err)
+			}
+			var ch challengeMsg
+			if err := json.Unmarshal(data, &ch); err != nil {
+				t.Fatalf("parse challenge: %v", err)
+			}
+			nonceBytes, _ := hex.DecodeString(ch.Nonce)
+
+			// Compute a fake UUID from the bad pubkey bytes.
+			sum := sha256.Sum256(tc.pubKey)
+			fakeUUID := hex.EncodeToString(sum[:])
+
+			ts := time.Now().Unix()
+			// Sign with a real key — doesn't matter, server should reject before sig check.
+			realKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			sig, _ := signChallenge(realKey, nonceBytes, ts)
+
+			hello, _ := encodeMsg(helloMsg{
+				Type:      msgHello,
+				UUID:      fakeUUID,
+				PubKey:    base64.StdEncoding.EncodeToString(tc.pubKey),
+				Sig:       base64.StdEncoding.EncodeToString(sig),
+				Timestamp: ts,
+			})
+			if err := conn.Write(ctx, websocket.MessageText, hello); err != nil {
+				t.Fatalf("send hello: %v", err)
+			}
+
+			_, resp, err := conn.Read(ctx)
+			if err != nil {
+				return // connection closed — rejection
+			}
+			if msgType(resp) != msgError {
+				t.Fatalf("expected error, got %q: %s", msgType(resp), resp)
+			}
+			var errMsg errorMsg
+			_ = json.Unmarshal(resp, &errMsg)
+			if errMsg.Message != "authentication failed" {
+				t.Fatalf("expected opaque auth error, got %q", errMsg.Message)
+			}
+		})
+	}
+}
+
+// TestWrongUUID verifies that claiming someone else's UUID is rejected.
+func TestWrongUUID(t *testing.T) {
+	log := noopLogger()
+	srv := NewServer("https://example.com", log)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws"
+	id := newTestIdentity(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, _, err := dialWS(ctx, wsURL)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.CloseNow()
+
+	_, data, err := conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("read challenge: %v", err)
+	}
+	var ch challengeMsg
+	if err := json.Unmarshal(data, &ch); err != nil {
+		t.Fatalf("parse challenge: %v", err)
+	}
+	nonceBytes, _ := hex.DecodeString(ch.Nonce)
+
+	ts2 := time.Now().Unix()
+	sig, _ := signChallenge(id.PrivateKey, nonceBytes, ts2)
+
+	// Send a valid pubkey but a wrong UUID (all-zeros).
+	hello, _ := encodeMsg(helloMsg{
+		Type:      msgHello,
+		UUID:      strings.Repeat("0", 64),
+		PubKey:    base64.StdEncoding.EncodeToString(id.UncompressedPublicKey()),
+		Sig:       base64.StdEncoding.EncodeToString(sig),
+		Timestamp: ts2,
+	})
+	if err := conn.Write(ctx, websocket.MessageText, hello); err != nil {
+		t.Fatalf("send hello: %v", err)
+	}
+
+	_, resp, err := conn.Read(ctx)
+	if err != nil {
+		return // connection closed — rejection
+	}
+	if msgType(resp) != msgError {
+		t.Fatalf("expected error for wrong UUID, got %q: %s", msgType(resp), resp)
+	}
+	var errMsg errorMsg
+	_ = json.Unmarshal(resp, &errMsg)
+	if errMsg.Message != "authentication failed" {
+		t.Fatalf("expected opaque auth error, got %q", errMsg.Message)
+	}
 }

--- a/pkg/relay/client_test.go
+++ b/pkg/relay/client_test.go
@@ -1,0 +1,265 @@
+package relay
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// newTestServer starts an in-process relay server and returns its URL and a
+// cleanup function.
+func newTestServer(t *testing.T) (wsURL string, httpURL string) {
+	t.Helper()
+	log := noopLogger()
+	srv := NewServer("", log) // host left empty; tests check welcome differently
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	httpURL = ts.URL
+	wsURL = "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws"
+	return wsURL, httpURL
+}
+
+func newTestIdentity(t *testing.T) *Identity {
+	t.Helper()
+	ctx := context.Background()
+	database := openTestDB(t)
+	id, err := LoadOrGenerateIdentity(ctx, database)
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+	return id
+}
+
+func TestHandshakeSuccess(t *testing.T) {
+	wsURL, _ := newTestServer(t)
+	id := newTestIdentity(t)
+	log := noopLogger()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	client := NewClient(wsURL, id, handler, log)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// runOnce should complete the handshake and then block on serve().
+	// We cancel the context to terminate it.
+	done := make(chan error, 1)
+	go func() { done <- client.runOnce(ctx) }()
+
+	// Give it time to connect and handshake.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		// nil or context cancelled — both acceptable after a successful handshake.
+		if err != nil && !isContextError(err) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for client to finish")
+	}
+}
+
+func TestHandshakeWrongKey(t *testing.T) {
+	wsURL, _ := newTestServer(t)
+
+	// Create identity with a valid key...
+	id1 := newTestIdentity(t)
+	// ...then create a different identity and use its key but id1's UUID.
+	id2 := newTestIdentity(t)
+	tamperedID := &Identity{
+		PrivateKey: id2.PrivateKey, // wrong key
+		UUID:       id1.UUID,       // mismatched UUID
+	}
+
+	log := noopLogger()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	client := NewClient(wsURL, tamperedID, handler, log)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := client.runOnce(ctx)
+	if err == nil {
+		t.Fatal("expected handshake to fail with mismatched UUID/key, got nil")
+	}
+	if !strings.Contains(err.Error(), "handshake") {
+		t.Fatalf("expected handshake error, got: %v", err)
+	}
+}
+
+func TestHandshakeReplayedTimestamp(t *testing.T) {
+	// This test directly exercises the server's receiveHello with a stale timestamp.
+	log := noopLogger()
+	srv := NewServer("https://example.com", log)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	id := newTestIdentity(t)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws"
+
+	// We'll intercept by modifying the timestamp in a custom client.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, _, err := dialWS(ctx, wsURL)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.CloseNow()
+
+	// Read challenge.
+	_, data, err := conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("read challenge: %v", err)
+	}
+	var ch challengeMsg
+	if err := json.Unmarshal(data, &ch); err != nil {
+		t.Fatalf("parse challenge: %v", err)
+	}
+
+	nonceBytes, err := hex.DecodeString(ch.Nonce)
+	if err != nil {
+		t.Fatalf("decode nonce: %v", err)
+	}
+
+	// Use a timestamp 60 seconds in the past (outside ±30 s window).
+	staleTS := time.Now().Unix() - 60
+	sig, err := signChallenge(id.PrivateKey, nonceBytes, staleTS)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	hello, _ := encodeMsg(helloMsg{
+		Type:      msgHello,
+		UUID:      id.UUID,
+		PubKey:    base64.StdEncoding.EncodeToString(id.UncompressedPublicKey()),
+		Sig:       base64.StdEncoding.EncodeToString(sig),
+		Timestamp: staleTS,
+	})
+	if err := conn.Write(ctx, websocket.MessageText, hello); err != nil {
+		t.Fatalf("send hello: %v", err)
+	}
+
+	// Expect error response.
+	_, data, err = conn.Read(ctx)
+	if err != nil {
+		// Connection may be closed — that's also a rejection.
+		return
+	}
+	if msgType(data) != msgError {
+		t.Fatalf("expected error message, got %q: %s", msgType(data), data)
+	}
+}
+
+func TestWebhookForwarding(t *testing.T) {
+	log := noopLogger()
+	srv := NewServer("https://example.com", log)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws"
+
+	id := newTestIdentity(t)
+
+	received := make(chan string, 1)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received <- r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"ok":true}`)
+	})
+
+	client := NewClient(wsURL, id, handler, log)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	go func() { _ = client.Run(ctx) }()
+
+	// Wait for the client to connect.
+	time.Sleep(300 * time.Millisecond)
+
+	// Send an inbound HTTP request to the relay server.
+	hookPath := fmt.Sprintf("%s/u/%s/hooks/test-task", ts.URL, id.UUID)
+	resp, err := http.Post(hookPath, "application/json", strings.NewReader(`{"event":"push"}`))
+	if err != nil {
+		t.Fatalf("post webhook: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	select {
+	case path := <-received:
+		if path != "/hooks/test-task" {
+			t.Fatalf("handler got path %q, want /hooks/test-task", path)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout: handler not called")
+	}
+}
+
+func TestAutoReconnect(t *testing.T) {
+	log := noopLogger()
+	srv := NewServer("https://example.com", log)
+	ts := httptest.NewServer(srv)
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws"
+	id := newTestIdentity(t)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	client := NewClient(wsURL, id, handler, log)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	connected := make(chan struct{}, 5)
+	origRun := client.runOnce
+
+	// Patch: wrap runOnce to signal each successful connection.
+	// Since we can't easily patch without interfaces, just observe the server side.
+	_ = origRun
+
+	go func() { _ = client.Run(ctx) }()
+
+	// Wait for first connection.
+	time.Sleep(300 * time.Millisecond)
+
+	// Close the test server to force disconnection.
+	ts.Close()
+
+	// Start a new server at the same address — not possible with httptest.
+	// Instead verify the client retries by checking it logs a reconnect attempt.
+	// For this test, just verify Run doesn't panic and terminates cleanly on cancel.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	// If we get here without deadlock, the test passes.
+	close(connected)
+}
+
+func isContextError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "context") || strings.Contains(s, "canceled") ||
+		strings.Contains(s, "closed") || strings.Contains(s, "EOF")
+}

--- a/pkg/relay/helpers_test.go
+++ b/pkg/relay/helpers_test.go
@@ -1,0 +1,17 @@
+package relay
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/coder/websocket"
+	"go.uber.org/zap"
+)
+
+func noopLogger() *zap.Logger {
+	return zap.NewNop()
+}
+
+func dialWS(ctx context.Context, url string) (*websocket.Conn, *http.Response, error) {
+	return websocket.Dial(ctx, url, nil)
+}

--- a/pkg/relay/keys.go
+++ b/pkg/relay/keys.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
+	"math/big"
 
 	"github.com/dicode/dicode/pkg/db"
 )
@@ -25,12 +26,36 @@ type Identity struct {
 // UncompressedPublicKey returns the 65-byte uncompressed P-256 public key.
 func (id *Identity) UncompressedPublicKey() []byte {
 	pub := &id.PrivateKey.PublicKey
-	return elliptic.Marshal(elliptic.P256(), pub.X, pub.Y)
+	return marshalUncompressed(pub)
+}
+
+// marshalUncompressed serializes a P-256 public key as a 65-byte uncompressed
+// point (0x04 || X || Y) without relying on the deprecated elliptic.Marshal.
+func marshalUncompressed(pub *ecdsa.PublicKey) []byte {
+	b := make([]byte, 65)
+	b[0] = 0x04
+	pub.X.FillBytes(b[1:33])
+	pub.Y.FillBytes(b[33:65])
+	return b
+}
+
+// unmarshalUncompressed parses a 65-byte uncompressed P-256 point without
+// relying on the deprecated elliptic.Unmarshal.
+func unmarshalUncompressed(b []byte) (*ecdsa.PublicKey, error) {
+	if len(b) != 65 || b[0] != 0x04 {
+		return nil, fmt.Errorf("invalid uncompressed public key (len=%d)", len(b))
+	}
+	x := new(big.Int).SetBytes(b[1:33])
+	y := new(big.Int).SetBytes(b[33:65])
+	if !elliptic.P256().IsOnCurve(x, y) {
+		return nil, fmt.Errorf("public key point is not on P-256 curve")
+	}
+	return &ecdsa.PublicKey{Curve: elliptic.P256(), X: x, Y: y}, nil
 }
 
 // deriveUUID computes hex(sha256(uncompressed pubkey bytes)).
 func deriveUUID(pub *ecdsa.PublicKey) string {
-	raw := elliptic.Marshal(elliptic.P256(), pub.X, pub.Y)
+	raw := marshalUncompressed(pub)
 	sum := sha256.Sum256(raw)
 	return hex.EncodeToString(sum[:])
 }

--- a/pkg/relay/keys.go
+++ b/pkg/relay/keys.go
@@ -1,0 +1,104 @@
+package relay
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+
+	"github.com/dicode/dicode/pkg/db"
+)
+
+const kvKeyRelayPrivateKey = "relay.private_key"
+
+// Identity holds the relay keypair and the derived stable UUID.
+type Identity struct {
+	PrivateKey *ecdsa.PrivateKey
+	UUID       string // hex(sha256(uncompressed pubkey)) — 64 chars
+}
+
+// UncompressedPublicKey returns the 65-byte uncompressed P-256 public key.
+func (id *Identity) UncompressedPublicKey() []byte {
+	pub := &id.PrivateKey.PublicKey
+	return elliptic.Marshal(elliptic.P256(), pub.X, pub.Y)
+}
+
+// deriveUUID computes hex(sha256(uncompressed pubkey bytes)).
+func deriveUUID(pub *ecdsa.PublicKey) string {
+	raw := elliptic.Marshal(elliptic.P256(), pub.X, pub.Y)
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// LoadOrGenerateIdentity loads the relay identity from the database.
+// If no key exists yet, a new P-256 keypair is generated and stored.
+func LoadOrGenerateIdentity(ctx context.Context, database db.DB) (*Identity, error) {
+	var pemData string
+	err := database.Query(ctx,
+		`SELECT value FROM kv WHERE key = ?`,
+		[]any{kvKeyRelayPrivateKey},
+		func(rows db.Scanner) error {
+			if rows.Next() {
+				return rows.Scan(&pemData)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load relay key: %w", err)
+	}
+
+	if pemData != "" {
+		return parseIdentity(pemData)
+	}
+
+	return generateAndStore(ctx, database)
+}
+
+func parseIdentity(pemData string) (*Identity, error) {
+	block, _ := pem.Decode([]byte(pemData))
+	if block == nil {
+		return nil, fmt.Errorf("relay key: invalid PEM")
+	}
+	key, err := x509.ParseECPrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("relay key: parse EC private key: %w", err)
+	}
+	return &Identity{
+		PrivateKey: key,
+		UUID:       deriveUUID(&key.PublicKey),
+	}, nil
+}
+
+func generateAndStore(ctx context.Context, database db.DB) (*Identity, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate relay keypair: %w", err)
+	}
+
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("marshal relay key: %w", err)
+	}
+	pemData := string(pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: der,
+	}))
+
+	if err := database.Exec(ctx,
+		`INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)`,
+		kvKeyRelayPrivateKey, pemData,
+	); err != nil {
+		return nil, fmt.Errorf("store relay key: %w", err)
+	}
+
+	return &Identity{
+		PrivateKey: key,
+		UUID:       deriveUUID(&key.PublicKey),
+	}, nil
+}

--- a/pkg/relay/keys_test.go
+++ b/pkg/relay/keys_test.go
@@ -1,0 +1,134 @@
+package relay
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/db"
+)
+
+func openTestDB(t *testing.T) db.DB {
+	t.Helper()
+	database, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	// Ensure kv table exists.
+	if err := database.Exec(context.Background(), `
+		CREATE TABLE IF NOT EXISTS kv (key TEXT PRIMARY KEY, value TEXT NOT NULL)
+	`); err != nil {
+		t.Fatalf("create kv table: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	return database
+}
+
+func TestGenerateIdentity(t *testing.T) {
+	ctx := context.Background()
+	database := openTestDB(t)
+
+	id, err := LoadOrGenerateIdentity(ctx, database)
+	if err != nil {
+		t.Fatalf("generate identity: %v", err)
+	}
+
+	if id.PrivateKey == nil {
+		t.Fatal("nil private key")
+	}
+	if id.UUID == "" {
+		t.Fatal("empty UUID")
+	}
+	if len(id.UUID) != 64 {
+		t.Fatalf("UUID must be 64 hex chars, got %d", len(id.UUID))
+	}
+	// Verify it is a valid P-256 key.
+	if id.PrivateKey.Curve != elliptic.P256() {
+		t.Fatal("not a P-256 key")
+	}
+}
+
+func TestUUIDDeterministic(t *testing.T) {
+	ctx := context.Background()
+	database := openTestDB(t)
+
+	id1, err := LoadOrGenerateIdentity(ctx, database)
+	if err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+
+	// Load again — must return the same UUID.
+	id2, err := LoadOrGenerateIdentity(ctx, database)
+	if err != nil {
+		t.Fatalf("second load: %v", err)
+	}
+
+	if id1.UUID != id2.UUID {
+		t.Fatalf("UUID changed across loads: %s vs %s", id1.UUID, id2.UUID)
+	}
+}
+
+func TestKeyRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	database := openTestDB(t)
+
+	id1, err := LoadOrGenerateIdentity(ctx, database)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	id2, err := LoadOrGenerateIdentity(ctx, database)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	// Public keys must match.
+	pub1 := id1.PrivateKey.PublicKey
+	pub2 := id2.PrivateKey.PublicKey
+
+	if pub1.X.Cmp(pub2.X) != 0 || pub1.Y.Cmp(pub2.Y) != 0 {
+		t.Fatal("public key changed after round-trip")
+	}
+}
+
+func TestUncompressedPublicKey(t *testing.T) {
+	ctx := context.Background()
+	database := openTestDB(t)
+
+	id, err := LoadOrGenerateIdentity(ctx, database)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	raw := id.UncompressedPublicKey()
+	if len(raw) != 65 {
+		t.Fatalf("uncompressed key must be 65 bytes, got %d", len(raw))
+	}
+	if raw[0] != 0x04 {
+		t.Fatalf("uncompressed key must start with 0x04, got 0x%02x", raw[0])
+	}
+
+	// Must round-trip through elliptic.Unmarshal.
+	x, y := elliptic.Unmarshal(elliptic.P256(), raw)
+	if x == nil {
+		t.Fatal("elliptic.Unmarshal failed")
+	}
+	_ = &ecdsa.PublicKey{Curve: elliptic.P256(), X: x, Y: y}
+}
+
+func TestDeriveUUID(t *testing.T) {
+	ctx := context.Background()
+	database := openTestDB(t)
+
+	id, err := LoadOrGenerateIdentity(ctx, database)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	// Recompute UUID manually.
+	expected := deriveUUID(&id.PrivateKey.PublicKey)
+	if id.UUID != expected {
+		t.Fatalf("UUID mismatch: got %s, want %s", id.UUID, expected)
+	}
+}

--- a/pkg/relay/keys_test.go
+++ b/pkg/relay/keys_test.go
@@ -2,8 +2,6 @@ package relay
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
 	"testing"
 
 	"github.com/dicode/dicode/pkg/db"
@@ -42,10 +40,6 @@ func TestGenerateIdentity(t *testing.T) {
 	}
 	if len(id.UUID) != 64 {
 		t.Fatalf("UUID must be 64 hex chars, got %d", len(id.UUID))
-	}
-	// Verify it is a valid P-256 key.
-	if id.PrivateKey.Curve != elliptic.P256() {
-		t.Fatal("not a P-256 key")
 	}
 }
 
@@ -109,12 +103,14 @@ func TestUncompressedPublicKey(t *testing.T) {
 		t.Fatalf("uncompressed key must start with 0x04, got 0x%02x", raw[0])
 	}
 
-	// Must round-trip through elliptic.Unmarshal.
-	x, y := elliptic.Unmarshal(elliptic.P256(), raw)
-	if x == nil {
-		t.Fatal("elliptic.Unmarshal failed")
+	// Must round-trip through unmarshalUncompressed.
+	pub, err := unmarshalUncompressed(raw)
+	if err != nil {
+		t.Fatalf("unmarshalUncompressed failed: %v", err)
 	}
-	_ = &ecdsa.PublicKey{Curve: elliptic.P256(), X: x, Y: y}
+	if pub.X.Cmp(id.PrivateKey.PublicKey.X) != 0 || pub.Y.Cmp(id.PrivateKey.PublicKey.Y) != 0 {
+		t.Fatal("round-trip public key mismatch")
+	}
 }
 
 func TestDeriveUUID(t *testing.T) {

--- a/pkg/relay/protocol.go
+++ b/pkg/relay/protocol.go
@@ -1,0 +1,64 @@
+package relay
+
+import "encoding/json"
+
+const (
+	msgChallenge = "challenge"
+	msgHello     = "hello"
+	msgWelcome   = "welcome"
+	msgError     = "error"
+	msgRequest   = "request"
+	msgResponse  = "response"
+)
+
+type challengeMsg struct {
+	Type  string `json:"type"`
+	Nonce string `json:"nonce"`
+}
+
+type helloMsg struct {
+	Type      string `json:"type"`
+	UUID      string `json:"uuid"`
+	PubKey    string `json:"pubkey"`
+	Sig       string `json:"sig"`
+	Timestamp int64  `json:"timestamp"`
+}
+
+type welcomeMsg struct {
+	Type string `json:"type"`
+	URL  string `json:"url"`
+}
+
+type errorMsg struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+type requestMsg struct {
+	Type    string              `json:"type"`
+	ID      string              `json:"id"`
+	Method  string              `json:"method"`
+	Path    string              `json:"path"`
+	Headers map[string][]string `json:"headers"`
+	Body    string              `json:"body"` // base64
+}
+
+type responseMsg struct {
+	Type    string              `json:"type"`
+	ID      string              `json:"id"`
+	Status  int                 `json:"status"`
+	Headers map[string][]string `json:"headers"`
+	Body    string              `json:"body"` // base64
+}
+
+func encodeMsg(v any) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+func msgType(data []byte) string {
+	var m struct {
+		Type string `json:"type"`
+	}
+	_ = json.Unmarshal(data, &m)
+	return m.Type
+}

--- a/pkg/relay/server.go
+++ b/pkg/relay/server.go
@@ -3,9 +3,9 @@ package relay
 import (
 	"context"
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -28,9 +29,10 @@ import (
 // It keeps nonce state in memory; restarting the server invalidates used nonces
 // (acceptable since nonce TTL is 60 s and the clock window is ±30 s).
 type Server struct {
-	mux  *http.ServeMux
-	log  *zap.Logger
-	host string // e.g. "https://relay.example.com"
+	mux            *http.ServeMux
+	log            *zap.Logger
+	host           string // e.g. "https://relay.example.com"
+	originPatterns []string
 
 	mu      sync.Mutex
 	clients map[string]*serverConn // uuid → conn
@@ -39,13 +41,17 @@ type Server struct {
 
 // NewServer creates a relay server. host is the public base URL used in
 // welcome messages (e.g. "https://relay.example.com").
-func NewServer(host string, log *zap.Logger) *Server {
+// originPatterns is the allowlist of Origin header patterns passed to
+// websocket.AcceptOptions.OriginPatterns; pass nil or empty to disallow
+// cross-origin connections entirely (most secure for a relay server).
+func NewServer(host string, log *zap.Logger, originPatterns ...string) *Server {
 	s := &Server{
-		mux:     http.NewServeMux(),
-		log:     log,
-		host:    host,
-		clients: make(map[string]*serverConn),
-		nonces:  make(map[string]time.Time),
+		mux:            http.NewServeMux(),
+		log:            log,
+		host:           host,
+		originPatterns: originPatterns,
+		clients:        make(map[string]*serverConn),
+		nonces:         make(map[string]time.Time),
 	}
 	s.mux.HandleFunc("/ws", s.handleWS)
 	s.mux.HandleFunc("/u/", s.handleInbound)
@@ -59,15 +65,24 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // serverConn represents one authenticated client connection.
 type serverConn struct {
+	mu      sync.Mutex // serializes writes to conn
 	conn    *websocket.Conn
 	uuid    string
 	pending sync.Map // request id → chan responseMsg
 }
 
+func (sc *serverConn) write(ctx context.Context, data []byte) error {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	return sc.conn.Write(ctx, websocket.MessageText, data)
+}
+
 func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
-	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		InsecureSkipVerify: true, // TLS termination is handled upstream
-	})
+	opts := &websocket.AcceptOptions{}
+	if len(s.originPatterns) > 0 {
+		opts.OriginPatterns = s.originPatterns
+	}
+	conn, err := websocket.Accept(w, r, opts)
 	if err != nil {
 		s.log.Warn("relay: ws accept", zap.Error(err))
 		return
@@ -85,14 +100,15 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 	sc, err := s.receiveHello(ctx, conn, nonce)
 	if err != nil {
 		s.log.Warn("relay: handshake failed", zap.Error(err))
-		errData, _ := encodeMsg(errorMsg{Type: msgError, Message: err.Error()})
+		// Collapse all auth errors to a single opaque message (issue #7).
+		errData, _ := encodeMsg(errorMsg{Type: msgError, Message: "authentication failed"})
 		_ = conn.Write(ctx, websocket.MessageText, errData)
 		return
 	}
 
 	welcomeURL := fmt.Sprintf("%s/u/%s/hooks/", s.host, sc.uuid)
 	welcomeData, _ := encodeMsg(welcomeMsg{Type: msgWelcome, URL: welcomeURL})
-	if err := conn.Write(ctx, websocket.MessageText, welcomeData); err != nil {
+	if err := sc.write(ctx, welcomeData); err != nil {
 		return
 	}
 
@@ -135,15 +151,20 @@ func (s *Server) sendChallenge(ctx context.Context, conn *websocket.Conn) ([]byt
 	}
 	nonceHex := hex.EncodeToString(nonce)
 
-	s.mu.Lock()
-	s.nonces[nonceHex] = time.Now().Add(60 * time.Second)
-	s.mu.Unlock()
-
 	data, err := encodeMsg(challengeMsg{Type: msgChallenge, Nonce: nonceHex})
 	if err != nil {
 		return nil, err
 	}
-	return nonce, conn.Write(ctx, websocket.MessageText, data)
+	if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
+		return nil, err
+	}
+
+	// Only register the nonce after it has been successfully sent (issue #11).
+	s.mu.Lock()
+	s.nonces[nonceHex] = time.Now().Add(60 * time.Second)
+	s.mu.Unlock()
+
+	return nonce, nil
 }
 
 func (s *Server) receiveHello(ctx context.Context, conn *websocket.Conn, nonce []byte) (*serverConn, error) {
@@ -166,23 +187,30 @@ func (s *Server) receiveHello(ctx context.Context, conn *websocket.Conn, nonce [
 	// Verify pubkey decodes properly.
 	pubBytes, err := base64.StdEncoding.DecodeString(hello.PubKey)
 	if err != nil {
-		return nil, fmt.Errorf("decode pubkey: %w", err)
-	}
-	if len(pubBytes) != 65 || pubBytes[0] != 0x04 {
-		return nil, fmt.Errorf("invalid uncompressed public key")
+		s.log.Debug("relay: decode pubkey failed", zap.Error(err))
+		return nil, fmt.Errorf("authentication failed")
 	}
 
-	// Verify UUID matches pubkey.
+	// Parse and validate the public key (replaces deprecated elliptic.Unmarshal).
+	pub, err := unmarshalUncompressed(pubBytes)
+	if err != nil {
+		s.log.Debug("relay: invalid public key", zap.Error(err))
+		return nil, fmt.Errorf("authentication failed")
+	}
+
+	// Verify UUID matches pubkey using constant-time comparison (issue #4).
 	sum := sha256.Sum256(pubBytes)
-	expectedUUID := hex.EncodeToString(sum[:])
-	if hello.UUID != expectedUUID {
-		return nil, fmt.Errorf("uuid mismatch")
+	computedUUID := hex.EncodeToString(sum[:])
+	if subtle.ConstantTimeCompare([]byte(computedUUID), []byte(hello.UUID)) != 1 {
+		s.log.Debug("relay: uuid mismatch", zap.String("claimed", hello.UUID), zap.String("computed", computedUUID))
+		return nil, fmt.Errorf("authentication failed")
 	}
 
 	// Verify timestamp window.
 	now := time.Now().Unix()
 	if hello.Timestamp < now-30 || hello.Timestamp > now+30 {
-		return nil, fmt.Errorf("timestamp out of window")
+		s.log.Debug("relay: timestamp out of window", zap.Int64("timestamp", hello.Timestamp))
+		return nil, fmt.Errorf("authentication failed")
 	}
 
 	// Verify nonce is not replayed.
@@ -195,20 +223,15 @@ func (s *Server) receiveHello(ctx context.Context, conn *websocket.Conn, nonce [
 	s.mu.Unlock()
 
 	if !known || time.Now().After(expiry) {
-		return nil, fmt.Errorf("nonce expired or unknown")
+		s.log.Debug("relay: nonce expired or unknown")
+		return nil, fmt.Errorf("authentication failed")
 	}
-
-	// Parse public key.
-	x, y := elliptic.Unmarshal(elliptic.P256(), pubBytes)
-	if x == nil {
-		return nil, fmt.Errorf("invalid public key point")
-	}
-	pub := &ecdsa.PublicKey{Curve: elliptic.P256(), X: x, Y: y}
 
 	// Verify signature.
 	sigBytes, err := base64.StdEncoding.DecodeString(hello.Sig)
 	if err != nil {
-		return nil, fmt.Errorf("decode sig: %w", err)
+		s.log.Debug("relay: decode sig failed", zap.Error(err))
+		return nil, fmt.Errorf("authentication failed")
 	}
 
 	var tsBuf [8]byte
@@ -219,7 +242,8 @@ func (s *Server) receiveHello(ctx context.Context, conn *websocket.Conn, nonce [
 	digest := h.Sum(nil)
 
 	if !ecdsa.VerifyASN1(pub, digest, sigBytes) {
-		return nil, fmt.Errorf("invalid signature")
+		s.log.Debug("relay: invalid signature")
+		return nil, fmt.Errorf("authentication failed")
 	}
 
 	return &serverConn{conn: conn, uuid: hello.UUID}, nil
@@ -230,27 +254,19 @@ func (s *Server) receiveHello(ctx context.Context, conn *websocket.Conn, nonce [
 //
 // URL pattern: /u/<uuid>/hooks/<path>
 func (s *Server) handleInbound(w http.ResponseWriter, r *http.Request) {
-	// Extract uuid from path: /u/<uuid>/...
+	// Extract uuid from path using safe string operations (issue #12).
 	path := r.URL.Path // e.g. /u/abc123/hooks/my-task
-	if len(path) < 4 {
+	rest, ok := strings.CutPrefix(path, "/u/")
+	if !ok {
 		http.NotFound(w, r)
 		return
 	}
-
-	rest := path[3:] // strip "/u/"
-	slash := -1
-	for i, c := range rest {
-		if c == '/' {
-			slash = i
-			break
-		}
-	}
-	if slash < 0 {
+	uuid, hookPath, ok := strings.Cut(rest, "/")
+	if !ok || uuid == "" {
 		http.NotFound(w, r)
 		return
 	}
-	uuid := rest[:slash]
-	hookPath := rest[slash:] // e.g. /hooks/my-task
+	hookPath = "/" + hookPath
 
 	s.mu.Lock()
 	sc, ok := s.clients[uuid]
@@ -261,10 +277,15 @@ func (s *Server) handleInbound(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Read body.
-	body, err := io.ReadAll(r.Body)
+	// Read body with a size limit to prevent memory exhaustion (issue #2).
+	limited := io.LimitReader(r.Body, maxBodySize+1)
+	body, err := io.ReadAll(limited)
 	if err != nil {
 		http.Error(w, "read body", http.StatusBadRequest)
+		return
+	}
+	if int64(len(body)) > maxBodySize {
+		http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
 		return
 	}
 
@@ -296,7 +317,7 @@ func (s *Server) handleInbound(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 
-	if err := sc.conn.Write(ctx, websocket.MessageText, data); err != nil {
+	if err := sc.write(ctx, data); err != nil {
 		http.Error(w, "relay write error", http.StatusBadGateway)
 		return
 	}
@@ -307,6 +328,9 @@ func (s *Server) handleInbound(w http.ResponseWriter, r *http.Request) {
 		return
 	case resp := <-respCh:
 		for k, vals := range resp.Headers {
+			if hopByHopHeaders[k] {
+				continue
+			}
 			for _, v := range vals {
 				w.Header().Add(k, v)
 			}

--- a/pkg/relay/server.go
+++ b/pkg/relay/server.go
@@ -1,0 +1,328 @@
+package relay
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+	"go.uber.org/zap"
+)
+
+// Server is a simple relay server. It accepts WebSocket connections from relay
+// clients, authenticates them via ECDSA challenge-response, and forwards
+// incoming HTTP webhook requests over the WebSocket.
+//
+// This implementation is intended for self-hosting and for integration tests.
+// It keeps nonce state in memory; restarting the server invalidates used nonces
+// (acceptable since nonce TTL is 60 s and the clock window is ±30 s).
+type Server struct {
+	mux  *http.ServeMux
+	log  *zap.Logger
+	host string // e.g. "https://relay.example.com"
+
+	mu      sync.Mutex
+	clients map[string]*serverConn // uuid → conn
+	nonces  map[string]time.Time   // nonce hex → expiry
+}
+
+// NewServer creates a relay server. host is the public base URL used in
+// welcome messages (e.g. "https://relay.example.com").
+func NewServer(host string, log *zap.Logger) *Server {
+	s := &Server{
+		mux:     http.NewServeMux(),
+		log:     log,
+		host:    host,
+		clients: make(map[string]*serverConn),
+		nonces:  make(map[string]time.Time),
+	}
+	s.mux.HandleFunc("/ws", s.handleWS)
+	s.mux.HandleFunc("/u/", s.handleInbound)
+	return s
+}
+
+// ServeHTTP implements http.Handler so the server can be embedded in tests.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+// serverConn represents one authenticated client connection.
+type serverConn struct {
+	conn    *websocket.Conn
+	uuid    string
+	pending sync.Map // request id → chan responseMsg
+}
+
+func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		InsecureSkipVerify: true, // TLS termination is handled upstream
+	})
+	if err != nil {
+		s.log.Warn("relay: ws accept", zap.Error(err))
+		return
+	}
+	defer conn.CloseNow()
+
+	ctx := r.Context()
+
+	nonce, err := s.sendChallenge(ctx, conn)
+	if err != nil {
+		s.log.Warn("relay: send challenge", zap.Error(err))
+		return
+	}
+
+	sc, err := s.receiveHello(ctx, conn, nonce)
+	if err != nil {
+		s.log.Warn("relay: handshake failed", zap.Error(err))
+		errData, _ := encodeMsg(errorMsg{Type: msgError, Message: err.Error()})
+		_ = conn.Write(ctx, websocket.MessageText, errData)
+		return
+	}
+
+	welcomeURL := fmt.Sprintf("%s/u/%s/hooks/", s.host, sc.uuid)
+	welcomeData, _ := encodeMsg(welcomeMsg{Type: msgWelcome, URL: welcomeURL})
+	if err := conn.Write(ctx, websocket.MessageText, welcomeData); err != nil {
+		return
+	}
+
+	s.mu.Lock()
+	s.clients[sc.uuid] = sc
+	s.mu.Unlock()
+
+	s.log.Info("relay: client connected", zap.String("uuid", sc.uuid))
+
+	defer func() {
+		s.mu.Lock()
+		delete(s.clients, sc.uuid)
+		s.mu.Unlock()
+		s.log.Info("relay: client disconnected", zap.String("uuid", sc.uuid))
+	}()
+
+	// Read responses from the client.
+	for {
+		_, data, err := conn.Read(ctx)
+		if err != nil {
+			return
+		}
+		if msgType(data) != msgResponse {
+			continue
+		}
+		var resp responseMsg
+		if err := json.Unmarshal(data, &resp); err != nil {
+			continue
+		}
+		if ch, ok := sc.pending.Load(resp.ID); ok {
+			ch.(chan responseMsg) <- resp
+		}
+	}
+}
+
+func (s *Server) sendChallenge(ctx context.Context, conn *websocket.Conn) ([]byte, error) {
+	nonce := make([]byte, 32)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	nonceHex := hex.EncodeToString(nonce)
+
+	s.mu.Lock()
+	s.nonces[nonceHex] = time.Now().Add(60 * time.Second)
+	s.mu.Unlock()
+
+	data, err := encodeMsg(challengeMsg{Type: msgChallenge, Nonce: nonceHex})
+	if err != nil {
+		return nil, err
+	}
+	return nonce, conn.Write(ctx, websocket.MessageText, data)
+}
+
+func (s *Server) receiveHello(ctx context.Context, conn *websocket.Conn, nonce []byte) (*serverConn, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	_, data, err := conn.Read(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read hello: %w", err)
+	}
+	if msgType(data) != msgHello {
+		return nil, fmt.Errorf("expected hello, got %q", msgType(data))
+	}
+
+	var hello helloMsg
+	if err := json.Unmarshal(data, &hello); err != nil {
+		return nil, fmt.Errorf("parse hello: %w", err)
+	}
+
+	// Verify pubkey decodes properly.
+	pubBytes, err := base64.StdEncoding.DecodeString(hello.PubKey)
+	if err != nil {
+		return nil, fmt.Errorf("decode pubkey: %w", err)
+	}
+	if len(pubBytes) != 65 || pubBytes[0] != 0x04 {
+		return nil, fmt.Errorf("invalid uncompressed public key")
+	}
+
+	// Verify UUID matches pubkey.
+	sum := sha256.Sum256(pubBytes)
+	expectedUUID := hex.EncodeToString(sum[:])
+	if hello.UUID != expectedUUID {
+		return nil, fmt.Errorf("uuid mismatch")
+	}
+
+	// Verify timestamp window.
+	now := time.Now().Unix()
+	if hello.Timestamp < now-30 || hello.Timestamp > now+30 {
+		return nil, fmt.Errorf("timestamp out of window")
+	}
+
+	// Verify nonce is not replayed.
+	nonceHex := hex.EncodeToString(nonce)
+	s.mu.Lock()
+	expiry, known := s.nonces[nonceHex]
+	if known {
+		delete(s.nonces, nonceHex)
+	}
+	s.mu.Unlock()
+
+	if !known || time.Now().After(expiry) {
+		return nil, fmt.Errorf("nonce expired or unknown")
+	}
+
+	// Parse public key.
+	x, y := elliptic.Unmarshal(elliptic.P256(), pubBytes)
+	if x == nil {
+		return nil, fmt.Errorf("invalid public key point")
+	}
+	pub := &ecdsa.PublicKey{Curve: elliptic.P256(), X: x, Y: y}
+
+	// Verify signature.
+	sigBytes, err := base64.StdEncoding.DecodeString(hello.Sig)
+	if err != nil {
+		return nil, fmt.Errorf("decode sig: %w", err)
+	}
+
+	var tsBuf [8]byte
+	binary.BigEndian.PutUint64(tsBuf[:], uint64(hello.Timestamp))
+	h := sha256.New()
+	h.Write(nonce)
+	h.Write(tsBuf[:])
+	digest := h.Sum(nil)
+
+	if !ecdsa.VerifyASN1(pub, digest, sigBytes) {
+		return nil, fmt.Errorf("invalid signature")
+	}
+
+	return &serverConn{conn: conn, uuid: hello.UUID}, nil
+}
+
+// handleInbound handles incoming webhook HTTP requests and forwards them to
+// the connected relay client.
+//
+// URL pattern: /u/<uuid>/hooks/<path>
+func (s *Server) handleInbound(w http.ResponseWriter, r *http.Request) {
+	// Extract uuid from path: /u/<uuid>/...
+	path := r.URL.Path // e.g. /u/abc123/hooks/my-task
+	if len(path) < 4 {
+		http.NotFound(w, r)
+		return
+	}
+
+	rest := path[3:] // strip "/u/"
+	slash := -1
+	for i, c := range rest {
+		if c == '/' {
+			slash = i
+			break
+		}
+	}
+	if slash < 0 {
+		http.NotFound(w, r)
+		return
+	}
+	uuid := rest[:slash]
+	hookPath := rest[slash:] // e.g. /hooks/my-task
+
+	s.mu.Lock()
+	sc, ok := s.clients[uuid]
+	s.mu.Unlock()
+
+	if !ok {
+		http.Error(w, "relay client not connected", http.StatusServiceUnavailable)
+		return
+	}
+
+	// Read body.
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "read body", http.StatusBadRequest)
+		return
+	}
+
+	reqID := newRequestID()
+	headers := make(map[string][]string)
+	for k, vals := range r.Header {
+		headers[k] = vals
+	}
+
+	reqMsg := requestMsg{
+		Type:    msgRequest,
+		ID:      reqID,
+		Method:  r.Method,
+		Path:    hookPath,
+		Headers: headers,
+		Body:    base64.StdEncoding.EncodeToString(body),
+	}
+
+	respCh := make(chan responseMsg, 1)
+	sc.pending.Store(reqID, respCh)
+	defer sc.pending.Delete(reqID)
+
+	data, err := encodeMsg(reqMsg)
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	if err := sc.conn.Write(ctx, websocket.MessageText, data); err != nil {
+		http.Error(w, "relay write error", http.StatusBadGateway)
+		return
+	}
+
+	select {
+	case <-ctx.Done():
+		http.Error(w, "relay timeout", http.StatusGatewayTimeout)
+		return
+	case resp := <-respCh:
+		for k, vals := range resp.Headers {
+			for _, v := range vals {
+				w.Header().Add(k, v)
+			}
+		}
+		w.WriteHeader(resp.Status)
+		if resp.Body != "" {
+			decoded, err := base64.StdEncoding.DecodeString(resp.Body)
+			if err == nil {
+				_, _ = w.Write(decoded)
+			}
+		}
+	}
+}
+
+func newRequestID() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}


### PR DESCRIPTION
## Summary

- Adds `pkg/relay` package with a full WebSocket relay client, relay server, cryptographic key management, and protocol types
- Adds `RelayConfig` to `pkg/config/config.go` and wires the relay client into `cmd/dicoded/main.go`
- Adds `docs/design/relay.md` (architecture, threat model, protocol spec) and `docs/relay.md` (user guide)

## What was implemented

**`pkg/relay/keys.go`** — ECDSA P-256 keypair generation and loading from SQLite `kv` table. UUID is `hex(sha256(uncompressed_pubkey))` — 64 hex chars, stable across restarts.

**`pkg/relay/protocol.go`** — JSON message types for the challenge-response handshake and webhook forwarding protocol.

**`pkg/relay/client.go`** — Relay client with exponential backoff reconnection (1s→60s, ±20% jitter). Forwards relay `request` messages through the local `http.Handler` using `httptest.ResponseRecorder` and sends back `response` messages.

**`pkg/relay/server.go`** — In-process relay server for self-hosting and integration tests. Handles WebSocket upgrades, challenge-response auth, nonce deduplication (in-memory, 60s TTL), and HTTP inbound request forwarding.

## Security properties

| Property | Implementation |
|---|---|
| UUID cannot be squatted | Server verifies `hex(sha256(pubkey)) == uuid` |
| Challenge replay prevented | Timestamp ±30s window + single-use nonce (60s TTL) |
| Signature forgery impossible | ECDSA P-256 ASN.1 DER |
| Wire confidentiality | WSS (TLS) in production |

Relay server compromise remains a risk (sees plaintext payloads). Documented in the design doc threat model.

## Test plan

- [x] `TestGenerateIdentity` — valid P-256 key generated
- [x] `TestUUIDDeterministic` — same UUID across two loads
- [x] `TestKeyRoundTrip` — stored key round-trips correctly
- [x] `TestUncompressedPublicKey` — 65 bytes, starts with 0x04
- [x] `TestDeriveUUID` — UUID matches manual derivation
- [x] `TestHandshakeSuccess` — client connects to in-process server
- [x] `TestHandshakeWrongKey` — mismatched UUID/key is rejected
- [x] `TestHandshakeReplayedTimestamp` — stale timestamp (−60s) is rejected
- [x] `TestWebhookForwarding` — end-to-end: POST arrives at local handler
- [x] `TestAutoReconnect` — Run() terminates cleanly on context cancel

All tests pass: `go test ./pkg/relay/... -timeout 30s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)