### PR TITLE
feat(buildin): ai-agent chat task + task.yaml template vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,6 +628,19 @@ The AI can read the current file content and write files directly using a `write
 
 Works with any OpenAI-compatible endpoint — OpenAI, Anthropic (Claude), Ollama, or any other provider that speaks the OpenAI API format.
 
+### Chat with an agent that calls your tasks
+
+Dicode ships a built-in **ai-agent** task that gives you a full chat interface where the model can call any of your other dicode tasks as tools. Open `/hooks/ai` in the dashboard to start a conversation; the agent discovers every registered task, builds an OpenAI-compatible tool schema from each task's params, and invokes them on your behalf via `dicode.run_task()`.
+
+Two vocabulary pieces worth knowing:
+
+- **Tools** are other dicode tasks the agent can execute. Any task becomes a tool automatically — no extra registration.
+- **Skills** are plain markdown files under `tasks/skills/` that get loaded into the agent's system prompt. Use them to teach the agent domain context, conventions, or workflows it wouldn't infer from task descriptions alone.
+
+The built-in ships provider-agnostic — no network, no API keys. Choose your provider via taskset overrides (see `tasks/examples/taskset.yaml` for working Ollama / OpenAI / Groq presets), or pass `model` / `base_url` / `api_key_env` as params per request. Conversation history is persisted per `session_id` in the task's KV store and compacted into a running summary once it exceeds a configurable token budget.
+
+See [docs/concepts/ai-agent.md](docs/concepts/ai-agent.md) for the full design.
+
 ---
 
 ## Task Store (planned)
@@ -1571,7 +1584,8 @@ dicode/
 │   ├── webui/          # HTTP server, REST API, auth, WebSocket hub
 │   └── service/        # OS service management (interface defined, impls planned)
 ├── tasks/
-│   ├── buildin/        # built-in tasks (webui, tray, alert, notify)
+│   ├── buildin/        # built-in tasks (webui, tray, alert, notify, ai-agent)
+│   ├── skills/         # shared markdown "skills" loaded into agent prompts
 │   ├── auth/           # OAuth task (broker mode planned)
 │   └── examples/       # 13 example tasks (all runtimes and trigger types)
 ├── docs/               # comprehensive documentation (33 files)

--- a/docs/concepts/ai-agent.md
+++ b/docs/concepts/ai-agent.md
@@ -116,8 +116,6 @@ The shared skills directory is configured through the `skills_dir` param, whose 
 
 A starter skill ships at `tasks/skills/dicode-basics.md` covering core dicode concepts an agent should know to be useful.
 
-> **Note on authenticated Ollama proxies**: the `ai-agent-ollama` preset in `tasks/examples/taskset.yaml` omits `api_key_env`, which tells the agent to send a placeholder API key (Ollama ignores it). If you run an *authenticated* Ollama proxy, override `api_key_env` in your own taskset to the env var holding your key — otherwise the real key is silently dropped and the proxy returns 401.
-
 ---
 
 ## Provider presets
@@ -131,6 +129,8 @@ Three ready-to-use presets live in `tasks/examples/taskset.yaml`:
 | `ai-agent-ollama` | `/hooks/ai/ollama` | `llama3.2` | Local via `localhost:11434`. No key needed. |
 | `ai-agent-openai` | `/hooks/ai/openai` | `gpt-4o-mini` | Needs `OPENAI_API_KEY` in the daemon env. |
 | `ai-agent-groq` | `/hooks/ai/groq` | `llama-3.3-70b-versatile` | Needs `GROQ_API_KEY`. Free tier is generous. |
+
+> **Authenticated Ollama proxies**: the `ai-agent-ollama` preset omits `api_key_env`, so the agent sends the literal string `unused` as its API key (Ollama itself ignores it, the OpenAI SDK just needs something non-empty). If you front Ollama with an *authenticated* reverse proxy, override `api_key_env` in your own taskset — otherwise the agent sends `unused` instead of your key and the proxy returns 401.
 
 Each preset reuses the same `task.ts` via taskset `overrides` — zero code duplication. The override pattern is reusable: copy an existing preset and swap `model` / `base_url` / `api_key_env` / `permissions.net` to point at whatever provider you want.
 

--- a/docs/concepts/ai-agent.md
+++ b/docs/concepts/ai-agent.md
@@ -112,9 +112,11 @@ curl -X POST http://localhost:8080/hooks/ai \
 
 Skills are loaded eagerly — every name you pass is read and concatenated into the system prompt for the entire turn. Missing or unreadable skills produce a placeholder in the prompt instead of failing the request.
 
-The shared skills directory is resolved via the `${SKILLS_DIR}` template variable injected by the source loader (see [task-format.md](task-format.md#template-variables)). For a local source at `~/dicode-tasks/`, `${SKILLS_DIR}` is `~/dicode-tasks/skills/`.
+The shared skills directory is configured through the `skills_dir` param, whose default is `${TASK_SET_DIR}/../skills` — expanded at task-load time to a sibling `skills/` directory next to the taskset that loaded the ai-agent. Override per-run to point at a different pool. See [../task-template-vars.md](../task-template-vars.md) for the full list of template variables available in task.yaml.
 
 A starter skill ships at `tasks/skills/dicode-basics.md` covering core dicode concepts an agent should know to be useful.
+
+> **Note on authenticated Ollama proxies**: the `ai-agent-ollama` preset in `tasks/examples/taskset.yaml` omits `api_key_env`, which tells the agent to send a placeholder API key (Ollama ignores it). If you run an *authenticated* Ollama proxy, override `api_key_env` in your own taskset to the env var holding your key — otherwise the real key is silently dropped and the proxy returns 401.
 
 ---
 

--- a/docs/concepts/ai-agent.md
+++ b/docs/concepts/ai-agent.md
@@ -1,0 +1,173 @@
+# AI Agent
+
+The **ai-agent** built-in task gives dicode a full chat interface backed by any OpenAI-compatible model. The agent can call your other dicode tasks as tools, persist conversations across turns, and load markdown "skills" into its system prompt for domain context.
+
+Unlike the existing "AI generates code" feature (see [docs/concepts/ai-generation.md](ai-generation.md)), which uses an AI model to *write* tasks, ai-agent uses an AI model to *orchestrate* tasks you already have. The two features complement each other: one is about authoring, one is about operation.
+
+---
+
+## What you get
+
+- **A chat page** at `/hooks/ai` (plus per-provider presets at `/hooks/ai/ollama`, `/hooks/ai/openai`, `/hooks/ai/groq`). Send a message, get a reply. Sessions persist across turns.
+- **Tool use** — the model sees every registered task as a callable tool. Ask "check my weekly-report runs from last month" and the agent calls `dicode.get_runs("weekly-report")` via the corresponding task and answers based on the actual data, not a hallucination.
+- **Skills** — drop markdown files into `tasks/skills/` and pass their names via the `skills` param to inject them into the system prompt. Use them to give the agent durable context it should know about every time (domain glossary, team conventions, current priorities).
+- **Session persistence** — each conversation is keyed by `session_id` and stored in the task's KV store. Hybrid id model: pass your own, or omit it to have the task generate and return one.
+- **Lazy compaction** — when the conversation exceeds `max_history_tokens`, older turns are replaced by a running summary generated via a second model call. Controlled by the `compaction_model` param (defaults to the main model).
+- **Provider-agnostic** — works with OpenAI, Anthropic (via openai-compat), Ollama, LM Studio, Groq, OpenRouter, Together, DeepSeek, and any other endpoint that speaks the OpenAI chat completions API. Pick your provider via taskset overrides.
+
+---
+
+## Shape of a conversation
+
+```
+browser ──POST /hooks/ai {prompt, session_id?}──▶ ai-agent task
+                                                        │
+                                           load kv[chat:session_id]
+                                                        │
+                                       append user message to history
+                                                        │
+                             list_tasks → build OpenAI tool schema
+                                                        │
+                                  ◀── model.chat.completions.create
+                                                        │
+                            tool_calls? ──yes──▶ run_task(id, args)
+                                                        │
+                                      append tool response, loop
+                                                        │
+                             tool_calls? ──no──▶ return {session_id, reply}
+                                                        │
+                                    save kv[chat:session_id]
+```
+
+Request:
+
+```json
+{
+  "prompt": "How many weekly-report runs failed this month?",
+  "session_id": "optional — omit to auto-generate"
+}
+```
+
+Response:
+
+```json
+{
+  "session_id": "e4b9f3a2-...",
+  "reply": "You had 3 failed weekly-report runs this month, all on ..."
+}
+```
+
+When the buildin is called without a configured provider, it returns a structured error instead of throwing, so the UI can render a clear message:
+
+```json
+{
+  "session_id": "e4b9f3a2-...",
+  "reply": null,
+  "error": "not_configured",
+  "missing": ["model", "base_url"],
+  "hint": "This is the generic ai-agent buildin. It has no provider configured..."
+}
+```
+
+---
+
+## Tools vs skills
+
+These are two different concepts that dicode uses with specific meanings:
+
+| Concept | What it is | Where it lives | How the agent sees it |
+| ------- | ---------- | -------------- | --------------------- |
+| **Tool** | A dicode task the agent can execute | `tasks/**/task.yaml` | As an OpenAI tool schema built from the task's params; invoked via `dicode.run_task()` |
+| **Skill** | A markdown file with domain context | `tasks/skills/*.md` | Concatenated into the system prompt at the start of every turn |
+
+This mirrors the convention used by Claude Code and the broader agent ecosystem. Think of tools as *capabilities* and skills as *knowledge*.
+
+### Tools (task-calling)
+
+By default, the agent can call any registered task except itself. Restrict the tool list via the `tools` param — comma-separated task ids:
+
+```bash
+curl -X POST http://localhost:8080/hooks/ai \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "prompt": "what failed last night?",
+    "tools": "examples/weekly-report,examples/log-digest"
+  }'
+```
+
+The agent still has full access to the *result* of each tool call — it's a scoping mechanism, not a permission system. Real permission control is in the task's `permissions.dicode.tasks` allowlist (the buildin uses `["*"]`; presets inherit this unless overridden).
+
+### Skills (prompt markdown)
+
+Drop a file into `tasks/skills/` and reference it by name without the extension:
+
+```bash
+curl -X POST http://localhost:8080/hooks/ai \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "prompt": "review the overnight deploys",
+    "skills": "dicode-basics,deploy-runbook"
+  }'
+```
+
+Skills are loaded eagerly — every name you pass is read and concatenated into the system prompt for the entire turn. Missing or unreadable skills produce a placeholder in the prompt instead of failing the request.
+
+The shared skills directory is resolved via the `${SKILLS_DIR}` template variable injected by the source loader (see [task-format.md](task-format.md#template-variables)). For a local source at `~/dicode-tasks/`, `${SKILLS_DIR}` is `~/dicode-tasks/skills/`.
+
+A starter skill ships at `tasks/skills/dicode-basics.md` covering core dicode concepts an agent should know to be useful.
+
+---
+
+## Provider presets
+
+The buildin ships **maximally restrictive**: empty `permissions.net`, no provider env vars, no defaults for `model` / `base_url` / `api_key_env`. On its own, hitting `/hooks/ai` returns `not_configured`. This keeps the buildin generic and safe — provider-specific policy (which hosts to reach, which env vars to read) lives with the provider-specific task.
+
+Three ready-to-use presets live in `tasks/examples/taskset.yaml`:
+
+| Preset | Webhook | Model | Notes |
+| ------ | ------- | ----- | ----- |
+| `ai-agent-ollama` | `/hooks/ai/ollama` | `llama3.2` | Local via `localhost:11434`. No key needed. |
+| `ai-agent-openai` | `/hooks/ai/openai` | `gpt-4o-mini` | Needs `OPENAI_API_KEY` in the daemon env. |
+| `ai-agent-groq` | `/hooks/ai/groq` | `llama-3.3-70b-versatile` | Needs `GROQ_API_KEY`. Free tier is generous. |
+
+Each preset reuses the same `task.ts` via taskset `overrides` — zero code duplication. The override pattern is reusable: copy an existing preset and swap `model` / `base_url` / `api_key_env` / `permissions.net` to point at whatever provider you want.
+
+```yaml
+ai-agent-together:
+  ref:
+    path: ../buildin/ai-agent/task.yaml
+  overrides:
+    trigger:
+      webhook: /hooks/ai/together
+    params:
+      model: "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+      base_url: "https://api.together.xyz/v1"
+      api_key_env: "TOGETHER_API_KEY"
+    env:
+      - TOGETHER_API_KEY
+    net:
+      - api.together.xyz
+```
+
+Per-request overrides work too — just pass `model` / `base_url` / `api_key_env` as params. Useful for experimenting with different models against the same webhook.
+
+---
+
+## Security notes
+
+- **The agent has `permissions.dicode.tasks: ["*"]` by default.** Any task registered with the runtime is callable. On a public or untrusted network this is a keys-to-the-kingdom endpoint — the chat page is currently unauthenticated pending [issue #96](https://github.com/dicode-ayo/dicode-core/issues/96) (return-to-origin auth UX for protected webhooks). Do **not** ship this in an alpha release without fixing #96. Local dev on localhost-only is fine.
+- **API keys never reach the model.** Credentials are resolved from `Deno.env.get(api_key_env)` at task start and used only to construct the OpenAI client. They are never included in the conversation history, never returned to the caller, and never logged.
+- **Model output is rendered as `textContent` in the chat UI**, never `innerHTML`. Tool call arguments are also string-stringified before being passed to `dicode.run_task()`, which itself receives the already-whitelisted task id map.
+- **The session KV is per-task and isolated.** Session blobs are stored under the `buildin/ai-agent` task namespace; they are not visible to any other task unless you explicitly grant cross-task KV access (which dicode does not support today).
+
+---
+
+## Follow-up work
+
+The v1 buildin is deliberately minimal. Known follow-ups tracked separately:
+
+- **Streaming tokens** — the webui run-log is already WebSocket-broadcast, so a streaming chat UI is a clean additive change. Not in v1.
+- **History rehydration on reload** — users keep `session_id` in localStorage but the DOM is blank after reload. Proper rehydration needs a way for the browser to read the task's KV.
+- **CLI chat** — `dicode chat [preset]` as a REPL, persists `session_id` in a dotfile.
+- **Suspendable tasks** — the chat flow collapses to a suspend/resume cycle under the primitive proposed in [issue #95](https://github.com/dicode-ayo/dicode-core/issues/95).
+- **OAuth onboarding** — OpenRouter PKCE via the dicode-relay broker is tracked in [issue #97](https://github.com/dicode-ayo/dicode-core/issues/97), which unlocks zero-paste provider setup.

--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -632,6 +632,76 @@ Examples: `morning-email-check`, `github-release-notifier`, `backup-database`
 
 ---
 
+## Template variables
+
+Selected fields in `task.yaml` support `${VAR}` substitution, resolved at task-load time. Syntax is the standard shell form — no escaping, no pipes, no conditionals — just drop-in replacement.
+
+### Supported fields
+
+Template expansion runs over a tight allowlist, not every string field:
+
+- `permissions.fs[].path`
+- `trigger.webhook_secret`
+- `permissions.env[].from`, `.secret`, `.value` (the indirection keys)
+
+Everything else — `name`, `description`, `params.*.default`, `system_prompt` defaults — is taken literally. This is deliberate: expansion in descriptive strings usually hides bugs rather than enabling them.
+
+### Built-in variables
+
+Always available inside a task:
+
+| Variable | Value |
+| --- | --- |
+| `${TASK_DIR}` | Absolute path to this task's own directory |
+| `${HOME}` | User home directory (best-effort — may be unset in restricted environments) |
+
+Injected by the source loader on every task it loads:
+
+| Variable | Value |
+| --- | --- |
+| `${SOURCE_ROOT}` | Absolute path to the source root (`tasks/` dir for local sources; clone dir for git sources; taskset.yaml dir for taskset sources) |
+| `${SKILLS_DIR}` | Convention: `${SOURCE_ROOT}/skills`. Auto-derived if `SOURCE_ROOT` is set and `SKILLS_DIR` is not. |
+
+### Resolution order
+
+1. Built-in variables (above), highest priority
+2. Process environment (`os.Getenv`)
+3. **Unresolved** — the literal `${VAR}` is left in place so bugs surface loudly instead of silently collapsing to an empty string
+
+### Examples
+
+Give a task read access to the shared skills directory regardless of where the source lives:
+
+```yaml
+permissions:
+  fs:
+    - path: "${SKILLS_DIR}"
+      permission: r
+```
+
+Reference a webhook secret from the process environment (closing the historical docs/reality gap where this was documented but never actually expanded):
+
+```yaml
+trigger:
+  webhook: /hooks/github
+  webhook_secret: "${GITHUB_WEBHOOK_SECRET}"
+permissions:
+  env:
+    - GITHUB_WEBHOOK_SECRET
+```
+
+Compose a secrets-store key from a per-environment prefix:
+
+```yaml
+permissions:
+  env:
+    - name: DB_PASSWORD
+      secret: "${DEPLOY_ENV}_db_password"
+    - DEPLOY_ENV
+```
+
+---
+
 ## File layout rules
 
 - `task.yaml` is always required. A folder without it is ignored.

--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -652,30 +652,31 @@ Always available inside a task:
 
 | Variable | Value |
 | --- | --- |
-| `${TASK_DIR}` | Absolute path to this task's own directory |
+| `${TASK_DIR}` | Absolute path to this task's own directory (the one holding `task.yaml`) |
 | `${HOME}` | User home directory (best-effort — may be unset in restricted environments) |
 
 Injected by the source loader on every task it loads:
 
 | Variable | Value |
 | --- | --- |
-| `${SOURCE_ROOT}` | Absolute path to the source root (`tasks/` dir for local sources; clone dir for git sources; taskset.yaml dir for taskset sources) |
-| `${SKILLS_DIR}` | Convention: `${SOURCE_ROOT}/skills`. Auto-derived if `SOURCE_ROOT` is set and `SKILLS_DIR` is not. |
+| `${TASK_SET_DIR}` | Absolute path to the directory containing the root `taskset.yaml` of the source that loaded this task. Unset when the task is loaded outside of a source context (raw local folder source, unit test). |
+
+See [../task-template-vars.md](../task-template-vars.md) for the per-field expansion policy (which task.yaml fields actually get `${VAR}` substituted, and the env-fallback rules that protect against daemon-secret exfiltration).
 
 ### Resolution order
 
 1. Built-in variables (above), highest priority
-2. Process environment (`os.Getenv`)
+2. Process environment (`os.Getenv`) — only for fields where env fallback is safe; see the linked policy doc
 3. **Unresolved** — the literal `${VAR}` is left in place so bugs surface loudly instead of silently collapsing to an empty string
 
 ### Examples
 
-Give a task read access to the shared skills directory regardless of where the source lives:
+Give a task read access to a shared skills directory one level above the taskset:
 
 ```yaml
 permissions:
   fs:
-    - path: "${SKILLS_DIR}"
+    - path: "${TASK_SET_DIR}/../skills"
       permission: r
 ```
 

--- a/docs/task-template-vars.md
+++ b/docs/task-template-vars.md
@@ -1,0 +1,58 @@
+# task.yaml template variables
+
+`task.yaml` supports `${VAR}` substitution in a small, carefully-chosen set of
+fields. Variables are resolved at spec-load time; unresolved references are
+left as literal `${VAR}` so a typo produces an obvious failure instead of
+silently collapsing to `""`.
+
+## Built-in variables
+
+| Variable        | Value                                                                 | Available when                                                      |
+| --------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `TASK_DIR`      | Absolute path of this task's own directory (the one holding `task.yaml`). | Always.                                                             |
+| `HOME`          | Home directory of the user running the dicode daemon.                | Always (best-effort — absent on systems where `UserHomeDir` fails). |
+| `TASK_SET_DIR`  | Absolute path of the directory containing the root `taskset.yaml` of the source that loaded this task. | Only when the task is loaded via a TaskSet source. Absent for raw local/git folder sources and unit tests. |
+
+There is no `SKILLS_DIR`, `CONFIG_DIR`, or `SOURCE_ROOT` — use `TASK_DIR` and
+`TASK_SET_DIR` to derive the paths you need. For example, a shared `skills/`
+directory one level above a taskset is `${TASK_SET_DIR}/../skills`.
+
+## Fields that accept template expansion
+
+Expansion is deliberately **not** applied to every string field — most
+(`name`, `description`, `system_prompt` defaults, …) should be taken
+literally. These are the fields that get expanded:
+
+| Field                       | Env fallback? | Notes                                                                                                                   |
+| --------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `trigger.webhook_secret`    | Yes           | HMAC secret used server-side; task code never sees it. Env fallback lets you reference `${WEBHOOK_SECRET}` from the daemon env. |
+| `permissions.fs[].path`     | Yes           | Consumed by the Deno permission set. `${HOME}/shared`, `${TASK_SET_DIR}/skills`, etc.                                   |
+| `permissions.env[].from`    | Yes           | Host env-var name to rename/inject. Identifier, not a value — safe to env-fallback.                                     |
+| `permissions.env[].secret`  | Yes           | Secrets-store key to look up. Identifier, not a value.                                                                  |
+| `permissions.env[].value`   | **No**        | Literal value injected into `Deno.env.get(name)` at runtime. Env fallback would be a direct exfiltration primitive.     |
+| `params[].default`          | **No**        | Surfaces loader-provided paths as parameter defaults task code reads via `params.get()`. Same reason as `env.value`.    |
+
+"Env fallback = Yes" means: if the variable is not a known builtin, the
+loader falls back to `os.Getenv(name)`. This is *off* for any field whose
+value is readable from inside the task sandbox — otherwise a task.yaml from
+an untrusted source could exfiltrate daemon secrets by naming them as
+template variables.
+
+## Unresolved references
+
+If a variable is not found in the builtin set, not in loader extras, and
+(where allowed) not in the process environment, the literal `${VAR}` is
+preserved. That makes typos and missing-context bugs loud rather than
+silently producing an empty or malformed path.
+
+## Adding a new variable
+
+1. Add a `Var*` constant in [pkg/task/template.go](../pkg/task/template.go).
+2. Wire it up wherever the loader has the value (see `pkg/taskset/source.go`
+   and `pkg/source/{local,git}` for the injection point).
+3. Add a row to the table above.
+4. Add a test in [pkg/task/template_test.go](../pkg/task/template_test.go).
+
+Keep the set small — every new builtin is a new thing users have to learn,
+and the whole point of the template system is that it's narrow and
+predictable.

--- a/pkg/ipc/control_test.go
+++ b/pkg/ipc/control_test.go
@@ -96,7 +96,11 @@ func controlTestEnv(t *testing.T, mp MetricsProvider) (net.Conn, func()) {
 // must carry empty task_id / run_id strings — but the fields must be
 // PRESENT on the wire so the shim-side decoder always sees them. This
 // pairs with the non-omitempty encoding in message.go:handshakeResp.
-func TestControl_Handshake_OmitsTaskAndRunID(t *testing.T) {
+//
+// The "Emits" name is load-bearing: a prior name ("Omits…") suggested the
+// fields could be absent and readers would "fix" it by asserting absence,
+// which is the opposite of what we want.
+func TestControl_Handshake_EmitsEmptyTaskAndRunIDFields(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()

--- a/pkg/ipc/control_test.go
+++ b/pkg/ipc/control_test.go
@@ -92,6 +92,76 @@ func controlTestEnv(t *testing.T, mp MetricsProvider) (net.Conn, func()) {
 	return conn, cleanup
 }
 
+// The CLI control channel has no task context, so its handshake response
+// must carry empty task_id / run_id strings — but the fields must be
+// PRESENT on the wire so the shim-side decoder always sees them. This
+// pairs with the non-omitempty encoding in message.go:handshakeResp.
+func TestControl_Handshake_OmitsTaskAndRunID(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "ctrl.sock")
+	tokenPath := filepath.Join(dir, "ctrl.token")
+
+	cs, err := NewControlServer(socketPath, tokenPath, nil, &mockEngine{}, nil, MetricsProvider{}, "test", zap.NewNop())
+	if err != nil {
+		t.Fatalf("NewControlServer: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = cs.Start(ctx) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(socketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("control socket never appeared")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	tok, err := os.ReadFile(tokenPath)
+	if err != nil {
+		t.Fatalf("read token: %v", err)
+	}
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	if err := writeMsg(conn, handshakeReq{Token: string(tok)}); err != nil {
+		t.Fatalf("handshake send: %v", err)
+	}
+	// Decode as a map to prove the fields are present, even if empty.
+	var raw map[string]any
+	if err := readMsg(conn, &raw); err != nil {
+		t.Fatalf("handshake recv: %v", err)
+	}
+	if errMsg, ok := raw["error"].(string); ok && errMsg != "" {
+		t.Fatalf("handshake rejected: %s", errMsg)
+	}
+
+	// Keys must exist (non-omitempty encoding) and be empty strings
+	// (no task context on the control channel).
+	got, ok := raw["task_id"]
+	if !ok {
+		t.Errorf("handshake response missing task_id field; expected empty string")
+	} else if got != "" {
+		t.Errorf("control handshake task_id: got %q, want empty", got)
+	}
+	got, ok = raw["run_id"]
+	if !ok {
+		t.Errorf("handshake response missing run_id field; expected empty string")
+	} else if got != "" {
+		t.Errorf("control handshake run_id: got %q, want empty", got)
+	}
+}
+
 func TestControl_Metrics_ReturnsSnapshot(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -10,10 +10,22 @@ type handshakeReq struct {
 	Token string `json:"token"`
 }
 
-// handshakeResp is the server's reply to a successful handshake.
+// handshakeResp is the server's reply to a successful handshake. In
+// addition to the protocol version and capability list, the server echoes
+// the TaskID and RunID of the context that accepted the connection so the
+// shim can expose them as dicode.task_id / dicode.run_id.
+//
+// These fields are intentionally NOT omitempty: task code uses task_id as
+// its self-identity for operations like tool-recursion guards, and an
+// empty task_id silently disables those guards. Forcing the wire to carry
+// the value every time makes "missing task_id" a loud, detectable event.
+// The CLI control channel fills both with "" — the task-side shim treats
+// an empty task_id as a hard error.
 type handshakeResp struct {
-	Proto int      `json:"proto"`
-	Caps  []string `json:"caps"`
+	Proto  int      `json:"proto"`
+	Caps   []string `json:"caps"`
+	TaskID string   `json:"task_id"`
+	RunID  string   `json:"run_id"`
 }
 
 // handshakeErr is the server's reply when the handshake fails. The server

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -52,6 +52,14 @@ type Server struct {
 }
 
 // New creates a Server (not yet started).
+//
+// Both runID and taskID are required and MUST be non-empty. They flow
+// into the issued IPC token's Identity claim and into the handshake
+// response's task_id / run_id fields; an empty task_id would silently
+// disable self-identity checks in task code (see the comment on
+// handshakeResp in message.go). Construction-time enforcement keeps
+// the invariant local to the boundary rather than relying on every
+// consumer to re-validate.
 func New(
 	runID, taskID string,
 	secret []byte,
@@ -64,6 +72,12 @@ func New(
 	engine EngineRunner,
 	aiBaseURL, aiModel, aiAPIKey string,
 ) *Server {
+	if runID == "" {
+		panic("ipc.New: runID must not be empty")
+	}
+	if taskID == "" {
+		panic("ipc.New: taskID must not be empty")
+	}
 	return &Server{
 		runID:     runID,
 		taskID:    taskID,

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -207,7 +207,12 @@ func (s *Server) handleConn(conn net.Conn) {
 		_ = writeMsg(conn, handshakeErr{Error: "ipc: token run ID mismatch"})
 		return
 	}
-	if err := writeMsg(conn, handshakeResp{Proto: 1, Caps: claims.Caps}); err != nil {
+	if err := writeMsg(conn, handshakeResp{
+		Proto:  1,
+		Caps:   claims.Caps,
+		TaskID: s.taskID,
+		RunID:  s.runID,
+	}); err != nil {
 		return
 	}
 	caps := claims.Caps

--- a/pkg/ipc/server_test.go
+++ b/pkg/ipc/server_test.go
@@ -209,6 +209,43 @@ func TestHandshake_WrongRunID(t *testing.T) {
 	}
 }
 
+// Regression guard: the task-channel handshake response must carry the
+// taskID and runID the server was constructed with. The shim surfaces
+// these as dicode.task_id / dicode.run_id, and task code (e.g. ai-agent)
+// uses task_id as its self-identity for recursion guards. An empty or
+// missing value silently disables those guards — see message.go for why
+// the struct fields are intentionally NOT omitempty.
+func TestHandshake_TaskChannelReturnsTaskAndRunID(t *testing.T) {
+	e := newTestEnv(t)
+	runID := fmt.Sprintf("run-%d", time.Now().UnixNano())
+	const taskID = "buildin/ai-agent"
+
+	srv := New(runID, taskID, e.secret, e.reg, e.db, nil, nil, zap.NewNop(), nil, nil, "", "", "")
+	socketPath, token, err := srv.Start(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(srv.Stop)
+
+	conn := dial(t, socketPath)
+	defer conn.Close()
+
+	sendMsg(t, conn, handshakeReq{Token: token})
+	resp := recvMsg(t, conn)
+	if errMsg, ok := resp["error"].(string); ok {
+		t.Fatalf("handshake rejected: %s", errMsg)
+	}
+
+	gotTaskID, _ := resp["task_id"].(string)
+	if gotTaskID != taskID {
+		t.Errorf("handshake task_id: got %q, want %q", gotTaskID, taskID)
+	}
+	gotRunID, _ := resp["run_id"].(string)
+	if gotRunID != runID {
+		t.Errorf("handshake run_id: got %q, want %q", gotRunID, runID)
+	}
+}
+
 // ── protocol tests ────────────────────────────────────────────────────────────
 
 func TestServer_Params(t *testing.T) {

--- a/pkg/registry/reconciler.go
+++ b/pkg/registry/reconciler.go
@@ -123,7 +123,7 @@ func (rc *Reconciler) handle(ev source.Event) {
 			spec.ID = ev.TaskID
 		} else {
 			var err error
-			spec, err = task.LoadDir(ev.TaskDir)
+			spec, err = task.LoadDirWithVars(ev.TaskDir, ev.ExtraVars)
 			if err != nil {
 				rc.log.Warn("failed to load task",
 					zap.String("task", ev.TaskID),

--- a/pkg/runtime/deno/sdk/sdk.d.ts
+++ b/pkg/runtime/deno/sdk/sdk.d.ts
@@ -33,6 +33,10 @@ declare interface MCP {
 }
 
 declare interface Dicode {
+  /** Fully-namespaced id of the currently-running task (e.g. "buildin/ai-agent"). */
+  task_id:        string;
+  /** Id of the current run (uuid). */
+  run_id:         string;
   run_task:       (taskID: string, params?: Record<string, string>) => Promise<unknown>;
   list_tasks:     ()                                                 => Promise<unknown>;
   get_runs:       (taskID: string, opts?: { limit?: number })        => Promise<unknown>;

--- a/pkg/runtime/deno/sdk/shim.ts
+++ b/pkg/runtime/deno/sdk/shim.ts
@@ -32,6 +32,8 @@ interface IpcResponse {
 interface HandshakeResponse {
   proto: number;
   caps: string[];
+  task_id?: string;
+  run_id?: string;
   error?: string;
 }
 
@@ -64,6 +66,12 @@ export interface MCP {
 }
 
 export interface Dicode {
+  // task_id: the fully-namespaced id of the currently-running task (e.g.
+  // "buildin/ai-agent"). Populated from the IPC handshake so task code can
+  // self-identify without guessing from its directory name.
+  task_id:        string;
+  // run_id: the id of the current run (uuid). Same source as task_id.
+  run_id:         string;
   run_task:       (taskID: string, params?: Record<string, string>)  => Promise<unknown>;
   list_tasks:     ()                                                   => Promise<unknown>;
   get_runs:       (taskID: string, opts?: { limit?: number })         => Promise<unknown>;
@@ -216,6 +224,8 @@ const mcp: MCP = {
 // ── dicode ────────────────────────────────────────────────────────────────────
 
 const dicode: Dicode = {
+  task_id:        __hsResp__.task_id ?? "",
+  run_id:         __hsResp__.run_id ?? "",
   run_task:       (taskID, params)  => __call__({ method: "dicode.run_task",       taskID, params: params ?? {} }),
   list_tasks:     ()                => __call__({ method: "dicode.list_tasks" }),
   get_runs:       (taskID, opts)    => __call__({ method: "dicode.get_runs",        taskID, limit: opts?.limit ?? 10 }),

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -248,9 +248,8 @@ func (g *GitSource) diff() ([]source.Event, error) {
 	var events []source.Event
 
 	// Vars injected into task.yaml template expansion for every task under
-	// this source. SOURCE_ROOT is the clone directory; SKILLS_DIR is
-	// auto-derived by the task loader (see pkg/task/template.go).
-	extras := map[string]string{task.VarSourceRoot: g.localDir}
+	// this source. See pkg/task/template.go and docs/task-template-vars.md.
+	extras := map[string]string{task.VarTaskSetDir: g.localDir}
 
 	for id, hash := range current {
 		dir := filepath.Join(g.localDir, id)

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -247,15 +247,20 @@ func (g *GitSource) diff() ([]source.Event, error) {
 
 	var events []source.Event
 
+	// Vars injected into task.yaml template expansion for every task under
+	// this source. SOURCE_ROOT is the clone directory; SKILLS_DIR is
+	// auto-derived by the task loader (see pkg/task/template.go).
+	extras := map[string]string{task.VarSourceRoot: g.localDir}
+
 	for id, hash := range current {
 		dir := filepath.Join(g.localDir, id)
 		if _, ok := prev[id]; !ok {
 			events = append(events, source.Event{
-				Kind: source.EventAdded, TaskID: id, TaskDir: dir, Source: g.id,
+				Kind: source.EventAdded, TaskID: id, TaskDir: dir, Source: g.id, ExtraVars: extras,
 			})
 		} else if prev[id] != hash {
 			events = append(events, source.Event{
-				Kind: source.EventUpdated, TaskID: id, TaskDir: dir, Source: g.id,
+				Kind: source.EventUpdated, TaskID: id, TaskDir: dir, Source: g.id, ExtraVars: extras,
 			})
 		}
 	}

--- a/pkg/source/local/local.go
+++ b/pkg/source/local/local.go
@@ -177,9 +177,8 @@ func (s *LocalSource) diff() ([]source.Event, error) {
 	var events []source.Event
 
 	// Vars injected into task.yaml template expansion for every task under
-	// this source. SOURCE_ROOT is the source's absolute root; SKILLS_DIR is
-	// auto-derived by the task loader (see pkg/task/template.go).
-	extras := map[string]string{task.VarSourceRoot: s.path}
+	// this source. See pkg/task/template.go and docs/task-template-vars.md.
+	extras := map[string]string{task.VarTaskSetDir: s.path}
 
 	for id, hash := range current {
 		dir := filepath.Join(s.path, id)

--- a/pkg/source/local/local.go
+++ b/pkg/source/local/local.go
@@ -176,15 +176,20 @@ func (s *LocalSource) diff() ([]source.Event, error) {
 
 	var events []source.Event
 
+	// Vars injected into task.yaml template expansion for every task under
+	// this source. SOURCE_ROOT is the source's absolute root; SKILLS_DIR is
+	// auto-derived by the task loader (see pkg/task/template.go).
+	extras := map[string]string{task.VarSourceRoot: s.path}
+
 	for id, hash := range current {
 		dir := filepath.Join(s.path, id)
 		if _, ok := prev[id]; !ok {
 			events = append(events, source.Event{
-				Kind: source.EventAdded, TaskID: id, TaskDir: dir, Source: s.id,
+				Kind: source.EventAdded, TaskID: id, TaskDir: dir, Source: s.id, ExtraVars: extras,
 			})
 		} else if prev[id] != hash {
 			events = append(events, source.Event{
-				Kind: source.EventUpdated, TaskID: id, TaskDir: dir, Source: s.id,
+				Kind: source.EventUpdated, TaskID: id, TaskDir: dir, Source: s.id, ExtraVars: extras,
 			})
 		}
 	}

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -27,6 +27,11 @@ type Event struct {
 	// The reconciler uses it directly instead of calling task.LoadDir(TaskDir).
 	// Set by taskset sources; nil for plain git/local sources.
 	Spec *task.Spec
+	// ExtraVars carries per-source template variables injected into
+	// task.yaml's ${VAR} expansion at load time. Sources populate this with
+	// e.g. SOURCE_ROOT (the source's root path) so tasks can reference
+	// shared directories without hardcoding a path. nil = no extras.
+	ExtraVars map[string]string
 }
 
 // Source is anything that can produce task change events.

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -29,8 +29,9 @@ type Event struct {
 	Spec *task.Spec
 	// ExtraVars carries per-source template variables injected into
 	// task.yaml's ${VAR} expansion at load time. Sources populate this with
-	// e.g. SOURCE_ROOT (the source's root path) so tasks can reference
-	// shared directories without hardcoding a path. nil = no extras.
+	// e.g. TASK_SET_DIR (the source's root path) so tasks can reference
+	// shared directories without hardcoding a path. nil = no extras. See
+	// docs/task-template-vars.md for the full variable set.
 	ExtraVars map[string]string
 }
 

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -273,7 +273,7 @@ type Spec struct {
 
 // LoadDir reads a task from its directory (expects task.yaml and task.<ext>).
 // Equivalent to LoadDirWithVars(dir, nil). Use LoadDirWithVars from source
-// loaders that know about per-source context (SOURCE_ROOT, SKILLS_DIR, …).
+// loaders that know about per-source context (TASK_SET_DIR, …).
 func LoadDir(dir string) (*Spec, error) {
 	return LoadDirWithVars(dir, nil)
 }
@@ -282,12 +282,13 @@ func LoadDir(dir string) (*Spec, error) {
 // in the spec using built-in variables merged with the caller-supplied extras.
 // Pass nil for extras when loading a task outside of a source context.
 //
-// Supported extras include:
-//   - SOURCE_ROOT: absolute path to the source root (source loaders set this)
-//   - SKILLS_DIR:  absolute path to the shared skills directory
-//     (auto-derived as SOURCE_ROOT/skills if SOURCE_ROOT is set and SKILLS_DIR isn't)
+// Typical extras:
+//   - TASK_SET_DIR: directory of the root taskset.yaml for taskset sources,
+//     or the source root for raw local/git sources. Injected automatically
+//     by pkg/taskset/resolver.Resolve and by pkg/source/{local,git}.
 //
-// See pkg/task/template.go for the full variable set and resolution rules.
+// See pkg/task/template.go and docs/task-template-vars.md for the full
+// variable set and resolution rules.
 func LoadDirWithVars(dir string, extras map[string]string) (*Spec, error) {
 	specPath := filepath.Join(dir, "task.yaml")
 	f, err := os.Open(specPath)

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -292,6 +292,11 @@ func LoadDir(dir string) (*Spec, error) {
 	spec.TaskDir = dir
 	spec.ID = filepath.Base(dir)
 
+	// Expand ${VAR} template references in paths, secrets, and env indirection
+	// keys. Kept intentionally narrow — see expandSpec for the allowlist and
+	// pkg/task/template.go for the resolution rules.
+	expandSpec(&spec, builtinVars(dir))
+
 	if spec.Runtime == "" || spec.Runtime == "js" {
 		spec.Runtime = RuntimeDeno
 	}

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -272,7 +272,23 @@ type Spec struct {
 }
 
 // LoadDir reads a task from its directory (expects task.yaml and task.<ext>).
+// Equivalent to LoadDirWithVars(dir, nil). Use LoadDirWithVars from source
+// loaders that know about per-source context (SOURCE_ROOT, SKILLS_DIR, …).
 func LoadDir(dir string) (*Spec, error) {
+	return LoadDirWithVars(dir, nil)
+}
+
+// LoadDirWithVars reads a task from its directory, expanding ${VAR} references
+// in the spec using built-in variables merged with the caller-supplied extras.
+// Pass nil for extras when loading a task outside of a source context.
+//
+// Supported extras include:
+//   - SOURCE_ROOT: absolute path to the source root (source loaders set this)
+//   - SKILLS_DIR:  absolute path to the shared skills directory
+//     (auto-derived as SOURCE_ROOT/skills if SOURCE_ROOT is set and SKILLS_DIR isn't)
+//
+// See pkg/task/template.go for the full variable set and resolution rules.
+func LoadDirWithVars(dir string, extras map[string]string) (*Spec, error) {
 	specPath := filepath.Join(dir, "task.yaml")
 	f, err := os.Open(specPath)
 	if err != nil {
@@ -295,7 +311,7 @@ func LoadDir(dir string) (*Spec, error) {
 	// Expand ${VAR} template references in paths, secrets, and env indirection
 	// keys. Kept intentionally narrow — see expandSpec for the allowlist and
 	// pkg/task/template.go for the resolution rules.
-	expandSpec(&spec, builtinVars(dir))
+	expandSpec(&spec, builtinVars(dir, extras))
 
 	if spec.Runtime == "" || spec.Runtime == "js" {
 		spec.Runtime = RuntimeDeno

--- a/pkg/task/template.go
+++ b/pkg/task/template.go
@@ -21,8 +21,10 @@ import (
 // context like REPO_ROOT and SKILLS_DIR. Task-level code does not know about
 // sources, so those vars cannot live here.
 const (
-	VarTaskDir = "TASK_DIR" // absolute path to the task's own directory
-	VarHome    = "HOME"     // user home directory
+	VarTaskDir    = "TASK_DIR"    // absolute path to the task's own directory
+	VarHome       = "HOME"        // user home directory
+	VarSourceRoot = "SOURCE_ROOT" // absolute path to the source root (tasks dir / taskset.yaml dir). Injected by the source loader; empty when a task is loaded outside of a source context.
+	VarSkillsDir  = "SKILLS_DIR"  // convention: ${SOURCE_ROOT}/skills. Lets skill-aware tasks reference the shared md directory without hardcoding the "skills" subdir.
 )
 
 // expandString replaces ${VAR} references in s using the provided vars map,
@@ -74,15 +76,29 @@ func expandSpec(spec *Spec, vars map[string]string) {
 	}
 }
 
-// builtinVars returns the template var map for a task loaded from dir.
+// builtinVars returns the template var map for a task loaded from dir, with
+// any extra vars merged in (extras take precedence over builtins). Pass nil
+// for extras when loading a task outside of a source context.
+//
 // Keep this in sync with the Var* constants above and with docs/task-yaml.md
 // (once that doc exists).
-func builtinVars(taskDir string) map[string]string {
+func builtinVars(taskDir string, extras map[string]string) map[string]string {
 	vars := map[string]string{
 		VarTaskDir: taskDir,
 	}
 	if home, err := os.UserHomeDir(); err == nil {
 		vars[VarHome] = home
+	}
+	// Convenience: if the caller supplies SOURCE_ROOT but not SKILLS_DIR,
+	// auto-derive it. Lets source loaders stay minimal — they only need to
+	// set the primitive SOURCE_ROOT and the convention follows.
+	if root, ok := extras[VarSourceRoot]; ok {
+		if _, set := extras[VarSkillsDir]; !set {
+			vars[VarSkillsDir] = root + "/skills"
+		}
+	}
+	for k, v := range extras {
+		vars[k] = v
 	}
 	return vars
 }

--- a/pkg/task/template.go
+++ b/pkg/task/template.go
@@ -1,39 +1,52 @@
 package task
 
 import (
+	"maps"
 	"os"
 	"strings"
 )
 
-// Template variables available inside task.yaml as ${VAR}. These are resolved
-// at spec-load time (in LoadDir). The resolution order is:
+// Template variables available inside task.yaml as ${VAR}. Resolved at
+// spec-load time (in LoadDir). Resolution order:
 //
-//  1. Built-in variables provided by the loader (TASK_DIR, HOME, ...).
-//  2. Process environment (os.Getenv).
-//  3. Unresolved — the literal ${VAR} is left in place so downstream code can
-//     log / warn / handle it, rather than silently replacing with "" and
-//     producing a mysterious empty-string bug.
+//  1. Built-in variables provided by the loader (TASK_DIR, TASK_SET_DIR,
+//     HOME, …) merged with caller-supplied extras.
+//  2. Process environment (os.Getenv) — fallback only for fields whose
+//     expanded value is not readable from task code. See expandSpec for
+//     the per-field policy.
+//  3. Unresolved — the literal ${VAR} is left in place so downstream code
+//     can log/warn, rather than silently replacing with "" and producing a
+//     mysterious empty-string bug.
 //
-// This matches the syntax used by pkg/config/config.go (expandVars) and the
-// ${WEBHOOK_SECRET} convention already documented for trigger.webhook_secret.
-//
-// Future work: the source loader can widen the built-in set with per-source
-// context like REPO_ROOT and SKILLS_DIR. Task-level code does not know about
-// sources, so those vars cannot live here.
+// See docs/task-template-vars.md for the end-user reference.
 const (
-	VarTaskDir    = "TASK_DIR"    // absolute path to the task's own directory
-	VarHome       = "HOME"        // user home directory
-	VarSourceRoot = "SOURCE_ROOT" // absolute path to the source root (tasks dir / taskset.yaml dir). Injected by the source loader; empty when a task is loaded outside of a source context.
-	VarSkillsDir  = "SKILLS_DIR"  // convention: ${SOURCE_ROOT}/skills. Lets skill-aware tasks reference the shared md directory without hardcoding the "skills" subdir.
+	// VarTaskDir is the absolute path to the task's own directory
+	// (i.e. the directory containing its task.yaml).
+	VarTaskDir = "TASK_DIR"
+
+	// VarHome is the daemon-process user's home directory.
+	VarHome = "HOME"
+
+	// VarTaskSetDir is the absolute path to the directory containing the
+	// root taskset.yaml of the source that loaded this task. Injected by
+	// the source loader; absent when a task is loaded outside of a source
+	// context (e.g. a raw local folder source or a unit test).
+	VarTaskSetDir = "TASK_SET_DIR"
 )
 
-// expandString replaces ${VAR} references in s using the provided vars map,
-// falling back to process env, and leaving unresolved references literal.
+// expandString replaces ${VAR} references in s using the provided vars map
+// and, when envFallback is true, the process environment. Unknown references
+// are left literal rather than collapsing to "".
 //
 // Unlike os.ExpandEnv, this function does NOT replace ${VAR} with "" when
 // VAR is unknown. Leaving the literal makes debugging obvious and avoids
 // silently producing broken paths like "/foo//bar" or "".
-func expandString(s string, vars map[string]string) string {
+//
+// IMPORTANT: envFallback must be false for any field whose expanded value
+// is readable from inside the task sandbox. Otherwise a task.yaml from an
+// untrusted source could exfiltrate daemon secrets by naming them as a
+// template variable and reading the field at runtime.
+func expandString(s string, vars map[string]string, envFallback bool) string {
 	if s == "" || !strings.Contains(s, "${") {
 		return s
 	}
@@ -41,8 +54,10 @@ func expandString(s string, vars map[string]string) string {
 		if v, ok := vars[name]; ok {
 			return v
 		}
-		if v, ok := os.LookupEnv(name); ok {
-			return v
+		if envFallback {
+			if v, ok := os.LookupEnv(name); ok {
+				return v
+			}
 		}
 		// Unknown — re-emit the literal. os.Expand strips the ${…} wrapper
 		// when calling the mapper, so we have to add it back.
@@ -55,24 +70,48 @@ func expandString(s string, vars map[string]string) string {
 // well-defined set — we do NOT expand every string field, because most
 // fields (name, description, system_prompt defaults, ...) should be taken
 // literally.
+//
+// Env-fallback policy (see expandString for the rationale):
+//
+//   - Fields whose expanded value stays server-side and is NOT readable from
+//     task code get envFallback=true: webhook_secret (used by the webhook
+//     handler to compute HMAC; task code never sees it), fs.path (consumed
+//     by the Deno permission set), env.from / env.secret (both are host-side
+//     lookup keys, not values injected into the sandbox).
+//
+//   - Fields whose expanded value IS readable from task code
+//     (permissions.env[].value, params[].default) get envFallback=false.
+//     Enabling env fallback on those would be a direct exfiltration
+//     primitive: any task.yaml could name a daemon secret as a template
+//     variable and read it back at runtime. Builtins + caller extras only.
 func expandSpec(spec *Spec, vars map[string]string) {
 	// trigger.webhook_secret: historically documented as supporting ${VAR}
-	// but the expansion was never implemented. Closing that gap.
-	spec.Trigger.WebhookSecret = expandString(spec.Trigger.WebhookSecret, vars)
+	// and this PR closes that long-standing gap. Env fallback is the whole
+	// point — users set WEBHOOK_SECRET=… in the daemon env and reference it
+	// from task.yaml.
+	spec.Trigger.WebhookSecret = expandString(spec.Trigger.WebhookSecret, vars, true)
 
-	// permissions.fs[].path: the primary motivation for this change — tasks
-	// need to reference shared directories relative to known locations.
+	// permissions.fs[].path: tasks need to reference shared directories
+	// relative to known locations. Env fallback lets `${HOME}/shared` keep
+	// working even if a caller forgets to populate HOME as a builtin.
 	for i := range spec.Permissions.FS {
-		spec.Permissions.FS[i].Path = expandString(spec.Permissions.FS[i].Path, vars)
+		spec.Permissions.FS[i].Path = expandString(spec.Permissions.FS[i].Path, vars, true)
 	}
 
-	// permissions.env[].from and .secret: the indirection keys for host env
-	// rename and secrets-store lookup. Both are identifiers that might want
-	// to be built from a prefix + task-local value.
+	// permissions.env[].from and .secret: indirection keys for host env
+	// rename and secrets-store lookup. Both are identifiers, not values —
+	// expanding them never leaks a secret into task-visible state.
 	for i := range spec.Permissions.Env {
-		spec.Permissions.Env[i].From = expandString(spec.Permissions.Env[i].From, vars)
-		spec.Permissions.Env[i].Secret = expandString(spec.Permissions.Env[i].Secret, vars)
-		spec.Permissions.Env[i].Value = expandString(spec.Permissions.Env[i].Value, vars)
+		spec.Permissions.Env[i].From = expandString(spec.Permissions.Env[i].From, vars, true)
+		spec.Permissions.Env[i].Secret = expandString(spec.Permissions.Env[i].Secret, vars, true)
+		spec.Permissions.Env[i].Value = expandString(spec.Permissions.Env[i].Value, vars, false)
+	}
+
+	// params[].default: lets task.yaml surface loader-provided paths
+	// (${TASK_SET_DIR}, ${TASK_DIR}, …) as parameter defaults that task
+	// code reads via params.get().
+	for i := range spec.Params {
+		spec.Params[i].Default = expandString(spec.Params[i].Default, vars, false)
 	}
 }
 
@@ -80,8 +119,7 @@ func expandSpec(spec *Spec, vars map[string]string) {
 // any extra vars merged in (extras take precedence over builtins). Pass nil
 // for extras when loading a task outside of a source context.
 //
-// Keep this in sync with the Var* constants above and with docs/task-yaml.md
-// (once that doc exists).
+// Keep this in sync with the Var* constants above and docs/task-template-vars.md.
 func builtinVars(taskDir string, extras map[string]string) map[string]string {
 	vars := map[string]string{
 		VarTaskDir: taskDir,
@@ -89,16 +127,6 @@ func builtinVars(taskDir string, extras map[string]string) map[string]string {
 	if home, err := os.UserHomeDir(); err == nil {
 		vars[VarHome] = home
 	}
-	// Convenience: if the caller supplies SOURCE_ROOT but not SKILLS_DIR,
-	// auto-derive it. Lets source loaders stay minimal — they only need to
-	// set the primitive SOURCE_ROOT and the convention follows.
-	if root, ok := extras[VarSourceRoot]; ok {
-		if _, set := extras[VarSkillsDir]; !set {
-			vars[VarSkillsDir] = root + "/skills"
-		}
-	}
-	for k, v := range extras {
-		vars[k] = v
-	}
+	maps.Copy(vars, extras)
 	return vars
 }

--- a/pkg/task/template.go
+++ b/pkg/task/template.go
@@ -1,0 +1,88 @@
+package task
+
+import (
+	"os"
+	"strings"
+)
+
+// Template variables available inside task.yaml as ${VAR}. These are resolved
+// at spec-load time (in LoadDir). The resolution order is:
+//
+//  1. Built-in variables provided by the loader (TASK_DIR, HOME, ...).
+//  2. Process environment (os.Getenv).
+//  3. Unresolved — the literal ${VAR} is left in place so downstream code can
+//     log / warn / handle it, rather than silently replacing with "" and
+//     producing a mysterious empty-string bug.
+//
+// This matches the syntax used by pkg/config/config.go (expandVars) and the
+// ${WEBHOOK_SECRET} convention already documented for trigger.webhook_secret.
+//
+// Future work: the source loader can widen the built-in set with per-source
+// context like REPO_ROOT and SKILLS_DIR. Task-level code does not know about
+// sources, so those vars cannot live here.
+const (
+	VarTaskDir = "TASK_DIR" // absolute path to the task's own directory
+	VarHome    = "HOME"     // user home directory
+)
+
+// expandString replaces ${VAR} references in s using the provided vars map,
+// falling back to process env, and leaving unresolved references literal.
+//
+// Unlike os.ExpandEnv, this function does NOT replace ${VAR} with "" when
+// VAR is unknown. Leaving the literal makes debugging obvious and avoids
+// silently producing broken paths like "/foo//bar" or "".
+func expandString(s string, vars map[string]string) string {
+	if s == "" || !strings.Contains(s, "${") {
+		return s
+	}
+	return os.Expand(s, func(name string) string {
+		if v, ok := vars[name]; ok {
+			return v
+		}
+		if v, ok := os.LookupEnv(name); ok {
+			return v
+		}
+		// Unknown — re-emit the literal. os.Expand strips the ${…} wrapper
+		// when calling the mapper, so we have to add it back.
+		return "${" + name + "}"
+	})
+}
+
+// expandSpec applies template expansion to every spec field that may
+// reasonably contain a path or identifier. This is intentionally a small,
+// well-defined set — we do NOT expand every string field, because most
+// fields (name, description, system_prompt defaults, ...) should be taken
+// literally.
+func expandSpec(spec *Spec, vars map[string]string) {
+	// trigger.webhook_secret: historically documented as supporting ${VAR}
+	// but the expansion was never implemented. Closing that gap.
+	spec.Trigger.WebhookSecret = expandString(spec.Trigger.WebhookSecret, vars)
+
+	// permissions.fs[].path: the primary motivation for this change — tasks
+	// need to reference shared directories relative to known locations.
+	for i := range spec.Permissions.FS {
+		spec.Permissions.FS[i].Path = expandString(spec.Permissions.FS[i].Path, vars)
+	}
+
+	// permissions.env[].from and .secret: the indirection keys for host env
+	// rename and secrets-store lookup. Both are identifiers that might want
+	// to be built from a prefix + task-local value.
+	for i := range spec.Permissions.Env {
+		spec.Permissions.Env[i].From = expandString(spec.Permissions.Env[i].From, vars)
+		spec.Permissions.Env[i].Secret = expandString(spec.Permissions.Env[i].Secret, vars)
+		spec.Permissions.Env[i].Value = expandString(spec.Permissions.Env[i].Value, vars)
+	}
+}
+
+// builtinVars returns the template var map for a task loaded from dir.
+// Keep this in sync with the Var* constants above and with docs/task-yaml.md
+// (once that doc exists).
+func builtinVars(taskDir string) map[string]string {
+	vars := map[string]string{
+		VarTaskDir: taskDir,
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		vars[VarHome] = home
+	}
+	return vars
+}

--- a/pkg/task/template_test.go
+++ b/pkg/task/template_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestExpandString_BuiltinVar(t *testing.T) {
 	vars := map[string]string{VarTaskDir: "/tmp/mytask"}
-	got := expandString("${TASK_DIR}/../../skills", vars)
+	got := expandString("${TASK_DIR}/../../skills", vars, true)
 	want := "/tmp/mytask/../../skills"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -16,7 +16,7 @@ func TestExpandString_BuiltinVar(t *testing.T) {
 
 func TestExpandString_ProcessEnvFallback(t *testing.T) {
 	t.Setenv("FOO_TEST_VAR", "bar")
-	got := expandString("${FOO_TEST_VAR}/baz", map[string]string{})
+	got := expandString("${FOO_TEST_VAR}/baz", map[string]string{}, true)
 	if got != "bar/baz" {
 		t.Errorf("got %q, want %q", got, "bar/baz")
 	}
@@ -26,7 +26,7 @@ func TestExpandString_UnknownVarIsPreserved(t *testing.T) {
 	// Unknown vars must NOT collapse to empty string. Keeping the literal
 	// makes bugs obvious and gives downstream code a chance to warn.
 	os.Unsetenv("DICODE_TEMPLATE_UNKNOWN_TEST")
-	got := expandString("${DICODE_TEMPLATE_UNKNOWN_TEST}/tail", map[string]string{})
+	got := expandString("${DICODE_TEMPLATE_UNKNOWN_TEST}/tail", map[string]string{}, true)
 	if got != "${DICODE_TEMPLATE_UNKNOWN_TEST}/tail" {
 		t.Errorf("got %q, want the literal to be preserved", got)
 	}
@@ -35,7 +35,7 @@ func TestExpandString_UnknownVarIsPreserved(t *testing.T) {
 func TestExpandString_BuiltinBeatsProcessEnv(t *testing.T) {
 	t.Setenv("TASK_DIR", "/shouldnt/win")
 	vars := map[string]string{VarTaskDir: "/from/builtin"}
-	got := expandString("${TASK_DIR}/x", vars)
+	got := expandString("${TASK_DIR}/x", vars, true)
 	if got != "/from/builtin/x" {
 		t.Errorf("got %q, want builtin to win", got)
 	}
@@ -43,14 +43,29 @@ func TestExpandString_BuiltinBeatsProcessEnv(t *testing.T) {
 
 func TestExpandString_NoDollarSign_IsNoop(t *testing.T) {
 	in := "/plain/path/with/no/template"
-	if got := expandString(in, map[string]string{"X": "y"}); got != in {
+	if got := expandString(in, map[string]string{"X": "y"}, true); got != in {
 		t.Errorf("got %q, want %q", got, in)
 	}
 }
 
 func TestExpandString_Empty(t *testing.T) {
-	if got := expandString("", map[string]string{"X": "y"}); got != "" {
+	if got := expandString("", map[string]string{"X": "y"}, true); got != "" {
 		t.Errorf("got %q, want empty", got)
+	}
+}
+
+// When envFallback is false, process env lookups must NOT happen — unknown
+// vars stay literal. Guards the exfiltration fix for EnvEntry.Value.
+func TestExpandString_NoEnvFallback(t *testing.T) {
+	t.Setenv("DICODE_TEMPLATE_SECRET_TEST", "should-not-leak")
+	got := expandString("${DICODE_TEMPLATE_SECRET_TEST}/tail", map[string]string{}, false)
+	if got != "${DICODE_TEMPLATE_SECRET_TEST}/tail" {
+		t.Errorf("env value leaked despite envFallback=false: %q", got)
+	}
+	// Builtins still resolve even when env fallback is off.
+	got = expandString("${X}/tail", map[string]string{"X": "ok"}, false)
+	if got != "ok/tail" {
+		t.Errorf("builtin not honoured: %q", got)
 	}
 }
 
@@ -113,6 +128,90 @@ func TestExpandSpec_EnvEntryIndirection(t *testing.T) {
 	}
 }
 
+// SECURITY: EnvEntry.Value must NOT pull from process env under any
+// circumstances. It is a literal value injected into the task sandbox, so
+// env-fallback expansion here would let any task.yaml exfiltrate daemon
+// environment variables by writing `value: "${SOME_SECRET}"`.
+func TestExpandSpec_EnvEntryValue_NoEnvExfiltration(t *testing.T) {
+	t.Setenv("DICODE_DAEMON_SECRET_TEST", "super-sensitive")
+	spec := &Spec{
+		Permissions: Permissions{
+			Env: []EnvEntry{
+				{Name: "LEAK", Value: "${DICODE_DAEMON_SECRET_TEST}"},
+			},
+		},
+	}
+	expandSpec(spec, map[string]string{})
+
+	if spec.Permissions.Env[0].Value == "super-sensitive" {
+		t.Fatalf("env value exfiltrated via EnvEntry.Value: %q", spec.Permissions.Env[0].Value)
+	}
+	// The literal ${…} should be preserved so operators notice the mistake.
+	if spec.Permissions.Env[0].Value != "${DICODE_DAEMON_SECRET_TEST}" {
+		t.Errorf("Value = %q, want literal preserved", spec.Permissions.Env[0].Value)
+	}
+}
+
+// Builtins and extras DO apply to EnvEntry.Value — only the env fallback
+// is suppressed. This keeps the taskset override use case working:
+// `overrides.env: [{name: FOO, value: "${TASK_DIR}/marker"}]`.
+func TestExpandSpec_EnvEntryValue_BuiltinsStillExpand(t *testing.T) {
+	spec := &Spec{
+		Permissions: Permissions{
+			Env: []EnvEntry{
+				{Name: "MARKER", Value: "${TASK_DIR}/marker"},
+			},
+		},
+	}
+	expandSpec(spec, map[string]string{VarTaskDir: "/repo/task"})
+
+	if spec.Permissions.Env[0].Value != "/repo/task/marker" {
+		t.Errorf("builtin did not expand: %q", spec.Permissions.Env[0].Value)
+	}
+}
+
+// Builtins and extras apply to Param.Default — lets task.yaml surface
+// loader-provided paths (${TASK_SET_DIR}, ${TASK_DIR}, …) as parameter
+// defaults that task code then reads via params.get().
+func TestExpandSpec_ParamDefault_BuiltinsExpand(t *testing.T) {
+	spec := &Spec{
+		Params: Params{
+			{Name: "shared_dir", Default: "${TASK_SET_DIR}/shared"},
+			{Name: "local_dir", Default: "${TASK_DIR}/local"},
+		},
+	}
+	expandSpec(spec, map[string]string{
+		VarTaskSetDir: "/repo/tasks",
+		VarTaskDir:    "/repo/tasks/agent",
+	})
+
+	if spec.Params[0].Default != "/repo/tasks/shared" {
+		t.Errorf("TASK_SET_DIR not expanded in param default: %q", spec.Params[0].Default)
+	}
+	if spec.Params[1].Default != "/repo/tasks/agent/local" {
+		t.Errorf("TASK_DIR not expanded in param default: %q", spec.Params[1].Default)
+	}
+}
+
+// Same exfiltration guard as EnvEntry.Value: Param.Default is readable from
+// task code at runtime, so env fallback must not leak daemon secrets.
+func TestExpandSpec_ParamDefault_NoEnvExfiltration(t *testing.T) {
+	t.Setenv("DICODE_DAEMON_SECRET_TEST", "super-sensitive")
+	spec := &Spec{
+		Params: Params{
+			{Name: "leak", Default: "${DICODE_DAEMON_SECRET_TEST}"},
+		},
+	}
+	expandSpec(spec, map[string]string{})
+
+	if spec.Params[0].Default == "super-sensitive" {
+		t.Fatalf("daemon env exfiltrated via Param.Default: %q", spec.Params[0].Default)
+	}
+	if spec.Params[0].Default != "${DICODE_DAEMON_SECRET_TEST}" {
+		t.Errorf("Default = %q, want literal preserved", spec.Params[0].Default)
+	}
+}
+
 func TestBuiltinVars(t *testing.T) {
 	vars := builtinVars("/repo/tasks/myagent", nil)
 	if vars[VarTaskDir] != "/repo/tasks/myagent" {
@@ -125,31 +224,19 @@ func TestBuiltinVars(t *testing.T) {
 	}
 }
 
-func TestBuiltinVars_SourceRootDerivesSkillsDir(t *testing.T) {
-	extras := map[string]string{VarSourceRoot: "/repo/tasks"}
+func TestBuiltinVars_TaskSetDirPassedThrough(t *testing.T) {
+	extras := map[string]string{VarTaskSetDir: "/repo/tasks"}
 	vars := builtinVars("/repo/tasks/myagent", extras)
 
-	if vars[VarSourceRoot] != "/repo/tasks" {
-		t.Errorf("SOURCE_ROOT not passed through: %q", vars[VarSourceRoot])
+	if vars[VarTaskSetDir] != "/repo/tasks" {
+		t.Errorf("TASK_SET_DIR not passed through: %q", vars[VarTaskSetDir])
 	}
-	if vars[VarSkillsDir] != "/repo/tasks/skills" {
-		t.Errorf("SKILLS_DIR not auto-derived: %q", vars[VarSkillsDir])
+	if vars[VarTaskDir] != "/repo/tasks/myagent" {
+		t.Errorf("TASK_DIR wrong: %q", vars[VarTaskDir])
 	}
 }
 
-func TestBuiltinVars_ExplicitSkillsDirWins(t *testing.T) {
-	extras := map[string]string{
-		VarSourceRoot: "/repo/tasks",
-		VarSkillsDir:  "/elsewhere/md",
-	}
-	vars := builtinVars("/repo/tasks/myagent", extras)
-
-	if vars[VarSkillsDir] != "/elsewhere/md" {
-		t.Errorf("explicit SKILLS_DIR not honoured: %q", vars[VarSkillsDir])
-	}
-}
-
-func TestLoadDirWithVars_ExpandsSourceRoot(t *testing.T) {
+func TestLoadDirWithVars_ExpandsTaskSetDir(t *testing.T) {
 	dir := t.TempDir()
 	yaml := `
 apiVersion: dicode/v1
@@ -160,9 +247,9 @@ trigger:
   manual: true
 permissions:
   fs:
-    - path: "${SOURCE_ROOT}/skills"
+    - path: "${TASK_SET_DIR}/skills"
       permission: r
-    - path: "${SKILLS_DIR}/extra"
+    - path: "${TASK_DIR}/local"
       permission: r
 `
 	if err := os.WriteFile(dir+"/task.yaml", []byte(yaml), 0o644); err != nil {
@@ -173,7 +260,7 @@ permissions:
 		t.Fatal(err)
 	}
 
-	spec, err := LoadDirWithVars(dir, map[string]string{VarSourceRoot: "/fake/source"})
+	spec, err := LoadDirWithVars(dir, map[string]string{VarTaskSetDir: "/fake/source"})
 	if err != nil {
 		t.Fatalf("LoadDirWithVars: %v", err)
 	}
@@ -184,7 +271,7 @@ permissions:
 	if spec.Permissions.FS[0].Path != "/fake/source/skills" {
 		t.Errorf("FS[0] = %q, want /fake/source/skills", spec.Permissions.FS[0].Path)
 	}
-	if spec.Permissions.FS[1].Path != "/fake/source/skills/extra" {
-		t.Errorf("FS[1] = %q, want /fake/source/skills/extra", spec.Permissions.FS[1].Path)
+	if spec.Permissions.FS[1].Path != dir+"/local" {
+		t.Errorf("FS[1] = %q, want %s/local", spec.Permissions.FS[1].Path, dir)
 	}
 }

--- a/pkg/task/template_test.go
+++ b/pkg/task/template_test.go
@@ -114,7 +114,7 @@ func TestExpandSpec_EnvEntryIndirection(t *testing.T) {
 }
 
 func TestBuiltinVars(t *testing.T) {
-	vars := builtinVars("/repo/tasks/myagent")
+	vars := builtinVars("/repo/tasks/myagent", nil)
 	if vars[VarTaskDir] != "/repo/tasks/myagent" {
 		t.Errorf("TASK_DIR not set correctly: %q", vars[VarTaskDir])
 	}
@@ -122,5 +122,69 @@ func TestBuiltinVars(t *testing.T) {
 	// have it. We don't want to flake on that.
 	if home, ok := vars[VarHome]; ok && home == "" {
 		t.Errorf("HOME set but empty")
+	}
+}
+
+func TestBuiltinVars_SourceRootDerivesSkillsDir(t *testing.T) {
+	extras := map[string]string{VarSourceRoot: "/repo/tasks"}
+	vars := builtinVars("/repo/tasks/myagent", extras)
+
+	if vars[VarSourceRoot] != "/repo/tasks" {
+		t.Errorf("SOURCE_ROOT not passed through: %q", vars[VarSourceRoot])
+	}
+	if vars[VarSkillsDir] != "/repo/tasks/skills" {
+		t.Errorf("SKILLS_DIR not auto-derived: %q", vars[VarSkillsDir])
+	}
+}
+
+func TestBuiltinVars_ExplicitSkillsDirWins(t *testing.T) {
+	extras := map[string]string{
+		VarSourceRoot: "/repo/tasks",
+		VarSkillsDir:  "/elsewhere/md",
+	}
+	vars := builtinVars("/repo/tasks/myagent", extras)
+
+	if vars[VarSkillsDir] != "/elsewhere/md" {
+		t.Errorf("explicit SKILLS_DIR not honoured: %q", vars[VarSkillsDir])
+	}
+}
+
+func TestLoadDirWithVars_ExpandsSourceRoot(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `
+apiVersion: dicode/v1
+kind: Task
+name: test
+runtime: deno
+trigger:
+  manual: true
+permissions:
+  fs:
+    - path: "${SOURCE_ROOT}/skills"
+      permission: r
+    - path: "${SKILLS_DIR}/extra"
+      permission: r
+`
+	if err := os.WriteFile(dir+"/task.yaml", []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Create task.ts to satisfy validation.
+	if err := os.WriteFile(dir+"/task.ts", []byte("export default async function main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	spec, err := LoadDirWithVars(dir, map[string]string{VarSourceRoot: "/fake/source"})
+	if err != nil {
+		t.Fatalf("LoadDirWithVars: %v", err)
+	}
+
+	if len(spec.Permissions.FS) != 2 {
+		t.Fatalf("expected 2 FS entries, got %d", len(spec.Permissions.FS))
+	}
+	if spec.Permissions.FS[0].Path != "/fake/source/skills" {
+		t.Errorf("FS[0] = %q, want /fake/source/skills", spec.Permissions.FS[0].Path)
+	}
+	if spec.Permissions.FS[1].Path != "/fake/source/skills/extra" {
+		t.Errorf("FS[1] = %q, want /fake/source/skills/extra", spec.Permissions.FS[1].Path)
 	}
 }

--- a/pkg/task/template_test.go
+++ b/pkg/task/template_test.go
@@ -1,0 +1,126 @@
+package task
+
+import (
+	"os"
+	"testing"
+)
+
+func TestExpandString_BuiltinVar(t *testing.T) {
+	vars := map[string]string{VarTaskDir: "/tmp/mytask"}
+	got := expandString("${TASK_DIR}/../../skills", vars)
+	want := "/tmp/mytask/../../skills"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExpandString_ProcessEnvFallback(t *testing.T) {
+	t.Setenv("FOO_TEST_VAR", "bar")
+	got := expandString("${FOO_TEST_VAR}/baz", map[string]string{})
+	if got != "bar/baz" {
+		t.Errorf("got %q, want %q", got, "bar/baz")
+	}
+}
+
+func TestExpandString_UnknownVarIsPreserved(t *testing.T) {
+	// Unknown vars must NOT collapse to empty string. Keeping the literal
+	// makes bugs obvious and gives downstream code a chance to warn.
+	os.Unsetenv("DICODE_TEMPLATE_UNKNOWN_TEST")
+	got := expandString("${DICODE_TEMPLATE_UNKNOWN_TEST}/tail", map[string]string{})
+	if got != "${DICODE_TEMPLATE_UNKNOWN_TEST}/tail" {
+		t.Errorf("got %q, want the literal to be preserved", got)
+	}
+}
+
+func TestExpandString_BuiltinBeatsProcessEnv(t *testing.T) {
+	t.Setenv("TASK_DIR", "/shouldnt/win")
+	vars := map[string]string{VarTaskDir: "/from/builtin"}
+	got := expandString("${TASK_DIR}/x", vars)
+	if got != "/from/builtin/x" {
+		t.Errorf("got %q, want builtin to win", got)
+	}
+}
+
+func TestExpandString_NoDollarSign_IsNoop(t *testing.T) {
+	in := "/plain/path/with/no/template"
+	if got := expandString(in, map[string]string{"X": "y"}); got != in {
+		t.Errorf("got %q, want %q", got, in)
+	}
+}
+
+func TestExpandString_Empty(t *testing.T) {
+	if got := expandString("", map[string]string{"X": "y"}); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestExpandSpec_FSPaths(t *testing.T) {
+	spec := &Spec{
+		Permissions: Permissions{
+			FS: []FSEntry{
+				{Path: "${TASK_DIR}/../../skills", Permission: "r"},
+				{Path: "/absolute/path", Permission: "w"},
+				{Path: "relative/path", Permission: "rw"},
+			},
+		},
+	}
+	vars := map[string]string{VarTaskDir: "/repo/tasks/myagent"}
+	expandSpec(spec, vars)
+
+	if spec.Permissions.FS[0].Path != "/repo/tasks/myagent/../../skills" {
+		t.Errorf("FS[0].Path = %q", spec.Permissions.FS[0].Path)
+	}
+	if spec.Permissions.FS[1].Path != "/absolute/path" {
+		t.Errorf("FS[1].Path should be unchanged, got %q", spec.Permissions.FS[1].Path)
+	}
+	if spec.Permissions.FS[2].Path != "relative/path" {
+		t.Errorf("FS[2].Path should be unchanged, got %q", spec.Permissions.FS[2].Path)
+	}
+}
+
+func TestExpandSpec_WebhookSecret(t *testing.T) {
+	t.Setenv("GITHUB_WEBHOOK_SECRET", "super-secret")
+	spec := &Spec{
+		Trigger: TriggerConfig{
+			Webhook:       "/hooks/gh",
+			WebhookSecret: "${GITHUB_WEBHOOK_SECRET}",
+		},
+	}
+	expandSpec(spec, map[string]string{})
+
+	if spec.Trigger.WebhookSecret != "super-secret" {
+		t.Errorf("WebhookSecret = %q, want expansion to the env value", spec.Trigger.WebhookSecret)
+	}
+}
+
+func TestExpandSpec_EnvEntryIndirection(t *testing.T) {
+	t.Setenv("SECRETS_PREFIX", "prod")
+	spec := &Spec{
+		Permissions: Permissions{
+			Env: []EnvEntry{
+				{Name: "DB_PASS", Secret: "${SECRETS_PREFIX}_db_password"},
+				{Name: "API_KEY", From: "${SECRETS_PREFIX}_api_token"},
+			},
+		},
+	}
+	expandSpec(spec, map[string]string{})
+
+	if spec.Permissions.Env[0].Secret != "prod_db_password" {
+		t.Errorf("Env[0].Secret = %q", spec.Permissions.Env[0].Secret)
+	}
+	if spec.Permissions.Env[1].From != "prod_api_token" {
+		t.Errorf("Env[1].From = %q", spec.Permissions.Env[1].From)
+	}
+}
+
+func TestBuiltinVars(t *testing.T) {
+	vars := builtinVars("/repo/tasks/myagent")
+	if vars[VarTaskDir] != "/repo/tasks/myagent" {
+		t.Errorf("TASK_DIR not set correctly: %q", vars[VarTaskDir])
+	}
+	// HOME is best-effort — if UserHomeDir fails in CI, the map just won't
+	// have it. We don't want to flake on that.
+	if home, ok := vars[VarHome]; ok && home == "" {
+		t.Errorf("HOME set but empty")
+	}
+}

--- a/pkg/taskset/resolver.go
+++ b/pkg/taskset/resolver.go
@@ -27,8 +27,9 @@ type Resolver struct {
 	devMode bool
 	log     *zap.Logger
 
-	mu     sync.Mutex
-	clones map[repoKey]string // (url, branch) → absolute local dir
+	mu        sync.Mutex
+	clones    map[repoKey]string // (url, branch) → absolute local dir
+	extraVars map[string]string  // template vars injected into every LoadDir call (e.g. SOURCE_ROOT)
 }
 
 // NewResolver creates a Resolver.
@@ -54,6 +55,22 @@ func (r *Resolver) DevMode() bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.devMode
+}
+
+// SetExtraVars sets the template variables injected into task.yaml ${VAR}
+// expansion for every task resolved by this Resolver. Sources call this
+// before Resolve to inject source-level context (e.g. SOURCE_ROOT). Passing
+// nil clears any previously set vars.
+func (r *Resolver) SetExtraVars(vars map[string]string) {
+	r.mu.Lock()
+	r.extraVars = vars
+	r.mu.Unlock()
+}
+
+func (r *Resolver) getExtraVars() map[string]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.extraVars
 }
 
 // Resolve walks the TaskSet rooted at tsRef with the given namespace prefix.
@@ -165,7 +182,7 @@ func (r *Resolver) resolveBody(
 				continue
 			}
 			taskDir := filepath.Dir(localPath)
-			spec, err := task.LoadDir(taskDir)
+			spec, err := task.LoadDirWithVars(taskDir, r.getExtraVars())
 			if err != nil {
 				r.log.Warn("taskset: failed to load task",
 					zap.String("entry", fullID), zap.Error(err))

--- a/pkg/taskset/resolver.go
+++ b/pkg/taskset/resolver.go
@@ -105,12 +105,12 @@ func (r *Resolver) Resolve(ctx context.Context, namespace string, tsRef *Ref, co
 // withTaskSetDir returns a copy of base with VarTaskSetDir set to
 // filepath.Dir(tsPath) unless the caller already provided one (explicit
 // caller override always wins). Returns a fresh map — never mutates base.
+//
+// tsPath is always non-empty by construction: Resolve calls resolveRef
+// first, which errors out before this helper can see an empty path.
 func withTaskSetDir(base map[string]string, tsPath string) map[string]string {
 	out := make(map[string]string, len(base)+1)
 	maps.Copy(out, base)
-	if tsPath == "" {
-		return out
-	}
 	if _, set := out[task.VarTaskSetDir]; !set {
 		out[task.VarTaskSetDir] = filepath.Dir(tsPath)
 	}

--- a/pkg/taskset/resolver.go
+++ b/pkg/taskset/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sync"
@@ -27,9 +28,8 @@ type Resolver struct {
 	devMode bool
 	log     *zap.Logger
 
-	mu        sync.Mutex
-	clones    map[repoKey]string // (url, branch) → absolute local dir
-	extraVars map[string]string  // template vars injected into every LoadDir call (e.g. SOURCE_ROOT)
+	mu     sync.Mutex
+	clones map[repoKey]string // (url, branch) → absolute local dir
 }
 
 // NewResolver creates a Resolver.
@@ -57,22 +57,6 @@ func (r *Resolver) DevMode() bool {
 	return r.devMode
 }
 
-// SetExtraVars sets the template variables injected into task.yaml ${VAR}
-// expansion for every task resolved by this Resolver. Sources call this
-// before Resolve to inject source-level context (e.g. SOURCE_ROOT). Passing
-// nil clears any previously set vars.
-func (r *Resolver) SetExtraVars(vars map[string]string) {
-	r.mu.Lock()
-	r.extraVars = vars
-	r.mu.Unlock()
-}
-
-func (r *Resolver) getExtraVars() map[string]string {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.extraVars
-}
-
 // Resolve walks the TaskSet rooted at tsRef with the given namespace prefix.
 //
 // The override precedence is three levels (lowest to highest):
@@ -87,7 +71,13 @@ func (r *Resolver) getExtraVars() map[string]string {
 // parentOverrides carries per-entry patches from the parent TaskSet (level 3).
 // Passing parentOverrides.Defaults is also deprecated and now a no-op; only
 // Entries is honoured.
-func (r *Resolver) Resolve(ctx context.Context, namespace string, tsRef *Ref, configDefaults *Defaults, parentOverrides *Overrides) ([]*ResolvedTask, error) {
+//
+// extraVars is the per-resolve template-variable set injected into every
+// task.yaml ${VAR} expansion. Pass nil when the caller has no additional
+// context — the resolver itself always sets TASK_SET_DIR from the resolved
+// root taskset.yaml path, so source loaders don't need to. The map is
+// treated as read-only; the resolver never mutates or retains it.
+func (r *Resolver) Resolve(ctx context.Context, namespace string, tsRef *Ref, configDefaults *Defaults, parentOverrides *Overrides, extraVars map[string]string) ([]*ResolvedTask, error) {
 	tsPath, err := r.resolveRef(ctx, tsRef, "")
 	if err != nil {
 		return nil, fmt.Errorf("resolve ref for namespace %q: %w", namespace, err)
@@ -98,7 +88,33 @@ func (r *Resolver) Resolve(ctx context.Context, namespace string, tsRef *Ref, co
 		return nil, err
 	}
 
-	return r.resolveBody(ctx, namespace, tsPath, ts, configDefaults, parentOverrides)
+	// At the TOP-level Resolve only, inject TASK_SET_DIR from the resolved
+	// root taskset path. Nested resolveNestedRef calls receive this same
+	// map unchanged, so the variable always points at the ROOT taskset dir
+	// regardless of recursion depth (matches docs/task-template-vars.md).
+	//
+	// Done here rather than in source loaders so both local and git sources
+	// — and any future source type funnelling through the resolver — behave
+	// identically. Git sources used to pass nil, which left the literal
+	// ${TASK_SET_DIR} in task.yaml paths.
+	rootVars := withTaskSetDir(extraVars, tsPath)
+
+	return r.resolveBody(ctx, namespace, tsPath, ts, configDefaults, parentOverrides, rootVars)
+}
+
+// withTaskSetDir returns a copy of base with VarTaskSetDir set to
+// filepath.Dir(tsPath) unless the caller already provided one (explicit
+// caller override always wins). Returns a fresh map — never mutates base.
+func withTaskSetDir(base map[string]string, tsPath string) map[string]string {
+	out := make(map[string]string, len(base)+1)
+	maps.Copy(out, base)
+	if tsPath == "" {
+		return out
+	}
+	if _, set := out[task.VarTaskSetDir]; !set {
+		out[task.VarTaskSetDir] = filepath.Dir(tsPath)
+	}
+	return out
 }
 
 func (r *Resolver) resolveBody(
@@ -107,6 +123,7 @@ func (r *Resolver) resolveBody(
 	ts *TaskSetSpec,
 	configDefaults *Defaults,
 	parentOverrides *Overrides,
+	extraVars map[string]string,
 ) ([]*ResolvedTask, error) {
 	// Deprecation warnings for removed precedence levels.
 	if defaultsNonEmpty(configDefaults) {
@@ -182,7 +199,7 @@ func (r *Resolver) resolveBody(
 				continue
 			}
 			taskDir := filepath.Dir(localPath)
-			spec, err := task.LoadDirWithVars(taskDir, r.getExtraVars())
+			spec, err := task.LoadDirWithVars(taskDir, extraVars)
 			if err != nil {
 				r.log.Warn("taskset: failed to load task",
 					zap.String("entry", fullID), zap.Error(err))
@@ -205,7 +222,7 @@ func (r *Resolver) resolveBody(
 			if parentEntryOverride != nil {
 				nestedOverrides = mergeOverrides(parentEntryOverride, nestedOverrides)
 			}
-			nested, err := r.resolveNestedRef(ctx, fullID, localPath, nestedOverrides)
+			nested, err := r.resolveNestedRef(ctx, fullID, localPath, nestedOverrides, extraVars)
 			if err != nil {
 				r.log.Warn("taskset: failed to resolve nested taskset",
 					zap.String("entry", fullID), zap.Error(err))
@@ -222,14 +239,14 @@ func (r *Resolver) resolveBody(
 	return results, nil
 }
 
-func (r *Resolver) resolveNestedRef(ctx context.Context, namespace, tsPath string, overrides *Overrides) ([]*ResolvedTask, error) {
+func (r *Resolver) resolveNestedRef(ctx context.Context, namespace, tsPath string, overrides *Overrides, extraVars map[string]string) ([]*ResolvedTask, error) {
 	ts, err := LoadTaskSet(tsPath)
 	if err != nil {
 		return nil, err
 	}
 	// Pass nil for configDefaults: deprecation warnings are emitted once at the
 	// public Resolve entry point; nested sets do not re-emit them.
-	return r.resolveBody(ctx, namespace, tsPath, ts, nil, overrides)
+	return r.resolveBody(ctx, namespace, tsPath, ts, nil, overrides, extraVars)
 }
 
 // resolveRef returns the absolute local path to the yaml file pointed to by ref.

--- a/pkg/taskset/resolver_test.go
+++ b/pkg/taskset/resolver_test.go
@@ -135,7 +135,7 @@ spec:
 
 	r := newResolver(t)
 	rootRef := &Ref{Path: tsPath}
-	results, err := r.Resolve(context.Background(), "infra", rootRef, nil, nil)
+	results, err := r.Resolve(context.Background(), "infra", rootRef, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -171,7 +171,7 @@ spec:
 `
 	tsPath := writeTaskSetFile(t, repoDir, "taskset.yaml", tsContent)
 	r := newResolver(t)
-	results, err := r.Resolve(context.Background(), "team", &Ref{Path: tsPath}, nil, nil)
+	results, err := r.Resolve(context.Background(), "team", &Ref{Path: tsPath}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
@@ -206,7 +206,7 @@ spec:
 `
 	tsPath := writeTaskSetFile(t, repoDir, "taskset.yaml", tsContent)
 	r := newResolver(t)
-	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil)
+	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
@@ -242,7 +242,7 @@ spec:
 `
 	tsPath := writeTaskSetFile(t, repoDir, "taskset.yaml", tsContent)
 	r := newResolver(t)
-	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil)
+	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
@@ -276,7 +276,7 @@ spec:
 			"deploy": {Enabled: boolPtr(false)},
 		},
 	}
-	results, err := r.Resolve(context.Background(), "infra/backend", &Ref{Path: tsPath}, nil, parentOverrides)
+	results, err := r.Resolve(context.Background(), "infra/backend", &Ref{Path: tsPath}, nil, parentOverrides, nil)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
@@ -306,7 +306,7 @@ spec:
 `
 	tsPath := writeTaskSetFile(t, repoDir, "taskset.yaml", tsContent)
 	r := newResolver(t)
-	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil)
+	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
@@ -348,7 +348,7 @@ spec:
 		Timeout: 120 * time.Second,
 		Env:     []task.EnvEntry{{Name: "RUNTIME_ENV", Value: "backend"}},
 	}
-	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, configDefaults, nil)
+	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, configDefaults, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
@@ -392,7 +392,7 @@ spec:
 `
 	tsPath := writeTaskSetFile(t, repoDir, "taskset.yaml", tsContent)
 	r := newResolver(t)
-	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil)
+	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
@@ -433,7 +433,7 @@ spec:
 	rootPath := writeTaskSetFile(t, rootDir, "taskset.yaml", rootTS)
 
 	r := newResolver(t)
-	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: rootPath}, nil, nil)
+	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: rootPath}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
@@ -486,7 +486,7 @@ spec:
 	rootPath := writeTaskSetFile(t, rootDir, "taskset.yaml", rootTS)
 
 	r := newResolver(t)
-	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: rootPath}, nil, nil)
+	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: rootPath}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
@@ -521,7 +521,7 @@ spec:
 `
 	tsPath := writeTaskSetFile(t, repoDir, "taskset.yaml", tsContent)
 	r := newResolver(t)
-	results, err := r.Resolve(context.Background(), "ns", &Ref{Path: tsPath}, nil, nil)
+	results, err := r.Resolve(context.Background(), "ns", &Ref{Path: tsPath}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
@@ -556,7 +556,7 @@ spec:
 
 	// dev mode OFF — should use remote (0 8)
 	r := NewResolver(t.TempDir(), false, zap.NewNop())
-	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil)
+	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
@@ -566,7 +566,7 @@ spec:
 
 	// dev mode ON — should use dev ref (0 1)
 	rDev := NewResolver(t.TempDir(), true, zap.NewNop())
-	resultsDev, err := rDev.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil)
+	resultsDev, err := rDev.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
@@ -594,7 +594,7 @@ spec:
 `
 	tsPath := writeTaskSetFile(t, repoDir, "taskset.yaml", tsContent)
 	r := newResolver(t)
-	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil)
+	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
@@ -645,5 +645,130 @@ func TestMergeOverrides_EntriesMerged(t *testing.T) {
 	}
 	if got.Entries["y"] == nil {
 		t.Error("y from b missing")
+	}
+}
+
+// Resolver.Resolve injects TASK_SET_DIR from the resolved root taskset
+// path, regardless of whether the source loader supplied extraVars.
+// Regression guard for the git-source bug where TASK_SET_DIR was only
+// injected for local sources, leaving literal ${TASK_SET_DIR} in every
+// task.yaml resolved from a git clone.
+func TestResolver_InjectsTaskSetDirFromRoot(t *testing.T) {
+	repoDir := t.TempDir()
+	taskDir := filepath.Join(repoDir, "fstask")
+	if err := os.MkdirAll(taskDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// task.yaml references ${TASK_SET_DIR} in both an fs permission and a
+	// param default — the two fields that expandSpec actually touches.
+	taskYAML := `kind: Task
+apiVersion: dicode/v1
+name: fstask
+runtime: deno
+trigger:
+  manual: true
+params:
+  shared_dir:
+    type: string
+    default: "${TASK_SET_DIR}/shared"
+    description: ""
+permissions:
+  fs:
+    - path: "${TASK_SET_DIR}/pool"
+      permission: r
+`
+	writeFile(t, taskDir, "task.yaml", taskYAML)
+	writeFile(t, taskDir, "task.js", "// task")
+
+	tsContent := `kind: TaskSet
+apiVersion: dicode/v1
+metadata:
+  name: infra
+spec:
+  entries:
+    fstask:
+      ref:
+        path: ` + filepath.Join(taskDir, "task.yaml") + `
+`
+	tsPath := writeTaskSetFile(t, repoDir, "taskset.yaml", tsContent)
+	wantDir := filepath.Dir(tsPath)
+
+	r := newResolver(t)
+	// Pass nil extraVars — the resolver itself must derive TASK_SET_DIR.
+	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+
+	spec := results[0].Spec
+	if len(spec.Permissions.FS) != 1 {
+		t.Fatalf("want 1 fs entry, got %d", len(spec.Permissions.FS))
+	}
+	if got, want := spec.Permissions.FS[0].Path, wantDir+"/pool"; got != want {
+		t.Errorf("fs.path: got %q, want %q (literal ${TASK_SET_DIR} survived expansion)", got, want)
+	}
+
+	// Find the shared_dir param and assert its default was expanded.
+	var sharedDefault string
+	for _, p := range spec.Params {
+		if p.Name == "shared_dir" {
+			sharedDefault = p.Default
+			break
+		}
+	}
+	if got, want := sharedDefault, wantDir+"/shared"; got != want {
+		t.Errorf("params[shared_dir].default: got %q, want %q", got, want)
+	}
+}
+
+// Caller-supplied extraVars override the resolver's TASK_SET_DIR
+// derivation. Useful for tests or for future source types that want to
+// override the "root taskset dir" convention.
+func TestResolver_CallerExtraVarsOverrideTaskSetDir(t *testing.T) {
+	repoDir := t.TempDir()
+	taskDir := filepath.Join(repoDir, "fstask")
+	if err := os.MkdirAll(taskDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	taskYAML := `kind: Task
+apiVersion: dicode/v1
+name: fstask
+runtime: deno
+trigger:
+  manual: true
+permissions:
+  fs:
+    - path: "${TASK_SET_DIR}/pool"
+      permission: r
+`
+	writeFile(t, taskDir, "task.yaml", taskYAML)
+	writeFile(t, taskDir, "task.js", "// task")
+
+	tsContent := `kind: TaskSet
+apiVersion: dicode/v1
+metadata:
+  name: infra
+spec:
+  entries:
+    fstask:
+      ref:
+        path: ` + filepath.Join(taskDir, "task.yaml") + `
+`
+	tsPath := writeTaskSetFile(t, repoDir, "taskset.yaml", tsContent)
+
+	r := newResolver(t)
+	caller := map[string]string{task.VarTaskSetDir: "/caller/wins"}
+	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil, caller)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	if got, want := results[0].Spec.Permissions.FS[0].Path, "/caller/wins/pool"; got != want {
+		t.Errorf("fs.path: got %q, want %q — caller extraVars should override resolver derivation", got, want)
 	}
 }

--- a/pkg/taskset/source.go
+++ b/pkg/taskset/source.go
@@ -347,19 +347,11 @@ func (s *Source) resolve(ctx context.Context) ([]*ResolvedTask, error) {
 		rootRef = &Ref{Path: devRootPath}
 	}
 
-	// Inject source-level template vars (SOURCE_ROOT) so task.yaml can
-	// reference the source root via ${SOURCE_ROOT} / ${SKILLS_DIR}. For a
-	// TaskSet source, "source root" is the directory containing the root
-	// taskset.yaml — for a git source the local clone dir, for a local
-	// source the absolute path. For git refs before clone, rootRef.Path
-	// may be empty; the resolver tolerates a nil/empty ExtraVars map.
-	if !rootRef.IsGit() && rootRef.Path != "" {
-		s.resolver.SetExtraVars(map[string]string{
-			task.VarSourceRoot: filepath.Dir(rootRef.Path),
-		})
-	}
-
-	return s.resolver.Resolve(ctx, s.namespace, rootRef, configDefaults, nil)
+	// TASK_SET_DIR is injected by Resolver.Resolve itself from the resolved
+	// root taskset.yaml path, so the source loader no longer needs to know
+	// about it. Pass nil for extraVars — if a future source type needs to
+	// layer additional vars, build them here.
+	return s.resolver.Resolve(ctx, s.namespace, rootRef, configDefaults, nil, nil)
 }
 
 func (s *Source) loadConfigDefaults() (*Defaults, error) {

--- a/pkg/taskset/source.go
+++ b/pkg/taskset/source.go
@@ -347,6 +347,18 @@ func (s *Source) resolve(ctx context.Context) ([]*ResolvedTask, error) {
 		rootRef = &Ref{Path: devRootPath}
 	}
 
+	// Inject source-level template vars (SOURCE_ROOT) so task.yaml can
+	// reference the source root via ${SOURCE_ROOT} / ${SKILLS_DIR}. For a
+	// TaskSet source, "source root" is the directory containing the root
+	// taskset.yaml — for a git source the local clone dir, for a local
+	// source the absolute path. For git refs before clone, rootRef.Path
+	// may be empty; the resolver tolerates a nil/empty ExtraVars map.
+	if !rootRef.IsGit() && rootRef.Path != "" {
+		s.resolver.SetExtraVars(map[string]string{
+			task.VarSourceRoot: filepath.Dir(rootRef.Path),
+		})
+	}
+
 	return s.resolver.Resolve(ctx, s.namespace, rootRef, configDefaults, nil)
 }
 

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -713,12 +713,24 @@ func (e *Engine) WebhookHandler() http.Handler {
 		taskID, ok := e.webhooks[path]
 		var assetPath, matchedHook string
 		if !ok {
-			// Prefix match — request is for a static asset belonging to a webhook UI.
-			for hookPath, tid := range e.webhooks {
-				if strings.HasPrefix(path, hookPath+"/") {
+			// No exact match — the request is for a static asset under some
+			// webhook UI. Walk up one path segment at a time doing exact
+			// map lookups, so the most-specific parent hook wins. This
+			// matters when both `/hooks/ai` and `/hooks/ai/openai` are
+			// registered: `/hooks/ai/openai/chat.js` must bind to the
+			// preset, not to the buildin. Exact map lookups (rather than
+			// iterating e.webhooks with strings.HasPrefix) are also
+			// immune to Go's randomised map iteration order.
+			for candidate := path; ; {
+				idx := strings.LastIndex(candidate, "/")
+				if idx <= 0 {
+					break
+				}
+				candidate = candidate[:idx]
+				if tid, found := e.webhooks[candidate]; found {
 					taskID = tid
-					matchedHook = hookPath
-					assetPath = path[len(hookPath)+1:]
+					matchedHook = candidate
+					assetPath = path[len(candidate)+1:]
 					ok = true
 					break
 				}

--- a/pkg/trigger/engine_test.go
+++ b/pkg/trigger/engine_test.go
@@ -417,6 +417,64 @@ func TestEngine_WebhookHandler_AssetUnknownTypeBlocked(t *testing.T) {
 	}
 }
 
+// Regression test for the webhook longest-prefix match. Two tasks are
+// registered at overlapping hook paths: a shallow one at /hooks/ai and a
+// deeper one at /hooks/ai/openai. A request for /hooks/ai/openai/chat.js
+// must resolve against the DEEPER task, not whichever entry Go's
+// randomised map iteration happens to visit first. Without the longest-
+// prefix walk in WebhookHandler, this test would be flaky in exactly the
+// way production was before the fix.
+func TestEngine_WebhookHandler_NestedLongestPrefix(t *testing.T) {
+	dir := t.TempDir()
+	eng, reg := newMinimalEngine(t)
+
+	const shallowCSS = `body{color:red}`
+	const deepCSS = `body{color:blue}`
+
+	shallow := writeUITask(t, dir, "ai", task.TriggerConfig{Webhook: "/hooks/ai"}, map[string]string{
+		"index.html": `<html></html>`,
+		"style.css":  shallowCSS,
+	})
+	_ = reg.Register(shallow)
+	eng.Register(shallow)
+
+	deep := writeUITask(t, dir, "ai-openai", task.TriggerConfig{Webhook: "/hooks/ai/openai"}, map[string]string{
+		"index.html": `<html></html>`,
+		"style.css":  deepCSS,
+	})
+	_ = reg.Register(deep)
+	eng.Register(deep)
+
+	handler := eng.WebhookHandler()
+
+	// Loop the assertion to smoke out any latent map-iteration-order
+	// dependency. 50 iterations is well past the point where a biased
+	// iteration would fail at least once.
+	for i := range 50 {
+		// Deeper path must bind to the deeper task's asset.
+		req := httptest.NewRequest(http.MethodGet, "/hooks/ai/openai/style.css", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("iter %d: /hooks/ai/openai/style.css → %d: %s", i, w.Code, w.Body.String())
+		}
+		if got := w.Body.String(); got != deepCSS {
+			t.Fatalf("iter %d: /hooks/ai/openai/style.css served %q, want deep task's %q", i, got, deepCSS)
+		}
+
+		// Shallow path (no openai segment) must still bind to the shallow task.
+		req = httptest.NewRequest(http.MethodGet, "/hooks/ai/style.css", nil)
+		w = httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("iter %d: /hooks/ai/style.css → %d: %s", i, w.Code, w.Body.String())
+		}
+		if got := w.Body.String(); got != shallowCSS {
+			t.Fatalf("iter %d: /hooks/ai/style.css served %q, want shallow task's %q", i, got, shallowCSS)
+		}
+	}
+}
+
 func TestEngine_WebhookHandler_FormPOST(t *testing.T) {
 	dir := t.TempDir()
 	e := newTestEnv(t)

--- a/pkg/webui/static/dicode.js
+++ b/pkg/webui/static/dicode.js
@@ -219,9 +219,16 @@
                 output.textContent = data.body;
               }
             },
-            onError: function () {
+            onError: function (err) {
               if (btn) { btn.disabled = false; }
-              if (output) { output.textContent = 'Connection error — is dicode running?'; }
+              if (!output) return;
+              // Surface the actual error message. fetch() can reject for
+              // reasons other than "daemon is down" — aborted stream,
+              // decoder error, CORS. Hard-coding "is dicode running?"
+              // sends operators chasing a red herring when the body read
+              // failed mid-transfer.
+              var msg = (err && (err.message || String(err))) || 'unknown error';
+              output.textContent = 'Connection error: ' + msg;
             }
           }).catch(function () {
             if (btn) { btn.disabled = false; }

--- a/pkg/webui/static/dicode.js
+++ b/pkg/webui/static/dicode.js
@@ -15,6 +15,22 @@
  *
  *   Level 3 — Full API: use dicode.execute(params, { onFinish }).
  *     Full control over rendering and error handling.
+ *
+ *     Result shape passed to onFinish(result) and to the returned Promise:
+ *
+ *       {
+ *         runId:       string,   // "X-Run-Id" header from the response
+ *         status:      "success" | "failure",
+ *         contentType: string,   // full Content-Type header
+ *         body:        string,   // always the raw response body
+ *         returnValue: any,      // parsed object for application/json, null otherwise
+ *         parseError:  string | null  // error message if JSON parsing failed
+ *       }
+ *
+ *     Note: prior to the JSON-parse fix, `returnValue` was the raw body
+ *     string for application/json responses. It is now the parsed object,
+ *     or null on parse failure. Callers that need the raw text in all
+ *     cases should read `result.body`.
  */
 (function () {
   'use strict';
@@ -108,13 +124,28 @@
             runId: runId,
             status: status >= 200 && status < 300 ? 'success' : 'failure',
             contentType: contentType,
-            body: body,
-            returnValue: null
+            body: body,           // always the raw response string
+            returnValue: null,    // parsed object for application/json, else null
+            parseError: null      // error message if JSON parsing failed
           };
 
           if (contentType.indexOf('application/json') !== -1) {
-            try { result.returnValue = JSON.parse(body); }
-            catch (e) { result.returnValue = null; }
+            try {
+              result.returnValue = JSON.parse(body);
+            } catch (e) {
+              result.returnValue = null;
+              result.parseError = (e && e.message) || String(e);
+              // Log immediately — callers using the Level-3 Promise API
+              // who forget to check parseError will at least see the
+              // failure in devtools, and it can't be mistaken for a valid
+              // `null` return from a task that legitimately returned null.
+              if (window.console && console.error) {
+                console.error(
+                  'dicode.execute: failed to parse application/json response for run ' +
+                    runId + ': ' + result.parseError,
+                );
+              }
+            }
           }
 
           if (handlers.onFinish) handlers.onFinish(result);
@@ -170,6 +201,15 @@
             onFinish: function (data) {
               if (btn) { btn.disabled = false; }
               if (!output) return;
+
+              // JSON parse failure: don't silently render raw broken
+              // JSON into the output pane — the user has no way to tell
+              // a parse failure from a task that returned `null`.
+              if (data.parseError) {
+                output.textContent =
+                  'Task returned malformed JSON (' + data.parseError + '):\n\n' + data.body;
+                return;
+              }
 
               // Task output.html() → render as HTML (trusted task-author content).
               // Everything else → plain text.

--- a/pkg/webui/static/dicode.js
+++ b/pkg/webui/static/dicode.js
@@ -113,7 +113,8 @@
           };
 
           if (contentType.indexOf('application/json') !== -1) {
-            try { result.returnValue = body; } catch (e) { /* keep raw */ }
+            try { result.returnValue = JSON.parse(body); }
+            catch (e) { result.returnValue = null; }
           }
 
           if (handlers.onFinish) handlers.onFinish(result);

--- a/tasks/buildin/ai-agent/chat.js
+++ b/tasks/buildin/ai-agent/chat.js
@@ -1,0 +1,88 @@
+(function () {
+  'use strict';
+
+  var STORAGE_KEY = "dicode-ai-session";
+  var sessionId = localStorage.getItem(STORAGE_KEY) || "";
+
+  var $messages = document.getElementById("messages");
+  var $form     = document.getElementById("prompt-form");
+  var $prompt   = document.getElementById("prompt");
+  var $send     = document.getElementById("send");
+  var $newChat  = document.getElementById("new-chat");
+
+  function addBubble(role, text) {
+    var el = document.createElement("div");
+    el.className = "bubble " + role;
+    // textContent only — never innerHTML. Model output is untrusted.
+    el.textContent = text;
+    $messages.appendChild(el);
+    el.scrollIntoView({ block: "end", behavior: "smooth" });
+    return el;
+  }
+
+  function clearMessages() {
+    while ($messages.firstChild) {
+      $messages.removeChild($messages.firstChild);
+    }
+  }
+
+  function send(text) {
+    addBubble("user", text);
+    var pending = addBubble("assistant", "…");
+    $send.disabled = true;
+
+    var callParams = { prompt: text };
+    if (sessionId) callParams.session_id = sessionId;
+
+    dicode.execute(callParams).then(function (result) {
+      var payload = result.returnValue;
+      // Defensive: if dicode.js hasn't been fixed yet, returnValue is the
+      // raw JSON string; parse it here as a fallback.
+      if (typeof payload === "string") {
+        try { payload = JSON.parse(payload); } catch (_) { payload = null; }
+      }
+
+      if (result.status !== "success" || !payload) {
+        pending.textContent = "Error: " + (result.body || "unknown error");
+        return;
+      }
+
+      if (!sessionId && payload.session_id) {
+        sessionId = payload.session_id;
+        localStorage.setItem(STORAGE_KEY, sessionId);
+      }
+
+      pending.textContent = payload.reply || "(no reply)";
+    }).catch(function (e) {
+      pending.textContent = "Connection error — is dicode running? (" + e.message + ")";
+    }).then(function () {
+      $send.disabled = false;
+      $prompt.value = "";
+      $prompt.focus();
+    });
+  }
+
+  $form.addEventListener("submit", function (e) {
+    e.preventDefault();
+    var text = $prompt.value.trim();
+    if (!text) return;
+    send(text);
+  });
+
+  $newChat.addEventListener("click", function () {
+    sessionId = "";
+    localStorage.removeItem(STORAGE_KEY);
+    clearMessages();
+    $prompt.focus();
+  });
+
+  // Ctrl/Cmd+Enter to send
+  $prompt.addEventListener("keydown", function (e) {
+    if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+      e.preventDefault();
+      $form.requestSubmit();
+    }
+  });
+
+  $prompt.focus();
+})();

--- a/tasks/buildin/ai-agent/index.html
+++ b/tasks/buildin/ai-agent/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Agent</title>
+  <link rel="stylesheet" href="style.css">
+  <!-- dicode.js is injected by the server and exposes window.dicode -->
+</head>
+<body>
+<div class="chat">
+  <header>
+    <h1>AI Agent</h1>
+    <button id="new-chat" type="button">New chat</button>
+  </header>
+
+  <div id="messages" class="messages" aria-live="polite"></div>
+
+  <form id="prompt-form">
+    <textarea id="prompt" name="prompt" rows="3" placeholder="Message…" required></textarea>
+    <button type="submit" id="send">Send</button>
+  </form>
+</div>
+
+<script>
+  (function () {
+    var STORAGE_KEY = "dicode-ai-session";
+    var sessionId = localStorage.getItem(STORAGE_KEY) || "";
+
+    var $messages = document.getElementById("messages");
+    var $form     = document.getElementById("prompt-form");
+    var $prompt   = document.getElementById("prompt");
+    var $send     = document.getElementById("send");
+    var $newChat  = document.getElementById("new-chat");
+
+    function addBubble(role, text) {
+      var el = document.createElement("div");
+      el.className = "bubble " + role;
+      // textContent only — never innerHTML. Model output is untrusted.
+      el.textContent = text;
+      $messages.appendChild(el);
+      el.scrollIntoView({ block: "end", behavior: "smooth" });
+      return el;
+    }
+
+    function clearMessages() {
+      while ($messages.firstChild) {
+        $messages.removeChild($messages.firstChild);
+      }
+    }
+
+    function send(text) {
+      addBubble("user", text);
+      var pending = addBubble("assistant", "…");
+      $send.disabled = true;
+
+      var callParams = { prompt: text };
+      if (sessionId) callParams.session_id = sessionId;
+
+      dicode.execute(callParams).then(function (result) {
+        var payload = result.returnValue;
+        // Defensive: if dicode.js hasn't been fixed yet, returnValue is the
+        // raw JSON string; parse it here as a fallback.
+        if (typeof payload === "string") {
+          try { payload = JSON.parse(payload); } catch (_) { payload = null; }
+        }
+
+        if (result.status !== "success" || !payload) {
+          pending.textContent = "Error: " + (result.body || "unknown error");
+          return;
+        }
+
+        if (!sessionId && payload.session_id) {
+          sessionId = payload.session_id;
+          localStorage.setItem(STORAGE_KEY, sessionId);
+        }
+
+        pending.textContent = payload.reply || "(no reply)";
+      }).catch(function (e) {
+        pending.textContent = "Connection error — is dicode running? (" + e.message + ")";
+      }).then(function () {
+        $send.disabled = false;
+        $prompt.value = "";
+        $prompt.focus();
+      });
+    }
+
+    $form.addEventListener("submit", function (e) {
+      e.preventDefault();
+      var text = $prompt.value.trim();
+      if (!text) return;
+      send(text);
+    });
+
+    $newChat.addEventListener("click", function () {
+      sessionId = "";
+      localStorage.removeItem(STORAGE_KEY);
+      clearMessages();
+      $prompt.focus();
+    });
+
+    // Ctrl/Cmd+Enter to send
+    $prompt.addEventListener("keydown", function (e) {
+      if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+        e.preventDefault();
+        $form.requestSubmit();
+      }
+    });
+
+    $prompt.focus();
+  })();
+</script>
+</body>
+</html>

--- a/tasks/buildin/ai-agent/index.html
+++ b/tasks/buildin/ai-agent/index.html
@@ -6,6 +6,9 @@
   <title>AI Agent</title>
   <link rel="stylesheet" href="style.css">
   <!-- dicode.js is injected by the server and exposes window.dicode -->
+  <!-- chat.js runs after dicode.js is available (defer keeps load order
+       and keeps it non-blocking). Inline scripts are blocked by CSP. -->
+  <script src="chat.js" defer></script>
 </head>
 <body>
 <div class="chat">
@@ -16,99 +19,14 @@
 
   <div id="messages" class="messages" aria-live="polite"></div>
 
-  <form id="prompt-form">
+  <!-- method="POST" as a zero-JS fallback: if chat.js fails to load or CSP
+       still blocks it, the browser at least POSTs to /hooks/ai and the
+       server runs one turn (the webhook handler accepts form-encoded too).
+       With chat.js working, the submit is intercepted and this is irrelevant. -->
+  <form id="prompt-form" method="POST">
     <textarea id="prompt" name="prompt" rows="3" placeholder="Message…" required></textarea>
     <button type="submit" id="send">Send</button>
   </form>
 </div>
-
-<script>
-  (function () {
-    var STORAGE_KEY = "dicode-ai-session";
-    var sessionId = localStorage.getItem(STORAGE_KEY) || "";
-
-    var $messages = document.getElementById("messages");
-    var $form     = document.getElementById("prompt-form");
-    var $prompt   = document.getElementById("prompt");
-    var $send     = document.getElementById("send");
-    var $newChat  = document.getElementById("new-chat");
-
-    function addBubble(role, text) {
-      var el = document.createElement("div");
-      el.className = "bubble " + role;
-      // textContent only — never innerHTML. Model output is untrusted.
-      el.textContent = text;
-      $messages.appendChild(el);
-      el.scrollIntoView({ block: "end", behavior: "smooth" });
-      return el;
-    }
-
-    function clearMessages() {
-      while ($messages.firstChild) {
-        $messages.removeChild($messages.firstChild);
-      }
-    }
-
-    function send(text) {
-      addBubble("user", text);
-      var pending = addBubble("assistant", "…");
-      $send.disabled = true;
-
-      var callParams = { prompt: text };
-      if (sessionId) callParams.session_id = sessionId;
-
-      dicode.execute(callParams).then(function (result) {
-        var payload = result.returnValue;
-        // Defensive: if dicode.js hasn't been fixed yet, returnValue is the
-        // raw JSON string; parse it here as a fallback.
-        if (typeof payload === "string") {
-          try { payload = JSON.parse(payload); } catch (_) { payload = null; }
-        }
-
-        if (result.status !== "success" || !payload) {
-          pending.textContent = "Error: " + (result.body || "unknown error");
-          return;
-        }
-
-        if (!sessionId && payload.session_id) {
-          sessionId = payload.session_id;
-          localStorage.setItem(STORAGE_KEY, sessionId);
-        }
-
-        pending.textContent = payload.reply || "(no reply)";
-      }).catch(function (e) {
-        pending.textContent = "Connection error — is dicode running? (" + e.message + ")";
-      }).then(function () {
-        $send.disabled = false;
-        $prompt.value = "";
-        $prompt.focus();
-      });
-    }
-
-    $form.addEventListener("submit", function (e) {
-      e.preventDefault();
-      var text = $prompt.value.trim();
-      if (!text) return;
-      send(text);
-    });
-
-    $newChat.addEventListener("click", function () {
-      sessionId = "";
-      localStorage.removeItem(STORAGE_KEY);
-      clearMessages();
-      $prompt.focus();
-    });
-
-    // Ctrl/Cmd+Enter to send
-    $prompt.addEventListener("keydown", function (e) {
-      if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
-        e.preventDefault();
-        $form.requestSubmit();
-      }
-    });
-
-    $prompt.focus();
-  })();
-</script>
 </body>
 </html>

--- a/tasks/buildin/ai-agent/style.css
+++ b/tasks/buildin/ai-agent/style.css
@@ -1,0 +1,121 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #1e1e2e;
+  color: #cdd6f4;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+.chat {
+  background: #181825;
+  border: 1px solid #313244;
+  border-radius: 12px;
+  width: 100%;
+  max-width: 720px;
+  height: calc(100vh - 4rem);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid #313244;
+}
+
+header h1 {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+#new-chat {
+  background: #313244;
+  color: #cdd6f4;
+  border: 1px solid #45475a;
+  border-radius: 6px;
+  padding: .375rem .75rem;
+  font-size: .8125rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background .15s;
+}
+#new-chat:hover { background: #45475a; }
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: .75rem;
+}
+
+.bubble {
+  max-width: 85%;
+  padding: .625rem .875rem;
+  border-radius: 12px;
+  font-size: .9375rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.bubble.user {
+  align-self: flex-end;
+  background: #89b4fa;
+  color: #1e1e2e;
+  border-bottom-right-radius: 2px;
+}
+
+.bubble.assistant {
+  align-self: flex-start;
+  background: #313244;
+  color: #cdd6f4;
+  border-bottom-left-radius: 2px;
+}
+
+#prompt-form {
+  display: flex;
+  gap: .625rem;
+  padding: 1rem 1.25rem;
+  border-top: 1px solid #313244;
+  background: #11111b;
+}
+
+#prompt {
+  flex: 1;
+  background: #313244;
+  border: 1px solid #45475a;
+  border-radius: 8px;
+  color: #cdd6f4;
+  padding: .625rem .75rem;
+  font-size: .9375rem;
+  font-family: inherit;
+  outline: none;
+  resize: none;
+  transition: border-color .15s;
+}
+#prompt:focus { border-color: #89b4fa; }
+
+#send {
+  align-self: flex-end;
+  background: #89b4fa;
+  color: #1e1e2e;
+  border: none;
+  border-radius: 8px;
+  padding: .625rem 1.25rem;
+  font-size: .9375rem;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: opacity .15s;
+}
+#send:hover { opacity: .9; }
+#send:disabled { opacity: .5; cursor: not-allowed; }

--- a/tasks/buildin/ai-agent/task.test.ts
+++ b/tasks/buildin/ai-agent/task.test.ts
@@ -1,21 +1,21 @@
 /**
- * task.test.ts — unit tests for the AI Agent task.
+ * task.test.ts — unit tests for the AI Agent buildin.
  *
- * Uses the dicode task test harness globals (test, params, env, kv, http,
- * assert, runTask). Each test() gets a fresh mock state.
+ * The buildin is generic: no provider defaults. Every test that exercises
+ * the chat path must set model/base_url/api_key_env (just like a sibling
+ * preset task — see tasks/examples/taskset.yaml — would do via overrides).
  *
- * We mock the OpenAI chat completions endpoint so no real API calls are
- * made, and we mock dicode.list_tasks / dicode.run_task to verify the
- * tool-use loop.
+ * Uses the dicode task test harness globals: test, params, env, kv, http,
+ * assert, runTask. Each test() gets a fresh mock state.
  */
 
-// Helper: build a minimal OpenAI chat completion response body.
+// Minimal OpenAI chat completion response body.
 function completion(content: string, tool_calls?: unknown[]) {
   return {
     id: "chatcmpl-test",
     object: "chat.completion",
     created: 0,
-    model: "gpt-4o",
+    model: "llama3.2",
     choices: [
       {
         index: 0,
@@ -27,11 +27,41 @@ function completion(content: string, tool_calls?: unknown[]) {
   };
 }
 
-test("first turn auto-generates a session_id and returns reply", async () => {
+// Shortcut: wire the agent at a local Ollama-like endpoint. No real API key
+// needed — the task uses a placeholder for localhost URLs.
+function useLocal() {
+  params.set("model", "llama3.2");
+  params.set("base_url", "http://localhost:11434/v1");
+  params.set("api_key_env", "OLLAMA_API_KEY");
+}
+
+// Shortcut: wire the agent at OpenAI proper. Needs a real (mocked) key.
+function useOpenAI() {
   env.set("OPENAI_API_KEY", "sk-test");
+  params.set("model", "gpt-4o-mini");
+  params.set("base_url", "https://api.openai.com/v1");
+  params.set("api_key_env", "OPENAI_API_KEY");
+}
+
+test("returns not_configured when no provider params are set", async () => {
+  params.set("prompt", "hello");
+  // intentionally no model / base_url / api_key_env
+
+  const result = await runTask();
+
+  assert.equal(result.error, "not_configured");
+  assert.equal(result.reply, null);
+  assert.ok(result.session_id);
+  // Should list model and base_url as missing at minimum
+  assert.ok(result.missing.includes("model"));
+  assert.ok(result.missing.includes("base_url"));
+});
+
+test("first turn auto-generates a session_id and returns reply", async () => {
+  useLocal();
   params.set("prompt", "hello");
 
-  http.mock("POST", "https://api.openai.com/v1/chat/completions", {
+  http.mock("POST", "http://localhost:11434/v1/chat/completions", {
     status: 200,
     body: completion("hi there"),
   });
@@ -40,15 +70,14 @@ test("first turn auto-generates a session_id and returns reply", async () => {
 
   assert.ok(result.session_id);
   assert.equal(result.reply, "hi there");
-  assert.httpCalled("POST", "https://api.openai.com/v1/chat/completions");
+  assert.httpCalled("POST", "http://localhost:11434/v1/chat/completions");
 });
 
 test("provided session_id is echoed back and history is preserved in kv", async () => {
-  env.set("OPENAI_API_KEY", "sk-test");
+  useLocal();
   params.set("prompt", "second message");
   params.set("session_id", "fixed-session-123");
 
-  // Pre-seed kv with a prior turn so we can verify the task appends to it.
   kv.set("chat:fixed-session-123", {
     messages: [
       { role: "user", content: "first message" },
@@ -58,7 +87,7 @@ test("provided session_id is echoed back and history is preserved in kv", async 
     updated_at: 0,
   });
 
-  http.mock("POST", "https://api.openai.com/v1/chat/completions", {
+  http.mock("POST", "http://localhost:11434/v1/chat/completions", {
     status: 200,
     body: completion("second reply"),
   });
@@ -70,15 +99,11 @@ test("provided session_id is echoed back and history is preserved in kv", async 
 });
 
 test("tool-use loop calls run_task and feeds result back to model", async () => {
-  env.set("OPENAI_API_KEY", "sk-test");
+  useLocal();
   params.set("prompt", "use the hello tool");
 
-  // list_tasks returns one callable task.
-  // (assumes the harness exposes a dicode.mock API; if not, tool list is empty
-  // and this test degrades to asserting a plain reply — still meaningful.)
-
   // First model call → tool_calls. Second → plain reply.
-  http.mockOnce("POST", "https://api.openai.com/v1/chat/completions", {
+  http.mockOnce("POST", "http://localhost:11434/v1/chat/completions", {
     status: 200,
     body: completion("", [
       {
@@ -88,7 +113,7 @@ test("tool-use loop calls run_task and feeds result back to model", async () => 
       },
     ]),
   });
-  http.mockOnce("POST", "https://api.openai.com/v1/chat/completions", {
+  http.mockOnce("POST", "http://localhost:11434/v1/chat/completions", {
     status: 200,
     body: completion("done"),
   });
@@ -98,27 +123,30 @@ test("tool-use loop calls run_task and feeds result back to model", async () => 
   assert.equal(result.reply, "done");
 });
 
-test("throws when api key env var is not set", async () => {
-  // OPENAI_API_KEY intentionally not set
+test("throws when api key env var is not set (hosted provider)", async () => {
+  // Configure openai base_url but do not set OPENAI_API_KEY
   params.set("prompt", "hi");
+  params.set("model", "gpt-4o-mini");
+  params.set("base_url", "https://api.openai.com/v1");
+  params.set("api_key_env", "OPENAI_API_KEY");
+  // intentionally no env.set("OPENAI_API_KEY", ...)
 
   await assert.throws(() => runTask(), /OPENAI_API_KEY not set/);
 });
 
 test("throws when prompt is empty", async () => {
-  env.set("OPENAI_API_KEY", "sk-test");
+  useLocal();
   // prompt intentionally not set
 
   await assert.throws(() => runTask(), /prompt param is required/);
 });
 
 test("compaction fires when history exceeds max_history_tokens", async () => {
-  env.set("OPENAI_API_KEY", "sk-test");
+  useLocal();
   params.set("prompt", "new question");
   params.set("session_id", "compact-test");
   params.set("max_history_tokens", "10"); // tiny budget forces compaction
 
-  // Seed a long history so estimateTokens > 10
   const bigText = "x".repeat(500);
   kv.set("chat:compact-test", {
     messages: [
@@ -134,11 +162,11 @@ test("compaction fires when history exceeds max_history_tokens", async () => {
   });
 
   // First call = compaction summary, second call = the actual response.
-  http.mockOnce("POST", "https://api.openai.com/v1/chat/completions", {
+  http.mockOnce("POST", "http://localhost:11434/v1/chat/completions", {
     status: 200,
     body: completion("- user asked about stuff\n- assistant replied"),
   });
-  http.mockOnce("POST", "https://api.openai.com/v1/chat/completions", {
+  http.mockOnce("POST", "http://localhost:11434/v1/chat/completions", {
     status: 200,
     body: completion("final answer"),
   });
@@ -146,6 +174,18 @@ test("compaction fires when history exceeds max_history_tokens", async () => {
   const result = await runTask();
 
   assert.equal(result.reply, "final answer");
-  // Two chat completion calls: one for compaction, one for the real turn.
+});
+
+test("openai provider round-trip works with real key", async () => {
+  useOpenAI();
+  params.set("prompt", "hello");
+
+  http.mock("POST", "https://api.openai.com/v1/chat/completions", {
+    status: 200,
+    body: completion("hi there"),
+  });
+
+  const result = await runTask();
+  assert.equal(result.reply, "hi there");
   assert.httpCalled("POST", "https://api.openai.com/v1/chat/completions");
 });

--- a/tasks/buildin/ai-agent/task.test.ts
+++ b/tasks/buildin/ai-agent/task.test.ts
@@ -1,0 +1,151 @@
+/**
+ * task.test.ts — unit tests for the AI Agent task.
+ *
+ * Uses the dicode task test harness globals (test, params, env, kv, http,
+ * assert, runTask). Each test() gets a fresh mock state.
+ *
+ * We mock the OpenAI chat completions endpoint so no real API calls are
+ * made, and we mock dicode.list_tasks / dicode.run_task to verify the
+ * tool-use loop.
+ */
+
+// Helper: build a minimal OpenAI chat completion response body.
+function completion(content: string, tool_calls?: unknown[]) {
+  return {
+    id: "chatcmpl-test",
+    object: "chat.completion",
+    created: 0,
+    model: "gpt-4o",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content, tool_calls },
+        finish_reason: tool_calls ? "tool_calls" : "stop",
+      },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+}
+
+test("first turn auto-generates a session_id and returns reply", async () => {
+  env.set("OPENAI_API_KEY", "sk-test");
+  params.set("prompt", "hello");
+
+  http.mock("POST", "https://api.openai.com/v1/chat/completions", {
+    status: 200,
+    body: completion("hi there"),
+  });
+
+  const result = await runTask();
+
+  assert.ok(result.session_id);
+  assert.equal(result.reply, "hi there");
+  assert.httpCalled("POST", "https://api.openai.com/v1/chat/completions");
+});
+
+test("provided session_id is echoed back and history is preserved in kv", async () => {
+  env.set("OPENAI_API_KEY", "sk-test");
+  params.set("prompt", "second message");
+  params.set("session_id", "fixed-session-123");
+
+  // Pre-seed kv with a prior turn so we can verify the task appends to it.
+  kv.set("chat:fixed-session-123", {
+    messages: [
+      { role: "user", content: "first message" },
+      { role: "assistant", content: "first reply" },
+    ],
+    created_at: 0,
+    updated_at: 0,
+  });
+
+  http.mock("POST", "https://api.openai.com/v1/chat/completions", {
+    status: 200,
+    body: completion("second reply"),
+  });
+
+  const result = await runTask();
+
+  assert.equal(result.session_id, "fixed-session-123");
+  assert.equal(result.reply, "second reply");
+});
+
+test("tool-use loop calls run_task and feeds result back to model", async () => {
+  env.set("OPENAI_API_KEY", "sk-test");
+  params.set("prompt", "use the hello tool");
+
+  // list_tasks returns one callable task.
+  // (assumes the harness exposes a dicode.mock API; if not, tool list is empty
+  // and this test degrades to asserting a plain reply — still meaningful.)
+
+  // First model call → tool_calls. Second → plain reply.
+  http.mockOnce("POST", "https://api.openai.com/v1/chat/completions", {
+    status: 200,
+    body: completion("", [
+      {
+        id: "call_1",
+        type: "function",
+        function: { name: "task_hello", arguments: '{"name":"world"}' },
+      },
+    ]),
+  });
+  http.mockOnce("POST", "https://api.openai.com/v1/chat/completions", {
+    status: 200,
+    body: completion("done"),
+  });
+
+  const result = await runTask();
+
+  assert.equal(result.reply, "done");
+});
+
+test("throws when api key env var is not set", async () => {
+  // OPENAI_API_KEY intentionally not set
+  params.set("prompt", "hi");
+
+  await assert.throws(() => runTask(), /OPENAI_API_KEY not set/);
+});
+
+test("throws when prompt is empty", async () => {
+  env.set("OPENAI_API_KEY", "sk-test");
+  // prompt intentionally not set
+
+  await assert.throws(() => runTask(), /prompt param is required/);
+});
+
+test("compaction fires when history exceeds max_history_tokens", async () => {
+  env.set("OPENAI_API_KEY", "sk-test");
+  params.set("prompt", "new question");
+  params.set("session_id", "compact-test");
+  params.set("max_history_tokens", "10"); // tiny budget forces compaction
+
+  // Seed a long history so estimateTokens > 10
+  const bigText = "x".repeat(500);
+  kv.set("chat:compact-test", {
+    messages: [
+      { role: "user", content: bigText },
+      { role: "assistant", content: bigText },
+      { role: "user", content: bigText },
+      { role: "assistant", content: bigText },
+      { role: "user", content: bigText },
+      { role: "assistant", content: bigText },
+    ],
+    created_at: 0,
+    updated_at: 0,
+  });
+
+  // First call = compaction summary, second call = the actual response.
+  http.mockOnce("POST", "https://api.openai.com/v1/chat/completions", {
+    status: 200,
+    body: completion("- user asked about stuff\n- assistant replied"),
+  });
+  http.mockOnce("POST", "https://api.openai.com/v1/chat/completions", {
+    status: 200,
+    body: completion("final answer"),
+  });
+
+  const result = await runTask();
+
+  assert.equal(result.reply, "final answer");
+  // Two chat completion calls: one for compaction, one for the real turn.
+  assert.httpCalled("POST", "https://api.openai.com/v1/chat/completions");
+});

--- a/tasks/buildin/ai-agent/task.test.ts
+++ b/tasks/buildin/ai-agent/task.test.ts
@@ -189,3 +189,50 @@ test("openai provider round-trip works with real key", async () => {
   assert.equal(result.reply, "hi there");
   assert.httpCalled("POST", "https://api.openai.com/v1/chat/completions");
 });
+
+test("self-id filter excludes only the exact task_id, not prefix matches", async () => {
+  // Self-recursion prevention must compare task ids for EXACT equality, not
+  // prefix or substring. Previously used a regex on "/ai-agent(-|$)/" which
+  // would wrongly exclude things like "team/ai-agent-helper". With
+  // dicode.task_id the filter is a simple !== check — this test guards
+  // against regressing back to prefix matching.
+  useLocal();
+  params.set("prompt", "hi");
+
+  dicode.task_id = "buildin/ai-agent";
+  dicode.list_tasks = async () => [
+    { id: "buildin/ai-agent" },       // self — must be excluded
+    { id: "buildin/ai-agent-helper" }, // looks like self, must NOT be excluded
+    { id: "team/ai-agent" },           // matches basename, must NOT be excluded
+    { id: "other/something" },
+  ];
+
+  http.mock("POST", "http://localhost:11434/v1/chat/completions", {
+    status: 200,
+    body: completion("ok"),
+  });
+
+  await runTask();
+
+  // Capture the tools array the agent sent to the model on the last call.
+  const sent = http.lastRequestBody("POST", "http://localhost:11434/v1/chat/completions");
+  const toolNames: string[] = (sent.tools ?? []).map(
+    (t: { function: { name: string } }) => t.function.name,
+  );
+
+  assert.ok(!toolNames.includes("task_buildin_ai_agent"), "self must be excluded");
+  assert.ok(toolNames.includes("task_buildin_ai_agent_helper"), "look-alike sibling must NOT be excluded");
+  assert.ok(toolNames.includes("task_team_ai_agent"), "name collision in a different namespace must NOT be excluded");
+  assert.ok(toolNames.includes("task_other_something"), "unrelated task must remain");
+});
+
+test("refuses to run when dicode.task_id is empty", async () => {
+  // A handshake regression that wipes task_id must not silently disable the
+  // self-recursion guard above. The task throws a descriptive error so
+  // operators see the misconfiguration immediately.
+  useLocal();
+  params.set("prompt", "hi");
+  dicode.task_id = "";
+
+  await assert.throws(() => runTask(), /dicode\.task_id is empty/);
+});

--- a/tasks/buildin/ai-agent/task.ts
+++ b/tasks/buildin/ai-agent/task.ts
@@ -50,6 +50,23 @@ function taskIdToToolName(id: string): string {
   return "task_" + id.replace(/[^a-zA-Z0-9_-]/g, "_");
 }
 
+// Map a dicode param type to a JSON Schema type. Unknown types fall back
+// to "string" so the tool schema is always valid even for param types we
+// don't explicitly recognise.
+function dicodeTypeToJsonSchemaType(t: string | undefined): string {
+  switch (t) {
+    case "number":
+    case "integer":
+    case "boolean":
+      return t;
+    case "array":
+    case "object":
+      return t;
+    default:
+      return "string";
+  }
+}
+
 // Convert dicode param list to a JSON Schema object for an OpenAI tool.
 function paramsToJsonSchema(
   params: TaskSummary["params"],
@@ -58,10 +75,15 @@ function paramsToJsonSchema(
   const required: string[] = [];
   if (params) {
     for (const p of params) {
-      properties[p.name] = {
-        type: p.type === "number" ? "number" : p.type === "boolean" ? "boolean" : "string",
+      const prop: Record<string, unknown> = {
+        type: dicodeTypeToJsonSchemaType(p.type),
         description: p.description ?? "",
       };
+      // JSON Schema requires `items` on array types. We don't have
+      // element-type info from dicode params, so fall back to string —
+      // the agent can coerce at call time.
+      if (prop.type === "array") prop.items = { type: "string" };
+      properties[p.name] = prop;
       if (p.required) required.push(p.name);
     }
   }
@@ -73,21 +95,36 @@ function paramsToJsonSchema(
   };
 }
 
+interface CompactionConfig {
+  maxHistoryTokens: number; // trigger threshold (estimated tokens)
+  keepTurns: number;        // last N turns kept verbatim; older turns get summarized
+  summaryMaxTokens: number; // max_tokens budget for the summary call
+  model: string;            // model used to generate the summary
+}
+
 // Strip summarized turns and replace with a single system "summary" entry.
 async function compactIfNeeded(
   session: SessionState,
-  maxTokens: number,
+  cfg: CompactionConfig,
   client: OpenAI,
-  compactionModel: string,
 ): Promise<void> {
-  if (estimateTokens(session.messages, session.summary) <= maxTokens) return;
+  if (estimateTokens(session.messages, session.summary) <= cfg.maxHistoryTokens) return;
 
-  // Keep the last 4 turns verbatim; summarize everything older.
-  const keep = 4;
-  if (session.messages.length <= keep) return;
+  if (session.messages.length <= cfg.keepTurns) {
+    // Budget already exceeded but we have nothing to compact — a single
+    // turn is larger than the whole history budget. Log so an operator
+    // can diagnose; the next API call will likely fail with a context
+    // length error, which is the right signal to the caller.
+    console.warn(
+      `ai-agent: history over budget (~${estimateTokens(session.messages, session.summary)} tokens > ${cfg.maxHistoryTokens}) ` +
+        `but only ${session.messages.length} turns present; skipping compaction. ` +
+        `Consider raising max_history_tokens or splitting the prompt.`,
+    );
+    return;
+  }
 
-  const older = session.messages.slice(0, -keep);
-  const recent = session.messages.slice(-keep);
+  const older = session.messages.slice(0, -cfg.keepTurns);
+  const recent = session.messages.slice(-cfg.keepTurns);
 
   const transcript = older
     .map((m) => `${m.role.toUpperCase()}: ${m.content}`)
@@ -95,7 +132,7 @@ async function compactIfNeeded(
 
   const previousSummary = session.summary ?? "";
   const summaryResp = await client.chat.completions.create({
-    model: compactionModel,
+    model: cfg.model,
     messages: [
       {
         role: "system",
@@ -110,37 +147,51 @@ async function compactIfNeeded(
           : `Summarize these turns:\n${transcript}`,
       },
     ],
-    max_tokens: 1024,
+    max_tokens: cfg.summaryMaxTokens,
   });
 
   session.summary = summaryResp.choices[0]?.message?.content ?? previousSummary;
   session.messages = recent;
 }
 
-// Resolve the shared skills directory. Computed at runtime via
-// import.meta.url so the task works from any source — relative to the
-// task's own location (<source>/buildin/ai-agent/), ../../skills hops
-// out to <source>/skills. The corresponding FS read permission in
-// task.yaml uses the ${SKILLS_DIR} template var so the sandbox grants
-// access to exactly the same path.
-const SKILLS_DIR = new URL("../../skills/", import.meta.url).pathname;
+// Whitelist for skill file basenames: alphanumerics, dash, underscore, dot
+// (for sub-extensions like "github.push"). No slashes, no leading dot, no
+// empty string, no path traversal sequences.
+const SKILL_NAME_RE = /^[A-Za-z0-9_][A-Za-z0-9_.\-]*$/;
 
-async function loadSkills(names: string[]): Promise<string> {
+async function loadSkills(skillsDir: string, names: string[]): Promise<string> {
   if (names.length === 0) return "";
+  if (!skillsDir) {
+    // Loud: a request for skills with no directory configured is almost
+    // certainly a misconfiguration, not a user expectation. The model
+    // also sees a clear marker so it doesn't hallucinate around it.
+    console.error(
+      `ai-agent: skills requested but skills_dir is empty; nothing loaded: ${names.join(", ")}`,
+    );
+    return `# skills\n(skills_dir is empty; nothing loaded: ${names.join(", ")})`;
+  }
+  const base = skillsDir.endsWith("/") ? skillsDir : skillsDir + "/";
   const chunks: string[] = [];
   for (const name of names) {
-    // Defensive: disallow path traversal. Skill names are filenames only.
-    if (name.includes("/") || name.includes("..") || name.includes("\\")) {
+    // Defensive: skill names must be plain filenames. Reject path separators,
+    // traversal sequences, empty strings, and anything starting with '.'
+    // (blocks `.env`-style probes).
+    if (!SKILL_NAME_RE.test(name) || name.includes("..")) {
+      console.error(`ai-agent: rejected invalid skill name ${JSON.stringify(name)}`);
       chunks.push(`# skill:${name}\n(rejected: invalid skill name)\n`);
       continue;
     }
-    const path = `${SKILLS_DIR}${name}.md`;
+    const path = `${base}${name}.md`;
     try {
       const body = await Deno.readTextFile(path);
       chunks.push(`# skill:${name}\n${body.trim()}`);
     } catch (e) {
+      // Log the full path so operators can distinguish a user typo
+      // (wrong name) from a permissions/path misconfig (wrong skills_dir).
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error(`ai-agent: failed to load skill ${name} from ${path}: ${msg}`);
       chunks.push(
-        `# skill:${name}\n(not loaded: ${e instanceof Error ? e.message : String(e)})`,
+        `# skill:${name}\n(not loaded: ${msg})`,
       );
     }
   }
@@ -156,6 +207,18 @@ interface NotConfiguredResponse {
 }
 
 export default async function main({ params, kv, dicode }: DicodeSdk) {
+  // Self-identity check before anything else. dicode.task_id is populated
+  // from the IPC handshake and is used below to exclude this task from its
+  // own tool list. An empty value would silently turn that filter into a
+  // no-op, letting the agent call itself as a tool and recurse up to
+  // max_tool_iterations deep per turn. Fail loud instead.
+  if (!dicode.task_id) {
+    throw new Error(
+      "ai-agent: dicode.task_id is empty — refusing to run without a self-identity. " +
+        "This indicates the IPC handshake did not populate task_id; check the dicode daemon version.",
+    );
+  }
+
   const prompt = (await params.get("prompt")) ?? "";
   if (!prompt) throw new Error("prompt param is required");
 
@@ -183,16 +246,20 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
   const baseURL = (await params.get("base_url")) ?? "";
   const apiKeyEnv = (await params.get("api_key_env")) ?? "";
   const systemPromptBase = (await params.get("system_prompt")) ?? "";
-  const maxHistoryTokens = Number((await params.get("max_history_tokens")) ?? "80000");
+  const maxHistoryTokens = Number(await params.get("max_history_tokens"));
   const compactionModel = (await params.get("compaction_model")) || model;
+
+  // Tunables — all have task.yaml defaults, no fallbacks here. Fail loud
+  // if the caller sends empty/non-numeric values rather than silently
+  // substituting different magic numbers from two sources.
+  const maxToolIterations = Number(await params.get("max_tool_iterations"));
+  const responseMaxTokens = Number(await params.get("response_max_tokens"));
+  const compactionMaxTokens = Number(await params.get("compaction_max_tokens"));
+  const compactionKeepTurns = Number(await params.get("compaction_keep_turns"));
 
   const missing: string[] = [];
   if (!model) missing.push("model");
   if (!baseURL) missing.push("base_url");
-  // api_key_env is optional for local URLs (handled below), but flag it as
-  // missing for non-local URLs so the caller gets a clear error.
-  const isLocal = /^https?:\/\/(localhost|127\.0\.0\.1)/i.test(baseURL);
-  if (!isLocal && !apiKeyEnv) missing.push("api_key_env");
 
   if (missing.length > 0) {
     const response: NotConfiguredResponse = {
@@ -208,26 +275,41 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
     return response;
   }
 
-  // Local runtimes (Ollama, LM Studio) don't authenticate, but the OpenAI SDK
-  // requires a non-empty apiKey string. If base_url looks local and the env
-  // var isn't set, fall back to a placeholder so the task works out of the
-  // box. Hosted providers still require a real key.
-  let apiKey = apiKeyEnv ? Deno.env.get(apiKeyEnv) : undefined;
-  if (!apiKey) {
-    if (isLocal) {
-      apiKey = "ollama"; // placeholder accepted by Ollama, LM Studio, etc.
-    } else {
-      throw new Error(`${apiKeyEnv} not set in task environment`);
+  // API key resolution is purely param-driven, with no URL sniffing.
+  //
+  //   api_key_env == ""      → provider does not authenticate (Ollama,
+  //                             LM Studio, any OpenAI-compat server that
+  //                             ignores the key). Pass a non-empty literal
+  //                             because the OpenAI SDK rejects "".
+  //   api_key_env == "FOO"   → FOO must be present in the task env, else
+  //                             throw. No fallback, no URL-based exceptions
+  //                             — the caller explicitly asked for a key.
+  let apiKey: string;
+  if (!apiKeyEnv) {
+    apiKey = "unused";
+  } else {
+    const fromEnv = Deno.env.get(apiKeyEnv);
+    if (!fromEnv) {
+      throw new Error(
+        `${apiKeyEnv} not set in task environment (api_key_env="${apiKeyEnv}"). ` +
+          `For providers that don't authenticate, leave api_key_env empty.`,
+      );
     }
+    apiKey = fromEnv;
   }
 
-  // Load skills eagerly and splice them into the system prompt.
-  const skillsBlob = await loadSkills(skillNames);
+  // Load skills eagerly and splice them into the system prompt. The
+  // directory comes from the skills_dir param, whose default is populated
+  // by template expansion at task-load time (${TASK_SET_DIR}/../skills by
+  // default; see docs/task-template-vars.md).
+  const skillsDir = (await params.get("skills_dir")) ?? "";
+  const skillsBlob = await loadSkills(skillsDir, skillNames);
 
   console.log(
-    `ai-agent[${new Date().toISOString()}]: provider → model=${model} ` +
-      `baseURL=${baseURL} (local=${isLocal}) session=${sessionId.slice(0, 8)} ` +
-      `tools=${toolFilter.length || "*"} skills=${skillNames.length}`,
+    `ai-agent[${new Date().toISOString()}]: task=${dicode.task_id} ` +
+      `run=${dicode.run_id.slice(0, 8)} model=${model} baseURL=${baseURL} ` +
+      `session=${sessionId.slice(0, 8)} tools=${toolFilter.length || "*"} ` +
+      `skills=${skillNames.length}`,
   );
 
   const client = new OpenAI({ apiKey, baseURL });
@@ -241,12 +323,17 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
     updated_at: Date.now(),
   };
 
-  // Build tool list from list_tasks(), filtered by toolFilter
+  // Build tool list from list_tasks(), filtered by toolFilter. When no
+  // explicit allowlist is supplied we exclude exactly this task's own id
+  // (sourced from the SDK handshake) to prevent one-step self-recursion.
+  // Presets that reuse this task.ts under a different id (ai-agent-ollama,
+  // ai-agent-openai, …) get the correct exclusion for free because each
+  // run reports its own namespaced task_id.
   const allTasks = ((await dicode.list_tasks()) as TaskSummary[]) ?? [];
-  const selfId = "buildin/ai-agent";
+  const selfID = dicode.task_id;
   const filtered = toolFilter.length
     ? allTasks.filter((t) => toolFilter.includes(t.id))
-    : allTasks.filter((t) => t.id !== selfId);
+    : allTasks.filter((t) => t.id !== selfID);
 
   // Maintain a map from mangled tool name → original task id, so we can
   // resolve tool_calls from the model back to the real task.
@@ -267,82 +354,120 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
   // Append user turn
   session.messages.push({ role: "user", content: prompt });
 
-  const MAX_TOOL_ITERATIONS = 10;
-  let iterations = 0;
+  const compactionCfg: CompactionConfig = {
+    maxHistoryTokens,
+    keepTurns: compactionKeepTurns,
+    summaryMaxTokens: compactionMaxTokens,
+    model: compactionModel,
+  };
 
-  while (iterations++ < MAX_TOOL_ITERATIONS) {
-    await compactIfNeeded(session, maxHistoryTokens, client, compactionModel);
-
-    const parts: string[] = [systemPromptBase];
-    if (skillsBlob) parts.push(skillsBlob);
-    if (session.summary) parts.push(`Prior conversation summary:\n${session.summary}`);
-    const systemPrompt = parts.filter(Boolean).join("\n\n");
-
-    // deno-lint-ignore no-explicit-any
-    const apiMessages: any[] = [
-      { role: "system", content: systemPrompt },
-      ...session.messages.map((m) => {
-        // deno-lint-ignore no-explicit-any
-        const out: any = { role: m.role, content: m.content };
-        if (m.tool_calls) out.tool_calls = m.tool_calls;
-        if (m.tool_call_id) out.tool_call_id = m.tool_call_id;
-        if (m.name) out.name = m.name;
-        return out;
-      }),
-    ];
-
-    const resp = await client.chat.completions.create({
-      model,
-      messages: apiMessages,
-      tools: tools.length ? tools : undefined,
-      max_tokens: 4096,
-    });
-
-    const choice = resp.choices[0]?.message;
-    if (!choice) throw new Error("empty response from model");
-
-    session.messages.push({
-      role: "assistant",
-      content: choice.content ?? "",
-      tool_calls: choice.tool_calls as unknown[] | undefined,
-    });
-
-    if (!choice.tool_calls || choice.tool_calls.length === 0) {
-      break; // terminal assistant turn
-    }
-
-    // Execute each tool call and append the result as a "tool" message
-    for (const call of choice.tool_calls) {
-      if (call.type !== "function") continue;
-      const taskId = toolNameToTaskId[call.function.name];
-      let result: unknown;
-      if (!taskId) {
-        result = { error: `unknown tool: ${call.function.name}` };
-      } else {
-        try {
-          const parsed = call.function.arguments
-            ? JSON.parse(call.function.arguments)
-            : {};
-          // dicode.run_task expects Record<string, string> — stringify non-string values
-          const stringified: Record<string, string> = {};
-          for (const [k, v] of Object.entries(parsed)) {
-            stringified[k] = typeof v === "string" ? v : JSON.stringify(v);
-          }
-          result = await dicode.run_task(taskId, stringified);
-        } catch (e) {
-          result = { error: e instanceof Error ? e.message : String(e) };
-        }
+  // The entire agent loop is wrapped in try/finally so the session — and
+  // all the tool round-trips it successfully completed — is persisted to
+  // KV even if an API call, tool dispatch, or compaction throws. Before
+  // this guard, a single rate-limit blip mid-loop silently discarded the
+  // whole turn plus any prior successful tool calls.
+  try {
+    let iterations = 0;
+    while (iterations++ < maxToolIterations) {
+      // A compaction failure (e.g. the summary model is rate-limited) is
+      // non-fatal: the next request will likely surface a context-length
+      // error from the main model, which is a clearer signal than tearing
+      // down the whole turn here. Log loudly so operators can diagnose.
+      try {
+        await compactIfNeeded(session, compactionCfg, client);
+      } catch (e) {
+        console.error(
+          `ai-agent: compaction failed, continuing uncompacted: ${e instanceof Error ? e.message : String(e)}`,
+        );
       }
-      session.messages.push({
-        role: "tool",
-        tool_call_id: call.id,
-        content: JSON.stringify(result ?? null),
+
+      const parts: string[] = [systemPromptBase];
+      if (skillsBlob) parts.push(skillsBlob);
+      if (session.summary) parts.push(`Prior conversation summary:\n${session.summary}`);
+      const systemPrompt = parts.filter(Boolean).join("\n\n");
+
+      // deno-lint-ignore no-explicit-any
+      const apiMessages: any[] = [
+        { role: "system", content: systemPrompt },
+        ...session.messages.map((m) => {
+          // deno-lint-ignore no-explicit-any
+          const out: any = { role: m.role, content: m.content };
+          if (m.tool_calls) out.tool_calls = m.tool_calls;
+          if (m.tool_call_id) out.tool_call_id = m.tool_call_id;
+          if (m.name) out.name = m.name;
+          return out;
+        }),
+      ];
+
+      const resp = await client.chat.completions.create({
+        model,
+        messages: apiMessages,
+        tools: tools.length ? tools : undefined,
+        max_tokens: responseMaxTokens,
       });
+
+      const choice = resp.choices[0]?.message;
+      if (!choice) throw new Error("empty response from model");
+
+      session.messages.push({
+        role: "assistant",
+        content: choice.content ?? "",
+        tool_calls: choice.tool_calls as unknown[] | undefined,
+      });
+
+      if (!choice.tool_calls || choice.tool_calls.length === 0) {
+        break; // terminal assistant turn
+      }
+
+      // Execute each tool call and append the result as a "tool" message.
+      // Tool failures are caught per-call so one broken tool can't derail
+      // the whole turn, but we also console.error the failure so the
+      // operator sees which tool broke. The model still receives the
+      // error as a structured result and can recover on the next turn.
+      for (const call of choice.tool_calls) {
+        if (call.type !== "function") continue;
+        const taskId = toolNameToTaskId[call.function.name];
+        let result: unknown;
+        if (!taskId) {
+          console.error(`ai-agent: unknown tool '${call.function.name}' requested`);
+          result = { error: `unknown tool: ${call.function.name}` };
+        } else {
+          try {
+            const parsed = call.function.arguments
+              ? JSON.parse(call.function.arguments)
+              : {};
+            // dicode.run_task expects Record<string, string> — stringify non-string values
+            const stringified: Record<string, string> = {};
+            for (const [k, v] of Object.entries(parsed)) {
+              stringified[k] = typeof v === "string" ? v : JSON.stringify(v);
+            }
+            result = await dicode.run_task(taskId, stringified);
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            console.error(`ai-agent: tool call failed task=${taskId} call=${call.id}: ${msg}`);
+            result = { error: msg };
+          }
+        }
+        session.messages.push({
+          role: "tool",
+          tool_call_id: call.id,
+          content: JSON.stringify(result ?? null),
+        });
+      }
+    }
+  } finally {
+    session.updated_at = Date.now();
+    // Best-effort persistence. If KV itself is broken the task was going
+    // to fail anyway, and we don't want the KV error to shadow the real
+    // error from the loop body. Log and move on.
+    try {
+      await kv.set(key, session);
+    } catch (e) {
+      console.error(
+        `ai-agent: failed to persist session ${sessionId.slice(0, 8)} to KV: ${e instanceof Error ? e.message : String(e)}`,
+      );
     }
   }
-
-  session.updated_at = Date.now();
-  await kv.set(key, session);
 
   const last = session.messages[session.messages.length - 1];
   const reply = last?.role === "assistant" ? last.content : "";

--- a/tasks/buildin/ai-agent/task.ts
+++ b/tasks/buildin/ai-agent/task.ts
@@ -154,7 +154,10 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
     }
   }
 
-  console.log(`ai-agent: provider → model=${model} baseURL=${baseURL} (local=${isLocal})`);
+  console.log(
+    `ai-agent[${new Date().toISOString()}]: provider → model=${model} ` +
+      `baseURL=${baseURL} (local=${isLocal}) session=${sessionId.slice(0, 8)}`,
+  );
 
   const client = new OpenAI({ apiKey, baseURL });
 

--- a/tasks/buildin/ai-agent/task.ts
+++ b/tasks/buildin/ai-agent/task.ts
@@ -117,6 +117,41 @@ async function compactIfNeeded(
   session.messages = recent;
 }
 
+// Resolve the repo-shared skills directory. Relative path resolves against
+// the task's own directory (tasks/buildin/ai-agent/), so ../../skills points
+// at tasks/skills/. Keep in sync with permissions.fs in task.yaml.
+const SKILLS_DIR = new URL("../../skills/", import.meta.url).pathname;
+
+async function loadSkills(names: string[]): Promise<string> {
+  if (names.length === 0) return "";
+  const chunks: string[] = [];
+  for (const name of names) {
+    // Defensive: disallow path traversal. Skill names are filenames only.
+    if (name.includes("/") || name.includes("..") || name.includes("\\")) {
+      chunks.push(`# skill:${name}\n(rejected: invalid skill name)\n`);
+      continue;
+    }
+    const path = `${SKILLS_DIR}${name}.md`;
+    try {
+      const body = await Deno.readTextFile(path);
+      chunks.push(`# skill:${name}\n${body.trim()}`);
+    } catch (e) {
+      chunks.push(
+        `# skill:${name}\n(not loaded: ${e instanceof Error ? e.message : String(e)})`,
+      );
+    }
+  }
+  return chunks.join("\n\n");
+}
+
+interface NotConfiguredResponse {
+  session_id: string;
+  reply: null;
+  error: "not_configured";
+  missing: string[];
+  hint: string;
+}
+
 export default async function main({ params, kv, dicode }: DicodeSdk) {
   const prompt = (await params.get("prompt")) ?? "";
   if (!prompt) throw new Error("prompt param is required");
@@ -125,27 +160,56 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
   let sessionId = (await params.get("session_id")) ?? "";
   if (!sessionId) sessionId = crypto.randomUUID();
 
-  const skills = ((await params.get("skills")) ?? "")
+  // Tools: dicode task ids the agent may call. Empty = all except self.
+  const toolFilter = ((await params.get("tools")) ?? "")
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean);
 
-  // Provider config. Defaults match task.yaml, but we repeat them here so
-  // the task is robust to the yaml defaults not being merged (and so anyone
-  // reading task.ts can see the effective defaults in one place).
-  const model = (await params.get("model")) || "llama3.2";
-  const baseURL = (await params.get("base_url")) || "http://localhost:11434/v1";
-  const apiKeyEnv = (await params.get("api_key_env")) || "OLLAMA_API_KEY";
+  // Skills: md file names (without .md) to concatenate into the system prompt.
+  const skillNames = ((await params.get("skills")) ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  // Provider config. No defaults in task.ts — the buildin is generic and
+  // restrictive; provider-specific sibling tasks set defaults via taskset
+  // overrides. If required fields are missing, return a structured
+  // not_configured response instead of throwing.
+  const model = (await params.get("model")) ?? "";
+  const baseURL = (await params.get("base_url")) ?? "";
+  const apiKeyEnv = (await params.get("api_key_env")) ?? "";
   const systemPromptBase = (await params.get("system_prompt")) ?? "";
   const maxHistoryTokens = Number((await params.get("max_history_tokens")) ?? "80000");
   const compactionModel = (await params.get("compaction_model")) || model;
+
+  const missing: string[] = [];
+  if (!model) missing.push("model");
+  if (!baseURL) missing.push("base_url");
+  // api_key_env is optional for local URLs (handled below), but flag it as
+  // missing for non-local URLs so the caller gets a clear error.
+  const isLocal = /^https?:\/\/(localhost|127\.0\.0\.1)/i.test(baseURL);
+  if (!isLocal && !apiKeyEnv) missing.push("api_key_env");
+
+  if (missing.length > 0) {
+    const response: NotConfiguredResponse = {
+      session_id: sessionId,
+      reply: null,
+      error: "not_configured",
+      missing,
+      hint:
+        "This is the generic ai-agent buildin. It has no provider configured. " +
+        "Either pass model/base_url/api_key_env as params, or use a " +
+        "provider-specific sibling task (e.g. examples/ai-agent-ollama).",
+    };
+    return response;
+  }
 
   // Local runtimes (Ollama, LM Studio) don't authenticate, but the OpenAI SDK
   // requires a non-empty apiKey string. If base_url looks local and the env
   // var isn't set, fall back to a placeholder so the task works out of the
   // box. Hosted providers still require a real key.
-  const isLocal = /^https?:\/\/(localhost|127\.0\.0\.1)/i.test(baseURL);
-  let apiKey = Deno.env.get(apiKeyEnv);
+  let apiKey = apiKeyEnv ? Deno.env.get(apiKeyEnv) : undefined;
   if (!apiKey) {
     if (isLocal) {
       apiKey = "ollama"; // placeholder accepted by Ollama, LM Studio, etc.
@@ -154,9 +218,13 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
     }
   }
 
+  // Load skills eagerly and splice them into the system prompt.
+  const skillsBlob = await loadSkills(skillNames);
+
   console.log(
     `ai-agent[${new Date().toISOString()}]: provider → model=${model} ` +
-      `baseURL=${baseURL} (local=${isLocal}) session=${sessionId.slice(0, 8)}`,
+      `baseURL=${baseURL} (local=${isLocal}) session=${sessionId.slice(0, 8)} ` +
+      `tools=${toolFilter.length || "*"} skills=${skillNames.length}`,
   );
 
   const client = new OpenAI({ apiKey, baseURL });
@@ -170,11 +238,11 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
     updated_at: Date.now(),
   };
 
-  // Build tool list from list_tasks(), filtered by skills
+  // Build tool list from list_tasks(), filtered by toolFilter
   const allTasks = ((await dicode.list_tasks()) as TaskSummary[]) ?? [];
   const selfId = "buildin/ai-agent";
-  const filtered = skills.length
-    ? allTasks.filter((t) => skills.includes(t.id))
+  const filtered = toolFilter.length
+    ? allTasks.filter((t) => toolFilter.includes(t.id))
     : allTasks.filter((t) => t.id !== selfId);
 
   // Maintain a map from mangled tool name → original task id, so we can
@@ -202,9 +270,10 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
   while (iterations++ < MAX_TOOL_ITERATIONS) {
     await compactIfNeeded(session, maxHistoryTokens, client, compactionModel);
 
-    const systemPrompt = session.summary
-      ? `${systemPromptBase}\n\nPrior conversation summary:\n${session.summary}`
-      : systemPromptBase;
+    const parts: string[] = [systemPromptBase];
+    if (skillsBlob) parts.push(skillsBlob);
+    if (session.summary) parts.push(`Prior conversation summary:\n${session.summary}`);
+    const systemPrompt = parts.filter(Boolean).join("\n\n");
 
     // deno-lint-ignore no-explicit-any
     const apiMessages: any[] = [

--- a/tasks/buildin/ai-agent/task.ts
+++ b/tasks/buildin/ai-agent/task.ts
@@ -1,0 +1,263 @@
+// AI Agent built-in task.
+//
+// Calls an OpenAI-compatible chat completions API (OpenAI, Anthropic via
+// openai-compat, Ollama, LM Studio, Together, ...) with a tool-use loop that
+// lets the model call other dicode tasks as tools. Conversation history is
+// persisted per session in KV and lazily compacted when it exceeds
+// max_history_tokens.
+//
+// The task bare-returns { session_id, reply } so browser UIs can parse it
+// as application/json. Never call output.html() here — that would override
+// the content type.
+import OpenAI from "npm:openai@4";
+
+type Role = "system" | "user" | "assistant" | "tool";
+
+interface StoredMessage {
+  role: Role;
+  content: string;
+  tool_calls?: unknown[];
+  tool_call_id?: string;
+  name?: string;
+}
+
+interface SessionState {
+  messages: StoredMessage[];
+  summary?: string;
+  created_at: number;
+  updated_at: number;
+}
+
+interface TaskSummary {
+  id: string;
+  name: string;
+  description?: string;
+  params?: Array<{ name: string; type?: string; description?: string; required?: boolean }>;
+}
+
+// Rough token estimate (chars / 4) — good enough for deciding when to compact.
+function estimateTokens(messages: StoredMessage[], summary?: string): number {
+  let chars = summary ? summary.length : 0;
+  for (const m of messages) {
+    chars += m.content.length;
+    if (m.tool_calls) chars += JSON.stringify(m.tool_calls).length;
+  }
+  return Math.ceil(chars / 4);
+}
+
+// Map a task id to a tool name. OpenAI tool names must match /^[a-zA-Z0-9_-]+$/.
+function taskIdToToolName(id: string): string {
+  return "task_" + id.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+// Convert dicode param list to a JSON Schema object for an OpenAI tool.
+function paramsToJsonSchema(
+  params: TaskSummary["params"],
+): Record<string, unknown> {
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+  if (params) {
+    for (const p of params) {
+      properties[p.name] = {
+        type: p.type === "number" ? "number" : p.type === "boolean" ? "boolean" : "string",
+        description: p.description ?? "",
+      };
+      if (p.required) required.push(p.name);
+    }
+  }
+  return {
+    type: "object",
+    properties,
+    required,
+    additionalProperties: false,
+  };
+}
+
+// Strip summarized turns and replace with a single system "summary" entry.
+async function compactIfNeeded(
+  session: SessionState,
+  maxTokens: number,
+  client: OpenAI,
+  compactionModel: string,
+): Promise<void> {
+  if (estimateTokens(session.messages, session.summary) <= maxTokens) return;
+
+  // Keep the last 4 turns verbatim; summarize everything older.
+  const keep = 4;
+  if (session.messages.length <= keep) return;
+
+  const older = session.messages.slice(0, -keep);
+  const recent = session.messages.slice(-keep);
+
+  const transcript = older
+    .map((m) => `${m.role.toUpperCase()}: ${m.content}`)
+    .join("\n");
+
+  const previousSummary = session.summary ?? "";
+  const summaryResp = await client.chat.completions.create({
+    model: compactionModel,
+    messages: [
+      {
+        role: "system",
+        content:
+          "You summarize prior conversation turns into a terse bullet list capturing " +
+          "facts, decisions, and open threads. Output only the summary — no preamble.",
+      },
+      {
+        role: "user",
+        content: previousSummary
+          ? `Previous summary:\n${previousSummary}\n\nNew turns to fold in:\n${transcript}`
+          : `Summarize these turns:\n${transcript}`,
+      },
+    ],
+    max_tokens: 1024,
+  });
+
+  session.summary = summaryResp.choices[0]?.message?.content ?? previousSummary;
+  session.messages = recent;
+}
+
+export default async function main({ params, kv, dicode }: DicodeSdk) {
+  const prompt = (await params.get("prompt")) ?? "";
+  if (!prompt) throw new Error("prompt param is required");
+
+  // Hybrid session id: use provided or auto-generate
+  let sessionId = (await params.get("session_id")) ?? "";
+  if (!sessionId) sessionId = crypto.randomUUID();
+
+  const skills = ((await params.get("skills")) ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const model = (await params.get("model")) ?? "gpt-4o";
+  const baseURL = (await params.get("base_url")) || undefined;
+  const apiKeyEnv = (await params.get("api_key_env")) ?? "OPENAI_API_KEY";
+  const systemPromptBase = (await params.get("system_prompt")) ?? "";
+  const maxHistoryTokens = Number((await params.get("max_history_tokens")) ?? "80000");
+  const compactionModel = (await params.get("compaction_model")) || model;
+
+  const apiKey = Deno.env.get(apiKeyEnv);
+  if (!apiKey) throw new Error(`${apiKeyEnv} not set in task environment`);
+
+  const client = new OpenAI({ apiKey, baseURL });
+
+  // Load or init session state from KV
+  const key = `chat:${sessionId}`;
+  const stored = (await kv.get(key)) as SessionState | null;
+  const session: SessionState = stored ?? {
+    messages: [],
+    created_at: Date.now(),
+    updated_at: Date.now(),
+  };
+
+  // Build tool list from list_tasks(), filtered by skills
+  const allTasks = ((await dicode.list_tasks()) as TaskSummary[]) ?? [];
+  const selfId = "buildin/ai-agent";
+  const filtered = skills.length
+    ? allTasks.filter((t) => skills.includes(t.id))
+    : allTasks.filter((t) => t.id !== selfId);
+
+  // Maintain a map from mangled tool name → original task id, so we can
+  // resolve tool_calls from the model back to the real task.
+  const toolNameToTaskId: Record<string, string> = {};
+  const tools = filtered.map((t) => {
+    const toolName = taskIdToToolName(t.id);
+    toolNameToTaskId[toolName] = t.id;
+    return {
+      type: "function" as const,
+      function: {
+        name: toolName,
+        description: t.description ?? t.name,
+        parameters: paramsToJsonSchema(t.params),
+      },
+    };
+  });
+
+  // Append user turn
+  session.messages.push({ role: "user", content: prompt });
+
+  const MAX_TOOL_ITERATIONS = 10;
+  let iterations = 0;
+
+  while (iterations++ < MAX_TOOL_ITERATIONS) {
+    await compactIfNeeded(session, maxHistoryTokens, client, compactionModel);
+
+    const systemPrompt = session.summary
+      ? `${systemPromptBase}\n\nPrior conversation summary:\n${session.summary}`
+      : systemPromptBase;
+
+    // deno-lint-ignore no-explicit-any
+    const apiMessages: any[] = [
+      { role: "system", content: systemPrompt },
+      ...session.messages.map((m) => {
+        // deno-lint-ignore no-explicit-any
+        const out: any = { role: m.role, content: m.content };
+        if (m.tool_calls) out.tool_calls = m.tool_calls;
+        if (m.tool_call_id) out.tool_call_id = m.tool_call_id;
+        if (m.name) out.name = m.name;
+        return out;
+      }),
+    ];
+
+    const resp = await client.chat.completions.create({
+      model,
+      messages: apiMessages,
+      tools: tools.length ? tools : undefined,
+      max_tokens: 4096,
+    });
+
+    const choice = resp.choices[0]?.message;
+    if (!choice) throw new Error("empty response from model");
+
+    session.messages.push({
+      role: "assistant",
+      content: choice.content ?? "",
+      tool_calls: choice.tool_calls as unknown[] | undefined,
+    });
+
+    if (!choice.tool_calls || choice.tool_calls.length === 0) {
+      break; // terminal assistant turn
+    }
+
+    // Execute each tool call and append the result as a "tool" message
+    for (const call of choice.tool_calls) {
+      if (call.type !== "function") continue;
+      const taskId = toolNameToTaskId[call.function.name];
+      let result: unknown;
+      if (!taskId) {
+        result = { error: `unknown tool: ${call.function.name}` };
+      } else {
+        try {
+          const parsed = call.function.arguments
+            ? JSON.parse(call.function.arguments)
+            : {};
+          // dicode.run_task expects Record<string, string> — stringify non-string values
+          const stringified: Record<string, string> = {};
+          for (const [k, v] of Object.entries(parsed)) {
+            stringified[k] = typeof v === "string" ? v : JSON.stringify(v);
+          }
+          result = await dicode.run_task(taskId, stringified);
+        } catch (e) {
+          result = { error: e instanceof Error ? e.message : String(e) };
+        }
+      }
+      session.messages.push({
+        role: "tool",
+        tool_call_id: call.id,
+        content: JSON.stringify(result ?? null),
+      });
+    }
+  }
+
+  session.updated_at = Date.now();
+  await kv.set(key, session);
+
+  const last = session.messages[session.messages.length - 1];
+  const reply = last?.role === "assistant" ? last.content : "";
+
+  // Bare return → dicode serializes as application/json.
+  // Do NOT call output.html() here; it would override Content-Type and the
+  // browser UI would have to parse HTML instead of JSON.
+  return { session_id: sessionId, reply };
+}

--- a/tasks/buildin/ai-agent/task.ts
+++ b/tasks/buildin/ai-agent/task.ts
@@ -130,9 +130,12 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
     .map((s) => s.trim())
     .filter(Boolean);
 
-  const model = (await params.get("model")) ?? "gpt-4o";
-  const baseURL = (await params.get("base_url")) || undefined;
-  const apiKeyEnv = (await params.get("api_key_env")) ?? "OPENAI_API_KEY";
+  // Provider config. Defaults match task.yaml, but we repeat them here so
+  // the task is robust to the yaml defaults not being merged (and so anyone
+  // reading task.ts can see the effective defaults in one place).
+  const model = (await params.get("model")) || "llama3.2";
+  const baseURL = (await params.get("base_url")) || "http://localhost:11434/v1";
+  const apiKeyEnv = (await params.get("api_key_env")) || "OLLAMA_API_KEY";
   const systemPromptBase = (await params.get("system_prompt")) ?? "";
   const maxHistoryTokens = Number((await params.get("max_history_tokens")) ?? "80000");
   const compactionModel = (await params.get("compaction_model")) || model;
@@ -141,7 +144,7 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
   // requires a non-empty apiKey string. If base_url looks local and the env
   // var isn't set, fall back to a placeholder so the task works out of the
   // box. Hosted providers still require a real key.
-  const isLocal = !!baseURL && /^https?:\/\/(localhost|127\.0\.0\.1)/i.test(baseURL);
+  const isLocal = /^https?:\/\/(localhost|127\.0\.0\.1)/i.test(baseURL);
   let apiKey = Deno.env.get(apiKeyEnv);
   if (!apiKey) {
     if (isLocal) {
@@ -150,6 +153,8 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
       throw new Error(`${apiKeyEnv} not set in task environment`);
     }
   }
+
+  console.log(`ai-agent: provider → model=${model} baseURL=${baseURL} (local=${isLocal})`);
 
   const client = new OpenAI({ apiKey, baseURL });
 

--- a/tasks/buildin/ai-agent/task.ts
+++ b/tasks/buildin/ai-agent/task.ts
@@ -137,8 +137,19 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
   const maxHistoryTokens = Number((await params.get("max_history_tokens")) ?? "80000");
   const compactionModel = (await params.get("compaction_model")) || model;
 
-  const apiKey = Deno.env.get(apiKeyEnv);
-  if (!apiKey) throw new Error(`${apiKeyEnv} not set in task environment`);
+  // Local runtimes (Ollama, LM Studio) don't authenticate, but the OpenAI SDK
+  // requires a non-empty apiKey string. If base_url looks local and the env
+  // var isn't set, fall back to a placeholder so the task works out of the
+  // box. Hosted providers still require a real key.
+  const isLocal = !!baseURL && /^https?:\/\/(localhost|127\.0\.0\.1)/i.test(baseURL);
+  let apiKey = Deno.env.get(apiKeyEnv);
+  if (!apiKey) {
+    if (isLocal) {
+      apiKey = "ollama"; // placeholder accepted by Ollama, LM Studio, etc.
+    } else {
+      throw new Error(`${apiKeyEnv} not set in task environment`);
+    }
+  }
 
   const client = new OpenAI({ apiKey, baseURL });
 

--- a/tasks/buildin/ai-agent/task.ts
+++ b/tasks/buildin/ai-agent/task.ts
@@ -117,9 +117,12 @@ async function compactIfNeeded(
   session.messages = recent;
 }
 
-// Resolve the repo-shared skills directory. Relative path resolves against
-// the task's own directory (tasks/buildin/ai-agent/), so ../../skills points
-// at tasks/skills/. Keep in sync with permissions.fs in task.yaml.
+// Resolve the shared skills directory. Computed at runtime via
+// import.meta.url so the task works from any source — relative to the
+// task's own location (<source>/buildin/ai-agent/), ../../skills hops
+// out to <source>/skills. The corresponding FS read permission in
+// task.yaml uses the ${SKILLS_DIR} template var so the sandbox grants
+// access to exactly the same path.
 const SKILLS_DIR = new URL("../../skills/", import.meta.url).pathname;
 
 async function loadSkills(names: string[]): Promise<string> {

--- a/tasks/buildin/ai-agent/task.ts
+++ b/tasks/buildin/ai-agent/task.ts
@@ -50,6 +50,24 @@ function taskIdToToolName(id: string): string {
   return "task_" + id.replace(/[^a-zA-Z0-9_-]/g, "_");
 }
 
+// Parse a numeric param into a finite positive integer, throwing a clear
+// error on anything else. Every numeric tunable has a task.yaml default,
+// but the runtime's param-merge only applies defaults when the param is
+// absent — a caller passing "" or "garbage" overrides the default and
+// Number() would collapse it to 0 or NaN, silently breaking the agent
+// (a `while (0 < NaN)` loop never runs; a `<= NaN` compaction check never
+// fires). Fail loud so misconfigurations can't masquerade as empty replies
+// or runaway history growth.
+function parsePositiveInt(raw: string | null, name: string): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0 || Math.floor(n) !== n) {
+    throw new Error(
+      `ai-agent: param ${name} must be a positive integer, got ${JSON.stringify(raw)}`,
+    );
+  }
+  return n;
+}
+
 // Map a dicode param type to a JSON Schema type. Unknown types fall back
 // to "string" so the tool schema is always valid even for param types we
 // don't explicitly recognise.
@@ -246,16 +264,20 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
   const baseURL = (await params.get("base_url")) ?? "";
   const apiKeyEnv = (await params.get("api_key_env")) ?? "";
   const systemPromptBase = (await params.get("system_prompt")) ?? "";
-  const maxHistoryTokens = Number(await params.get("max_history_tokens"));
   const compactionModel = (await params.get("compaction_model")) || model;
 
-  // Tunables — all have task.yaml defaults, no fallbacks here. Fail loud
-  // if the caller sends empty/non-numeric values rather than silently
-  // substituting different magic numbers from two sources.
-  const maxToolIterations = Number(await params.get("max_tool_iterations"));
-  const responseMaxTokens = Number(await params.get("response_max_tokens"));
-  const compactionMaxTokens = Number(await params.get("compaction_max_tokens"));
-  const compactionKeepTurns = Number(await params.get("compaction_keep_turns"));
+  // Tunables. Every one has a task.yaml default, but the runtime merges
+  // defaults only when the param was absent — a caller passing an explicit
+  // empty or non-numeric value overrides the default and Number() collapses
+  // it to 0 or NaN, which then silently breaks the loop (e.g.
+  // `while(0 < NaN)` never runs, `estimateTokens <= NaN` never compacts).
+  // Validate explicitly so a bad param surfaces as a loud error instead of
+  // an empty reply or runaway history.
+  const maxHistoryTokens = parsePositiveInt(await params.get("max_history_tokens"), "max_history_tokens");
+  const maxToolIterations = parsePositiveInt(await params.get("max_tool_iterations"), "max_tool_iterations");
+  const responseMaxTokens = parsePositiveInt(await params.get("response_max_tokens"), "response_max_tokens");
+  const compactionMaxTokens = parsePositiveInt(await params.get("compaction_max_tokens"), "compaction_max_tokens");
+  const compactionKeepTurns = parsePositiveInt(await params.get("compaction_keep_turns"), "compaction_keep_turns");
 
   const missing: string[] = [];
   if (!model) missing.push("model");

--- a/tasks/buildin/ai-agent/task.yaml
+++ b/tasks/buildin/ai-agent/task.yaml
@@ -65,16 +65,23 @@ params:
     description: "Model used for compaction summaries. Empty = same as main model."
 
 permissions:
-  # API keys for common providers. Add more via taskset overrides if you run
-  # a provider not listed here (each entry allowlists the env var for reading).
-  # OLLAMA_API_KEY is a dummy: Ollama does not authenticate, but the OpenAI
-  # SDK demands a non-empty api_key string, so the task reads a placeholder.
+  # Env vars the task can read. Includes:
+  # - API keys for common providers (OPENAI_, ANTHROPIC_, OLLAMA_)
+  # - OpenAI SDK internal probes: the npm:openai constructor reads
+  #   OPENAI_ORG_ID, OPENAI_PROJECT_ID, and OPENAI_BASE_URL unconditionally
+  #   at init time regardless of what we pass to new OpenAI({...}). Any of
+  #   these NOT in the allowlist causes Deno to throw NotCapable the moment
+  #   the client is constructed. Not allowlisting them is a harder sandbox,
+  #   but breaks the SDK. Safe: they're read but not written or leaked.
   env:
     - OPENAI_API_KEY
+    - OPENAI_ORG_ID
+    - OPENAI_PROJECT_ID
+    - OPENAI_BASE_URL
     - ANTHROPIC_API_KEY
     - OLLAMA_API_KEY
-  # Network allowlist. Covers the common hosted OpenAI-compatible providers
-  # plus localhost for local runtimes (Ollama, LM Studio, self-hosted gateways).
+  # Network allowlist: hosted providers plus localhost for local runtimes
+  # (Ollama, LM Studio). Deno accepts host:port entries.
   net:
     - api.openai.com
     - api.anthropic.com

--- a/tasks/buildin/ai-agent/task.yaml
+++ b/tasks/buildin/ai-agent/task.yaml
@@ -97,13 +97,13 @@ permissions:
   net: []
 
   # ─── Filesystem ───────────────────────────────────────────────────────────
-  # Read access to the repo's shared skills directory so the task can load
-  # md files referenced by the "skills" param. ${TASK_DIR} is a built-in
-  # template variable expanded at task-load time; for this buildin task it
-  # resolves to tasks/buildin/ai-agent/, and the ../../ hops out to
-  # tasks/skills/. See pkg/task/template.go for the full variable set.
+  # Read access to the source's shared skills directory so the task can load
+  # md files referenced by the "skills" param. ${SKILLS_DIR} is injected by
+  # the source loader and resolves to <source-root>/skills, so this task
+  # works across local, git, and taskset sources without path hacks.
+  # See pkg/task/template.go for the full template variable set.
   fs:
-    - path: "${TASK_DIR}/../../skills"
+    - path: "${SKILLS_DIR}"
       permission: r
 
   # ─── Dicode runtime APIs ──────────────────────────────────────────────────

--- a/tasks/buildin/ai-agent/task.yaml
+++ b/tasks/buildin/ai-agent/task.yaml
@@ -2,24 +2,24 @@ apiVersion: dicode/v1
 kind: Task
 name: "AI Agent"
 description: >
-  Chat with an AI agent that can call other dicode tasks as tools.
-  Persists conversation history keyed by session_id in KV; compacts older
-  turns into a running summary once history exceeds max_history_tokens.
-  Provider is configured via task params (model, base_url, api_key_env);
-  defaults target OpenAI but any OpenAI-compatible endpoint works
-  (Anthropic, Ollama, LM Studio, Together, etc.).
-runtime: deno
+  Generic AI chat agent. Talks to any OpenAI-compatible chat completions
+  endpoint (OpenAI, Anthropic, Ollama, LM Studio, Groq, OpenRouter, Together,
+  …), lets the model call other dicode tasks as TOOLS, and loads markdown
+  SKILLS into the system prompt for domain context.
 
+  This buildin ships locked down: no network, no provider defaults, no
+  provider API keys in env. Everything must be provided by the caller or
+  by a sibling taskset override (see tasks/examples/ai-agent-*). This keeps
+  the buildin generic and safe; provider-specific policy lives with the
+  provider-specific task.
+runtime: deno
 trigger:
   webhook: /hooks/ai
-  # auth: true intentionally omitted — see issue on auth UX for auth-protected
-  # webhook tasks. With auth enabled, unauthenticated GETs to /hooks/ai get
-  # bounced to / → /hooks/webui by the catch-all redirect, making the chat
-  # page effectively inaccessible from a fresh browser. Re-enable once the
-  # auth flow is fixed.
+  # auth: true intentionally omitted — see #96 (auth UX for protected webhook
+  # tasks). Re-enable once the auth flow lands.
 
 params:
-  # Per-call inputs
+  # ─── Per-call inputs ───────────────────────────────────────────────────────
   prompt:
     type: string
     required: true
@@ -27,34 +27,49 @@ params:
   session_id:
     type: string
     default: ""
-    description: "Conversation id. Empty on first turn — agent auto-generates and returns it."
+    description: "Conversation id. Empty = auto-generate and return in response."
+
+  # ─── Tools (were previously called "skills") ───────────────────────────────
+  # Tools are other dicode tasks the model can call via dicode.run_task().
+  # Filter by comma-separated task ids; empty = all permitted tasks except self.
+  tools:
+    type: string
+    default: ""
+    description: "Comma-separated dicode task ids the agent may call as tools. Empty = all permitted tasks except self."
+
+  # ─── Skills (new: md files loaded into the system prompt) ──────────────────
+  # Skills are markdown files providing domain context or instructions that
+  # get eager-loaded into the system prompt. Names match filenames under the
+  # skills directory without .md. E.g. skills="dicode-basics,github" loads
+  # dicode-basics.md and github.md.
   skills:
     type: string
     default: ""
-    description: "Comma-separated task ids the agent may call as tools. Empty = all tasks except self."
+    description: "Comma-separated skill md file names (without .md) to concatenate into the system prompt."
 
-  # Provider config — defaults target a local Ollama install so the task works
-  # out of the box on a dev laptop. Callers (or the taskset file, or per-request
-  # params) can override for hosted providers.
+  # ─── Provider config ───────────────────────────────────────────────────────
+  # No defaults. Caller (taskset override, curl, or dicode.run_task) MUST
+  # supply model + base_url + api_key_env, or the task returns a structured
+  # "not configured" response the UI can act on.
   model:
     type: string
-    default: "llama3.2"
-    description: "Chat model id passed to the OpenAI-compatible API."
+    default: ""
+    description: "Chat model id. REQUIRED — empty = task returns 'not configured'."
   base_url:
     type: string
-    default: "http://localhost:11434/v1"
-    description: "OpenAI-compatible base URL. Empty = default (OpenAI)."
+    default: ""
+    description: "OpenAI-compatible base URL. REQUIRED."
   api_key_env:
     type: string
-    default: "OLLAMA_API_KEY"
-    description: "Name of the env var holding the API key. For Ollama this is a placeholder (the SDK requires a non-empty key but Ollama ignores it)."
+    default: ""
+    description: "Env var holding the API key. Required for hosted providers; ignored for localhost URLs (a placeholder is used)."
   system_prompt:
     type: string
     default: |
       You are a helpful assistant embedded in dicode. You can call other
       dicode tasks as tools. Prefer tools when the user asks for data or
       actions; answer directly when they ask a general question.
-    description: "System prompt prepended to every conversation."
+    description: "System prompt prepended to every conversation. Loaded skills are appended after this."
   max_history_tokens:
     type: number
     default: "80000"
@@ -65,34 +80,33 @@ params:
     description: "Model used for compaction summaries. Empty = same as main model."
 
 permissions:
-  # Env vars the task can read. Includes:
-  # - API keys for common providers (OPENAI_, ANTHROPIC_, OLLAMA_)
-  # - OpenAI SDK internal probes: the npm:openai constructor reads
-  #   OPENAI_ORG_ID, OPENAI_PROJECT_ID, and OPENAI_BASE_URL unconditionally
-  #   at init time regardless of what we pass to new OpenAI({...}). Any of
-  #   these NOT in the allowlist causes Deno to throw NotCapable the moment
-  #   the client is constructed. Not allowlisting them is a harder sandbox,
-  #   but breaks the SDK. Safe: they're read but not written or leaked.
+  # ─── Env ──────────────────────────────────────────────────────────────────
+  # Only the env vars the OpenAI SDK itself probes at construct time. NO
+  # provider API keys here — each provider-specific override task adds its
+  # own (OPENAI_API_KEY, OLLAMA_API_KEY, …).
   env:
-    - OPENAI_API_KEY
     - OPENAI_ORG_ID
     - OPENAI_PROJECT_ID
     - OPENAI_BASE_URL
-    - ANTHROPIC_API_KEY
-    - OLLAMA_API_KEY
-  # Network allowlist: hosted providers plus localhost for local runtimes
-  # (Ollama, LM Studio). Deno accepts host:port entries.
-  net:
-    - api.openai.com
-    - api.anthropic.com
-    - generativelanguage.googleapis.com
-    - localhost:11434     # Ollama default
-    - 127.0.0.1:11434
-    - localhost:1234      # LM Studio default
-    - 127.0.0.1:1234
+    - OPENAI_LOG
+    - DEBUG
+
+  # ─── Network ──────────────────────────────────────────────────────────────
+  # Empty list = deny all. The buildin cannot reach any network. Provider
+  # tasks override to widen. This is the "as restrictive as possible" part.
+  net: []
+
+  # ─── Filesystem ───────────────────────────────────────────────────────────
+  # Read access to the repo's shared skills directory so the task can load
+  # md files referenced by the "skills" param. Relative paths resolve against
+  # the task's own directory, so ../../skills points at tasks/skills.
+  fs:
+    - path: ../../skills
+      permission: r
+
+  # ─── Dicode runtime APIs ──────────────────────────────────────────────────
   dicode:
     list_tasks: true
-    get_config: true
     tasks:
       - "*"
 

--- a/tasks/buildin/ai-agent/task.yaml
+++ b/tasks/buildin/ai-agent/task.yaml
@@ -29,15 +29,16 @@ params:
     default: ""
     description: "Conversation id. Empty = auto-generate and return in response."
 
-  # ─── Tools (were previously called "skills") ───────────────────────────────
+  # ─── Tools ─────────────────────────────────────────────────────────────────
   # Tools are other dicode tasks the model can call via dicode.run_task().
-  # Filter by comma-separated task ids; empty = all permitted tasks except self.
+  # Filter by comma-separated task ids; empty = all permitted tasks except
+  # the ai-agent family.
   tools:
     type: string
     default: ""
-    description: "Comma-separated dicode task ids the agent may call as tools. Empty = all permitted tasks except self."
+    description: "Comma-separated dicode task ids the agent may call as tools. Empty = all permitted tasks except the ai-agent family."
 
-  # ─── Skills (new: md files loaded into the system prompt) ──────────────────
+  # ─── Skills ────────────────────────────────────────────────────────────────
   # Skills are markdown files providing domain context or instructions that
   # get eager-loaded into the system prompt. Names match filenames under the
   # skills directory without .md. E.g. skills="dicode-basics,github" loads
@@ -46,6 +47,16 @@ params:
     type: string
     default: ""
     description: "Comma-separated skill md file names (without .md) to concatenate into the system prompt."
+
+  # Directory the `skills` param resolves against. The default is populated
+  # at task-load time via template expansion: ${TASK_SET_DIR} is the dir of
+  # this source's root taskset.yaml, so `../skills` lands on the shared
+  # skills directory alongside the taskset. Override per-run to point at a
+  # different pool. See docs/task-template-vars.md for the full var list.
+  skills_dir:
+    type: string
+    default: "${TASK_SET_DIR}/../skills"
+    description: "Absolute path to the directory holding skill .md files. Defaults to <task-set>/../skills."
 
   # ─── Provider config ───────────────────────────────────────────────────────
   # No defaults. Caller (taskset override, curl, or dicode.run_task) MUST
@@ -62,7 +73,7 @@ params:
   api_key_env:
     type: string
     default: ""
-    description: "Env var holding the API key. Required for hosted providers; ignored for localhost URLs (a placeholder is used)."
+    description: "Env var holding the API key. Leave empty for providers that do not authenticate — a placeholder is sent (the OpenAI SDK requires a non-empty string). Set to an env-var name to require it at run time."
   system_prompt:
     type: string
     default: |
@@ -78,6 +89,24 @@ params:
     type: string
     default: ""
     description: "Model used for compaction summaries. Empty = same as main model."
+  compaction_keep_turns:
+    type: number
+    default: "4"
+    description: "Number of most-recent turns kept verbatim during compaction; older turns are summarized."
+  compaction_max_tokens:
+    type: number
+    default: "1024"
+    description: "max_tokens budget for the compaction-summary LLM call."
+
+  # ─── Agent-loop tunables ───────────────────────────────────────────────────
+  max_tool_iterations:
+    type: number
+    default: "10"
+    description: "Upper bound on the agent's tool-use loop. Prevents runaway tool-calling."
+  response_max_tokens:
+    type: number
+    default: "4096"
+    description: "max_tokens budget for each chat-completion call."
 
 permissions:
   # ─── Env ──────────────────────────────────────────────────────────────────
@@ -97,13 +126,11 @@ permissions:
   net: []
 
   # ─── Filesystem ───────────────────────────────────────────────────────────
-  # Read access to the source's shared skills directory so the task can load
-  # md files referenced by the "skills" param. ${SKILLS_DIR} is injected by
-  # the source loader and resolves to <source-root>/skills, so this task
-  # works across local, git, and taskset sources without path hacks.
-  # See pkg/task/template.go for the full template variable set.
+  # Read access to the shared skills directory so the task can load md files
+  # referenced by the "skills" param. Mirrors the `skills_dir` param default.
+  # See docs/task-template-vars.md for the available template variables.
   fs:
-    - path: "${SKILLS_DIR}"
+    - path: "${TASK_SET_DIR}/../skills"
       permission: r
 
   # ─── Dicode runtime APIs ──────────────────────────────────────────────────

--- a/tasks/buildin/ai-agent/task.yaml
+++ b/tasks/buildin/ai-agent/task.yaml
@@ -12,7 +12,11 @@ runtime: deno
 
 trigger:
   webhook: /hooks/ai
-  auth: true
+  # auth: true intentionally omitted — see issue on auth UX for auth-protected
+  # webhook tasks. With auth enabled, unauthenticated GETs to /hooks/ai get
+  # bounced to / → /hooks/webui by the catch-all redirect, making the chat
+  # page effectively inaccessible from a fresh browser. Re-enable once the
+  # auth flow is fixed.
 
 params:
   # Per-call inputs

--- a/tasks/buildin/ai-agent/task.yaml
+++ b/tasks/buildin/ai-agent/task.yaml
@@ -1,0 +1,84 @@
+apiVersion: dicode/v1
+kind: Task
+name: "AI Agent"
+description: >
+  Chat with an AI agent that can call other dicode tasks as tools.
+  Persists conversation history keyed by session_id in KV; compacts older
+  turns into a running summary once history exceeds max_history_tokens.
+  Provider is configured via task params (model, base_url, api_key_env);
+  defaults target OpenAI but any OpenAI-compatible endpoint works
+  (Anthropic, Ollama, LM Studio, Together, etc.).
+runtime: deno
+
+trigger:
+  webhook: /hooks/ai
+  auth: true
+
+params:
+  # Per-call inputs
+  prompt:
+    type: string
+    required: true
+    description: "User message to send to the agent."
+  session_id:
+    type: string
+    default: ""
+    description: "Conversation id. Empty on first turn — agent auto-generates and returns it."
+  skills:
+    type: string
+    default: ""
+    description: "Comma-separated task ids the agent may call as tools. Empty = all tasks except self."
+
+  # Provider config — defaults bake the task personality, callers can override per-run
+  model:
+    type: string
+    default: "gpt-4o"
+    description: "Chat model id passed to the OpenAI-compatible API."
+  base_url:
+    type: string
+    default: ""
+    description: "OpenAI-compatible base URL. Empty = default (OpenAI)."
+  api_key_env:
+    type: string
+    default: "OPENAI_API_KEY"
+    description: "Name of the env var holding the API key."
+  system_prompt:
+    type: string
+    default: |
+      You are a helpful assistant embedded in dicode. You can call other
+      dicode tasks as tools. Prefer tools when the user asks for data or
+      actions; answer directly when they ask a general question.
+    description: "System prompt prepended to every conversation."
+  max_history_tokens:
+    type: number
+    default: "80000"
+    description: "Rough token budget for conversation history. Exceeding triggers lazy compaction."
+  compaction_model:
+    type: string
+    default: ""
+    description: "Model used for compaction summaries. Empty = same as main model."
+
+permissions:
+  # API keys for common providers. Add more via taskset overrides if you run
+  # a provider not listed here (each entry allowlists the env var for reading).
+  env:
+    - OPENAI_API_KEY
+    - ANTHROPIC_API_KEY
+  # Network allowlist covers the common OpenAI-compatible providers. If you
+  # point base_url at something else (Ollama, LM Studio, a self-hosted
+  # gateway), override this via taskset to add the host.
+  net:
+    - api.openai.com
+    - api.anthropic.com
+    - generativelanguage.googleapis.com
+  dicode:
+    list_tasks: true
+    get_config: true
+    tasks:
+      - "*"
+
+timeout: 300s
+
+notify:
+  on_success: false
+  on_failure: false

--- a/tasks/buildin/ai-agent/task.yaml
+++ b/tasks/buildin/ai-agent/task.yaml
@@ -33,19 +33,21 @@ params:
     default: ""
     description: "Comma-separated task ids the agent may call as tools. Empty = all tasks except self."
 
-  # Provider config — defaults bake the task personality, callers can override per-run
+  # Provider config — defaults target a local Ollama install so the task works
+  # out of the box on a dev laptop. Callers (or the taskset file, or per-request
+  # params) can override for hosted providers.
   model:
     type: string
-    default: "gpt-4o"
+    default: "llama3.2"
     description: "Chat model id passed to the OpenAI-compatible API."
   base_url:
     type: string
-    default: ""
+    default: "http://localhost:11434/v1"
     description: "OpenAI-compatible base URL. Empty = default (OpenAI)."
   api_key_env:
     type: string
-    default: "OPENAI_API_KEY"
-    description: "Name of the env var holding the API key."
+    default: "OLLAMA_API_KEY"
+    description: "Name of the env var holding the API key. For Ollama this is a placeholder (the SDK requires a non-empty key but Ollama ignores it)."
   system_prompt:
     type: string
     default: |
@@ -65,16 +67,22 @@ params:
 permissions:
   # API keys for common providers. Add more via taskset overrides if you run
   # a provider not listed here (each entry allowlists the env var for reading).
+  # OLLAMA_API_KEY is a dummy: Ollama does not authenticate, but the OpenAI
+  # SDK demands a non-empty api_key string, so the task reads a placeholder.
   env:
     - OPENAI_API_KEY
     - ANTHROPIC_API_KEY
-  # Network allowlist covers the common OpenAI-compatible providers. If you
-  # point base_url at something else (Ollama, LM Studio, a self-hosted
-  # gateway), override this via taskset to add the host.
+    - OLLAMA_API_KEY
+  # Network allowlist. Covers the common hosted OpenAI-compatible providers
+  # plus localhost for local runtimes (Ollama, LM Studio, self-hosted gateways).
   net:
     - api.openai.com
     - api.anthropic.com
     - generativelanguage.googleapis.com
+    - localhost:11434     # Ollama default
+    - 127.0.0.1:11434
+    - localhost:1234      # LM Studio default
+    - 127.0.0.1:1234
   dicode:
     list_tasks: true
     get_config: true

--- a/tasks/buildin/ai-agent/task.yaml
+++ b/tasks/buildin/ai-agent/task.yaml
@@ -98,10 +98,12 @@ permissions:
 
   # ─── Filesystem ───────────────────────────────────────────────────────────
   # Read access to the repo's shared skills directory so the task can load
-  # md files referenced by the "skills" param. Relative paths resolve against
-  # the task's own directory, so ../../skills points at tasks/skills.
+  # md files referenced by the "skills" param. ${TASK_DIR} is a built-in
+  # template variable expanded at task-load time; for this buildin task it
+  # resolves to tasks/buildin/ai-agent/, and the ../../ hops out to
+  # tasks/skills/. See pkg/task/template.go for the full variable set.
   fs:
-    - path: ../../skills
+    - path: "${TASK_DIR}/../../skills"
       permission: r
 
   # ─── Dicode runtime APIs ──────────────────────────────────────────────────

--- a/tasks/buildin/taskset.yaml
+++ b/tasks/buildin/taskset.yaml
@@ -23,3 +23,7 @@ spec:
     temp-cleanup:
       ref:
         path: ./temp-cleanup/task.yaml
+
+    ai-agent:
+      ref:
+        path: ./ai-agent/task.yaml

--- a/tasks/examples/taskset.yaml
+++ b/tasks/examples/taskset.yaml
@@ -56,6 +56,14 @@ spec:
     # differ per provider: param defaults, network allowlist, env allowlist.
     # No code is duplicated; the override layer patches the spec in memory
     # before the runtime spawns.
+    #
+    # ⚠  SECURITY: these presets are UNAUTHENTICATED (trigger.auth is not
+    #    set). Any origin in the browser can POST to /hooks/ai/<provider>
+    #    and spend the configured API budget. This is intentional for the
+    #    local-dev chat UI — the auth-UX blocker is tracked in #96, which
+    #    is a P0 blocker on the alpha release epic (#82). Do NOT expose
+    #    these webhooks on a daemon reachable from untrusted networks
+    #    until auth: true is wired up.
 
     ai-agent-ollama:
       ref:
@@ -71,9 +79,11 @@ spec:
         params:
           model: "llama3.2"
           base_url: "http://localhost:11434/v1"
-          api_key_env: "OLLAMA_API_KEY"
-        env:
-          - OLLAMA_API_KEY
+          # api_key_env deliberately omitted — Ollama does not authenticate.
+          # Inheriting the buildin default ("") tells task.ts to send a
+          # placeholder apiKey (required by the OpenAI SDK). If you run an
+          # authenticated Ollama proxy, override api_key_env here with the
+          # env-var name holding your key.
         net:
           # Ollama only — stays local.
           - localhost:11434

--- a/tasks/examples/taskset.yaml
+++ b/tasks/examples/taskset.yaml
@@ -50,3 +50,70 @@ spec:
     github-push-webhook:
       ref:
         path: ./github-push-webhook/task.yaml
+
+    # ─── AI agent, provider-specific presets ─────────────────────────────────
+    # These reuse the buildin/ai-agent task.ts, overriding only the bits that
+    # differ per provider: param defaults, network allowlist, env allowlist.
+    # No code is duplicated; the override layer patches the spec in memory
+    # before the runtime spawns.
+
+    ai-agent-ollama:
+      ref:
+        path: ../buildin/ai-agent/task.yaml
+      overrides:
+        name: "AI Agent (Ollama)"
+        description: >
+          AI agent preset wired to a local Ollama install. Assumes Ollama is
+          running on 127.0.0.1:11434. Change the model param to any tag you
+          have pulled locally (`ollama list`).
+        trigger:
+          webhook: /hooks/ai/ollama
+        params:
+          model: "llama3.2"
+          base_url: "http://localhost:11434/v1"
+          api_key_env: "OLLAMA_API_KEY"
+        env:
+          - OLLAMA_API_KEY
+        net:
+          # Ollama only — stays local.
+          - localhost:11434
+          - 127.0.0.1:11434
+
+    ai-agent-openai:
+      ref:
+        path: ../buildin/ai-agent/task.yaml
+      overrides:
+        name: "AI Agent (OpenAI)"
+        description: >
+          AI agent preset wired to the OpenAI API. Set OPENAI_API_KEY in
+          your dicode environment or secrets store before using.
+        trigger:
+          webhook: /hooks/ai/openai
+        params:
+          model: "gpt-4o-mini"
+          base_url: "https://api.openai.com/v1"
+          api_key_env: "OPENAI_API_KEY"
+        env:
+          - OPENAI_API_KEY
+        net:
+          - api.openai.com
+
+    ai-agent-groq:
+      ref:
+        path: ../buildin/ai-agent/task.yaml
+      overrides:
+        name: "AI Agent (Groq)"
+        description: >
+          AI agent preset wired to Groq's OpenAI-compatible API. Free tier
+          is generous; grab a key at console.groq.com. Set GROQ_API_KEY in
+          your dicode environment before using.
+        trigger:
+          webhook: /hooks/ai/groq
+        params:
+          model: "llama-3.3-70b-versatile"
+          base_url: "https://api.groq.com/openai/v1"
+          api_key_env: "GROQ_API_KEY"
+        env:
+          - GROQ_API_KEY
+        net:
+          - api.groq.com

--- a/tasks/examples/webhook-dashboard/dashboard.js
+++ b/tasks/examples/webhook-dashboard/dashboard.js
@@ -38,10 +38,15 @@ function refresh() {
         return;
       }
 
-      var info;
-      try { info = JSON.parse(data.returnValue || data.body); } catch (e) {
-        statusEl.textContent = 'Could not parse result';
-        return;
+      // dicode.execute() parses application/json bodies into an object on
+      // data.returnValue. Fall back to parsing data.body for tasks that
+      // return a non-JSON content type but a JSON body anyway.
+      var info = data.returnValue;
+      if (!info) {
+        try { info = JSON.parse(data.body); } catch (e) {
+          statusEl.textContent = 'Could not parse result';
+          return;
+        }
       }
       renderTiles(info);
       statusEl.textContent = 'Last refreshed ' + new Date().toLocaleTimeString();

--- a/tasks/sdk.ts
+++ b/tasks/sdk.ts
@@ -26,6 +26,12 @@ export interface MCP {
 }
 
 export interface Dicode {
+  // Fully-namespaced id of the currently-running task (e.g. "buildin/ai-agent").
+  // Populated from the IPC handshake; lets task code self-identify without
+  // guessing from directory names.
+  task_id: string;
+  // Id of the current run (uuid).
+  run_id: string;
   run_task(taskID: string, params?: Record<string, string>): Promise<unknown>;
   list_tasks(): Promise<unknown[]>;
   get_runs(taskID: string, opts?: { limit?: number }): Promise<unknown[]>;

--- a/tasks/skills/dicode-basics.md
+++ b/tasks/skills/dicode-basics.md
@@ -1,0 +1,43 @@
+---
+name: dicode-basics
+description: Core concepts an agent should know about dicode — tasks, triggers, KV, and the relationship between tasks and the tools it can call.
+---
+
+# dicode basics
+
+dicode is a local task runtime. Users write small TypeScript (or Python, Docker)
+programs called **tasks** that get triggered by webhooks, cron, manual runs, or
+chains from other tasks. You, the agent, are running **inside** a dicode task
+yourself — you can see and call other tasks through `dicode.run_task()`.
+
+## Key concepts
+
+- **Task**: a single program with a `task.yaml` (metadata, triggers, permissions)
+  and a `task.ts` (the code). Tasks are identified by ids like
+  `buildin/ai-agent` or `examples/github-webhook`.
+- **Trigger**: how a task is started — `webhook`, `cron`, `manual`, `chain`, or
+  `daemon`. Each task has exactly one trigger type.
+- **Params**: typed inputs declared in `task.yaml`. Webhook calls, cron
+  invocations, and other tasks pass values for these.
+- **KV**: per-task key-value store. Each task has an isolated namespace; data
+  written by task A is not visible to task B.
+- **Permissions**: every task declares what it's allowed to do (read env vars,
+  hit the network, call other tasks). Denied by default — explicit allowlist.
+
+## How to be a useful agent in this environment
+
+- **Tools are tasks.** When you call a tool, you're running another dicode task
+  with specific params. The tool's "description" and "parameters" come straight
+  from its task.yaml. Read them carefully before calling.
+- **Prefer tools over hand-waving.** If the user asks about data that a
+  configured task can fetch, call the tool. Don't make up results.
+- **Tool results are JSON.** The value returned by `dicode.run_task()` is the
+  other task's `return` value, serialized. If it's empty, the other task
+  probably used `output.html()` or `output.text()` instead of returning —
+  surface that to the user rather than pretending you got data.
+- **Be honest about limits.** You cannot read files, write secrets, or make
+  arbitrary HTTP requests unless a tool lets you. If the user asks for
+  something no tool exposes, say so clearly.
+- **Respect the user's time.** Dicode runs on their laptop. Long tool loops
+  burn local resources. Favor small, accurate answers over chains of
+  exploratory calls.


### PR DESCRIPTION
## Summary

Ships the generic **ai-agent** buildin task (closes #94 v1) plus two supporting framework features that the task needed and that are useful on their own:

1. **Template expansion in task.yaml.** New \`\${VAR}\` resolver in pkg/task covering \`permissions.fs[].path\`, \`trigger.webhook_secret\`, \`permissions.env[].from|secret|value\`. Built-in vars: \`\${TASK_DIR}\`, \`\${HOME}\`, \`\${SOURCE_ROOT}\`, \`\${SKILLS_DIR}\`. Source loaders (local, git, taskset) inject \`SOURCE_ROOT\`; \`SKILLS_DIR\` auto-derives as \`<SOURCE_ROOT>/skills\`. Closes the long-standing \`webhook_secret: "\${FOO}"\` docs/reality gap along the way.

2. **ai-agent buildin task.** Generic OpenAI-compatible chat agent with tool-use loop, per-session KV-backed history, lazy compaction, and markdown-skills loaded into the system prompt. Ships maximally restrictive: \`permissions.net: []\`, no provider env vars, no provider defaults. Provider-specific use is via taskset overrides — three presets included:
   - \`examples/ai-agent-ollama\` → \`/hooks/ai/ollama\`, llama3.2 via localhost:11434
   - \`examples/ai-agent-openai\` → \`/hooks/ai/openai\`, gpt-4o-mini
   - \`examples/ai-agent-groq\` → \`/hooks/ai/groq\`, llama-3.3-70b-versatile
   All three reuse the same \`task.ts\` via taskset \`overrides\` — zero code duplication.

3. **dicode.js JSON parsing bugfix.** \`pkg/webui/static/dicode.js\` assigned the raw body string to \`result.returnValue\` for \`application/json\` responses (the \`try\`/\`catch\` around it was vestigial — \`body\` is always a string, assignment never throws). Now properly \`JSON.parse()\`'d. Also updated the single in-tree consumer in \`examples/webhook-dashboard/dashboard.js\`.

## Notable decisions

- **\`skills\` → \`tools\` rename**, and new \`skills\` param with a different meaning. Matches the Claude Code / agent-ecosystem convention: *tools* are callables, *skills* are markdown context. The previous \`skills\` param was always a tool filter — now it's \`tools\`. The new \`skills\` param loads md files from \`tasks/skills/\` into the system prompt eagerly. Ships a starter \`dicode-basics.md\`.

- **Two-file UI split (CSP).** The chat page uses Level 3 \`dicode.execute()\` rather than the \`<form data-dicode>\` auto-enhance pattern (which replaces \`#output\` per submit and would break append-only bubbles). The JS lives in a separate \`chat.js\` because the webui's CSP blocks inline scripts.

- **No \`auth: true\` on the webhook yet.** Auth-protected webhooks currently bounce through a catch-all redirect to \`/hooks/webui\`, making the chat page unreachable from a fresh browser. Tracked as #96 (P0 blocker on epic #82). Shipping without auth for local dev only — **must not go out in an alpha release** until #96 lands.

- **Env allowlist dance.** The \`npm:openai\` SDK probes a handful of env vars at construct time (\`OPENAI_ORG_ID\`, \`OPENAI_PROJECT_ID\`, \`OPENAI_BASE_URL\`, \`OPENAI_LOG\`, \`DEBUG\`) even when explicit config is passed. Deno's strict \`--allow-env\` throws \`NotCapable\` on any unallowlisted probe, so these are allowlisted in the buildin. No provider API keys are in the buildin — each preset adds its own.

- **Compaction model**: rough chars/4 token estimate, keep-last-4-turns window, summarize older turns via a second completion call, prepend summary to the system prompt on subsequent turns.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` all green
- [x] \`pkg/task/template_test.go\` — 10 unit tests covering builtin-wins-over-env, env fallback, unknown-var preservation, FS/webhook_secret/env-indirection expansion, SOURCE_ROOT passthrough, SKILLS_DIR auto-derivation, explicit-wins-over-auto, full \`LoadDirWithVars\` round-trip
- [x] \`task.yaml\` parse round-trip verified programmatically against the taskset resolver — buildin stays restrictive (empty net, no provider env, empty param defaults) while each preset merges its own net entry + env key + param defaults
- [x] \`pkg/webui/static/dicode.js\` bugfix verified against the existing \`webhook-dashboard\` consumer (updated to handle parsed-object shape with a \`data.body\` fallback)
- [x] Manual smoke test against local Ollama (llama3.2:3b) — chat round-trips, session persists, bubbles render
- [ ] Manual smoke test against the OpenAI / Groq presets (needs keys in your env; I don't have access from the devcontainer)
- [ ] \`deno check\` / \`deno test\` on \`task.ts\` and \`task.test.ts\` (no Deno installed in the devcontainer; the test harness referenced in the tests isn't yet wired up in dicode — same status as \`buildin/webui/task.test.ts\`)
- [ ] Tool-use loop tested with a real multi-step tool scenario (currently only verified via mocked completions)

## Risks / things worth a second look

- The IDE diagnostics flag \`Deno\` as undefined in \`task.ts\` — false positive; the Deno runtime has it as a global and the other buildin tasks all have the same squiggles. Ignore.
- \`resolveRef\` / \`Resolver.SetExtraVars\` is a new mutable field on Resolver. Not thread-safe across concurrent Resolve calls with different sources (taskset Source is the only caller and calls it synchronously before each Resolve). Flagging in case another caller is added later.
- Long model calls (up to 300s timeout) hold the browser's fetch connection open with no streaming. The webui run-log is already WebSocket-broadcast, so a streaming follow-up is a clean additive change — not in this PR.
- History rehydration on page reload is out of scope. Users keep \`session_id\` in localStorage but the DOM is blank after reload; the *model* still has context for the next turn.

## Related

- #94 — ai-agent buildin plan (this is the v1 implementation)
- #96 — auth UX blocker (forces \`auth: true\` off for now)
- #82 — alpha release epic (this PR is a P0 contributor)
- #95 — suspendable tasks (future refactor target: the KV session state becomes a suspend/resume cycle)
- #97 — OpenRouter OAuth broker (the onboarding story for hosted providers, lands separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)