### PR TITLE
feat: temp file cleanup via builtin task

### DIFF
--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -197,7 +197,9 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	debug := rt.log.Core().Enabled(zap.DebugLevel)
 
 	// Write the shim as a proper ES module to a temp file.
-	shimFile, err := os.CreateTemp("", "dicode-shim-*.ts")
+	// Run ID is embedded between the prefix and the __<random> suffix so the
+	// tasks/buildin/temp-cleanup builtin can correlate orphaned files with runs.
+	shimFile, err := os.CreateTemp("", "dicode-shim-"+runID+"__*.ts")
 	if err != nil {
 		status = registry.StatusFailure
 		result.Error = fmt.Errorf("create shim file: %w", err)
@@ -216,7 +218,7 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	shimFile.Close()
 
 	// Write the wrapper that imports both and calls the user's exported main().
-	runnerFile, err := os.CreateTemp("", "dicode-runner-*.ts")
+	runnerFile, err := os.CreateTemp("", "dicode-runner-"+runID+"__*.ts")
 	if err != nil {
 		status = registry.StatusFailure
 		result.Error = fmt.Errorf("create runner file: %w", err)

--- a/pkg/runtime/deno/temp_naming_test.go
+++ b/pkg/runtime/deno/temp_naming_test.go
@@ -1,0 +1,53 @@
+package deno
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestTempFileNamingEmbedsRunID verifies that os.CreateTemp with the
+// "dicode-<kind>-<runID>__*" pattern produces filenames from which the
+// run_id can be parsed back out. The buildin/temp-cleanup task relies
+// on this naming to match temp files against currently-running runs.
+func TestTempFileNamingEmbedsRunID(t *testing.T) {
+	cases := []struct {
+		name   string
+		prefix string
+		runID  string
+	}{
+		{"shim with uuid", "dicode-shim-", "550e8400-e29b-41d4-a716-446655440000"},
+		{"runner with uuid", "dicode-runner-", "550e8400-e29b-41d4-a716-446655440000"},
+		{"task with uuid", "dicode-task-", "550e8400-e29b-41d4-a716-446655440000"},
+		{"runID without dashes", "dicode-shim-", "abcdef0123456789"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, err := os.CreateTemp("", tc.prefix+tc.runID+"__*.ts")
+			if err != nil {
+				t.Fatalf("CreateTemp: %v", err)
+			}
+			name := f.Name()
+			_ = f.Close()
+			t.Cleanup(func() { _ = os.Remove(name) })
+
+			base := name
+			if idx := strings.LastIndexByte(name, '/'); idx >= 0 {
+				base = name[idx+1:]
+			}
+			if !strings.HasPrefix(base, tc.prefix) {
+				t.Errorf("name %q missing prefix %q", base, tc.prefix)
+			}
+			rest := strings.TrimPrefix(base, tc.prefix)
+			sep := strings.Index(rest, "__")
+			if sep < 0 {
+				t.Fatalf("name %q has no __ separator", base)
+			}
+			got := rest[:sep]
+			if got != tc.runID {
+				t.Errorf("parsed run_id = %q, want %q (full name %q)", got, tc.runID, base)
+			}
+		})
+	}
+}

--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -245,7 +245,7 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 		return result, nil
 	}
 
-	tmpFile, err := os.CreateTemp("", "dicode-task-*.py")
+	tmpFile, err := os.CreateTemp("", "dicode-task-"+runID+"__*.py")
 	if err != nil {
 		status = registry.StatusFailure
 		result.Error = fmt.Errorf("create temp file: %w", err)

--- a/tasks/buildin/taskset.yaml
+++ b/tasks/buildin/taskset.yaml
@@ -19,3 +19,7 @@ spec:
     webui:
       ref:
         path: ./webui/task.yaml
+
+    temp-cleanup:
+      ref:
+        path: ./temp-cleanup/task.yaml

--- a/tasks/buildin/temp-cleanup/task.ts
+++ b/tasks/buildin/temp-cleanup/task.ts
@@ -1,0 +1,76 @@
+// Deletes orphaned task temp files from /tmp.
+//
+// Each dicode runtime writes its wrapper to a file named
+//   dicode-<kind>-<runID>__<rand>.<ext>
+// where <kind> is one of shim | runner | task, <runID> is the UUID
+// assigned by the registry, and the double-underscore separates the
+// run_id from Go's CreateTemp random suffix (UUIDs contain dashes, so
+// a single dash would be ambiguous).
+//
+// A file is considered an orphan iff its embedded run_id is not in the
+// set of currently-running runs. Files whose name does not match the
+// expected shape are left alone.
+
+const PREFIXES = ["dicode-shim-", "dicode-runner-", "dicode-task-"];
+const TEMP_DIR = "/tmp";
+
+interface TaskSummary {
+  id: string;
+}
+
+interface Run {
+  ID: string;
+  Status: string;
+}
+
+function parseRunID(name: string): string | null {
+  for (const prefix of PREFIXES) {
+    if (!name.startsWith(prefix)) continue;
+    const rest = name.slice(prefix.length);
+    const sep = rest.indexOf("__");
+    if (sep <= 0) return null;
+    return rest.slice(0, sep);
+  }
+  return null;
+}
+
+async function collectRunningRunIDs(dicode: Dicode): Promise<Set<string>> {
+  const running = new Set<string>();
+  const tasks = (await dicode.list_tasks()) as TaskSummary[];
+  for (const t of tasks) {
+    const runs = (await dicode.get_runs(t.id, { limit: 100 })) as Run[];
+    for (const r of runs) {
+      if (r.Status === "running") running.add(r.ID);
+    }
+  }
+  return running;
+}
+
+export default async function main({ dicode }: DicodeSdk) {
+  const running = await collectRunningRunIDs(dicode);
+
+  let scanned = 0;
+  let deleted = 0;
+  let skipped = 0;
+
+  for await (const entry of Deno.readDir(TEMP_DIR)) {
+    if (!entry.isFile) continue;
+    const runID = parseRunID(entry.name);
+    if (runID === null) continue;
+    scanned++;
+    if (running.has(runID)) {
+      skipped++;
+      continue;
+    }
+    const path = `${TEMP_DIR}/${entry.name}`;
+    try {
+      await Deno.remove(path);
+      deleted++;
+    } catch (err) {
+      console.warn("remove failed", path, String(err));
+    }
+  }
+
+  console.log("temp-cleanup", { scanned, deleted, skipped, running: running.size });
+  return { scanned, deleted, skipped, running: running.size };
+}

--- a/tasks/buildin/temp-cleanup/task.yaml
+++ b/tasks/buildin/temp-cleanup/task.yaml
@@ -1,0 +1,30 @@
+apiVersion: dicode/v1
+kind: Task
+name: "Temp File Cleanup"
+description: |
+  Deletes orphaned task temp files from the OS temp directory. Every
+  dicode task runtime writes its wrapper/shim to a file named
+  dicode-<kind>-<runID>__*.<ext>. A defer removes the file on normal
+  exit, but a daemon crash or SIGKILL can leave files behind.
+
+  This task lists currently-running runs via the dicode SDK and deletes
+  any temp file whose embedded run_id is not in the running set. Files
+  with unparseable names (legacy or manual) are left alone.
+runtime: deno
+
+trigger:
+  cron: "*/10 * * * *"  # every 10 minutes
+
+permissions:
+  fs:
+    - path: /tmp
+      permission: rw
+  dicode:
+    list_tasks: true
+    get_runs: true
+
+timeout: 60s
+
+notify:
+  on_success: false
+  on_failure: true


### PR DESCRIPTION
## Summary

Replaces the mtime-based goroutine from #72 with a builtin dicode task that uses authoritative run status.

- Embeds `run_id` in all three runtime temp file names via the pattern `dicode-<kind>-<runID>__<rand>.<ext>` (deno shim, deno runner, python task).
- New `tasks/buildin/temp-cleanup/` — cron every 10 min, lists running runs via `dicode.list_tasks` + `dicode.get_runs`, deletes any `/tmp/dicode-*` file whose embedded run_id is not in the running set.
- Files with unparseable names (legacy, manual, pre-migration) are left alone — no mtime fallback.

## Why this replaces #72

#72 used mtime as the orphan heuristic, which cannot distinguish a legitimately long-running task's temp file from a stale one. The new design queries the registry directly: `status == running` → keep, anything else → delete. One rule, authoritative.

## Files

- `pkg/runtime/deno/runtime.go` — 2 `CreateTemp` call sites updated
- `pkg/runtime/python/runtime.go` — 1 `CreateTemp` call site updated
- `pkg/runtime/deno/temp_naming_test.go` — new; round-trips the naming convention
- `tasks/buildin/temp-cleanup/task.yaml` + `task.ts` — the cleanup task
- `tasks/buildin/taskset.yaml` — register new task

Closes #72

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/runtime/deno/... -run TestTempFileNaming`
- [x] `go test ./pkg/runtime/...`
- [x] `golangci-lint run` (on touched files — zero new issues)
- [ ] Manual: start daemon, trigger a long-running task, confirm its shim file survives a cleanup cycle
- [ ] Manual: SIGKILL the daemon mid-run, restart, confirm orphaned shim file is removed on next cleanup cycle