### PR TITLE
feat(cli): `dicode relay login` — claim a daemon to a relay user

### DIFF
--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -16,6 +16,7 @@
 //	secrets list                    list secret keys
 //	secrets set <key> <value>       store a secret
 //	secrets delete <key>            delete a secret
+//	relay login [--token=...] [--label=...]  claim this daemon to a relay user
 //	version                         print version and exit
 package main
 
@@ -94,43 +95,11 @@ func dispatch(c *ipc.ControlClient, args []string) error {
 		return cmdSecrets(c, args[1:])
 	case "relay":
 		if len(args) < 2 {
-			return fmt.Errorf("usage: dicode relay <trust-broker> --yes")
+			return fmt.Errorf("usage: dicode relay <login|trust-broker> [flags]")
 		}
 		return cmdRelay(c, args[1:])
 	default:
 		return fmt.Errorf("unknown command %q — run 'dicode' for usage", args[0])
-	}
-}
-
-func cmdRelay(c *ipc.ControlClient, args []string) error {
-	switch args[0] {
-	case "trust-broker":
-		force := false
-		for _, a := range args[1:] {
-			switch a {
-			case "--yes", "-y":
-				force = true
-			default:
-				return fmt.Errorf("unknown flag %q — usage: dicode relay trust-broker --yes", a)
-			}
-		}
-		if !force {
-			fmt.Fprintln(os.Stderr, "This will clear the pinned broker signing key.")
-			fmt.Fprintln(os.Stderr, "The next relay reconnect will trust-on-first-use the broker's current key.")
-			fmt.Fprintln(os.Stderr, "Re-run with --yes to confirm.")
-			return fmt.Errorf("aborted")
-		}
-		resp, err := c.Send(ipc.Request{Method: "cli.relay.trust_broker"})
-		if err != nil {
-			return err
-		}
-		if resp.Error != "" {
-			return fmt.Errorf("%s", resp.Error)
-		}
-		fmt.Println("Broker pubkey pin cleared. Restart the daemon to accept the new broker key.")
-		return nil
-	default:
-		return fmt.Errorf("unknown relay subcommand %q", args[0])
 	}
 }
 
@@ -225,9 +194,33 @@ func cmdStatus(c *ipc.ControlClient, taskID string) error {
 	if resp.Error != "" {
 		return fmt.Errorf("%s", resp.Error)
 	}
+	// When querying the daemon (no taskID), render a compact human summary
+	// including the relay linkage line. Otherwise keep the raw run payload.
+	if taskID == "" {
+		var ds ipc.DaemonStatus
+		if err := remarshal(resp.Result, &ds); err == nil && ds.Version != "" {
+			fmt.Printf("dicode %s — uptime %ds, %d tasks\n", ds.Version, ds.UptimeSec, ds.TaskCount)
+			fmt.Println(formatRelayStatusLine(ds.Relay))
+			return nil
+		}
+	}
 	out, _ := json.MarshalIndent(resp.Result, "", "  ")
 	fmt.Println(string(out))
 	return nil
+}
+
+// formatRelayStatusLine renders the relay linkage state for `dicode status`.
+func formatRelayStatusLine(rs ipc.RelayStatus) string {
+	if !rs.Enabled {
+		return "Relay: disabled"
+	}
+	if !rs.Linked {
+		return "Relay: not linked (run `dicode relay login`)"
+	}
+	if rs.GithubLogin != "" {
+		return fmt.Sprintf("Relay: linked to @%s", rs.GithubLogin)
+	}
+	return "Relay: linked"
 }
 
 func cmdSecrets(c *ipc.ControlClient, args []string) error {
@@ -381,6 +374,8 @@ Commands:
   secrets list                    list secret keys
   secrets set <key> <value>       store a secret
   secrets delete <key>            delete a secret
+  relay login [flags]             claim this daemon to a relay user account
+                                  flags: --token, --label, --base-url, --no-browser
   version                         print version
 `)
 }

--- a/cmd/dicode/relay.go
+++ b/cmd/dicode/relay.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
@@ -11,6 +12,10 @@ import (
 
 	"github.com/dicode/dicode/pkg/ipc"
 )
+
+// maxPastedClaimTokenLen caps what we accept from stdin paste so a
+// malicious or accidental 1MB paste doesn't bloat the IPC frame.
+const maxPastedClaimTokenLen = 1024
 
 // cmdRelay dispatches `dicode relay <subcommand>`.
 func cmdRelay(c *ipc.ControlClient, args []string) error {
@@ -65,6 +70,10 @@ func cmdRelayLogin(c *ipc.ControlClient, args []string) error {
 		return err
 	}
 
+	if warning := plaintextBaseURLWarning(*baseURLFlag); warning != "" {
+		fmt.Fprintln(os.Stderr, warning)
+	}
+
 	token := *tokenFlag
 	if token == "" {
 		dashURL := buildDashboardURL(*baseURLFlag)
@@ -84,6 +93,9 @@ func cmdRelayLogin(c *ipc.ControlClient, args []string) error {
 		if token == "" {
 			return fmt.Errorf("claim token required")
 		}
+	}
+	if len(token) > maxPastedClaimTokenLen {
+		return fmt.Errorf("claim token exceeds %d bytes", maxPastedClaimTokenLen)
 	}
 
 	resp, err := c.Send(ipc.Request{
@@ -135,10 +147,39 @@ func openInBrowser(url string) error {
 	return cmd.Start()
 }
 
-// shortUUID returns an abbreviated uuid for terminal output.
+// shortUUID returns an abbreviated uuid for terminal output. Uses ASCII
+// ellipsis so output is safe on legacy Windows consoles / cp1252 pipes.
 func shortUUID(u string) string {
 	if len(u) <= 12 {
 		return u
 	}
-	return u[:12] + "…"
+	return u[:12] + "..."
+}
+
+// plaintextBaseURLWarning returns a warning string when the supplied base
+// URL is plaintext http AND not pointing at a local development host.
+// Returns the empty string when the URL is https, empty, or localhost-only.
+func plaintextBaseURLWarning(baseURL string) string {
+	if baseURL == "" {
+		return ""
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return ""
+	}
+	if parsed.Scheme != "http" {
+		return ""
+	}
+	host := parsed.Hostname()
+	switch host {
+	case "", "localhost", "127.0.0.1", "::1":
+		return ""
+	}
+	if strings.HasSuffix(host, ".localhost") {
+		return ""
+	}
+	return fmt.Sprintf(
+		"warning: relay base URL is plaintext http, use https in production: %s",
+		baseURL,
+	)
 }

--- a/cmd/dicode/relay.go
+++ b/cmd/dicode/relay.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/dicode/dicode/pkg/ipc"
+)
+
+// cmdRelay dispatches `dicode relay <subcommand>`.
+func cmdRelay(c *ipc.ControlClient, args []string) error {
+	switch args[0] {
+	case "login":
+		return cmdRelayLogin(c, args[1:])
+	case "trust-broker":
+		return cmdRelayTrustBroker(c, args[1:])
+	default:
+		return fmt.Errorf("unknown relay subcommand %q (try: login, trust-broker)", args[0])
+	}
+}
+
+func cmdRelayTrustBroker(c *ipc.ControlClient, args []string) error {
+	force := false
+	for _, a := range args {
+		switch a {
+		case "--yes", "-y":
+			force = true
+		default:
+			return fmt.Errorf("unknown flag %q — usage: dicode relay trust-broker --yes", a)
+		}
+	}
+	if !force {
+		fmt.Fprintln(os.Stderr, "This will clear the pinned broker signing key.")
+		fmt.Fprintln(os.Stderr, "The next relay reconnect will trust-on-first-use the broker's current key.")
+		fmt.Fprintln(os.Stderr, "Re-run with --yes to confirm.")
+		return fmt.Errorf("aborted")
+	}
+	resp, err := c.Send(ipc.Request{Method: "cli.relay.trust_broker"})
+	if err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	fmt.Println("Broker pubkey pin cleared. Restart the daemon to accept the new broker key.")
+	return nil
+}
+
+// cmdRelayLogin runs the interactive or non-interactive daemon claim flow.
+// It never logs the claim token and never touches the daemon's private key —
+// all crypto runs inside the daemon via cli.relay.login.
+func cmdRelayLogin(c *ipc.ControlClient, args []string) error {
+	fs := flag.NewFlagSet("relay login", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	tokenFlag := fs.String("token", "", "claim token issued by the relay dashboard")
+	labelFlag := fs.String("label", "", "human-readable daemon label")
+	baseURLFlag := fs.String("base-url", "", "override relay base URL (dev/self-hosted)")
+	noBrowser := fs.Bool("no-browser", false, "do not try to open the dashboard in a browser")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	token := *tokenFlag
+	if token == "" {
+		dashURL := buildDashboardURL(*baseURLFlag)
+		fmt.Printf("Open %s in your browser and copy the claim token.\n", dashURL)
+		if !*noBrowser {
+			if err := openInBrowser(dashURL); err != nil {
+				fmt.Fprintf(os.Stderr, "dicode: could not open browser automatically: %v\n", err)
+			}
+		}
+		fmt.Print("Paste the claim token: ")
+		reader := bufio.NewReader(os.Stdin)
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("read claim token: %w", err)
+		}
+		token = strings.TrimSpace(line)
+		if token == "" {
+			return fmt.Errorf("claim token required")
+		}
+	}
+
+	resp, err := c.Send(ipc.Request{
+		Method:     "cli.relay.login",
+		ClaimToken: token,
+		Label:      *labelFlag,
+		BaseURL:    *baseURLFlag,
+	})
+	if err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	var result ipc.RelayLoginResult
+	if err := remarshal(resp.Result, &result); err != nil {
+		return err
+	}
+	if result.GithubLogin != "" {
+		fmt.Printf("Daemon %s claimed as @%s\n", shortUUID(result.UUID), result.GithubLogin)
+	} else {
+		fmt.Printf("Daemon %s claimed\n", shortUUID(result.UUID))
+	}
+	return nil
+}
+
+// buildDashboardURL assembles the URL that shows the claim token. The base
+// URL override is optional; the relay has a sensible default.
+func buildDashboardURL(override string) string {
+	base := strings.TrimRight(override, "/")
+	if base == "" {
+		base = "https://relay.dicode.app"
+	}
+	return base + "/dashboard/claim"
+}
+
+// openInBrowser launches a cross-platform URL handler. Falls back silently
+// when no opener is available — the URL is always printed first anyway.
+func openInBrowser(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	return cmd.Start()
+}
+
+// shortUUID returns an abbreviated uuid for terminal output.
+func shortUUID(u string) string {
+	if len(u) <= 12 {
+		return u
+	}
+	return u[:12] + "…"
+}

--- a/cmd/dicode/relay_test.go
+++ b/cmd/dicode/relay_test.go
@@ -51,10 +51,35 @@ func TestShortUUID(t *testing.T) {
 	}
 	long := strings.Repeat("a", 64)
 	got := shortUUID(long)
-	if !strings.HasSuffix(got, "…") {
-		t.Fatalf("expected ellipsis suffix, got %q", got)
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("expected ASCII ellipsis suffix, got %q", got)
 	}
-	if len(got) > 16 {
+	if len(got) > 20 {
 		t.Fatalf("shortened uuid too long: %q", got)
+	}
+}
+
+func TestPlaintextBaseURLWarning(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"empty", "", false},
+		{"https", "https://relay.dicode.app", false},
+		{"localhost", "http://localhost:5553", false},
+		{"127.0.0.1", "http://127.0.0.1:5553", false},
+		{"ipv6 loopback", "http://[::1]:5553", false},
+		{"*.localhost", "http://dev.localhost:5553", false},
+		{"plain http", "http://relay.example.com", true},
+		{"malformed", "::::not a url::::", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := plaintextBaseURLWarning(tc.in) != ""
+			if got != tc.want {
+				t.Fatalf("plaintextBaseURLWarning(%q) warned=%v want=%v", tc.in, got, tc.want)
+			}
+		})
 	}
 }

--- a/cmd/dicode/relay_test.go
+++ b/cmd/dicode/relay_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/ipc"
+)
+
+func TestFormatRelayStatusLine(t *testing.T) {
+	cases := []struct {
+		name string
+		in   ipc.RelayStatus
+		want string
+	}{
+		{"disabled", ipc.RelayStatus{}, "Relay: disabled"},
+		{"not-linked", ipc.RelayStatus{Enabled: true}, "Relay: not linked (run `dicode relay login`)"},
+		{"linked", ipc.RelayStatus{Enabled: true, Linked: true, GithubLogin: "octocat"}, "Relay: linked to @octocat"},
+		{"linked-no-login", ipc.RelayStatus{Enabled: true, Linked: true}, "Relay: linked"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatRelayStatusLine(tc.in)
+			if got != tc.want {
+				t.Fatalf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildDashboardURL(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", "https://relay.dicode.app/dashboard/claim"},
+		{"http://localhost:5553", "http://localhost:5553/dashboard/claim"},
+		{"http://localhost:5553/", "http://localhost:5553/dashboard/claim"},
+	}
+	for _, tc := range cases {
+		got := buildDashboardURL(tc.in)
+		if got != tc.want {
+			t.Fatalf("in=%q got %q want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestShortUUID(t *testing.T) {
+	if shortUUID("abc") != "abc" {
+		t.Fatalf("short uuid should pass through")
+	}
+	long := strings.Repeat("a", 64)
+	got := shortUUID(long)
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("expected ellipsis suffix, got %q", got)
+	}
+	if len(got) > 16 {
+		t.Fatalf("shortened uuid too long: %q", got)
+	}
+}

--- a/cmd/dicoded/main.go
+++ b/cmd/dicoded/main.go
@@ -226,6 +226,7 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 					zap.String("expected_scheme", "wss:// or ws://"))
 			}
 			g.Go(func() error { pending.StartSweep(ctx); return nil })
+			ctrlSrv.SetRelayHooks(buildRelayHooks(cfg.Relay.ServerURL, id, database))
 			g.Go(func() error { return rc.Run(ctx) })
 		}
 	}

--- a/cmd/dicoded/relay_hooks.go
+++ b/cmd/dicoded/relay_hooks.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/ipc"
+	"github.com/dicode/dicode/pkg/relay"
+)
+
+// buildRelayHooks adapts the relay package to the ipc.ControlServer so that
+// cli.status and cli.relay.login have an identity-aware backend without ipc
+// importing pkg/relay.
+func buildRelayHooks(defaultBaseURL string, id *relay.Identity, database db.DB) ipc.RelayHooks {
+	httpClient := &http.Client{Timeout: 20 * time.Second}
+
+	status := func(ctx context.Context) (ipc.RelayStatus, error) {
+		s := ipc.RelayStatus{Enabled: true, UUID: id.UUID}
+		cs, err := relay.LoadClaimStatus(ctx, database)
+		if err != nil {
+			return s, nil // best effort — never block status on kv errors
+		}
+		s.Linked = cs.Linked()
+		s.GithubLogin = cs.GithubLogin
+		s.ClaimedAt = cs.ClaimedAt
+		return s, nil
+	}
+
+	login := func(ctx context.Context, claimToken, label, baseURLOverride string) (ipc.RelayLoginResult, error) {
+		baseURL := defaultBaseURL
+		if baseURLOverride != "" {
+			baseURL = baseURLOverride
+		}
+		result, err := relay.Claim(ctx, httpClient, baseURL, id, claimToken, label, database)
+		if err != nil {
+			return ipc.RelayLoginResult{}, err
+		}
+		return ipc.RelayLoginResult{UUID: result.UUID, GithubLogin: result.GithubLogin}, nil
+	}
+
+	return ipc.RelayHooks{Status: status, Login: login}
+}

--- a/pkg/ipc/capability.go
+++ b/pkg/ipc/capability.go
@@ -52,6 +52,7 @@ const (
 	CapCLILogs    = "cli.logs"    // fetch log entries for a run
 	CapCLIStatus  = "cli.status"  // daemon health and uptime
 	CapCLISecrets = "cli.secrets" // list / set / delete secrets
+	CapCLIRelay   = "cli.relay"   // claim this daemon to a relay user account
 )
 
 // cliCaps is the full capability set granted to every CLI client.
@@ -62,6 +63,7 @@ func cliCaps() []string {
 		CapCLILogs,
 		CapCLIStatus,
 		CapCLISecrets,
+		CapCLIRelay,
 	}
 }
 

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -40,6 +40,32 @@ type ControlServer struct {
 
 	startedAt time.Time
 	version   string
+
+	// relayHooks provides optional accessors for the daemon's relay identity
+	// and claim actions. Wired by the daemon after the relay client is built;
+	// nil when the relay feature is disabled.
+	relayHooks RelayHooks
+}
+
+// RelayHooks is the ControlServer's interface to the relay subsystem. Passing
+// these in via SetRelayHooks keeps ControlServer ignorant of pkg/relay, which
+// avoids an import cycle and keeps IPC tests side-effect-free.
+type RelayHooks struct {
+	// Status returns the current linkage state for cli.status. Must be safe to
+	// call with nil receiver state and must never return an error that blocks
+	// the status response — return (RelayStatus{}, nil) on best effort.
+	Status func(ctx context.Context) (RelayStatus, error)
+
+	// Login performs the daemon claim flow. Returns the resulting user login
+	// and UUID on success, or a descriptive error otherwise. Must never log
+	// the claim token.
+	Login func(ctx context.Context, claimToken, label, baseURLOverride string) (RelayLoginResult, error)
+}
+
+// SetRelayHooks wires the relay accessors into the control server. Call this
+// after NewControlServer if the daemon has initialised its relay identity.
+func (cs *ControlServer) SetRelayHooks(h RelayHooks) {
+	cs.relayHooks = h
 }
 
 // NewControlServer creates a ControlServer. Call Start to begin accepting
@@ -214,6 +240,9 @@ func (cs *ControlServer) dispatch(ctx context.Context, req Request) (any, error)
 	case "cli.relay.trust_broker":
 		return cs.handleTrustBroker(ctx)
 
+	case "cli.relay.login":
+		return cs.handleRelayLogin(ctx, req)
+
 	default:
 		return nil, fmt.Errorf("unknown method: %s", req.Method)
 	}
@@ -221,11 +250,28 @@ func (cs *ControlServer) dispatch(ctx context.Context, req Request) (any, error)
 
 func (cs *ControlServer) handlePing() DaemonStatus {
 	all := cs.reg.All()
-	return DaemonStatus{
+	status := DaemonStatus{
 		Version:   cs.version,
 		UptimeSec: int64(time.Since(cs.startedAt).Seconds()),
 		TaskCount: len(all),
 	}
+	if cs.relayHooks.Status != nil {
+		// Best effort — never block ping on a relay status failure.
+		if rs, err := cs.relayHooks.Status(context.Background()); err == nil {
+			status.Relay = rs
+		}
+	}
+	return status
+}
+
+func (cs *ControlServer) handleRelayLogin(ctx context.Context, req Request) (any, error) {
+	if cs.relayHooks.Login == nil {
+		return nil, errors.New("relay is not enabled on this daemon")
+	}
+	if req.ClaimToken == "" {
+		return nil, errors.New("claimToken required")
+	}
+	return cs.relayHooks.Login(ctx, req.ClaimToken, req.Label, req.BaseURL)
 }
 
 func (cs *ControlServer) handleList() ([]TaskSummary, error) {

--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -84,6 +84,11 @@ type Request struct {
 	RunID       string `json:"runID,omitempty"`
 	StringValue string `json:"stringValue,omitempty"` // cli.secrets.set value
 	Follow      bool   `json:"follow,omitempty"`      // cli.logs — reserved for streaming
+
+	// cli.relay.login
+	ClaimToken string `json:"claimToken,omitempty"`
+	Label      string `json:"label,omitempty"`
+	BaseURL    string `json:"baseURL,omitempty"` // optional override
 }
 
 // Response is an outbound message to a connected client.
@@ -148,10 +153,28 @@ type LogEntry struct {
 
 // DaemonStatus is the cli.status response.
 type DaemonStatus struct {
-	Version   string `json:"version"`
-	UptimeSec int64  `json:"uptimeSec"`
-	TaskCount int    `json:"taskCount"`
-	RunCount  int    `json:"runCount"` // runs in the last 24h
+	Version   string      `json:"version"`
+	UptimeSec int64       `json:"uptimeSec"`
+	TaskCount int         `json:"taskCount"`
+	RunCount  int         `json:"runCount"` // runs in the last 24h
+	Relay     RelayStatus `json:"relay"`
+}
+
+// RelayStatus describes the daemon's relay linkage state, surfaced by
+// cli.status so `dicode status` can tell users whether they're linked to a
+// relay user account.
+type RelayStatus struct {
+	Enabled     bool   `json:"enabled"`
+	UUID        string `json:"uuid,omitempty"`
+	Linked      bool   `json:"linked"`
+	GithubLogin string `json:"githubLogin,omitempty"`
+	ClaimedAt   string `json:"claimedAt,omitempty"`
+}
+
+// RelayLoginResult is the cli.relay.login response body.
+type RelayLoginResult struct {
+	UUID        string `json:"uuid"`
+	GithubLogin string `json:"githubLogin,omitempty"`
 }
 
 // RunResult is returned by EngineRunner.WaitRun.

--- a/pkg/relay/claim.go
+++ b/pkg/relay/claim.go
@@ -25,6 +25,11 @@ const (
 	kvKeyRelayClaimAt     = "relay.claim_at"
 
 	claimRequestTimeout = 20 * time.Second
+
+	// maxClaimTokenLen caps the claim token to avoid wasting work hashing
+	// unbounded paste buffers. Real tokens are short signed payloads well
+	// under this limit.
+	maxClaimTokenLen = 1024
 )
 
 // BuildClaimSignature signs the canonical claim preimage with the daemon's
@@ -43,6 +48,9 @@ func BuildClaimSignature(identity *Identity, claimToken string) (string, error) 
 	}
 	if claimToken == "" {
 		return "", errors.New("claim: empty claim token")
+	}
+	if len(claimToken) > maxClaimTokenLen {
+		return "", fmt.Errorf("claim: token exceeds %d bytes", maxClaimTokenLen)
 	}
 
 	uuidBytes, err := hex.DecodeString(identity.UUID)
@@ -211,6 +219,10 @@ func mapClaimError(status int, body []byte) error {
 	return base
 }
 
+// persistClaimFlags writes the three kv flags atomically. Running them
+// outside a transaction would risk leaving the daemon half-claimed
+// (relay.claim_status=ok without a matching user/at) if the second or
+// third write failed mid-flight.
 func persistClaimFlags(ctx context.Context, database db.DB, result *ClaimResult) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 	pairs := [][2]string{
@@ -218,15 +230,17 @@ func persistClaimFlags(ctx context.Context, database db.DB, result *ClaimResult)
 		{kvKeyRelayClaimUser, result.GithubLogin},
 		{kvKeyRelayClaimAt, now},
 	}
-	for _, p := range pairs {
-		if err := database.Exec(ctx,
-			`INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)`,
-			p[0], p[1],
-		); err != nil {
-			return err
+	return database.Tx(ctx, func(tx db.DB) error {
+		for _, p := range pairs {
+			if err := tx.Exec(ctx,
+				`INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)`,
+				p[0], p[1],
+			); err != nil {
+				return err
+			}
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 // LoadClaimStatus returns the persisted claim state, or an empty status if

--- a/pkg/relay/claim.go
+++ b/pkg/relay/claim.go
@@ -1,0 +1,276 @@
+package relay
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+)
+
+const (
+	kvKeyRelayClaimStatus = "relay.claim_status"
+	kvKeyRelayClaimUser   = "relay.claim_user"
+	kvKeyRelayClaimAt     = "relay.claim_at"
+
+	claimRequestTimeout = 20 * time.Second
+)
+
+// BuildClaimSignature signs the canonical claim preimage with the daemon's
+// private key. The preimage is defined in dicode-relay issue #14:
+//
+//	preimage = utf8_bytes(claimToken) || hex_decode(identity.UUID)
+//	message  = sha256(preimage)
+//	sig      = ECDSA-P256-SHA256-DER(privkey, message)
+//
+// The uuid is the 32 raw bytes obtained by hex-decoding identity.UUID, NOT
+// the ASCII bytes of the hex string — the server side in #14 must match.
+// Returns the base64-encoded DER signature ready for JSON transport.
+func BuildClaimSignature(identity *Identity, claimToken string) (string, error) {
+	if identity == nil || identity.PrivateKey == nil {
+		return "", errors.New("claim: nil identity")
+	}
+	if claimToken == "" {
+		return "", errors.New("claim: empty claim token")
+	}
+
+	uuidBytes, err := hex.DecodeString(identity.UUID)
+	if err != nil {
+		return "", fmt.Errorf("claim: decode uuid: %w", err)
+	}
+	if len(uuidBytes) != 32 {
+		return "", fmt.Errorf("claim: uuid must decode to 32 bytes, got %d", len(uuidBytes))
+	}
+
+	h := sha256.New()
+	h.Write([]byte(claimToken))
+	h.Write(uuidBytes)
+	digest := h.Sum(nil)
+
+	sig, err := ecdsa.SignASN1(rand.Reader, identity.PrivateKey, digest)
+	if err != nil {
+		return "", fmt.Errorf("claim: sign: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(sig), nil
+}
+
+// ClaimRequest is the JSON body POSTed to the relay's /api/daemons/claim
+// endpoint. Field names match the schema pinned in dicode-relay issue #14.
+type ClaimRequest struct {
+	ClaimToken string `json:"claim_token"`
+	UUID       string `json:"uuid"`
+	PubKey     string `json:"pubkey"`
+	Sig        string `json:"sig"`
+	Label      string `json:"label,omitempty"`
+}
+
+// ClaimResponse is the expected 2xx body from the relay.
+type ClaimResponse struct {
+	OK          bool   `json:"ok"`
+	GithubLogin string `json:"github_login,omitempty"`
+}
+
+// ClaimErrorResponse is the JSON body returned by the relay on non-2xx.
+type ClaimErrorResponse struct {
+	Error string `json:"error,omitempty"`
+	Hint  string `json:"hint,omitempty"`
+}
+
+// ClaimResult is the successful outcome of a claim call, suitable for
+// persisting and displaying to the user.
+type ClaimResult struct {
+	UUID        string `json:"uuid"`
+	GithubLogin string `json:"githubLogin,omitempty"`
+}
+
+// Claim performs the full daemon claim flow:
+//  1. Build the ECDSA attestation over (claimToken || uuid)
+//  2. POST ClaimRequest to {baseURL}/api/daemons/claim
+//  3. On 2xx, persist KV flags so `dicode status` can surface the linked state
+//
+// It returns a friendly error message mapped from the HTTP status code on
+// failure. The claim token is never logged.
+func Claim(
+	ctx context.Context,
+	httpClient *http.Client,
+	baseURL string,
+	identity *Identity,
+	claimToken, label string,
+	database db.DB,
+) (*ClaimResult, error) {
+	if baseURL == "" {
+		return nil, errors.New("claim: relay base URL is empty")
+	}
+	if identity == nil {
+		return nil, errors.New("claim: nil identity")
+	}
+
+	sig, err := BuildClaimSignature(identity, claimToken)
+	if err != nil {
+		return nil, err
+	}
+
+	body := ClaimRequest{
+		ClaimToken: claimToken,
+		UUID:       identity.UUID,
+		PubKey:     base64.StdEncoding.EncodeToString(identity.UncompressedPublicKey()),
+		Sig:        sig,
+		Label:      label,
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("claim: marshal body: %w", err)
+	}
+
+	endpoint := strings.TrimRight(baseURL, "/") + "/api/daemons/claim"
+	reqCtx, cancel := context.WithTimeout(ctx, claimRequestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("claim: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: claimRequestTimeout}
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("claim: relay unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		var ok ClaimResponse
+		_ = json.Unmarshal(respBody, &ok)
+		result := &ClaimResult{UUID: identity.UUID, GithubLogin: ok.GithubLogin}
+		if database != nil {
+			if err := persistClaimFlags(ctx, database, result); err != nil {
+				return result, fmt.Errorf("claim: persist kv: %w", err)
+			}
+		}
+		return result, nil
+	}
+
+	return nil, mapClaimError(resp.StatusCode, respBody)
+}
+
+// mapClaimError turns a non-2xx HTTP response into a user-friendly error.
+// Exported error sentinels let callers distinguish cases programmatically.
+var (
+	ErrClaimTokenInvalid = errors.New("claim token is invalid or expired")
+	ErrClaimConflict     = errors.New("daemon is already claimed by a different user")
+	ErrClaimForbidden    = errors.New("relay rejected the claim")
+	ErrClaimBadRequest   = errors.New("relay rejected the claim request")
+	ErrClaimServer       = errors.New("relay returned a server error")
+)
+
+func mapClaimError(status int, body []byte) error {
+	var parsed ClaimErrorResponse
+	_ = json.Unmarshal(body, &parsed)
+
+	var base error
+	switch status {
+	case http.StatusUnauthorized:
+		base = ErrClaimTokenInvalid
+	case http.StatusConflict:
+		base = ErrClaimConflict
+	case http.StatusForbidden:
+		base = ErrClaimForbidden
+	case http.StatusBadRequest:
+		base = ErrClaimBadRequest
+	default:
+		if status >= 500 {
+			base = ErrClaimServer
+		} else {
+			base = fmt.Errorf("relay returned HTTP %d", status)
+		}
+	}
+
+	if parsed.Error != "" {
+		if parsed.Hint != "" {
+			return fmt.Errorf("%w: %s (%s)", base, parsed.Error, parsed.Hint)
+		}
+		return fmt.Errorf("%w: %s", base, parsed.Error)
+	}
+	return base
+}
+
+func persistClaimFlags(ctx context.Context, database db.DB, result *ClaimResult) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	pairs := [][2]string{
+		{kvKeyRelayClaimStatus, "ok"},
+		{kvKeyRelayClaimUser, result.GithubLogin},
+		{kvKeyRelayClaimAt, now},
+	}
+	for _, p := range pairs {
+		if err := database.Exec(ctx,
+			`INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)`,
+			p[0], p[1],
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// LoadClaimStatus returns the persisted claim state, or an empty status if
+// the daemon has never been claimed. Safe to call when the KV table is empty.
+func LoadClaimStatus(ctx context.Context, database db.DB) (ClaimStatus, error) {
+	var s ClaimStatus
+	if database == nil {
+		return s, nil
+	}
+	keys := []struct {
+		k    string
+		dest *string
+	}{
+		{kvKeyRelayClaimStatus, &s.Status},
+		{kvKeyRelayClaimUser, &s.GithubLogin},
+		{kvKeyRelayClaimAt, &s.ClaimedAt},
+	}
+	for _, item := range keys {
+		var v string
+		err := database.Query(ctx,
+			`SELECT value FROM kv WHERE key = ?`,
+			[]any{item.k},
+			func(rows db.Scanner) error {
+				if rows.Next() {
+					return rows.Scan(&v)
+				}
+				return nil
+			},
+		)
+		if err != nil {
+			return s, err
+		}
+		*item.dest = v
+	}
+	return s, nil
+}
+
+// ClaimStatus summarises the daemon-side view of whether it has been claimed
+// by a relay user account.
+type ClaimStatus struct {
+	Status      string `json:"status,omitempty"`      // "" | "ok"
+	GithubLogin string `json:"githubLogin,omitempty"` // empty if unknown
+	ClaimedAt   string `json:"claimedAt,omitempty"`   // RFC3339 or ""
+}
+
+// Linked reports whether the daemon has successfully been claimed.
+func (c ClaimStatus) Linked() bool { return c.Status == "ok" }

--- a/pkg/relay/claim_test.go
+++ b/pkg/relay/claim_test.go
@@ -1,0 +1,322 @@
+package relay
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"math/big"
+	mrand "math/rand"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/db"
+)
+
+// newDeterministicIdentity returns a P-256 keypair derived from a fixed seed
+// so assertions on the public UUID are stable across runs.
+func newDeterministicIdentity(t *testing.T, seed int64) *Identity {
+	t.Helper()
+	// Deterministic reader for ecdsa.GenerateKey — sufficient for tests; never
+	// use math/rand for real key material.
+	r := mrand.New(mrand.NewSource(seed)) //nolint:gosec // deterministic test vector
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), &deterministicReader{r: r})
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return &Identity{
+		PrivateKey: priv,
+		UUID:       deriveUUID(&priv.PublicKey),
+	}
+}
+
+type deterministicReader struct{ r *mrand.Rand }
+
+func (d *deterministicReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = byte(d.r.Intn(256))
+	}
+	return len(p), nil
+}
+
+func TestBuildClaimSignature_PreimageShape(t *testing.T) {
+	id := newDeterministicIdentity(t, 1)
+	claimToken := "dcrct_test_token_0123456789"
+
+	sigB64, err := BuildClaimSignature(id, claimToken)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	sig, err := base64.StdEncoding.DecodeString(sigB64)
+	if err != nil {
+		t.Fatalf("decode base64 sig: %v", err)
+	}
+
+	// Canonical preimage from dicode-relay#14 clarification:
+	//   preimage = utf8(claim_token) || hex_decode(uuid)
+	uuidBytes, err := hex.DecodeString(id.UUID)
+	if err != nil {
+		t.Fatalf("decode uuid: %v", err)
+	}
+	if len(uuidBytes) != 32 {
+		t.Fatalf("uuid must decode to 32 bytes, got %d", len(uuidBytes))
+	}
+
+	h := sha256.New()
+	h.Write([]byte(claimToken))
+	h.Write(uuidBytes)
+	digest := h.Sum(nil)
+
+	if !ecdsa.VerifyASN1(&id.PrivateKey.PublicKey, digest, sig) {
+		t.Fatalf("signature did not verify against canonical preimage")
+	}
+
+	// Rejection: the ASCII-of-hex variant must NOT verify — that is the exact
+	// mistake the #14 comment pins down.
+	hBad := sha256.New()
+	hBad.Write([]byte(claimToken))
+	hBad.Write([]byte(id.UUID))
+	if ecdsa.VerifyASN1(&id.PrivateKey.PublicKey, hBad.Sum(nil), sig) {
+		t.Fatalf("signature verified against ASCII-hex variant; #14 ambiguity resurfaced")
+	}
+}
+
+func TestBuildClaimSignature_RealKeyRoundTrip(t *testing.T) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen: %v", err)
+	}
+	id := &Identity{PrivateKey: priv, UUID: deriveUUID(&priv.PublicKey)}
+
+	sigB64, err := BuildClaimSignature(id, "live-token")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	sig, _ := base64.StdEncoding.DecodeString(sigB64)
+	uuidBytes, _ := hex.DecodeString(id.UUID)
+	h := sha256.Sum256(append([]byte("live-token"), uuidBytes...))
+	if !ecdsa.VerifyASN1(&priv.PublicKey, h[:], sig) {
+		t.Fatalf("round-trip verify failed")
+	}
+}
+
+func TestBuildClaimSignature_ErrorCases(t *testing.T) {
+	if _, err := BuildClaimSignature(nil, "tok"); err == nil {
+		t.Fatalf("expected error for nil identity")
+	}
+	id := newDeterministicIdentity(t, 2)
+	if _, err := BuildClaimSignature(id, ""); err == nil {
+		t.Fatalf("expected error for empty claim token")
+	}
+	broken := &Identity{PrivateKey: id.PrivateKey, UUID: "not-hex"}
+	if _, err := BuildClaimSignature(broken, "tok"); err == nil {
+		t.Fatalf("expected error for non-hex uuid")
+	}
+	tooShort := &Identity{PrivateKey: id.PrivateKey, UUID: "deadbeef"}
+	if _, err := BuildClaimSignature(tooShort, "tok"); err == nil {
+		t.Fatalf("expected error for uuid not 32 bytes")
+	}
+	// Ensure the placeholder import stays used even if we later prune cases.
+	_ = new(big.Int)
+}
+
+// fakeDB is a minimal in-memory db.DB implementation for claim tests.
+type fakeDB struct {
+	store map[string]string
+}
+
+func newFakeDB() *fakeDB                     { return &fakeDB{store: map[string]string{}} }
+func (f *fakeDB) Ping(context.Context) error { return nil }
+func (f *fakeDB) Close() error               { return nil }
+func (f *fakeDB) Tx(ctx context.Context, fn func(tx db.DB) error) error {
+	return fn(f)
+}
+func (f *fakeDB) Exec(_ context.Context, sql string, args ...any) error {
+	if !strings.Contains(sql, "INSERT OR REPLACE INTO kv") {
+		return nil
+	}
+	if len(args) != 2 {
+		return nil
+	}
+	key, _ := args[0].(string)
+	val, _ := args[1].(string)
+	f.store[key] = val
+	return nil
+}
+func (f *fakeDB) Query(_ context.Context, sql string, args []any, fn func(db.Scanner) error) error {
+	if !strings.Contains(sql, "SELECT value FROM kv WHERE key") {
+		return fn(&fakeScanner{})
+	}
+	key, _ := args[0].(string)
+	if v, ok := f.store[key]; ok {
+		return fn(&fakeScanner{rows: []string{v}})
+	}
+	return fn(&fakeScanner{})
+}
+
+type fakeScanner struct {
+	rows []string
+	idx  int
+}
+
+func (s *fakeScanner) Next() bool {
+	if s.idx >= len(s.rows) {
+		return false
+	}
+	s.idx++
+	return true
+}
+func (s *fakeScanner) Scan(dest ...any) error {
+	if p, ok := dest[0].(*string); ok {
+		*p = s.rows[s.idx-1]
+	}
+	return nil
+}
+
+func TestClaim_HappyPath(t *testing.T) {
+	id := newDeterministicIdentity(t, 3)
+	database := newFakeDB()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/daemons/claim" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("missing content-type")
+		}
+		var body ClaimRequest
+		raw, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Errorf("bad request body: %v", err)
+		}
+		if body.UUID != id.UUID {
+			t.Errorf("uuid mismatch: got %q want %q", body.UUID, id.UUID)
+		}
+		if body.ClaimToken != "test-token-xyz" {
+			t.Errorf("claim_token mismatch: %q", body.ClaimToken)
+		}
+		if body.Label != "my-laptop" {
+			t.Errorf("label mismatch: %q", body.Label)
+		}
+		// Re-verify signature server-side so the full preimage contract is
+		// exercised in both directions.
+		sig, _ := base64.StdEncoding.DecodeString(body.Sig)
+		uuidBytes, _ := hex.DecodeString(id.UUID)
+		h := sha256.New()
+		h.Write([]byte(body.ClaimToken))
+		h.Write(uuidBytes)
+		if !ecdsa.VerifyASN1(&id.PrivateKey.PublicKey, h.Sum(nil), sig) {
+			t.Errorf("signature did not verify on the fake server")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ClaimResponse{OK: true, GithubLogin: "octocat"})
+	}))
+	defer server.Close()
+
+	result, err := Claim(context.Background(), server.Client(), server.URL, id, "test-token-xyz", "my-laptop", database)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if result.GithubLogin != "octocat" {
+		t.Fatalf("unexpected github login: %q", result.GithubLogin)
+	}
+	if database.store[kvKeyRelayClaimStatus] != "ok" {
+		t.Fatalf("claim status not persisted: %+v", database.store)
+	}
+	if database.store[kvKeyRelayClaimUser] != "octocat" {
+		t.Fatalf("claim user not persisted")
+	}
+	if database.store[kvKeyRelayClaimAt] == "" {
+		t.Fatalf("claim_at not persisted")
+	}
+
+	status, err := LoadClaimStatus(context.Background(), database)
+	if err != nil {
+		t.Fatalf("load claim status: %v", err)
+	}
+	if !status.Linked() {
+		t.Fatalf("expected linked state, got %+v", status)
+	}
+	if status.GithubLogin != "octocat" {
+		t.Fatalf("load: github_login mismatch: %q", status.GithubLogin)
+	}
+}
+
+func TestClaim_ErrorMapping(t *testing.T) {
+	id := newDeterministicIdentity(t, 4)
+
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   error
+	}{
+		{"expired", http.StatusUnauthorized, `{"error":"token expired"}`, ErrClaimTokenInvalid},
+		{"conflict", http.StatusConflict, `{"error":"already claimed"}`, ErrClaimConflict},
+		{"forbidden", http.StatusForbidden, `{"error":"nope"}`, ErrClaimForbidden},
+		{"badrequest", http.StatusBadRequest, `{"error":"bad sig"}`, ErrClaimBadRequest},
+		{"server", http.StatusInternalServerError, `{"error":"boom"}`, ErrClaimServer},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			_, err := Claim(context.Background(), srv.Client(), srv.URL, id, "tok", "", nil)
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if !errorsIs(err, tc.want) {
+				t.Fatalf("error mapping mismatch: got %v want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestClaim_NetworkError(t *testing.T) {
+	id := newDeterministicIdentity(t, 5)
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv.Close()
+	_, err := Claim(context.Background(), &http.Client{}, srv.URL, id, "tok", "", nil)
+	if err == nil {
+		t.Fatalf("expected network error")
+	}
+	if !strings.Contains(err.Error(), "relay unreachable") {
+		t.Fatalf("error should indicate unreachability: %v", err)
+	}
+}
+
+func TestClaim_RejectsEmptyBaseURL(t *testing.T) {
+	id := newDeterministicIdentity(t, 6)
+	if _, err := Claim(context.Background(), nil, "", id, "tok", "", nil); err == nil {
+		t.Fatalf("expected error for empty base url")
+	}
+}
+
+// errorsIs unwraps with the stdlib unwrap convention; a local shim to avoid
+// a second errors import cluttering the file.
+func errorsIs(err, target error) bool {
+	for err != nil {
+		if err == target {
+			return true
+		}
+		type unwrapper interface{ Unwrap() error }
+		u, ok := err.(unwrapper)
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
+	return false
+}

--- a/pkg/relay/claim_test.go
+++ b/pkg/relay/claim_test.go
@@ -9,8 +9,8 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
-	"math/big"
 	mrand "math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -123,20 +123,34 @@ func TestBuildClaimSignature_ErrorCases(t *testing.T) {
 	if _, err := BuildClaimSignature(tooShort, "tok"); err == nil {
 		t.Fatalf("expected error for uuid not 32 bytes")
 	}
-	// Ensure the placeholder import stays used even if we later prune cases.
-	_ = new(big.Int)
+	oversize := strings.Repeat("a", maxClaimTokenLen+1)
+	if _, err := BuildClaimSignature(id, oversize); err == nil {
+		t.Fatalf("expected error for oversized claim token")
+	}
 }
 
 // fakeDB is a minimal in-memory db.DB implementation for claim tests.
+// Tx snapshots and rolls back on error so we can exercise the atomicity
+// contract of persistClaimFlags.
 type fakeDB struct {
-	store map[string]string
+	store     map[string]string
+	failAfter int // if > 0, Exec fails on the n-th kv write (1-indexed)
+	execCount int
 }
 
 func newFakeDB() *fakeDB                     { return &fakeDB{store: map[string]string{}} }
 func (f *fakeDB) Ping(context.Context) error { return nil }
 func (f *fakeDB) Close() error               { return nil }
 func (f *fakeDB) Tx(ctx context.Context, fn func(tx db.DB) error) error {
-	return fn(f)
+	snapshot := make(map[string]string, len(f.store))
+	for k, v := range f.store {
+		snapshot[k] = v
+	}
+	if err := fn(f); err != nil {
+		f.store = snapshot
+		return err
+	}
+	return nil
 }
 func (f *fakeDB) Exec(_ context.Context, sql string, args ...any) error {
 	if !strings.Contains(sql, "INSERT OR REPLACE INTO kv") {
@@ -144,6 +158,10 @@ func (f *fakeDB) Exec(_ context.Context, sql string, args ...any) error {
 	}
 	if len(args) != 2 {
 		return nil
+	}
+	f.execCount++
+	if f.failAfter > 0 && f.execCount == f.failAfter {
+		return errors.New("simulated write failure")
 	}
 	key, _ := args[0].(string)
 	val, _ := args[1].(string)
@@ -277,7 +295,7 @@ func TestClaim_ErrorMapping(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected error")
 			}
-			if !errorsIs(err, tc.want) {
+			if !errors.Is(err, tc.want) {
 				t.Fatalf("error mapping mismatch: got %v want %v", err, tc.want)
 			}
 		})
@@ -304,19 +322,43 @@ func TestClaim_RejectsEmptyBaseURL(t *testing.T) {
 	}
 }
 
-// errorsIs unwraps with the stdlib unwrap convention; a local shim to avoid
-// a second errors import cluttering the file.
-func errorsIs(err, target error) bool {
-	for err != nil {
-		if err == target {
-			return true
-		}
-		type unwrapper interface{ Unwrap() error }
-		u, ok := err.(unwrapper)
-		if !ok {
-			return false
-		}
-		err = u.Unwrap()
+func TestPersistClaimFlags_AtomicRollback(t *testing.T) {
+	fake := newFakeDB()
+	fake.failAfter = 2 // second write fails → whole tx rolls back
+
+	err := persistClaimFlags(context.Background(), fake, &ClaimResult{
+		UUID:        "u",
+		GithubLogin: "octocat",
+	})
+	if err == nil {
+		t.Fatalf("expected simulated write failure")
 	}
-	return false
+	// Nothing should have been committed: if the first write survived, we
+	// would have a half-claimed daemon with status=ok but no user/at.
+	if _, ok := fake.store[kvKeyRelayClaimStatus]; ok {
+		t.Fatalf("claim_status leaked out of aborted tx: %+v", fake.store)
+	}
+	if len(fake.store) != 0 {
+		t.Fatalf("expected empty store after rollback, got %+v", fake.store)
+	}
+}
+
+func TestPersistClaimFlags_HappyPathCommits(t *testing.T) {
+	fake := newFakeDB()
+	err := persistClaimFlags(context.Background(), fake, &ClaimResult{
+		UUID:        "u",
+		GithubLogin: "octocat",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fake.store[kvKeyRelayClaimStatus] != "ok" {
+		t.Fatalf("status not committed: %+v", fake.store)
+	}
+	if fake.store[kvKeyRelayClaimUser] != "octocat" {
+		t.Fatalf("user not committed: %+v", fake.store)
+	}
+	if fake.store[kvKeyRelayClaimAt] == "" {
+		t.Fatalf("at not committed: %+v", fake.store)
+	}
 }


### PR DESCRIPTION
Implements `dicode-ayo/dicode-relay#15` for epic `dicode-ayo/dicode-relay#11`.

## Summary

Adds `dicode relay login`, the CLI that binds a running daemon to a relay user account by signing a claim token with the daemon's existing P-256 private key and POSTing it to the relay's `/api/daemons/claim` endpoint.

## What's in this PR

**Client-side claim primitives** (`pkg/relay/claim.go`)
- `BuildClaimSignature` — ECDSA over the canonical preimage from the dicode-relay#14 clarification: `sha256(utf8(claim_token) || hex_decode(uuid))`. The uuid is the **32 raw decoded bytes**, not the ASCII hex string.
- `Claim` — full HTTP round-trip with 20s timeout, exported error sentinels per HTTP status (`ErrClaimTokenInvalid`, `ErrClaimConflict`, `ErrClaimForbidden`, `ErrClaimBadRequest`, `ErrClaimServer`), persists `relay.claim_status`/`relay.claim_user`/`relay.claim_at` in the existing db kv table on success.
- `LoadClaimStatus` / `ClaimStatus` — read-side for `dicode status`.

**IPC wiring** (`pkg/ipc/`)
- New `cli.relay.login` method, `CapCLIRelay` capability, `RelayStatus` embedded in `DaemonStatus`, `RelayHooks` indirection struct. **`pkg/ipc` never imports `pkg/relay`** — the daemon main wires hooks after `LoadOrGenerateIdentity` to avoid an import cycle.

**CLI** (`cmd/dicode/`)
- `dicode relay login` subcommand with interactive and non-interactive (`--token`, `--label`, `--base-url`, `--no-browser`) modes.
- Cross-platform browser opener (darwin/linux/windows).
- `dicode status` renders a new `Relay: linked to @<login>` / `Relay: not linked` / `Relay: disabled` line when querying the daemon.

**Daemon** (`cmd/dicoded/`)
- `buildRelayHooks` connects `LoadClaimStatus` + `Claim` to the control server after the relay identity loads.

## Signature preimage test vector

Used in `pkg/relay/claim_test.go::TestBuildClaimSignature_PreimageShape` — the server side (dicode-relay#14) must reproduce this:

```
preimage = utf8_bytes(claim_token) || hex_decode(identity.UUID)   // 32 raw bytes, NOT ascii hex
message  = sha256(preimage)                                        // 32 bytes
sig      = ECDSA-P256-SHA256-DER(privkey, message)                 // wire form: base64(DER)
```

The test asserts:
- A signature produced over the correct preimage verifies.
- A signature produced over the ASCII-hex variant does NOT verify — this is the exact ambiguity pinned down in https://github.com/dicode-ayo/dicode-relay/issues/14#issuecomment-4231170668.

Deterministic keypairs are used so the assertion is reproducible.

## Hard rules observed

- Daemon keypair is **reused**, never regenerated.
- Claim token and private key are **never logged**.
- No destructive git ops.

## Dependency

**Depends on `dicode-ayo/dicode-relay#14`** (the server-side claim endpoint). Until that ships the CLI has no real endpoint to talk to, but the unit tests fully validate the request shape and signature preimage, so #14 can land against the vector above without any surprises.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `make test` — all packages pass
- [x] `make lint` — clean
- [x] `gofmt -l` — clean
- [ ] End-to-end test against a running relay (blocked on #14)

Local output:

```
$ make test
ok  	github.com/dicode/dicode/cmd/dicode	0.003s
ok  	github.com/dicode/dicode/pkg/config	0.003s
ok  	github.com/dicode/dicode/pkg/db	0.010s
ok  	github.com/dicode/dicode/pkg/deno	0.004s
ok  	github.com/dicode/dicode/pkg/ipc	0.381s
ok  	github.com/dicode/dicode/pkg/registry	0.531s
ok  	github.com/dicode/dicode/pkg/relay	1.159s
ok  	github.com/dicode/dicode/pkg/runtime/deno	1.224s
ok  	github.com/dicode/dicode/pkg/secrets	0.141s
ok  	github.com/dicode/dicode/pkg/source/local	4.209s
ok  	github.com/dicode/dicode/pkg/taskset	6.023s
ok  	github.com/dicode/dicode/pkg/trigger	0.637s
ok  	github.com/dicode/dicode/pkg/webui	0.124s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)