### PR TITLE
feat(oauth): relay broker flow — daemon plumbing, builtins, AAD binding, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1504,6 +1504,18 @@ The relay client authenticates via challenge-response (no passwords, no accounts
 - Asset serving for webhook UIs (CSS, JS, images)
 - dicode.js SDK serving (`/dicode.js`)
 
+### OAuth broker (relay required)
+
+When the relay is enabled, two built-in tasks handle the full OAuth dance for 14+ providers without requiring you to register an app with the provider:
+
+```sh
+dicode run buildin/auth-start provider=slack
+# prints a signed /auth/slack URL — open it in a browser
+# after consent, tokens land in SLACK_ACCESS_TOKEN (and friends)
+```
+
+The relay broker runs the code exchange on its side, ECIES-encrypts the token bundle to your daemon's P-256 public key, and forwards it over the existing WSS tunnel to a reserved `/hooks/oauth-complete` path. Plaintext tokens never cross the JS runtime — decrypt, parse, and secrets-write all happen in Go-process memory. See [docs/oauth.md](docs/oauth.md#broker-flow-relay-required) for the threat model and the full list of supported providers.
+
 ### Self-hosted relay
 
 For high-security environments, run your own relay server instead of using `relay.dicode.app`:
@@ -1586,7 +1598,7 @@ dicode/
 ├── tasks/
 │   ├── buildin/        # built-in tasks (webui, tray, alert, notify, ai-agent)
 │   ├── skills/         # shared markdown "skills" loaded into agent prompts
-│   ├── auth/           # OAuth task (broker mode planned)
+│   ├── auth/           # legacy per-provider OAuth tasks (self-hosted flow)
 │   └── examples/       # 13 example tasks (all runtimes and trigger types)
 ├── docs/               # comprehensive documentation (33 files)
 ├── dicode.yaml         # example config

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -92,8 +92,45 @@ func dispatch(c *ipc.ControlClient, args []string) error {
 			return fmt.Errorf("usage: dicode secrets <list|set|delete> [args...]")
 		}
 		return cmdSecrets(c, args[1:])
+	case "relay":
+		if len(args) < 2 {
+			return fmt.Errorf("usage: dicode relay <trust-broker> --yes")
+		}
+		return cmdRelay(c, args[1:])
 	default:
 		return fmt.Errorf("unknown command %q — run 'dicode' for usage", args[0])
+	}
+}
+
+func cmdRelay(c *ipc.ControlClient, args []string) error {
+	switch args[0] {
+	case "trust-broker":
+		force := false
+		for _, a := range args[1:] {
+			switch a {
+			case "--yes", "-y":
+				force = true
+			default:
+				return fmt.Errorf("unknown flag %q — usage: dicode relay trust-broker --yes", a)
+			}
+		}
+		if !force {
+			fmt.Fprintln(os.Stderr, "This will clear the pinned broker signing key.")
+			fmt.Fprintln(os.Stderr, "The next relay reconnect will trust-on-first-use the broker's current key.")
+			fmt.Fprintln(os.Stderr, "Re-run with --yes to confirm.")
+			return fmt.Errorf("aborted")
+		}
+		resp, err := c.Send(ipc.Request{Method: "cli.relay.trust_broker"})
+		if err != nil {
+			return err
+		}
+		if resp.Error != "" {
+			return fmt.Errorf("%s", resp.Error)
+		}
+		fmt.Println("Broker pubkey pin cleared. Restart the daemon to accept the new broker key.")
+		return nil
+	default:
+		return fmt.Errorf("unknown relay subcommand %q", args[0])
 	}
 }
 

--- a/cmd/dicoded/main.go
+++ b/cmd/dicoded/main.go
@@ -217,9 +217,15 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 			// across runs so auth-start and auth-relay correlate by
 			// session id. The broker speaks HTTPS at the same host as the
 			// WSS relay endpoint.
+			pending := relay.NewPendingSessions()
 			if brokerURL := deriveBrokerBaseURL(cfg.Relay.ServerURL); brokerURL != "" {
-				denoRT.SetOAuthBroker(id, brokerURL, relay.NewPendingSessions())
+				denoRT.SetOAuthBroker(id, brokerURL, pending)
+			} else {
+				log.Warn("relay: could not derive broker base URL from server_url — OAuth broker disabled",
+					zap.String("server_url", cfg.Relay.ServerURL),
+					zap.String("expected_scheme", "wss:// or ws://"))
 			}
+			g.Go(func() error { pending.StartSweep(ctx); return nil })
 			g.Go(func() error { return rc.Run(ctx) })
 		}
 	}

--- a/cmd/dicoded/main.go
+++ b/cmd/dicoded/main.go
@@ -191,7 +191,7 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 			return cm.ChildRSSMB, cm.ChildCPUMs
 		},
 	}
-	ctrlSrv, err := ipc.NewControlServer(socketPath, tokenPath, reg, eng, localSecrets, mp, version, log)
+	ctrlSrv, err := ipc.NewControlServer(socketPath, tokenPath, reg, eng, localSecrets, mp, version, log, database)
 	if err != nil {
 		return fmt.Errorf("build control server: %w", err)
 	}
@@ -209,7 +209,7 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 		if err != nil {
 			log.Warn("relay: identity init failed, relay disabled", zap.Error(err))
 		} else {
-			rc := relay.NewClient(cfg.Relay.ServerURL, id, port, log)
+			rc := relay.NewClient(cfg.Relay.ServerURL, id, port, database, log)
 			srv.SetRelayClient(rc)
 			// Wire the daemon's relay identity into the deno runtime so
 			// the auth-start and auth-relay built-in tasks can drive the
@@ -219,7 +219,7 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 			// WSS relay endpoint.
 			pending := relay.NewPendingSessions()
 			if brokerURL := deriveBrokerBaseURL(cfg.Relay.ServerURL); brokerURL != "" {
-				denoRT.SetOAuthBroker(id, brokerURL, pending)
+				denoRT.SetOAuthBroker(id, brokerURL, pending, rc.BrokerPubkey)
 			} else {
 				log.Warn("relay: could not derive broker base URL from server_url — OAuth broker disabled",
 					zap.String("server_url", cfg.Relay.ServerURL),

--- a/cmd/dicoded/main.go
+++ b/cmd/dicoded/main.go
@@ -132,7 +132,7 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	gateway := ipc.NewGateway()
 
 	// 6. Managed runtimes + trigger engine.
-	managedRuntimes, eng, err := buildRuntimes(ctx, cfg, reg, secretsChain, localSecrets, database, log, gateway)
+	managedRuntimes, eng, denoRT, err := buildRuntimes(ctx, cfg, reg, secretsChain, localSecrets, database, log, gateway)
 	if err != nil {
 		return err
 	}
@@ -211,6 +211,15 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 		} else {
 			rc := relay.NewClient(cfg.Relay.ServerURL, id, port, log)
 			srv.SetRelayClient(rc)
+			// Wire the daemon's relay identity into the deno runtime so
+			// the auth-start and auth-relay built-in tasks can drive the
+			// broker flow via dicode.oauth.*. Pending sessions are shared
+			// across runs so auth-start and auth-relay correlate by
+			// session id. The broker speaks HTTPS at the same host as the
+			// WSS relay endpoint.
+			if brokerURL := deriveBrokerBaseURL(cfg.Relay.ServerURL); brokerURL != "" {
+				denoRT.SetOAuthBroker(id, brokerURL, relay.NewPendingSessions())
+			}
 			g.Go(func() error { return rc.Run(ctx) })
 		}
 	}
@@ -227,10 +236,10 @@ func buildRuntimes(
 	database db.DB,
 	log *zap.Logger,
 	gateway *ipc.Gateway,
-) ([]pkgruntime.ManagedRuntime, *trigger.Engine, error) {
+) ([]pkgruntime.ManagedRuntime, *trigger.Engine, *denoruntime.Runtime, error) {
 	denoRT, err := denoruntime.New(reg, secretsChain, database, log)
 	if err != nil {
-		return nil, nil, fmt.Errorf("init deno runtime: %w", err)
+		return nil, nil, nil, fmt.Errorf("init deno runtime: %w", err)
 	}
 	eng := trigger.New(reg, denoRT, log)
 	eng.SetDB(database)
@@ -317,7 +326,21 @@ func buildRuntimes(
 		}
 	}
 
-	return managed, eng, nil
+	return managed, eng, denoRT, nil
+}
+
+// deriveBrokerBaseURL converts a relay WSS URL (e.g. wss://relay.dicode.app)
+// into the matching HTTPS broker base URL. Returns empty if the input scheme
+// is not ws/wss.
+func deriveBrokerBaseURL(wsURL string) string {
+	switch {
+	case strings.HasPrefix(wsURL, "wss://"):
+		return "https://" + strings.TrimPrefix(wsURL, "wss://")
+	case strings.HasPrefix(wsURL, "ws://"):
+		return "http://" + strings.TrimPrefix(wsURL, "ws://")
+	default:
+		return ""
+	}
 }
 
 func buildSecretsChain(cfg *config.Config, dataDir string, database db.DB, log *zap.Logger) (secrets.Chain, secrets.Manager) {

--- a/docs/followups/oauth-relay-rotation.md
+++ b/docs/followups/oauth-relay-rotation.md
@@ -1,0 +1,94 @@
+# Follow-up: relay identity rotation CLI
+
+**Status:** work complete on branch `feat/oauth-relay-rotation`, deferred
+from the main OAuth broker PR (`feat/oauth-relay-client`) so the main PR
+stays focused on the broker flow itself.
+
+**Open this as a GitHub issue and link the follow-up branch.**
+
+## Background
+
+The daemon's relay identity is a long-lived ECDSA P-256 keypair stored in
+the local SQLite KV at `relay.private_key`. The derived UUID
+(`hex(sha256(uncompressed_pubkey))`) becomes the stable prefix for every
+`https://relay.dicode.app/u/<uuid>/hooks/...` URL the user has ever
+shared, and secures both the WSS handshake and the signed
+`/auth/:provider` broker requests.
+
+Up to this PR there is no way to rotate that key. If a user suspects
+compromise — e.g. laptop stolen, private key leaked by a misconfigured
+backup — the only path is to delete the KV row manually, which silently
+invalidates every shared webhook URL without operator awareness.
+
+## What the follow-up branch contains
+
+Branch: [`feat/oauth-relay-rotation`](../../../../tree/feat/oauth-relay-rotation)
+
+- `pkg/relay/keys.go` — public `RotateIdentity(ctx, db)` function that
+  delegates to the existing `generateAndStore` path (which already uses
+  `INSERT OR REPLACE`).
+- `pkg/relay/keys_test.go` — `TestRotateIdentity` verifying the UUID
+  changes and the new key persists across reloads.
+- `pkg/relay/oauth_pending.go` — new `Clear()` method on
+  `PendingSessions`. Rotation flushes in-flight flows because any
+  arriving delivery was encrypted to the now-retired public key.
+- `pkg/ipc/control.go` — new `RelayIdentityRotator` callback type,
+  new `SetRelayIdentityRotator` setter on `ControlServer`, new
+  `RelayRotateResult` response struct, new `handleRelayRotate` handler,
+  and a dispatch case for `cli.relay.rotate_identity`.
+- `pkg/ipc/control_test.go` — `TestControl_RelayRotate_NotEnabled` and
+  `TestControl_RelayRotate_InvokesRotator`.
+- `cmd/dicoded/main.go` — inside the `if cfg.Relay.Enabled` block,
+  wires a closure that calls `relay.RotateIdentity` and
+  `PendingSessions.Clear` on demand.
+- `cmd/dicode/main.go` — new `relay rotate-identity` subcommand behind
+  a `--yes` confirmation gate. Updates the `usage()` help text.
+
+All tests on the branch pass.
+
+## Known limitation
+
+The running relay WSS client keeps using the old in-memory
+`*relay.Identity` pointer until the daemon restarts. The callback
+updates the database and invalidates pending OAuth flows, but it does
+not atomically swap the in-memory identity the already-dialed WSS
+connection holds.
+
+The CLI surfaces this as a warning in `RelayRotateResult.Warning`
+("Restart the daemon to activate the new identity on the WSS relay
+connection"), which is honest but suboptimal. A proper fix requires:
+
+1. A mutex on `relay.Client.identity` (currently an unprotected
+   pointer field).
+2. A new `Client.ReplaceIdentity(*Identity)` method that swaps the
+   pointer under the mutex and cancels the current `runOnce` loop so
+   the reconnect happens under the new identity.
+3. The relay server's in-memory registry will see the old UUID go away
+   (connection dropped) and the new UUID come up on the reconnect.
+4. Any pending HTTP requests waiting on a `forward(oldUUID, ...)` call
+   should be failed fast rather than left hanging.
+
+That's a ~50-line change in `pkg/relay/client.go` plus a concurrency
+test. It was left out of the follow-up branch to keep the rotation work
+reviewable on its own.
+
+## What needs to happen to merge
+
+1. Open a GitHub issue pointing at this doc and the
+   `feat/oauth-relay-rotation` branch.
+2. Decide whether to ship the "documented caveat + restart required"
+   version first (small) or block on the hot-swap fix (larger).
+3. If shipping the caveat version: review the branch as-is, merge.
+4. If blocking on hot-swap: add the `Client.ReplaceIdentity` plumbing
+   on the same branch before review.
+
+## Threat-model recap
+
+The reviewer who flagged this gap (see the round-1 design review
+discussion) specifically said rotation is *out of scope for the broker
+PR but must exist*. The concern is that exposing any key-touching
+primitive to task code — even the narrow `dicode.oauth.build_auth_url`
+and `dicode.oauth.store_token` primitives that ship in the main PR —
+makes the non-rotatable nature of the identity more load-bearing than
+it was before. Adding rotation closes the blast radius: if a leak is
+suspected, `dicode relay rotate-identity --yes` is the recovery path.

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -2,9 +2,122 @@
 
 dicode ships a built-in OAuth 2.0 system that handles the full authorization flow for 15 providers out of the box. Once authorized, tokens are stored as secrets and automatically refreshed — your tasks just read them from the environment.
 
+Two flows are supported. Pick the one that matches your deployment:
+
+| Flow | When to use | Requires |
+|---|---|---|
+| **Broker flow** (`buildin/auth-start`) | Default when the daemon is connected to a dicode relay. Zero OAuth app registration. | `relay.enabled: true` in `dicode.yaml` |
+| **Local flow** (`auth/<provider>-oauth` tasks) | Self-hosted deployments, air-gapped installs, or when you want to use your own OAuth app | You register the OAuth app with the provider and set `<PROVIDER>_CLIENT_ID` / `_CLIENT_SECRET` secrets |
+
+The rest of this document covers both. The broker flow is the simpler of the two and is the recommended default for developer machines.
+
 ---
 
-## How it works
+## Broker flow (relay required)
+
+When the relay client is enabled in `dicode.yaml`, two built-in tasks handle the OAuth dance end-to-end. You do not register an app with the provider — the relay operator has already done that for 14+ providers.
+
+### 1. Start the flow
+
+```sh
+dicode run buildin/auth-start provider=slack
+```
+
+The task prints a signed `/auth/slack` URL. Open it in a browser and complete the provider's consent screen. The URL is valid for about a minute and bound to your daemon's relay identity — no one else can complete the flow on your behalf.
+
+Optional scope override:
+
+```sh
+dicode run buildin/auth-start provider=slack scope="channels:read chat:write"
+```
+
+### 2. Wait for the token delivery
+
+The relay broker exchanges the authorization code with the provider, ECIES-encrypts the token bundle to your daemon's long-lived P-256 public key, and forwards the encrypted envelope over the existing WSS tunnel to `/hooks/oauth-complete`. The `buildin/auth-relay` built-in receives it, asks the daemon to decrypt via `dicode.oauth.store_token`, and writes the result to secrets.
+
+Plaintext tokens never cross the JS runtime boundary — decrypt, parse, and `secrets.Set` all happen in Go-process memory, so a careless `console.log(input)` in a downstream task cannot leak credentials.
+
+### 3. Consume the token
+
+After delivery, the following secrets are populated under a naming convention derived from the provider:
+
+| Secret | Meaning |
+|---|---|
+| `<PROVIDER>_ACCESS_TOKEN` | Access token. Always present. |
+| `<PROVIDER>_REFRESH_TOKEN` | Refresh token, if the provider returned one. |
+| `<PROVIDER>_EXPIRES_AT` | RFC3339 expiry timestamp, if the provider returned `expires_in`. |
+| `<PROVIDER>_SCOPE` | Granted scopes, if the provider returned a scope string. |
+| `<PROVIDER>_TOKEN_TYPE` | Token type (`Bearer`, `bot`, etc.), if provided. |
+
+`<PROVIDER>` is the provider key upper-cased (`SLACK`, `GITHUB`, `GOOGLE`, …).
+
+Inject the token into your task like any other secret:
+
+```yaml
+# tasks/my-slack-bot/task.yaml
+permissions:
+  env:
+    - name: SLACK_TOKEN
+      secret: SLACK_ACCESS_TOKEN
+```
+
+```ts
+// tasks/my-slack-bot/task.ts
+const token = Deno.env.get("SLACK_TOKEN")!;
+const res = await fetch("https://slack.com/api/auth.test", {
+  headers: { Authorization: `Bearer ${token}` },
+});
+```
+
+### Security model
+
+- **ECDSA-signed initiation** — the `/auth/:provider` URL is signed by the daemon's P-256 identity key. The broker verifies the signature against the pubkey it knows for that UUID (from the live WSS registry) before starting the flow.
+- **PKCE binding in the signed payload** — the broker's own challenge is cryptographically bound to the daemon that initiated the flow, preventing challenge-swap hijacks.
+- **ECIES token delivery** — tokens are encrypted to the daemon's public key before leaving the broker process. Even a compromised relay operator or CDN cannot read them.
+- **Type-as-AAD domain separation** — the envelope's message-type tag is bound into AES-GCM's authenticated data. A future ciphertext that reuses this same ECIES scheme under a different type label cannot be coaxed through the daemon's decrypt path.
+- **Single-use pending sessions** — each `build_auth_url` call creates a session id that the daemon tracks and consumes on delivery. Unknown or expired sessions are rejected outright, which closes the chosen-salt oracle against the identity key.
+- **Reserved delivery path** — the trigger engine refuses to bind `/hooks/oauth-complete` to any task other than `buildin/auth-relay`, which keeps a user task from accidentally (or maliciously) shadowing the delivery sink.
+- **Audit log** — every successful delivery emits a structured metadata-only log entry (task, run, provider, session id, secret names written) so operators can trace incidents without the token ever reaching an observability pipeline.
+
+### Task-level API
+
+Two IPC primitives back the built-ins. You almost never call them directly — use `dicode run buildin/auth-start` and the built-in webhook task — but they are available to any task that declares the matching permission:
+
+```yaml
+permissions:
+  dicode:
+    oauth_init:  true   # grants dicode.oauth.build_auth_url
+    oauth_store: true   # grants dicode.oauth.store_token
+```
+
+```ts
+// build_auth_url: create a signed /auth/:provider URL
+const { url, session_id } = await dicode.oauth.build_auth_url("slack", "channels:read");
+
+// store_token: consume an incoming delivery envelope, decrypt in Go,
+//              and write credentials to the secrets store.
+const result = await dicode.oauth.store_token(input);
+// result.secrets is the list of secret names written; plaintext stays in Go.
+```
+
+Both primitives are inert on daemons where `relay.enabled: false`, so the built-ins degrade cleanly when the relay is not configured.
+
+### Failure modes
+
+| Symptom | Cause |
+|---|---|
+| `oauth broker not configured on this daemon` | `relay.enabled: false`, or `BASE_URL` could not be derived from `relay.server_url`. |
+| `unknown or expired session` | More than ~6 minutes elapsed between `build_auth_url` and the browser completing the flow; retry. |
+| `decrypt failed` | Daemon restart between `build_auth_url` and the delivery (pending session was in memory), or the daemon's relay identity was rotated mid-flow. |
+| `daemon not connected` | The WSS tunnel was not open when the browser hit `/auth/:provider`. Start the daemon first, wait for the `relay connected` log line, then run `auth-start`. |
+
+---
+
+## Local flow (self-hosted, no broker)
+
+If you run your own dicode instance without the relay — or you want to use your own OAuth app for a specific provider — the original local-task flow is still fully supported. Each provider is a **webhook task** that implements the OAuth flow end-to-end on your daemon.
+
+### How it works
 
 Each provider is a **webhook task** that implements the OAuth flow:
 

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -106,6 +106,27 @@ client.
 
 ---
 
+## OAuth broker
+
+When connected to a relay that exposes the OAuth broker (the default at
+`relay.dicode.app`), the daemon gains two built-in tasks that perform the
+authorization flow without any provider-side app registration:
+
+- `buildin/auth-start` — generates a signed `/auth/:provider` URL via
+  `dicode.oauth.build_auth_url` and prints it for the user to open.
+- `buildin/auth-relay` — receives the encrypted token delivery on the
+  reserved `/hooks/oauth-complete` path and writes the resulting
+  credentials straight into secrets via `dicode.oauth.store_token`.
+
+Plaintext tokens never reach task code: decrypt, parse, and `secrets.Set`
+all happen in Go-process memory. The full flow, security model, and
+failure modes are documented in [oauth.md](./oauth.md).
+
+If the relay is disabled, the broker primitives return "not configured"
+and you should use the local OAuth flow instead (see the same doc).
+
+---
+
 ## Self-hosting the relay server
 
 The relay server is included in the dicode repository (`pkg/relay/server.go`).

--- a/docs/testing/oauth-integration-manual.md
+++ b/docs/testing/oauth-integration-manual.md
@@ -1,0 +1,315 @@
+# OAuth Broker Integration Test — Manual Runbook
+
+End-to-end test of the relay broker OAuth flow between a local
+`dicode-relay` (TypeScript) and `dicoded` (Go). Exercises the full
+chain: WSS handshake → `build_auth_url` → browser consent → Grant
+callback → ECIES encrypt + broker sign → WSS delivery → daemon
+decrypt + verify + `store_token` → secrets written.
+
+---
+
+## Prerequisites
+
+```
+# Both repos checked out side by side
+/workspaces/dicode-relay/    # feat/oauth-aad-domain-sep branch
+/workspaces/dicode-core/     # feat/oauth-relay-client branch
+
+# Node.js 22+, Go 1.25+, Deno (auto-installed by dicode on first run)
+
+# A Slack OAuth app (or any provider — Slack is PKCE-only, simplest)
+# Create at https://api.slack.com/apps → From Scratch
+# OAuth redirect URL: http://localhost:5553/connect/slack/callback
+# Bot Token Scopes: channels:read (or whatever you want)
+# Copy the Client ID
+```
+
+---
+
+## Step 1: Start the relay server
+
+```bash
+cd /workspaces/dicode-relay
+
+# Create a minimal .env for local dev
+cat > .env <<EOF
+PORT=5553
+BASE_URL=http://localhost:5553
+SLACK_CLIENT_ID=<your-slack-client-id>
+EOF
+
+# Start the relay (auto-generates broker signing key on first run)
+node --env-file=.env dist/index.js
+# Or if not built yet:
+npm run build && node --env-file=.env dist/index.js
+# Or for dev mode with auto-reload:
+SLACK_CLIENT_ID=<id> npm run dev
+```
+
+**Expected output:**
+
+```
+broker: generated signing key at /workspaces/dicode-relay/broker-signing-key.pem
+dicode-relay listening on port 5553
+Base URL: http://localhost:5553
+```
+
+**Verify:** `curl http://localhost:5553/health` → `{"ok":true}`
+
+---
+
+## Step 2: Build and start the daemon
+
+```bash
+cd /workspaces/dicode-core
+
+# Build
+make build
+
+# Ensure dicode.yaml points at the local relay
+# (should already be set from the existing config)
+grep -A2 'relay:' dicode.yaml
+# relay:
+#   enabled: true
+#   server_url: ws://localhost:5553
+
+# Start the daemon
+./dicoded
+```
+
+**Expected output (look for these lines):**
+
+```
+{"level":"info","msg":"relay connected","url":"http://localhost:5553/u/<your-uuid>/hooks/"}
+{"level":"info","msg":"relay: pinned broker signing key (trust-on-first-use)","pubkey":"MFkwEwYH…"}
+```
+
+The first line confirms the WSS tunnel is up. The second confirms
+TOFU pinning of the broker's signing key.
+
+**Note your UUID** from the `url` field — you'll need it later.
+
+---
+
+## Step 3: Start the OAuth flow
+
+In a **separate terminal**:
+
+```bash
+cd /workspaces/dicode-core
+
+# Trigger the auth-start builtin task
+./dicode run buildin/auth-start provider=slack
+```
+
+**Expected output:**
+
+```
+OAuth flow started for slack.
+
+Open this URL in a browser to authorize:
+
+  http://localhost:5553/auth/slack?session=<uuid>&challenge=<b64>&relay_uuid=<hex>&sig=<b64>&timestamp=<ts>
+
+Session: <session-uuid>
+```
+
+---
+
+## Step 4: Complete the OAuth flow in a browser
+
+1. Copy the URL from step 3 and open it in a browser.
+2. The relay broker validates the daemon's ECDSA signature.
+3. Browser redirects to Slack's OAuth consent page.
+4. Approve the app.
+5. Slack redirects back to `http://localhost:5553/connect/slack/callback?code=...`
+6. Grant exchanges the code for a token.
+7. The relay broker:
+   - ECIES-encrypts the token to the daemon's pubkey
+   - Signs the envelope with its broker signing key
+   - Forwards via the WSS tunnel to `/hooks/oauth-complete`
+8. Browser shows: "Authorization complete. You may close this tab."
+
+---
+
+## Step 5: Verify the token landed
+
+```bash
+# Check secrets
+./dicode secrets list | grep SLACK
+```
+
+**Expected output:**
+
+```
+SLACK_ACCESS_TOKEN
+SLACK_SCOPE
+SLACK_TOKEN_TYPE
+```
+
+(Slack doesn't return `refresh_token` or `expires_in` for bot tokens,
+so only these three appear.)
+
+```bash
+# Verify the access token works
+./dicode secrets list   # just to see the names
+
+# Check the daemon log for the audit entry
+grep "oauth token delivered" ~/.dicode/daemon.log
+```
+
+**Expected log entry:**
+
+```json
+{"level":"info","msg":"oauth token delivered","task":"buildin/auth-relay","run":"<id>","provider":"slack","session":"<first-8-chars>","secrets":["SLACK_ACCESS_TOKEN","SLACK_SCOPE","SLACK_TOKEN_TYPE"]}
+```
+
+---
+
+## Step 6: Verify broker signature enforcement
+
+Test that a forged envelope is rejected. In a separate terminal:
+
+```bash
+# Craft a fake delivery and POST it directly to the daemon
+curl -X POST http://localhost:8080/hooks/oauth-complete \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "type": "oauth_token_delivery",
+    "session_id": "00000000-0000-0000-0000-000000000000",
+    "ephemeral_pubkey": "AAAA",
+    "ciphertext": "BBBB",
+    "nonce": "CCCC"
+  }'
+```
+
+**Expected:** The request is rejected. The buildin/auth-relay task
+runs but `store_token` fails because:
+1. No valid `broker_sig` field → "delivery envelope missing broker_sig"
+2. Even if you add a fake sig → "broker signature verification failed"
+3. Even if you somehow bypass sig → "unknown or expired session"
+
+Check the daemon run log to confirm:
+
+```bash
+./dicode logs <run-id-from-output>
+```
+
+---
+
+## Step 7: Verify TOFU broker key pinning
+
+Test that the daemon rejects a relay with a different signing key.
+
+```bash
+# Stop the relay server (Ctrl-C)
+
+# Delete the auto-generated broker key
+rm /workspaces/dicode-relay/broker-signing-key.pem
+
+# Restart the relay — it generates a NEW key
+node --env-file=.env dist/index.js
+```
+
+**Expected daemon behavior:** The relay client reconnects but the
+handshake fails because the new broker pubkey doesn't match the
+pinned one. The daemon log should show:
+
+```
+relay: BROKER PUBKEY CHANGED — the relay server presented a different
+signing key than the one pinned on first connect. If the relay operator
+rotated their key, run `dicode relay trust-broker --yes` to accept the
+new key. Connection rejected to prevent token substitution attacks.
+```
+
+**Recovery:**
+
+```bash
+./dicode relay trust-broker --yes
+# → Broker pubkey pin cleared. Restart the daemon to accept the new broker key.
+
+# Restart the daemon
+# (or just wait — the relay client will reconnect and re-pin automatically)
+```
+
+---
+
+## Step 8: Test re-auth (stale secret cleanup)
+
+Run the flow again to verify stale secrets from a previous auth are
+cleaned up:
+
+```bash
+./dicode run buildin/auth-start provider=slack scope="channels:read chat:write"
+# Open the URL, authorize with different scopes
+# Verify SLACK_SCOPE reflects the new scopes
+./dicode secrets list | grep SLACK
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `oauth broker not configured on this daemon` | `relay.enabled: false` in dicode.yaml, or `server_url` has wrong scheme | Set `enabled: true` and `server_url: ws://localhost:5553` |
+| `daemon not connected` on browser | Daemon hasn't connected the WSS tunnel yet | Wait for `relay connected` in daemon log, then retry |
+| `invalid signature` at `/auth/slack` | Clock skew > 30s between relay and daemon | Sync clocks; check `timestamp` query param |
+| `unknown provider: slack` | `SLACK_CLIENT_ID` not set in relay env | Add to `.env` and restart relay |
+| `Encryption failed` at callback | Daemon disconnected between auth-start and callback | Ensure daemon stays connected; retry the flow |
+| `BROKER PUBKEY CHANGED` on reconnect | Broker key was regenerated (new .pem file) | Run `dicode relay trust-broker --yes` then restart daemon |
+| Token not appearing in secrets | Check daemon log for `store_token` errors | `./dicode logs <run-id>` on the auth-relay run |
+
+---
+
+## What this tests
+
+| Layer | What's exercised |
+|---|---|
+| WSS tunnel | Real WebSocket handshake with ECDSA challenge-response |
+| ECDSA signing | Daemon signs `/auth/:provider` URL; broker verifies |
+| PKCE binding | Challenge bound into signed payload |
+| Grant OAuth | Real code exchange with Slack (or whichever provider) |
+| ECIES encryption | Broker encrypts token to daemon pubkey |
+| Type-as-AAD | Domain separation via GCM authenticated data |
+| Broker signing | Broker signs envelope; daemon verifies |
+| TOFU pinning | Daemon pins broker pubkey on first connect |
+| Pending sessions | Session created on build_auth_url, consumed on delivery |
+| Secret storage | Token written to encrypted SQLite via secrets manager |
+| Stale cleanup | Re-auth deletes previous secrets before writing new ones |
+| Audit logging | Metadata-only log entry on successful delivery |
+
+---
+
+## Without a real OAuth provider (headless/CI)
+
+For automated testing without a browser or real Slack app, you can
+bypass Grant by directly hitting the relay's callback endpoint after
+creating a session. This simulates what Grant does after the code
+exchange.
+
+```bash
+# 1. Start auth flow normally
+RESULT=$(./dicode run buildin/auth-start provider=slack 2>&1)
+SESSION=$(echo "$RESULT" | grep "Session:" | awk '{print $2}')
+
+# 2. Hit the relay's callback directly (bypasses Grant + Slack)
+#    Grant's querystring transport means tokens arrive as query params.
+curl "http://localhost:5553/callback/slack?access_token=xoxb-test-token-123&state=${SESSION}&scope=channels:read&token_type=bot"
+
+# 3. Verify the test token landed
+./dicode secrets list | grep SLACK
+# → SLACK_ACCESS_TOKEN should contain xoxb-test-token-123
+```
+
+This works because:
+- `state` in Grant maps to the session ID
+- The callback handler looks up the session, encrypts, signs, and forwards
+- The daemon doesn't care whether the token came from a real provider
+
+**Note:** This bypass only works if Grant's middleware doesn't intercept
+`/callback/slack` before the broker router does. In the current setup
+with `transport: "querystring"`, Grant redirects TO the callback URL
+with tokens as query params — so the broker router at
+`GET /callback/:provider` receives them directly. Hitting it manually
+with the same query params is functionally identical.

--- a/pkg/ipc/capability.go
+++ b/pkg/ipc/capability.go
@@ -37,7 +37,9 @@ const (
 	CapTasksList   = "tasks.list"    // dicode.list_tasks
 	CapRunsList    = "runs.list"     // dicode.get_runs
 	CapConfigRead  = "config.read"   // dicode.get_config
-	CapMCPCall     = "mcp.call"      // mcp.list_tools, mcp.call — also checked against allowed_mcp
+	CapMCPCall   = "mcp.call"   // mcp.list_tools, mcp.call — also checked against allowed_mcp
+	CapOAuthInit = "oauth.init" // dicode.oauth.build_auth_url — for the auth-start built-in task
+	CapOAuthStore = "oauth.store" // dicode.oauth.store_token — for the auth-relay built-in task
 
 	// Reserved for CLI and WebUI clients (not issued to task shims today).
 	CapHTTPRegister  = "http.register" // register HTTP handler routes (issue #54)

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -11,7 +11,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/dicode/dicode/pkg/db"
 	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/relay"
 	"github.com/dicode/dicode/pkg/secrets"
 	"github.com/dicode/dicode/pkg/task"
 	"go.uber.org/zap"
@@ -33,6 +35,7 @@ type ControlServer struct {
 	engine          EngineRunner
 	secrets         secrets.Manager // nil if no local provider configured
 	metricsProvider MetricsProvider
+	database        db.DB           // for broker pubkey trust pinning; nil in tests
 	log             *zap.Logger
 
 	startedAt time.Time
@@ -50,6 +53,7 @@ func NewControlServer(
 	mp MetricsProvider,
 	version string,
 	log *zap.Logger,
+	database db.DB,
 ) (*ControlServer, error) {
 	secret := make([]byte, 32)
 	if _, err := rand.Read(secret); err != nil {
@@ -64,6 +68,7 @@ func NewControlServer(
 		engine:          engine,
 		secrets:         secretsMgr,
 		metricsProvider: mp,
+		database:        database,
 		log:             log,
 		startedAt:       time.Now(),
 		version:         version,
@@ -205,6 +210,9 @@ func (cs *ControlServer) dispatch(ctx context.Context, req Request) (any, error)
 
 	case "cli.metrics":
 		return cs.handleMetrics(), nil
+
+	case "cli.relay.trust_broker":
+		return cs.handleTrustBroker(ctx)
 
 	default:
 		return nil, fmt.Errorf("unknown method: %s", req.Method)
@@ -361,6 +369,23 @@ func (cs *ControlServer) handleMetrics() MetricsSnapshot {
 	}
 
 	return snap
+}
+
+// handleTrustBroker deletes the TOFU-pinned broker pubkey so the next relay
+// reconnect will re-pin whatever the broker announces. This is the recovery
+// path when the broker operator rotates their signing key.
+func (cs *ControlServer) handleTrustBroker(ctx context.Context) (any, error) {
+	if cs.database == nil {
+		return nil, fmt.Errorf("database not available")
+	}
+	if err := relay.ReplaceBrokerPubkey(ctx, cs.database, ""); err != nil {
+		return nil, fmt.Errorf("clear broker pubkey: %w", err)
+	}
+	cs.log.Warn("broker pubkey pin cleared — next relay reconnect will TOFU-pin the new key")
+	return map[string]string{
+		"status":  "ok",
+		"message": "Broker pubkey pin cleared. Restart the daemon (or wait for reconnect) to accept the new broker key.",
+	}, nil
 }
 
 // triggerLabel returns a human-readable trigger description for a task spec.

--- a/pkg/ipc/control_test.go
+++ b/pkg/ipc/control_test.go
@@ -24,7 +24,7 @@ func controlTestEnv(t *testing.T, mp MetricsProvider) (net.Conn, func()) {
 	log := zap.NewNop()
 	eng := &mockEngine{}
 
-	cs, err := NewControlServer(socketPath, tokenPath, nil, eng, nil, mp, "test", log)
+	cs, err := NewControlServer(socketPath, tokenPath, nil, eng, nil, mp, "test", log, nil)
 	if err != nil {
 		t.Fatalf("NewControlServer: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestControl_Handshake_EmitsEmptyTaskAndRunIDFields(t *testing.T) {
 	socketPath := filepath.Join(dir, "ctrl.sock")
 	tokenPath := filepath.Join(dir, "ctrl.token")
 
-	cs, err := NewControlServer(socketPath, tokenPath, nil, &mockEngine{}, nil, MetricsProvider{}, "test", zap.NewNop())
+	cs, err := NewControlServer(socketPath, tokenPath, nil, &mockEngine{}, nil, MetricsProvider{}, "test", zap.NewNop(), nil)
 	if err != nil {
 		t.Fatalf("NewControlServer: %v", err)
 	}

--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -65,6 +65,11 @@ type Request struct {
 	Tool    string          `json:"tool,omitempty"`
 	Args    json.RawMessage `json:"args,omitempty"`
 
+	// dicode.oauth.* — exposed only to the auth-relay built-in task
+	Provider string          `json:"provider,omitempty"` // oauth.build_auth_url
+	Scope    string          `json:"scope,omitempty"`    // oauth.build_auth_url — optional scope override
+	Envelope json.RawMessage `json:"envelope,omitempty"` // oauth.store_token — OAuthTokenDeliveryPayload JSON
+
 	// http.register (daemon tasks register an HTTP pattern with the gateway)
 	Pattern  string `json:"pattern,omitempty"`
 	StreamID string `json:"streamID,omitempty"`

--- a/pkg/ipc/oauth_store.go
+++ b/pkg/ipc/oauth_store.go
@@ -1,0 +1,104 @@
+package ipc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dicode/dicode/pkg/secrets"
+)
+
+// storeOAuthToken parses a decrypted token bundle from the relay broker and
+// writes its fields into the secrets store under a provider-scoped naming
+// convention. Returns the list of secret names written so the caller can
+// report them without ever touching the plaintext values.
+//
+// Naming: <PROVIDER>_ACCESS_TOKEN plus optional _REFRESH_TOKEN, _EXPIRES_AT,
+// _SCOPE, _TOKEN_TYPE suffixes. Provider is upper-cased and sanitised so a
+// malicious provider value cannot inject unexpected key prefixes.
+func storeOAuthToken(ctx context.Context, mgr secrets.Manager, provider string, plaintext []byte) ([]string, error) {
+	prefix, err := sanitizeProviderPrefix(provider)
+	if err != nil {
+		return nil, err
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(plaintext, &raw); err != nil {
+		return nil, fmt.Errorf("parse token json: %w", err)
+	}
+
+	accessToken, _ := raw["access_token"].(string)
+	if accessToken == "" {
+		return nil, fmt.Errorf("token payload missing access_token")
+	}
+
+	written := make([]string, 0, 5)
+	setIf := func(name, value string) error {
+		if value == "" {
+			return nil
+		}
+		if err := mgr.Set(ctx, name, value); err != nil {
+			return fmt.Errorf("set %s: %w", name, err)
+		}
+		written = append(written, name)
+		return nil
+	}
+
+	if err := setIf(prefix+"_ACCESS_TOKEN", accessToken); err != nil {
+		return nil, err
+	}
+	if refresh, _ := raw["refresh_token"].(string); refresh != "" {
+		if err := setIf(prefix+"_REFRESH_TOKEN", refresh); err != nil {
+			return nil, err
+		}
+	}
+	if scope, _ := raw["scope"].(string); scope != "" {
+		if err := setIf(prefix+"_SCOPE", scope); err != nil {
+			return nil, err
+		}
+	}
+	if tokenType, _ := raw["token_type"].(string); tokenType != "" {
+		if err := setIf(prefix+"_TOKEN_TYPE", tokenType); err != nil {
+			return nil, err
+		}
+	}
+	// expires_in arrives as a JSON number; convert to an absolute RFC3339
+	// timestamp so refresh tooling can compare without re-interpreting units.
+	var expiresIn int64
+	switch v := raw["expires_in"].(type) {
+	case float64:
+		expiresIn = int64(v)
+	case string:
+		_, _ = fmt.Sscanf(v, "%d", &expiresIn)
+	}
+	if expiresIn > 0 {
+		expiresAt := time.Now().Add(time.Duration(expiresIn) * time.Second).UTC().Format(time.RFC3339)
+		if err := setIf(prefix+"_EXPIRES_AT", expiresAt); err != nil {
+			return nil, err
+		}
+	}
+	return written, nil
+}
+
+// sanitizeProviderPrefix upper-cases and restricts provider to [A-Z0-9_],
+// rejecting anything else so an attacker who somehow plants a pending
+// session with a crafted provider string cannot write to arbitrary secret
+// keys (e.g. overwriting an existing secret via "slack_access_token;rm").
+func sanitizeProviderPrefix(provider string) (string, error) {
+	p := strings.ToUpper(strings.TrimSpace(provider))
+	if p == "" {
+		return "", fmt.Errorf("provider required")
+	}
+	for _, r := range p {
+		switch {
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '_':
+		default:
+			return "", fmt.Errorf("invalid provider %q", provider)
+		}
+	}
+	return p, nil
+}

--- a/pkg/ipc/oauth_store.go
+++ b/pkg/ipc/oauth_store.go
@@ -4,16 +4,39 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/dicode/dicode/pkg/secrets"
 )
 
+// oauthSecretSuffixes is the fixed set of suffixes storeOAuthToken writes.
+// Before writing a new bundle, all existing keys with these suffixes are
+// deleted so a re-auth that omits a field (e.g. no refresh_token on the
+// second Google consent) does not leave stale values from the prior auth.
+var oauthSecretSuffixes = []string{
+	"_ACCESS_TOKEN",
+	"_REFRESH_TOKEN",
+	"_EXPIRES_AT",
+	"_SCOPE",
+	"_TOKEN_TYPE",
+}
+
+// maxExpiresInSeconds caps the expires_in field to avoid int64 overflow when
+// converting seconds to time.Duration (nanoseconds). 10 years is generous;
+// no legitimate OAuth provider issues tokens that live longer.
+const maxExpiresInSeconds = 10 * 365 * 24 * 3600
+
 // storeOAuthToken parses a decrypted token bundle from the relay broker and
 // writes its fields into the secrets store under a provider-scoped naming
 // convention. Returns the list of secret names written so the caller can
 // report them without ever touching the plaintext values.
+//
+// Before writing, the full set of <PREFIX>_* keys is deleted unconditionally.
+// This prevents stale credentials from a prior auth surviving alongside
+// fresh values from a new auth (e.g. old refresh_token alongside new
+// access_token after a re-consent flow that didn't return a refresh_token).
 //
 // Naming: <PROVIDER>_ACCESS_TOKEN plus optional _REFRESH_TOKEN, _EXPIRES_AT,
 // _SCOPE, _TOKEN_TYPE suffixes. Provider is upper-cased and sanitised so a
@@ -32,6 +55,12 @@ func storeOAuthToken(ctx context.Context, mgr secrets.Manager, provider string, 
 	accessToken, _ := raw["access_token"].(string)
 	if accessToken == "" {
 		return nil, fmt.Errorf("token payload missing access_token")
+	}
+
+	// Delete all prior values under this prefix before writing the new set.
+	// Errors on delete are tolerated (key may not exist).
+	for _, suffix := range oauthSecretSuffixes {
+		_ = mgr.Delete(ctx, prefix+suffix)
 	}
 
 	written := make([]string, 0, 5)
@@ -64,14 +93,20 @@ func storeOAuthToken(ctx context.Context, mgr secrets.Manager, provider string, 
 			return nil, err
 		}
 	}
+
 	// expires_in arrives as a JSON number; convert to an absolute RFC3339
 	// timestamp so refresh tooling can compare without re-interpreting units.
+	// Clamped to maxExpiresInSeconds to avoid int64 overflow in the
+	// seconds → Duration(nanoseconds) conversion.
 	var expiresIn int64
 	switch v := raw["expires_in"].(type) {
 	case float64:
 		expiresIn = int64(v)
 	case string:
-		_, _ = fmt.Sscanf(v, "%d", &expiresIn)
+		expiresIn, _ = strconv.ParseInt(v, 10, 64)
+	}
+	if expiresIn > maxExpiresInSeconds {
+		expiresIn = maxExpiresInSeconds
 	}
 	if expiresIn > 0 {
 		expiresAt := time.Now().Add(time.Duration(expiresIn) * time.Second).UTC().Format(time.RFC3339)
@@ -86,10 +121,17 @@ func storeOAuthToken(ctx context.Context, mgr secrets.Manager, provider string, 
 // rejecting anything else so an attacker who somehow plants a pending
 // session with a crafted provider string cannot write to arbitrary secret
 // keys (e.g. overwriting an existing secret via "slack_access_token;rm").
+//
+// Additional guards: minimum 2 characters and no leading/trailing underscore,
+// to prevent collision with unrelated secret namespaces (e.g. a provider of
+// "_FOO" would produce "__FOO_ACCESS_TOKEN").
 func sanitizeProviderPrefix(provider string) (string, error) {
 	p := strings.ToUpper(strings.TrimSpace(provider))
-	if p == "" {
-		return "", fmt.Errorf("provider required")
+	if len(p) < 2 {
+		return "", fmt.Errorf("provider must be at least 2 characters, got %q", provider)
+	}
+	if p[0] == '_' || p[len(p)-1] == '_' {
+		return "", fmt.Errorf("provider must not start or end with underscore: %q", provider)
 	}
 	for _, r := range p {
 		switch {

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -642,11 +642,18 @@ func (s *Server) handleConn(conn net.Conn) {
 			// run received which delivery without the token ever touching
 			// an observability pipeline.
 			if s.log != nil {
+				// Truncate session id to first 8 chars — enough for
+				// correlation, avoids persisting the full signed-payload
+				// component in long-term log storage.
+				sid := authReq.SessionID
+				if len(sid) > 8 {
+					sid = sid[:8]
+				}
 				s.log.Info("oauth token delivered",
 					zap.String("task", s.taskID),
 					zap.String("run", s.runID),
 					zap.String("provider", authReq.Provider),
-					zap.String("session", authReq.SessionID),
+					zap.String("session", sid),
 					zap.Strings("secrets", written),
 				)
 			}

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -35,9 +35,10 @@ type Server struct {
 	spec     *task.Spec
 	engine   EngineRunner
 	secrets      secrets.Manager         // optional; enables dicode.secrets_set / dicode.secrets_delete
-	oauthID      *relay.Identity         // optional; enables dicode.oauth.* for the auth built-ins
-	oauthURL     string                  // broker base URL, e.g. "https://relay.dicode.app"
-	oauthPending *relay.PendingSessions  // tracks outstanding /auth/:provider flows by session id
+	oauthID         *relay.Identity         // optional; enables dicode.oauth.* for the auth built-ins
+	oauthURL        string                  // broker base URL, e.g. "https://relay.dicode.app"
+	oauthPending    *relay.PendingSessions  // tracks outstanding /auth/:provider flows by session id
+	brokerPubkeyFn  func() string           // returns the TOFU-pinned broker pubkey (base64 SPKI DER)
 	log          *zap.Logger
 
 	aiBaseURL string
@@ -113,10 +114,11 @@ func (s *Server) SetSecrets(m secrets.Manager) { s.secrets = m }
 // pending is shared across all per-run ipc.Server instances so that an
 // auth-start run and the subsequent auth-complete webhook run can correlate
 // on session id.
-func (s *Server) SetOAuthBroker(id *relay.Identity, baseURL string, pending *relay.PendingSessions) {
+func (s *Server) SetOAuthBroker(id *relay.Identity, baseURL string, pending *relay.PendingSessions, brokerPubkeyFn func() string) {
 	s.oauthID = id
 	s.oauthURL = baseURL
 	s.oauthPending = pending
+	s.brokerPubkeyFn = brokerPubkeyFn
 }
 
 // Start creates the Unix socket and begins accepting connections.
@@ -616,6 +618,18 @@ func (s *Server) handleConn(conn net.Conn) {
 			if err := json.Unmarshal(req.Envelope, &env); err != nil {
 				reply(req.ID, nil, "ipc: decode envelope: "+err.Error())
 				continue
+			}
+			// Verify broker authenticity before consuming the pending
+			// session or touching any crypto. If the broker pubkey is
+			// pinned (TOFU on first connect), a forged envelope from a
+			// local process or MitM is rejected here.
+			if s.brokerPubkeyFn != nil {
+				if bpk := s.brokerPubkeyFn(); bpk != "" {
+					if err := relay.VerifyBrokerSig(bpk, &env); err != nil {
+						reply(req.ID, nil, "ipc: "+err.Error())
+						continue
+					}
+				}
 			}
 			authReq, err := s.oauthPending.Take(env.SessionID)
 			if err != nil {

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dicode/dicode/pkg/db"
 	mcpclient "github.com/dicode/dicode/pkg/mcp/client"
 	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/relay"
 	"github.com/dicode/dicode/pkg/secrets"
 	"github.com/dicode/dicode/pkg/task"
 	"go.uber.org/zap"
@@ -33,8 +34,11 @@ type Server struct {
 	input    any
 	spec     *task.Spec
 	engine   EngineRunner
-	secrets  secrets.Manager // optional; enables dicode.secrets_set / dicode.secrets_delete
-	log      *zap.Logger
+	secrets      secrets.Manager         // optional; enables dicode.secrets_set / dicode.secrets_delete
+	oauthID      *relay.Identity         // optional; enables dicode.oauth.* for the auth built-ins
+	oauthURL     string                  // broker base URL, e.g. "https://relay.dicode.app"
+	oauthPending *relay.PendingSessions  // tracks outstanding /auth/:provider flows by session id
+	log          *zap.Logger
 
 	aiBaseURL string
 	aiModel   string
@@ -100,6 +104,21 @@ func New(
 // can call dicode.secrets_set() and dicode.secrets_delete().
 func (s *Server) SetSecrets(m secrets.Manager) { s.secrets = m }
 
+// SetOAuthBroker wires the daemon's relay identity (used to sign /auth URLs
+// and decrypt token deliveries) plus the broker base URL and the
+// daemon-wide PendingSessions store. The task-side dicode.oauth.* API is
+// inert until this is set, so the auth-relay built-in task must gracefully
+// degrade when the relay client is not enabled in dicode.yaml.
+//
+// pending is shared across all per-run ipc.Server instances so that an
+// auth-start run and the subsequent auth-complete webhook run can correlate
+// on session id.
+func (s *Server) SetOAuthBroker(id *relay.Identity, baseURL string, pending *relay.PendingSessions) {
+	s.oauthID = id
+	s.oauthURL = baseURL
+	s.oauthPending = pending
+}
+
 // Start creates the Unix socket and begins accepting connections.
 // Returns the socket path and a capability token to pass to the subprocess.
 func (s *Server) Start(ctx context.Context) (socketPath, token string, err error) {
@@ -136,6 +155,12 @@ func (s *Server) Start(ctx context.Context) (socketPath, token string, err error
 		}
 		if dp.SecretsWrite {
 			caps = append(caps, CapSecretsWrite)
+		}
+		if dp.OAuthInit {
+			caps = append(caps, CapOAuthInit)
+		}
+		if dp.OAuthStore {
+			caps = append(caps, CapOAuthStore)
 		}
 	}
 	if s.spec != nil && s.spec.Trigger.Daemon && s.gateway != nil {
@@ -533,6 +558,89 @@ func (s *Server) handleConn(conn net.Conn) {
 				continue
 			}
 			reply(req.ID, true, "")
+
+		// ── dicode.oauth.* ────────────────────────────────────────────────
+		// Two purpose-specific primitives, each gated by its own capability.
+		// Neither exposes raw sign-with-identity-key or raw-decrypt — the
+		// payload layouts are hardcoded so a compromised task cannot coax
+		// the identity key into signing a WSS handshake digest or acting
+		// as a decryption oracle for ciphertexts the broker never issued.
+
+		case "dicode.oauth.build_auth_url":
+			if !hasCap(caps, CapOAuthInit) {
+				reply(req.ID, nil, "ipc: permission denied (oauth.init)")
+				continue
+			}
+			if s.oauthID == nil || s.oauthURL == "" || s.oauthPending == nil {
+				reply(req.ID, nil, "ipc: oauth broker not configured on this daemon")
+				continue
+			}
+			if req.Provider == "" {
+				reply(req.ID, nil, "ipc: provider required")
+				continue
+			}
+			url, authReq, err := relay.BuildAuthURL(s.oauthURL, s.oauthID, req.Provider, req.Scope, time.Now().Unix())
+			if err != nil {
+				reply(req.ID, nil, err.Error())
+				continue
+			}
+			// Track this flow so store_token can validate the delivery's
+			// session id against a request we actually issued.
+			s.oauthPending.Add(authReq)
+			reply(req.ID, map[string]any{
+				"url":        url,
+				"session_id": authReq.SessionID,
+				"provider":   authReq.Provider,
+				"timestamp":  authReq.Timestamp,
+				"relay_uuid": s.oauthID.UUID,
+			}, "")
+
+		case "dicode.oauth.store_token":
+			if !hasCap(caps, CapOAuthStore) {
+				reply(req.ID, nil, "ipc: permission denied (oauth.store)")
+				continue
+			}
+			if s.oauthID == nil || s.oauthPending == nil {
+				reply(req.ID, nil, "ipc: oauth broker not configured on this daemon")
+				continue
+			}
+			if s.secrets == nil {
+				reply(req.ID, nil, "ipc: no secrets provider configured")
+				continue
+			}
+			if len(req.Envelope) == 0 {
+				reply(req.ID, nil, "ipc: envelope required")
+				continue
+			}
+			var env relay.OAuthTokenDeliveryPayload
+			if err := json.Unmarshal(req.Envelope, &env); err != nil {
+				reply(req.ID, nil, "ipc: decode envelope: "+err.Error())
+				continue
+			}
+			authReq, err := s.oauthPending.Take(env.SessionID)
+			if err != nil {
+				reply(req.ID, nil, "ipc: unknown or expired session")
+				continue
+			}
+			plaintext, err := relay.DecryptOAuthToken(s.oauthID, &env)
+			if err != nil {
+				reply(req.ID, nil, "ipc: decrypt failed")
+				continue
+			}
+			written, err := storeOAuthToken(context.Background(), s.secrets, authReq.Provider, plaintext)
+			// Best-effort zeroization; Go can't guarantee it but this shrinks
+			// the window in process memory regardless.
+			for i := range plaintext {
+				plaintext[i] = 0
+			}
+			if err != nil {
+				reply(req.ID, nil, "ipc: store secret: "+err.Error())
+				continue
+			}
+			reply(req.ID, map[string]any{
+				"provider": authReq.Provider,
+				"secrets":  written,
+			}, "")
 
 		// ── mcp.* ─────────────────────────────────────────────────────────
 

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -637,6 +637,19 @@ func (s *Server) handleConn(conn net.Conn) {
 				reply(req.ID, nil, "ipc: store secret: "+err.Error())
 				continue
 			}
+			// Structured audit entry. Fields are deliberately metadata-only
+			// so that an operator tailing the run log can trace which task
+			// run received which delivery without the token ever touching
+			// an observability pipeline.
+			if s.log != nil {
+				s.log.Info("oauth token delivered",
+					zap.String("task", s.taskID),
+					zap.String("run", s.runID),
+					zap.String("provider", authReq.Provider),
+					zap.String("session", authReq.SessionID),
+					zap.Strings("secrets", written),
+				)
+			}
 			reply(req.ID, map[string]any{
 				"provider": authReq.Provider,
 				"secrets":  written,

--- a/pkg/ipc/server_oauth_test.go
+++ b/pkg/ipc/server_oauth_test.go
@@ -1,0 +1,337 @@
+package ipc
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdh"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/relay"
+	"github.com/dicode/dicode/pkg/secrets"
+	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/hkdf"
+)
+
+// memSecrets is a minimal secrets.Manager for tests.
+type memSecrets struct {
+	data map[string]string
+}
+
+func newMemSecrets() *memSecrets                    { return &memSecrets{data: map[string]string{}} }
+func (m *memSecrets) List(_ context.Context) ([]string, error) {
+	out := make([]string, 0, len(m.data))
+	for k := range m.data {
+		out = append(out, k)
+	}
+	return out, nil
+}
+func (m *memSecrets) Set(_ context.Context, k, v string) error { m.data[k] = v; return nil }
+func (m *memSecrets) Delete(_ context.Context, k string) error { delete(m.data, k); return nil }
+func (m *memSecrets) Get(_ context.Context, k string) (string, error) {
+	return m.data[k], nil
+}
+func (m *memSecrets) Name() string { return "mem" }
+
+var _ secrets.Manager = (*memSecrets)(nil)
+
+func newOAuthIdentity(t *testing.T) *relay.Identity {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	pubBytes := append([]byte{0x04}, append(key.PublicKey.X.FillBytes(make([]byte, 32)), key.PublicKey.Y.FillBytes(make([]byte, 32))...)...)
+	sum := sha256.Sum256(pubBytes)
+	return &relay.Identity{PrivateKey: key, UUID: hex.EncodeToString(sum[:])}
+}
+
+type oauthEnv struct {
+	conn     net.Conn
+	srv      *Server
+	identity *relay.Identity
+	pending  *relay.PendingSessions
+	secrets  *memSecrets
+}
+
+// startOAuthServer wires an ipc.Server with both oauth capabilities granted
+// and a shared PendingSessions store. Both permissions on one test server is
+// fine — production splits init/store across two separate built-in tasks,
+// but the server-side dispatch logic is identical regardless.
+func startOAuthServer(t *testing.T) *oauthEnv {
+	t.Helper()
+	env := newTestEnv(t)
+	spec := specWithDicode("auth-relay", &task.DicodePermissions{OAuthInit: true, OAuthStore: true})
+
+	runID := fmt.Sprintf("test-%d", time.Now().UnixNano())
+	srv := New(runID, spec.ID, env.secret, env.reg, env.db, nil, nil, zap.NewNop(), spec, nil, "", "", "")
+	identity := newOAuthIdentity(t)
+	pending := relay.NewPendingSessions()
+	secretsMgr := newMemSecrets()
+	srv.SetOAuthBroker(identity, "https://relay.dicode.app", pending)
+	srv.SetSecrets(secretsMgr)
+
+	socketPath, token, err := srv.Start(context.Background())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(srv.Stop)
+
+	conn := dial(t, socketPath)
+	t.Cleanup(func() { conn.Close() })
+	caps := doHandshake(t, conn, token)
+
+	var init, store bool
+	for _, c := range caps {
+		if c == CapOAuthInit {
+			init = true
+		}
+		if c == CapOAuthStore {
+			store = true
+		}
+	}
+	if !init || !store {
+		t.Fatalf("expected both oauth.init and oauth.store caps; got %v", caps)
+	}
+	return &oauthEnv{conn: conn, srv: srv, identity: identity, pending: pending, secrets: secretsMgr}
+}
+
+func TestServer_OAuth_BuildAuthURL_RegistersPending(t *testing.T) {
+	e := startOAuthServer(t)
+
+	sendMsg(t, e.conn, map[string]any{
+		"id":       "1",
+		"method":   "dicode.oauth.build_auth_url",
+		"provider": "slack",
+		"scope":    "channels:read",
+	})
+	resp := recvMsg(t, e.conn)
+	if resp["error"] != nil {
+		t.Fatalf("unexpected error: %v", resp["error"])
+	}
+	result, ok := resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("bad result type: %T", resp["result"])
+	}
+	for _, k := range []string{"url", "session_id", "provider", "relay_uuid"} {
+		if _, ok := result[k]; !ok {
+			t.Fatalf("missing field %q: %v", k, result)
+		}
+	}
+	if result["relay_uuid"] != e.identity.UUID {
+		t.Fatalf("relay_uuid mismatch")
+	}
+	if e.pending.Len() != 1 {
+		t.Fatalf("expected pending session to be registered; len=%d", e.pending.Len())
+	}
+}
+
+func TestServer_OAuth_BuildAuthURL_DeniedWithoutInit(t *testing.T) {
+	env := newTestEnv(t)
+	// Spec has OAuthStore but NOT OAuthInit — build_auth_url must be rejected.
+	spec := specWithDicode("leaky", &task.DicodePermissions{OAuthStore: true})
+	runID := fmt.Sprintf("test-%d", time.Now().UnixNano())
+	srv := New(runID, spec.ID, env.secret, env.reg, env.db, nil, nil, zap.NewNop(), spec, nil, "", "", "")
+	srv.SetOAuthBroker(newOAuthIdentity(t), "https://relay.dicode.app", relay.NewPendingSessions())
+	socketPath, token, err := srv.Start(context.Background())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(srv.Stop)
+	conn := dial(t, socketPath)
+	t.Cleanup(func() { conn.Close() })
+	doHandshake(t, conn, token)
+
+	sendMsg(t, conn, map[string]any{"id": "1", "method": "dicode.oauth.build_auth_url", "provider": "slack"})
+	resp := recvMsg(t, conn)
+	if errStr, _ := resp["error"].(string); errStr == "" {
+		t.Fatalf("expected permission denied")
+	}
+}
+
+func TestServer_OAuth_StoreToken_RoundTrip(t *testing.T) {
+	e := startOAuthServer(t)
+
+	// Issue an auth request so the pending session exists.
+	sendMsg(t, e.conn, map[string]any{"id": "1", "method": "dicode.oauth.build_auth_url", "provider": "slack"})
+	initResp := recvMsg(t, e.conn)
+	sessionID := initResp["result"].(map[string]any)["session_id"].(string)
+
+	tokenJSON := []byte(`{"access_token":"xoxb-1","refresh_token":"r1","expires_in":3600,"scope":"channels:read","token_type":"bot"}`)
+	envelope := sealForDaemon(t, e.identity, sessionID, tokenJSON)
+	envBytes, _ := json.Marshal(envelope)
+
+	sendMsg(t, e.conn, map[string]any{
+		"id":       "2",
+		"method":   "dicode.oauth.store_token",
+		"envelope": json.RawMessage(envBytes),
+	})
+	resp := recvMsg(t, e.conn)
+	if resp["error"] != nil {
+		t.Fatalf("unexpected error: %v", resp["error"])
+	}
+	if e.secrets.data["SLACK_ACCESS_TOKEN"] != "xoxb-1" {
+		t.Fatalf("access token not stored: %+v", e.secrets.data)
+	}
+	if e.secrets.data["SLACK_REFRESH_TOKEN"] != "r1" {
+		t.Fatalf("refresh token not stored")
+	}
+	if e.secrets.data["SLACK_SCOPE"] != "channels:read" {
+		t.Fatalf("scope not stored")
+	}
+	if e.secrets.data["SLACK_TOKEN_TYPE"] != "bot" {
+		t.Fatalf("token_type not stored")
+	}
+	exp := e.secrets.data["SLACK_EXPIRES_AT"]
+	if _, err := time.Parse(time.RFC3339, exp); err != nil {
+		t.Fatalf("expires_at not RFC3339: %q", exp)
+	}
+	if e.pending.Len() != 0 {
+		t.Fatalf("pending session should be consumed; len=%d", e.pending.Len())
+	}
+}
+
+func TestServer_OAuth_StoreToken_UnknownSession(t *testing.T) {
+	e := startOAuthServer(t)
+
+	// Do not register a pending session. Craft an envelope with an
+	// arbitrary session id — store_token must reject it even though
+	// decryption would succeed.
+	sessionID := "550e8400-e29b-41d4-a716-446655440000"
+	envelope := sealForDaemon(t, e.identity, sessionID, []byte(`{"access_token":"x"}`))
+	envBytes, _ := json.Marshal(envelope)
+
+	sendMsg(t, e.conn, map[string]any{
+		"id":       "1",
+		"method":   "dicode.oauth.store_token",
+		"envelope": json.RawMessage(envBytes),
+	})
+	resp := recvMsg(t, e.conn)
+	if errStr, _ := resp["error"].(string); errStr == "" {
+		t.Fatalf("expected unknown-session error")
+	}
+	if len(e.secrets.data) != 0 {
+		t.Fatalf("secrets should be untouched on rejection")
+	}
+}
+
+func TestServer_OAuth_StoreToken_TamperedCiphertext(t *testing.T) {
+	e := startOAuthServer(t)
+
+	sendMsg(t, e.conn, map[string]any{"id": "1", "method": "dicode.oauth.build_auth_url", "provider": "slack"})
+	initResp := recvMsg(t, e.conn)
+	sessionID := initResp["result"].(map[string]any)["session_id"].(string)
+
+	envelope := sealForDaemon(t, e.identity, sessionID, []byte(`{"access_token":"x"}`))
+	// Flip the ciphertext.
+	ct, _ := base64.StdEncoding.DecodeString(envelope.Ciphertext)
+	ct[0] ^= 0xFF
+	envelope.Ciphertext = base64.StdEncoding.EncodeToString(ct)
+	envBytes, _ := json.Marshal(envelope)
+
+	sendMsg(t, e.conn, map[string]any{
+		"id":       "2",
+		"method":   "dicode.oauth.store_token",
+		"envelope": json.RawMessage(envBytes),
+	})
+	resp := recvMsg(t, e.conn)
+	if errStr, _ := resp["error"].(string); errStr == "" {
+		t.Fatalf("expected decrypt error")
+	}
+	// Tampered delivery MUST still evict the pending session — otherwise a
+	// retry loop could brute-force something.
+	if e.pending.Len() != 0 {
+		t.Fatalf("pending session should be consumed on tamper")
+	}
+}
+
+func TestServer_OAuth_StoreToken_RejectsEmptyType(t *testing.T) {
+	e := startOAuthServer(t)
+
+	sendMsg(t, e.conn, map[string]any{"id": "1", "method": "dicode.oauth.build_auth_url", "provider": "slack"})
+	initResp := recvMsg(t, e.conn)
+	sessionID := initResp["result"].(map[string]any)["session_id"].(string)
+
+	envelope := sealForDaemon(t, e.identity, sessionID, []byte(`{"access_token":"x"}`))
+	envelope.Type = "" // strip the type tag
+	envBytes, _ := json.Marshal(envelope)
+
+	sendMsg(t, e.conn, map[string]any{
+		"id":       "2",
+		"method":   "dicode.oauth.store_token",
+		"envelope": json.RawMessage(envBytes),
+	})
+	resp := recvMsg(t, e.conn)
+	if errStr, _ := resp["error"].(string); errStr == "" {
+		t.Fatalf("expected type-required error")
+	}
+}
+
+func TestServer_OAuth_NotConfigured(t *testing.T) {
+	env := newTestEnv(t)
+	spec := specWithDicode("auth-relay", &task.DicodePermissions{OAuthInit: true})
+	runID := fmt.Sprintf("test-%d", time.Now().UnixNano())
+	// Do NOT call SetOAuthBroker — oauth.* should report not-configured.
+	srv := New(runID, spec.ID, env.secret, env.reg, env.db, nil, nil, zap.NewNop(), spec, nil, "", "", "")
+	socketPath, token, err := srv.Start(context.Background())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(srv.Stop)
+	conn := dial(t, socketPath)
+	t.Cleanup(func() { conn.Close() })
+	doHandshake(t, conn, token)
+
+	sendMsg(t, conn, map[string]any{"id": "1", "method": "dicode.oauth.build_auth_url", "provider": "slack"})
+	resp := recvMsg(t, conn)
+	if errStr, _ := resp["error"].(string); errStr == "" {
+		t.Fatalf("expected not-configured error")
+	}
+}
+
+// sealForDaemon mirrors dicode-relay src/broker/crypto.ts eciesEncrypt.
+func sealForDaemon(t *testing.T, identity *relay.Identity, sessionID string, plaintext []byte) *relay.OAuthTokenDeliveryPayload {
+	t.Helper()
+	daemonPub, err := ecdh.P256().NewPublicKey(identity.UncompressedPublicKey())
+	if err != nil {
+		t.Fatalf("daemon pub: %v", err)
+	}
+	eph, err := ecdh.P256().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("eph: %v", err)
+	}
+	shared, err := eph.ECDH(daemonPub)
+	if err != nil {
+		t.Fatalf("ecdh: %v", err)
+	}
+	encKey := make([]byte, 32)
+	if _, err := io.ReadFull(hkdf.New(sha256.New, shared, []byte(sessionID), []byte("dicode-oauth-token")), encKey); err != nil {
+		t.Fatalf("hkdf: %v", err)
+	}
+	iv := make([]byte, 12)
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		t.Fatalf("iv: %v", err)
+	}
+	block, _ := aes.NewCipher(encKey)
+	aead, _ := cipher.NewGCM(block)
+	ct := aead.Seal(nil, iv, plaintext, nil)
+	return &relay.OAuthTokenDeliveryPayload{
+		Type:            "oauth_token_delivery",
+		SessionID:       sessionID,
+		EphemeralPubkey: base64.StdEncoding.EncodeToString(eph.PublicKey().Bytes()),
+		Ciphertext:      base64.StdEncoding.EncodeToString(ct),
+		Nonce:           base64.StdEncoding.EncodeToString(iv),
+	}
+}

--- a/pkg/ipc/server_oauth_test.go
+++ b/pkg/ipc/server_oauth_test.go
@@ -326,7 +326,7 @@ func sealForDaemon(t *testing.T, identity *relay.Identity, sessionID string, pla
 	}
 	block, _ := aes.NewCipher(encKey)
 	aead, _ := cipher.NewGCM(block)
-	ct := aead.Seal(nil, iv, plaintext, nil)
+	ct := aead.Seal(nil, iv, plaintext, []byte("oauth_token_delivery"))
 	return &relay.OAuthTokenDeliveryPayload{
 		Type:            "oauth_token_delivery",
 		SessionID:       sessionID,

--- a/pkg/ipc/server_oauth_test.go
+++ b/pkg/ipc/server_oauth_test.go
@@ -80,7 +80,7 @@ func startOAuthServer(t *testing.T) *oauthEnv {
 	identity := newOAuthIdentity(t)
 	pending := relay.NewPendingSessions()
 	secretsMgr := newMemSecrets()
-	srv.SetOAuthBroker(identity, "https://relay.dicode.app", pending)
+	srv.SetOAuthBroker(identity, "https://relay.dicode.app", pending, nil)
 	srv.SetSecrets(secretsMgr)
 
 	socketPath, token, err := srv.Start(context.Background())
@@ -144,7 +144,7 @@ func TestServer_OAuth_BuildAuthURL_DeniedWithoutInit(t *testing.T) {
 	spec := specWithDicode("leaky", &task.DicodePermissions{OAuthStore: true})
 	runID := fmt.Sprintf("test-%d", time.Now().UnixNano())
 	srv := New(runID, spec.ID, env.secret, env.reg, env.db, nil, nil, zap.NewNop(), spec, nil, "", "", "")
-	srv.SetOAuthBroker(newOAuthIdentity(t), "https://relay.dicode.app", relay.NewPendingSessions())
+	srv.SetOAuthBroker(newOAuthIdentity(t), "https://relay.dicode.app", relay.NewPendingSessions(), nil)
 	socketPath, token, err := srv.Start(context.Background())
 	if err != nil {
 		t.Fatalf("Start: %v", err)

--- a/pkg/relay/broker_pin.go
+++ b/pkg/relay/broker_pin.go
@@ -1,0 +1,97 @@
+package relay
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dicode/dicode/pkg/db"
+)
+
+// kvKeyBrokerPubkey is the SQLite KV key where the daemon stores the
+// broker's SPKI public key after trust-on-first-use discovery. The value
+// is the raw base64 SPKI DER string received in the WSS welcome message.
+const kvKeyBrokerPubkey = "relay.broker_pubkey"
+
+// BrokerPubkeyPinResult describes the outcome of a TOFU pin check.
+type BrokerPubkeyPinResult int
+
+const (
+	// BrokerPubkeyPinNew means no key was previously stored — first connect.
+	BrokerPubkeyPinNew BrokerPubkeyPinResult = iota
+	// BrokerPubkeyPinMatch means the received key matches the stored one.
+	BrokerPubkeyPinMatch
+	// BrokerPubkeyPinMismatch means the received key differs from the stored one.
+	BrokerPubkeyPinMismatch
+)
+
+// CheckAndPinBrokerPubkey implements TOFU (trust-on-first-use) for the
+// broker's signing public key.
+//
+//   - First connect (no stored key): stores the received key, returns PinNew.
+//   - Subsequent connect (key matches): returns PinMatch. No DB write.
+//   - Key changed: returns PinMismatch. Does NOT overwrite — the operator
+//     must run `dicode relay trust-broker --yes` to accept the new key.
+func CheckAndPinBrokerPubkey(ctx context.Context, database db.DB, received string) (BrokerPubkeyPinResult, error) {
+	if received == "" {
+		return BrokerPubkeyPinNew, nil // broker didn't announce a key — legacy mode
+	}
+
+	var stored string
+	err := database.Query(ctx,
+		`SELECT value FROM kv WHERE key = ?`,
+		[]any{kvKeyBrokerPubkey},
+		func(rows db.Scanner) error {
+			if rows.Next() {
+				return rows.Scan(&stored)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return 0, fmt.Errorf("load broker pubkey: %w", err)
+	}
+
+	if stored == "" {
+		// First time — trust on first use.
+		if err := database.Exec(ctx,
+			`INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)`,
+			kvKeyBrokerPubkey, received,
+		); err != nil {
+			return 0, fmt.Errorf("store broker pubkey: %w", err)
+		}
+		return BrokerPubkeyPinNew, nil
+	}
+
+	if stored == received {
+		return BrokerPubkeyPinMatch, nil
+	}
+
+	return BrokerPubkeyPinMismatch, nil
+}
+
+// ReplaceBrokerPubkey unconditionally overwrites the stored broker pubkey.
+// Called by `dicode relay trust-broker --yes` when the operator explicitly
+// accepts a new broker key.
+func ReplaceBrokerPubkey(ctx context.Context, database db.DB, newKey string) error {
+	return database.Exec(ctx,
+		`INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)`,
+		kvKeyBrokerPubkey, newKey,
+	)
+}
+
+// LoadBrokerPubkey reads the currently pinned broker public key from the
+// database. Returns "" if no key is pinned.
+func LoadBrokerPubkey(ctx context.Context, database db.DB) (string, error) {
+	var stored string
+	err := database.Query(ctx,
+		`SELECT value FROM kv WHERE key = ?`,
+		[]any{kvKeyBrokerPubkey},
+		func(rows db.Scanner) error {
+			if rows.Next() {
+				return rows.Scan(&stored)
+			}
+			return nil
+		},
+	)
+	return stored, err
+}

--- a/pkg/relay/client.go
+++ b/pkg/relay/client.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+	"github.com/dicode/dicode/pkg/db"
 	"go.uber.org/zap"
 )
 
@@ -43,16 +44,28 @@ type Client struct {
 	serverURL   string
 	identity    *Identity
 	localPort   int
+	db          db.DB // for TOFU broker pubkey pinning
 	log         *zap.Logger
 	localClient *http.Client
 
 	hookMu      sync.RWMutex
 	hookBaseURL string // set after successful handshake from welcome message
+
+	brokerMu     sync.RWMutex
+	brokerPubkey string // cached pinned broker pubkey (base64 SPKI DER)
+}
+
+// BrokerPubkey returns the currently pinned broker public key (base64 SPKI DER).
+// Returns "" if the broker hasn't announced one yet.
+func (c *Client) BrokerPubkey() string {
+	c.brokerMu.RLock()
+	defer c.brokerMu.RUnlock()
+	return c.brokerPubkey
 }
 
 // NewClient creates a relay client. serverURL must be a wss:// URL.
 // In test/dev environments ws:// is accepted but a warning is logged.
-func NewClient(serverURL string, identity *Identity, localPort int, log *zap.Logger) *Client {
+func NewClient(serverURL string, identity *Identity, localPort int, database db.DB, log *zap.Logger) *Client {
 	if !strings.HasPrefix(serverURL, "wss://") && !strings.HasPrefix(serverURL, "ws://") {
 		log.Error("relay: serverURL must start with wss:// or ws://", zap.String("url", serverURL))
 	} else if strings.HasPrefix(serverURL, "ws://") {
@@ -63,6 +76,7 @@ func NewClient(serverURL string, identity *Identity, localPort int, log *zap.Log
 		serverURL:   serverURL,
 		identity:    identity,
 		localPort:   localPort,
+		db:          database,
 		log:         log,
 		localClient: &http.Client{Timeout: 25 * time.Second},
 	}
@@ -201,6 +215,32 @@ func (c *Client) handshake(ctx context.Context, conn *websocket.Conn, sendMu *sy
 		c.hookMu.Lock()
 		c.hookBaseURL = w.URL
 		c.hookMu.Unlock()
+
+		// TOFU broker pubkey pinning: on first connect, store the broker's
+		// signing pubkey. On reconnect, verify it hasn't changed.
+		if w.BrokerPubkey != "" && c.db != nil {
+			result, err := CheckAndPinBrokerPubkey(ctx, c.db, w.BrokerPubkey)
+			if err != nil {
+				return fmt.Errorf("broker pubkey pin: %w", err)
+			}
+			switch result {
+			case BrokerPubkeyPinNew:
+				c.log.Info("relay: pinned broker signing key (trust-on-first-use)",
+					zap.String("pubkey", w.BrokerPubkey[:16]+"…"))
+			case BrokerPubkeyPinMatch:
+				// Expected path on reconnect — nothing to log.
+			case BrokerPubkeyPinMismatch:
+				return fmt.Errorf(
+					"relay: BROKER PUBKEY CHANGED — the relay server presented a different signing key "+
+						"than the one pinned on first connect. If the relay operator rotated their key, "+
+						"run `dicode relay trust-broker --yes` to accept the new key. "+
+						"Connection rejected to prevent token substitution attacks")
+			}
+			c.brokerMu.Lock()
+			c.brokerPubkey = w.BrokerPubkey
+			c.brokerMu.Unlock()
+		}
+
 		c.log.Info("relay connected", zap.String("url", w.URL))
 		return nil
 	case msgError:

--- a/pkg/relay/client_test.go
+++ b/pkg/relay/client_test.go
@@ -59,7 +59,7 @@ func TestHandshakeSuccess(t *testing.T) {
 	_, portStr, _ := net.SplitHostPort(localSrv.Listener.Addr().String())
 	port, _ := strconv.Atoi(portStr)
 
-	client := NewClient(wsURL, id, port, log)
+	client := NewClient(wsURL, id, port, nil, log)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -100,7 +100,7 @@ func TestHandshakeWrongKey(t *testing.T) {
 	defer localSrv.Close()
 	_, portStr, _ := net.SplitHostPort(localSrv.Listener.Addr().String())
 	port, _ := strconv.Atoi(portStr)
-	client := NewClient(wsURL, tamperedID, port, log)
+	client := NewClient(wsURL, tamperedID, port, nil, log)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -199,7 +199,7 @@ func TestWebhookForwarding(t *testing.T) {
 	_, portStr, _ := net.SplitHostPort(localSrv.Listener.Addr().String())
 	port, _ := strconv.Atoi(portStr)
 
-	client := NewClient(wsURL, id, port, log)
+	client := NewClient(wsURL, id, port, nil, log)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -264,7 +264,7 @@ func TestAutoReconnect(t *testing.T) {
 	_, portStr, _ := net.SplitHostPort(localSrv.Listener.Addr().String())
 	port, _ := strconv.Atoi(portStr)
 
-	client := NewClient(wsURL, id, port, log)
+	client := NewClient(wsURL, id, port, nil, log)
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -328,7 +328,7 @@ func TestRelayBaseHeader(t *testing.T) {
 	_, portStr, _ := net.SplitHostPort(localSrv.Listener.Addr().String())
 	port, _ := strconv.Atoi(portStr)
 
-	client := NewClient(wsURL, id, port, log)
+	client := NewClient(wsURL, id, port, nil, log)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 

--- a/pkg/relay/keys.go
+++ b/pkg/relay/keys.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"context"
+	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -39,17 +40,18 @@ func marshalUncompressed(pub *ecdsa.PublicKey) []byte {
 	return b
 }
 
-// unmarshalUncompressed parses a 65-byte uncompressed P-256 point without
-// relying on the deprecated elliptic.Unmarshal.
+// unmarshalUncompressed parses a 65-byte uncompressed P-256 point.
+// Uses crypto/ecdh for on-curve validation (elliptic.IsOnCurve is deprecated).
 func unmarshalUncompressed(b []byte) (*ecdsa.PublicKey, error) {
 	if len(b) != 65 || b[0] != 0x04 {
 		return nil, fmt.Errorf("invalid uncompressed public key (len=%d)", len(b))
 	}
+	// Validate via ecdh.P256().NewPublicKey which performs an on-curve check.
+	if _, err := ecdh.P256().NewPublicKey(b); err != nil {
+		return nil, fmt.Errorf("public key point is not on P-256 curve: %w", err)
+	}
 	x := new(big.Int).SetBytes(b[1:33])
 	y := new(big.Int).SetBytes(b[33:65])
-	if !elliptic.P256().IsOnCurve(x, y) {
-		return nil, fmt.Errorf("public key point is not on P-256 curve")
-	}
 	return &ecdsa.PublicKey{Curve: elliptic.P256(), X: x, Y: y}, nil
 }
 

--- a/pkg/relay/oauth.go
+++ b/pkg/relay/oauth.go
@@ -160,11 +160,17 @@ func BuildAuthURL(baseURL string, identity *Identity, provider, scope string, no
 	}, nil
 }
 
+// OAuthDeliveryType is the wire-format type tag on token delivery envelopes.
+// It is used both as the explicit guard in DecryptOAuthToken and as AES-GCM
+// AAD on both ends (relay: eciesEncrypt, daemon: aead.Open). Keep in sync
+// with dicode-relay src/broker/crypto.ts.
+const OAuthDeliveryType = "oauth_token_delivery"
+
 // OAuthTokenDeliveryPayload is the JSON body the broker POSTs to
 // /hooks/oauth-complete on the daemon, wrapped in the relay request envelope.
 // It mirrors OAuthTokenDeliveryPayload in dicode-relay src/relay/protocol.ts.
 type OAuthTokenDeliveryPayload struct {
-	Type            string `json:"type"`             // always "oauth_token_delivery"
+	Type            string `json:"type"`             // must equal OAuthDeliveryType
 	SessionID       string `json:"session_id"`       // matches the original AuthRequest
 	EphemeralPubkey string `json:"ephemeral_pubkey"` // base64 std, 65-byte uncompressed P-256
 	Ciphertext      string `json:"ciphertext"`       // base64 std, AES-256-GCM ct || 16-byte tag
@@ -189,7 +195,7 @@ func DecryptOAuthToken(identity *Identity, payload *OAuthTokenDeliveryPayload) (
 	// makes aead.Open fail. This is domain separation: the daemon identity
 	// key can never be asked to decrypt a future ciphertext that reuses
 	// this same ECIES scheme under a different Type label.
-	if payload.Type != "oauth_token_delivery" {
+	if payload.Type != OAuthDeliveryType {
 		return nil, fmt.Errorf("unexpected payload type: %q", payload.Type)
 	}
 

--- a/pkg/relay/oauth.go
+++ b/pkg/relay/oauth.go
@@ -7,6 +7,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
@@ -170,11 +171,12 @@ const OAuthDeliveryType = "oauth_token_delivery"
 // /hooks/oauth-complete on the daemon, wrapped in the relay request envelope.
 // It mirrors OAuthTokenDeliveryPayload in dicode-relay src/relay/protocol.ts.
 type OAuthTokenDeliveryPayload struct {
-	Type            string `json:"type"`             // must equal OAuthDeliveryType
-	SessionID       string `json:"session_id"`       // matches the original AuthRequest
-	EphemeralPubkey string `json:"ephemeral_pubkey"` // base64 std, 65-byte uncompressed P-256
-	Ciphertext      string `json:"ciphertext"`       // base64 std, AES-256-GCM ct || 16-byte tag
-	Nonce           string `json:"nonce"`            // base64 std, 12 bytes
+	Type            string `json:"type"`                        // must equal OAuthDeliveryType
+	SessionID       string `json:"session_id"`                  // matches the original AuthRequest
+	EphemeralPubkey string `json:"ephemeral_pubkey"`            // base64 std, 65-byte uncompressed P-256
+	Ciphertext      string `json:"ciphertext"`                  // base64 std, AES-256-GCM ct || 16-byte tag
+	Nonce           string `json:"nonce"`                       // base64 std, 12 bytes
+	BrokerSig       string `json:"broker_sig,omitempty"`        // base64 ECDSA sig over sha256(type||session_id||eph||ct||nonce)
 }
 
 // DecryptOAuthToken decrypts an OAuthTokenDeliveryPayload using the daemon's
@@ -258,6 +260,54 @@ func DecryptOAuthToken(identity *Identity, payload *OAuthTokenDeliveryPayload) (
 		return nil, fmt.Errorf("aes-gcm open: %w", err)
 	}
 	return pt, nil
+}
+
+// VerifyBrokerSig verifies the broker's ECDSA signature over the delivery
+// envelope's immutable fields. brokerPubkeyBase64 is the base64-encoded SPKI
+// DER public key received (and TOFU-pinned) from the relay's welcome message.
+//
+// The signed payload is sha256(type || session_id || ephemeral_pubkey ||
+// ciphertext || nonce) — identical concatenation order on both sides.
+func VerifyBrokerSig(brokerPubkeyBase64 string, payload *OAuthTokenDeliveryPayload) error {
+	if brokerPubkeyBase64 == "" {
+		return fmt.Errorf("no broker pubkey pinned — cannot verify delivery authenticity")
+	}
+	if payload.BrokerSig == "" {
+		return fmt.Errorf("delivery envelope missing broker_sig — broker may be outdated")
+	}
+	pubDER, err := base64.StdEncoding.DecodeString(brokerPubkeyBase64)
+	if err != nil {
+		return fmt.Errorf("decode broker pubkey: %w", err)
+	}
+
+	// Reconstruct the exact digest the broker signed.
+	h := sha256.New()
+	h.Write([]byte(payload.Type))
+	h.Write([]byte(payload.SessionID))
+	h.Write([]byte(payload.EphemeralPubkey))
+	h.Write([]byte(payload.Ciphertext))
+	h.Write([]byte(payload.Nonce))
+	digest := h.Sum(nil)
+
+	sigBytes, err := base64.StdEncoding.DecodeString(payload.BrokerSig)
+	if err != nil {
+		return fmt.Errorf("decode broker sig: %w", err)
+	}
+
+	// Parse the SPKI DER public key.
+	pub, err := x509.ParsePKIXPublicKey(pubDER)
+	if err != nil {
+		return fmt.Errorf("parse broker pubkey: %w", err)
+	}
+	ecPub, ok := pub.(*ecdsa.PublicKey)
+	if !ok {
+		return fmt.Errorf("broker pubkey is not ECDSA")
+	}
+
+	if !ecdsa.VerifyASN1(ecPub, digest, sigBytes) {
+		return fmt.Errorf("broker signature verification failed — envelope may have been tampered with or forged")
+	}
+	return nil
 }
 
 // ecdsaToECDH converts a P-256 ECDSA private key to a crypto/ecdh private key

--- a/pkg/relay/oauth.go
+++ b/pkg/relay/oauth.go
@@ -1,0 +1,255 @@
+package relay
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdh"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+
+	"github.com/google/uuid"
+	"golang.org/x/crypto/hkdf"
+)
+
+// hkdfInfo is the fixed info string used when deriving the AES key for
+// OAuth token delivery. It must match the relay broker
+// (see dicode-relay src/broker/crypto.ts).
+const hkdfInfo = "dicode-oauth-token"
+
+// AuthRequest is the data the daemon needs to track for a pending OAuth flow.
+// The relay broker stores its own copy keyed by SessionID; the daemon keeps
+// PKCEVerifier locally so the verifier never crosses the network.
+type AuthRequest struct {
+	Provider      string
+	SessionID     string // UUID v4, with dashes
+	PKCEVerifier  string // base64url, no padding
+	PKCEChallenge string // base64url(sha256(verifier))
+	Timestamp     int64  // unix seconds
+}
+
+// BuildAuthSignedPayload returns the byte sequence the daemon must sign when
+// initiating an OAuth flow via the broker. It must mirror buildSignedPayload()
+// in dicode-relay src/broker/crypto.ts exactly:
+//
+//	sha256(
+//	  session_id_bytes      // 16 bytes, UUID v4 hex-decoded (dashes stripped)
+//	  pkce_challenge_bytes  // base64url-decoded
+//	  relay_uuid_bytes      // 32 bytes, hex-decoded
+//	  provider_utf8_bytes
+//	  timestamp_be_uint64   // 8 bytes
+//	)
+func BuildAuthSignedPayload(sessionID, pkceChallenge, relayUUID, provider string, timestamp int64) ([]byte, error) {
+	sidHex := strings.ReplaceAll(sessionID, "-", "")
+	sidBytes, err := hex.DecodeString(sidHex)
+	if err != nil {
+		return nil, fmt.Errorf("session id: %w", err)
+	}
+	if len(sidBytes) != 16 {
+		return nil, fmt.Errorf("session id must decode to 16 bytes, got %d", len(sidBytes))
+	}
+
+	challengeBytes, err := base64.RawURLEncoding.DecodeString(pkceChallenge)
+	if err != nil {
+		return nil, fmt.Errorf("pkce challenge: %w", err)
+	}
+
+	relayBytes, err := hex.DecodeString(relayUUID)
+	if err != nil {
+		return nil, fmt.Errorf("relay uuid: %w", err)
+	}
+	if len(relayBytes) != 32 {
+		return nil, fmt.Errorf("relay uuid must decode to 32 bytes, got %d", len(relayBytes))
+	}
+
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], uint64(timestamp))
+
+	h := sha256.New()
+	h.Write(sidBytes)
+	h.Write(challengeBytes)
+	h.Write(relayBytes)
+	h.Write([]byte(provider))
+	h.Write(ts[:])
+	return h.Sum(nil), nil
+}
+
+// SignAuthPayload signs the precomputed payload with the daemon's ECDSA P-256
+// private key and returns the standard-base64-encoded ASN.1 DER signature.
+func SignAuthPayload(priv *ecdsa.PrivateKey, payload []byte) (string, error) {
+	sig, err := ecdsa.SignASN1(rand.Reader, priv, payload)
+	if err != nil {
+		return "", fmt.Errorf("ecdsa sign: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(sig), nil
+}
+
+// generatePKCE returns a fresh PKCE verifier (32 random bytes, base64url) and
+// the matching S256 challenge.
+func generatePKCE() (verifier, challenge string, err error) {
+	var raw [32]byte
+	if _, err := io.ReadFull(rand.Reader, raw[:]); err != nil {
+		return "", "", fmt.Errorf("read random: %w", err)
+	}
+	verifier = base64.RawURLEncoding.EncodeToString(raw[:])
+	sum := sha256.Sum256([]byte(verifier))
+	challenge = base64.RawURLEncoding.EncodeToString(sum[:])
+	return verifier, challenge, nil
+}
+
+// BuildAuthURL constructs a signed `/auth/:provider` URL pointing at the relay
+// broker. The returned AuthRequest carries the session id and PKCE verifier
+// that the daemon must remember to correlate the eventual token delivery.
+//
+//	baseURL  e.g. "https://relay.dicode.app"
+//	scope    optional space-separated scope override (empty = use broker default)
+func BuildAuthURL(baseURL string, identity *Identity, provider, scope string, now int64) (string, *AuthRequest, error) {
+	if identity == nil || identity.PrivateKey == nil {
+		return "", nil, fmt.Errorf("identity required")
+	}
+	if provider == "" {
+		return "", nil, fmt.Errorf("provider required")
+	}
+
+	verifier, challenge, err := generatePKCE()
+	if err != nil {
+		return "", nil, err
+	}
+
+	sessionID := uuid.NewString()
+
+	payload, err := BuildAuthSignedPayload(sessionID, challenge, identity.UUID, provider, now)
+	if err != nil {
+		return "", nil, err
+	}
+	sig, err := SignAuthPayload(identity.PrivateKey, payload)
+	if err != nil {
+		return "", nil, err
+	}
+
+	u, err := url.Parse(strings.TrimRight(baseURL, "/") + "/auth/" + url.PathEscape(provider))
+	if err != nil {
+		return "", nil, fmt.Errorf("parse base url: %w", err)
+	}
+	q := u.Query()
+	q.Set("session", sessionID)
+	q.Set("challenge", challenge)
+	q.Set("relay_uuid", identity.UUID)
+	q.Set("sig", sig)
+	q.Set("timestamp", fmt.Sprintf("%d", now))
+	if scope != "" {
+		q.Set("scope", scope)
+	}
+	u.RawQuery = q.Encode()
+
+	return u.String(), &AuthRequest{
+		Provider:      provider,
+		SessionID:     sessionID,
+		PKCEVerifier:  verifier,
+		PKCEChallenge: challenge,
+		Timestamp:     now,
+	}, nil
+}
+
+// OAuthTokenDeliveryPayload is the JSON body the broker POSTs to
+// /hooks/oauth-complete on the daemon, wrapped in the relay request envelope.
+// It mirrors OAuthTokenDeliveryPayload in dicode-relay src/relay/protocol.ts.
+type OAuthTokenDeliveryPayload struct {
+	Type            string `json:"type"`             // always "oauth_token_delivery"
+	SessionID       string `json:"session_id"`       // matches the original AuthRequest
+	EphemeralPubkey string `json:"ephemeral_pubkey"` // base64 std, 65-byte uncompressed P-256
+	Ciphertext      string `json:"ciphertext"`       // base64 std, AES-256-GCM ct || 16-byte tag
+	Nonce           string `json:"nonce"`            // base64 std, 12 bytes
+}
+
+// DecryptOAuthToken decrypts an OAuthTokenDeliveryPayload using the daemon's
+// long-lived private key. It performs ECDH against the broker's ephemeral
+// public key, derives a 32-byte AES-256 key via HKDF-SHA256 (with the session
+// id as salt and "dicode-oauth-token" as info), and finally AES-256-GCM
+// decrypts the payload. The 16-byte GCM auth tag is appended to the ciphertext
+// per the broker convention; this function splits it back off.
+func DecryptOAuthToken(identity *Identity, payload *OAuthTokenDeliveryPayload) ([]byte, error) {
+	if identity == nil || identity.PrivateKey == nil {
+		return nil, fmt.Errorf("identity required")
+	}
+	if payload == nil {
+		return nil, fmt.Errorf("payload required")
+	}
+	if payload.Type != "" && payload.Type != "oauth_token_delivery" {
+		return nil, fmt.Errorf("unexpected payload type: %s", payload.Type)
+	}
+
+	ephBytes, err := base64.StdEncoding.DecodeString(payload.EphemeralPubkey)
+	if err != nil {
+		return nil, fmt.Errorf("decode ephemeral pubkey: %w", err)
+	}
+	curve := ecdh.P256()
+	ephPub, err := curve.NewPublicKey(ephBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse ephemeral pubkey: %w", err)
+	}
+
+	// Convert the long-lived ECDSA key to an ECDH key on the same curve.
+	daemonECDH, err := ecdsaToECDH(identity.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("convert daemon key: %w", err)
+	}
+
+	shared, err := daemonECDH.ECDH(ephPub)
+	if err != nil {
+		return nil, fmt.Errorf("ecdh: %w", err)
+	}
+
+	encKey := make([]byte, 32)
+	kdf := hkdf.New(sha256.New, shared, []byte(payload.SessionID), []byte(hkdfInfo))
+	if _, err := io.ReadFull(kdf, encKey); err != nil {
+		return nil, fmt.Errorf("hkdf: %w", err)
+	}
+
+	iv, err := base64.StdEncoding.DecodeString(payload.Nonce)
+	if err != nil {
+		return nil, fmt.Errorf("decode nonce: %w", err)
+	}
+	if len(iv) != 12 {
+		return nil, fmt.Errorf("nonce must be 12 bytes, got %d", len(iv))
+	}
+
+	ctWithTag, err := base64.StdEncoding.DecodeString(payload.Ciphertext)
+	if err != nil {
+		return nil, fmt.Errorf("decode ciphertext: %w", err)
+	}
+	if len(ctWithTag) < 16 {
+		return nil, fmt.Errorf("ciphertext too short for gcm tag")
+	}
+
+	block, err := aes.NewCipher(encKey)
+	if err != nil {
+		return nil, fmt.Errorf("aes: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("gcm: %w", err)
+	}
+	// crypto/cipher GCM expects ct || tag, which matches the broker layout.
+	pt, err := aead.Open(nil, iv, ctWithTag, nil)
+	if err != nil {
+		return nil, fmt.Errorf("aes-gcm open: %w", err)
+	}
+	return pt, nil
+}
+
+// ecdsaToECDH converts a P-256 ECDSA private key to a crypto/ecdh private key
+// so it can participate in ECDH against the broker's ephemeral key.
+func ecdsaToECDH(priv *ecdsa.PrivateKey) (*ecdh.PrivateKey, error) {
+	if name := priv.PublicKey.Curve.Params().Name; name != "P-256" {
+		return nil, fmt.Errorf("only P-256 supported, got %s", name)
+	}
+	return ecdh.P256().NewPrivateKey(priv.D.FillBytes(make([]byte, 32)))
+}

--- a/pkg/relay/oauth.go
+++ b/pkg/relay/oauth.go
@@ -184,12 +184,11 @@ func DecryptOAuthToken(identity *Identity, payload *OAuthTokenDeliveryPayload) (
 	if payload == nil {
 		return nil, fmt.Errorf("payload required")
 	}
-	// Require an explicit, known type tag. The relay broker always sets
-	// Type="oauth_token_delivery"; accepting envelopes with an empty type
-	// would let a future (or malicious) sender of any other encrypted-to-
-	// this-daemon ciphertext reuse the same decrypt path. Until the relay
-	// and daemon both support binding Type as GCM AAD (coordinated change,
-	// tracked separately), requiring a non-empty tag is the best we can do.
+	// Require an explicit, known type tag. The tag is also bound into the
+	// GCM authenticated data below, so a mismatch (or tampering in transit)
+	// makes aead.Open fail. This is domain separation: the daemon identity
+	// key can never be asked to decrypt a future ciphertext that reuses
+	// this same ECIES scheme under a different Type label.
 	if payload.Type != "oauth_token_delivery" {
 		return nil, fmt.Errorf("unexpected payload type: %q", payload.Type)
 	}
@@ -246,7 +245,9 @@ func DecryptOAuthToken(identity *Identity, payload *OAuthTokenDeliveryPayload) (
 		return nil, fmt.Errorf("gcm: %w", err)
 	}
 	// crypto/cipher GCM expects ct || tag, which matches the broker layout.
-	pt, err := aead.Open(nil, iv, ctWithTag, nil)
+	// Type is passed as AAD — the broker binds the same bytes on encrypt,
+	// so any mismatch (or in-transit tampering of Type) makes Open fail.
+	pt, err := aead.Open(nil, iv, ctWithTag, []byte(payload.Type))
 	if err != nil {
 		return nil, fmt.Errorf("aes-gcm open: %w", err)
 	}

--- a/pkg/relay/oauth.go
+++ b/pkg/relay/oauth.go
@@ -24,14 +24,15 @@ import (
 // (see dicode-relay src/broker/crypto.ts).
 const hkdfInfo = "dicode-oauth-token"
 
-// AuthRequest is the data the daemon needs to track for a pending OAuth flow.
-// The relay broker stores its own copy keyed by SessionID; the daemon keeps
-// PKCEVerifier locally so the verifier never crosses the network.
+// AuthRequest is the data the daemon needs to track for a pending OAuth
+// flow. The challenge is retained only because it's part of the signed
+// payload the broker verifies — the daemon never runs the code exchange
+// itself (Grant on the relay handles PKCE upstream), so no verifier is
+// stored here.
 type AuthRequest struct {
 	Provider      string
 	SessionID     string // UUID v4, with dashes
-	PKCEVerifier  string // base64url, no padding
-	PKCEChallenge string // base64url(sha256(verifier))
+	PKCEChallenge string // base64url(sha256(random verifier)) — bound into the signed payload
 	Timestamp     int64  // unix seconds
 }
 
@@ -91,22 +92,24 @@ func SignAuthPayload(priv *ecdsa.PrivateKey, payload []byte) (string, error) {
 	return base64.StdEncoding.EncodeToString(sig), nil
 }
 
-// generatePKCE returns a fresh PKCE verifier (32 random bytes, base64url) and
-// the matching S256 challenge.
-func generatePKCE() (verifier, challenge string, err error) {
+// generatePKCEChallenge returns a fresh base64url S256 challenge. The
+// underlying verifier is intentionally discarded: the daemon never completes
+// the code exchange itself — Grant on the relay side runs its own PKCE
+// against the upstream provider. Our challenge exists solely to bind the
+// daemon's signed payload to a value that cannot be swapped in the URL.
+func generatePKCEChallenge() (string, error) {
 	var raw [32]byte
 	if _, err := io.ReadFull(rand.Reader, raw[:]); err != nil {
-		return "", "", fmt.Errorf("read random: %w", err)
+		return "", fmt.Errorf("read random: %w", err)
 	}
-	verifier = base64.RawURLEncoding.EncodeToString(raw[:])
+	verifier := base64.RawURLEncoding.EncodeToString(raw[:])
 	sum := sha256.Sum256([]byte(verifier))
-	challenge = base64.RawURLEncoding.EncodeToString(sum[:])
-	return verifier, challenge, nil
+	return base64.RawURLEncoding.EncodeToString(sum[:]), nil
 }
 
-// BuildAuthURL constructs a signed `/auth/:provider` URL pointing at the relay
-// broker. The returned AuthRequest carries the session id and PKCE verifier
-// that the daemon must remember to correlate the eventual token delivery.
+// BuildAuthURL constructs a signed `/auth/:provider` URL pointing at the
+// relay broker and returns the matching AuthRequest for the daemon-side
+// pending store.
 //
 //	baseURL  e.g. "https://relay.dicode.app"
 //	scope    optional space-separated scope override (empty = use broker default)
@@ -118,7 +121,7 @@ func BuildAuthURL(baseURL string, identity *Identity, provider, scope string, no
 		return "", nil, fmt.Errorf("provider required")
 	}
 
-	verifier, challenge, err := generatePKCE()
+	challenge, err := generatePKCEChallenge()
 	if err != nil {
 		return "", nil, err
 	}
@@ -152,7 +155,6 @@ func BuildAuthURL(baseURL string, identity *Identity, provider, scope string, no
 	return u.String(), &AuthRequest{
 		Provider:      provider,
 		SessionID:     sessionID,
-		PKCEVerifier:  verifier,
 		PKCEChallenge: challenge,
 		Timestamp:     now,
 	}, nil
@@ -182,8 +184,14 @@ func DecryptOAuthToken(identity *Identity, payload *OAuthTokenDeliveryPayload) (
 	if payload == nil {
 		return nil, fmt.Errorf("payload required")
 	}
-	if payload.Type != "" && payload.Type != "oauth_token_delivery" {
-		return nil, fmt.Errorf("unexpected payload type: %s", payload.Type)
+	// Require an explicit, known type tag. The relay broker always sets
+	// Type="oauth_token_delivery"; accepting envelopes with an empty type
+	// would let a future (or malicious) sender of any other encrypted-to-
+	// this-daemon ciphertext reuse the same decrypt path. Until the relay
+	// and daemon both support binding Type as GCM AAD (coordinated change,
+	// tracked separately), requiring a non-empty tag is the best we can do.
+	if payload.Type != "oauth_token_delivery" {
+		return nil, fmt.Errorf("unexpected payload type: %q", payload.Type)
 	}
 
 	ephBytes, err := base64.StdEncoding.DecodeString(payload.EphemeralPubkey)

--- a/pkg/relay/oauth_pending.go
+++ b/pkg/relay/oauth_pending.go
@@ -1,0 +1,102 @@
+package relay
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// DefaultPendingTTL bounds how long the daemon remembers an outstanding OAuth
+// flow. The relay broker expires its own session at 5 minutes; we add a small
+// grace window so an in-flight callback can still be correlated by session id
+// after the broker has already forwarded the encrypted delivery.
+const DefaultPendingTTL = 6 * time.Minute
+
+// ErrPendingNotFound is returned when a session id is not (or no longer)
+// tracked in the PendingSessions store.
+var ErrPendingNotFound = errors.New("oauth: pending session not found")
+
+// PendingSessions is a TTL-bounded in-memory map of OAuth flows that have
+// been initiated but not yet completed. Its purpose is to bind each incoming
+// token delivery on /hooks/oauth-complete to an AuthRequest the daemon
+// actually issued — without this check, dicode.oauth.store_token would
+// accept any envelope that happened to be encrypted to the daemon's public
+// key, handing a malicious caller a chosen-salt oracle on the identity key.
+//
+// The store is intentionally non-persistent. A daemon restart invalidates
+// outstanding flows; the user re-initiates. The relay broker's own session
+// TTL is the same order of magnitude, so persistence would buy little.
+type PendingSessions struct {
+	mu      sync.Mutex
+	byID    map[string]*AuthRequest
+	ttl     time.Duration
+	nowFunc func() time.Time
+}
+
+// NewPendingSessions creates an empty store with DefaultPendingTTL.
+func NewPendingSessions() *PendingSessions {
+	return &PendingSessions{
+		byID:    make(map[string]*AuthRequest),
+		ttl:     DefaultPendingTTL,
+		nowFunc: time.Now,
+	}
+}
+
+// Add registers a freshly-issued AuthRequest. The caller is responsible for
+// making the session id unique (uuid.NewString in BuildAuthURL guarantees it
+// in practice). Existing entries under the same id are overwritten.
+func (s *PendingSessions) Add(req *AuthRequest) {
+	if req == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.byID[req.SessionID] = req
+}
+
+// Take atomically returns the AuthRequest for a given session id and removes
+// it from the store. The caller must hold exclusive access to the returned
+// struct — it will not be returned to anyone else. If no matching entry
+// exists (or the entry has expired) Take returns ErrPendingNotFound.
+//
+// Take is the correct primitive for /hooks/oauth-complete handling: the
+// delivery is single-use, so we want to evict on read even if downstream
+// decrypt/parse/store later fails (a failed delivery must not leave the
+// session re-usable as a decryption oracle).
+func (s *PendingSessions) Take(sessionID string) (*AuthRequest, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	req, ok := s.byID[sessionID]
+	if !ok {
+		return nil, ErrPendingNotFound
+	}
+	delete(s.byID, sessionID)
+	if s.nowFunc().Sub(time.Unix(req.Timestamp, 0)) > s.ttl {
+		return nil, ErrPendingNotFound
+	}
+	return req, nil
+}
+
+// SweepExpired removes any sessions whose issue timestamp is older than ttl.
+// Intended for a background ticker, but correctness does not depend on it —
+// Take performs a lazy expiry check on every read.
+func (s *PendingSessions) SweepExpired() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cutoff := s.nowFunc().Add(-s.ttl)
+	removed := 0
+	for id, req := range s.byID {
+		if time.Unix(req.Timestamp, 0).Before(cutoff) {
+			delete(s.byID, id)
+			removed++
+		}
+	}
+	return removed
+}
+
+// Len reports the number of currently tracked sessions. Test-only convenience.
+func (s *PendingSessions) Len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.byID)
+}

--- a/pkg/relay/oauth_pending.go
+++ b/pkg/relay/oauth_pending.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"time"
@@ -59,10 +60,11 @@ func (s *PendingSessions) Add(req *AuthRequest) {
 // struct — it will not be returned to anyone else. If no matching entry
 // exists (or the entry has expired) Take returns ErrPendingNotFound.
 //
-// Take is the correct primitive for /hooks/oauth-complete handling: the
-// delivery is single-use, so we want to evict on read even if downstream
-// decrypt/parse/store later fails (a failed delivery must not leave the
-// session re-usable as a decryption oracle).
+// Take is the correct primitive for /hooks/oauth-complete handling: it
+// enforces single-use binding of a delivery to a request the daemon
+// actually issued. Evicting on read (even if downstream decrypt/parse/
+// store later fails) guarantees that a token-delivery envelope cannot be
+// replayed to trigger repeated decryptions of the same ciphertext.
 func (s *PendingSessions) Take(sessionID string) (*AuthRequest, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -99,4 +101,20 @@ func (s *PendingSessions) Len() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.byID)
+}
+
+// StartSweep runs SweepExpired on a ticker until ctx is cancelled.
+// Safe to call from a background goroutine at daemon startup; the method
+// returns when the context is done.
+func (s *PendingSessions) StartSweep(ctx context.Context) {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.SweepExpired()
+		}
+	}
 }

--- a/pkg/relay/oauth_pending_test.go
+++ b/pkg/relay/oauth_pending_test.go
@@ -1,0 +1,70 @@
+package relay
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func newAuthReq(sessionID string, ts int64) *AuthRequest {
+	return &AuthRequest{
+		Provider:  "slack",
+		SessionID: sessionID,
+		Timestamp: ts,
+	}
+}
+
+func TestPendingSessions_AddTake(t *testing.T) {
+	store := NewPendingSessions()
+	store.Add(newAuthReq("s-1", time.Now().Unix()))
+	if store.Len() != 1 {
+		t.Fatalf("len: %d", store.Len())
+	}
+
+	got, err := store.Take("s-1")
+	if err != nil {
+		t.Fatalf("take: %v", err)
+	}
+	if got.SessionID != "s-1" || got.Provider != "slack" {
+		t.Fatalf("bad take: %+v", got)
+	}
+	if store.Len() != 0 {
+		t.Fatalf("take should evict")
+	}
+}
+
+func TestPendingSessions_TakeMissing(t *testing.T) {
+	store := NewPendingSessions()
+	if _, err := store.Take("nope"); !errors.Is(err, ErrPendingNotFound) {
+		t.Fatalf("expected ErrPendingNotFound, got %v", err)
+	}
+}
+
+func TestPendingSessions_TakeExpired(t *testing.T) {
+	store := NewPendingSessions()
+	frozen := time.Now()
+	store.nowFunc = func() time.Time { return frozen }
+	store.ttl = time.Second
+
+	// Timestamp the session as 10s ago; nowFunc is frozen at 'now'.
+	store.Add(newAuthReq("s-old", frozen.Add(-10*time.Second).Unix()))
+	if _, err := store.Take("s-old"); !errors.Is(err, ErrPendingNotFound) {
+		t.Fatalf("expected expired → ErrPendingNotFound, got %v", err)
+	}
+}
+
+func TestPendingSessions_Sweep(t *testing.T) {
+	store := NewPendingSessions()
+	frozen := time.Now()
+	store.nowFunc = func() time.Time { return frozen }
+	store.ttl = time.Minute
+
+	store.Add(newAuthReq("fresh", frozen.Unix()))
+	store.Add(newAuthReq("stale", frozen.Add(-2*time.Minute).Unix()))
+	if removed := store.SweepExpired(); removed != 1 {
+		t.Fatalf("expected 1 removed, got %d", removed)
+	}
+	if store.Len() != 1 {
+		t.Fatalf("len after sweep: %d", store.Len())
+	}
+}

--- a/pkg/relay/oauth_test.go
+++ b/pkg/relay/oauth_test.go
@@ -1,0 +1,245 @@
+package relay
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdh"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"io"
+	"net/url"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+// newOAuthTestIdentity creates a fresh in-memory P-256 identity (no DB writes).
+func newOAuthTestIdentity(t *testing.T) *Identity {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return &Identity{
+		PrivateKey: key,
+		UUID:       deriveUUID(&key.PublicKey),
+	}
+}
+
+func TestBuildAuthSignedPayload_Deterministic(t *testing.T) {
+	const (
+		sessionID = "550e8400-e29b-41d4-a716-446655440000"
+		challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+		relayUUID = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+		provider  = "slack"
+		ts        = int64(1_700_000_000)
+	)
+
+	got1, err := BuildAuthSignedPayload(sessionID, challenge, relayUUID, provider, ts)
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	got2, err := BuildAuthSignedPayload(sessionID, challenge, relayUUID, provider, ts)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if string(got1) != string(got2) {
+		t.Fatalf("non-deterministic output")
+	}
+
+	// Sanity check against an inline reference computation: the two
+	// implementations (Go here and TS in dicode-relay) must agree, but we
+	// also lock in this byte sequence so accidental changes are caught.
+	sidBytes, _ := hex.DecodeString(strings.ReplaceAll(sessionID, "-", ""))
+	chBytes, _ := base64.RawURLEncoding.DecodeString(challenge)
+	relayBytes, _ := hex.DecodeString(relayUUID)
+	var tsBytes [8]byte
+	binary.BigEndian.PutUint64(tsBytes[:], uint64(ts))
+	h := sha256.New()
+	h.Write(sidBytes)
+	h.Write(chBytes)
+	h.Write(relayBytes)
+	h.Write([]byte(provider))
+	h.Write(tsBytes[:])
+	want := h.Sum(nil)
+	if string(got1) != string(want) {
+		t.Fatalf("payload mismatch:\n got=%x\nwant=%x", got1, want)
+	}
+}
+
+func TestBuildAuthSignedPayload_RejectsBadInputs(t *testing.T) {
+	cases := []struct {
+		name      string
+		sessionID string
+		challenge string
+		relay     string
+	}{
+		{"bad session", "not-a-uuid", "E9MelhoazOwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM", strings.Repeat("a", 64)},
+		{"bad challenge", "550e8400e29b41d4a716446655440000", "!!!not base64url!!!", strings.Repeat("a", 64)},
+		{"short relay", "550e8400e29b41d4a716446655440000", "E9MelhoazOwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM", "deadbeef"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := BuildAuthSignedPayload(tc.sessionID, tc.challenge, tc.relay, "slack", 1); err == nil {
+				t.Fatalf("expected error")
+			}
+		})
+	}
+}
+
+func TestBuildAuthURL_RoundTripVerify(t *testing.T) {
+	id := newOAuthTestIdentity(t)
+
+	rawURL, req, err := BuildAuthURL("https://relay.dicode.app", id, "slack", "channels:read users:read", 1_700_000_000)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if req.Provider != "slack" || req.SessionID == "" || req.PKCEVerifier == "" || req.PKCEChallenge == "" {
+		t.Fatalf("incomplete AuthRequest: %+v", req)
+	}
+
+	// PKCE verifier → challenge consistency.
+	sum := sha256.Sum256([]byte(req.PKCEVerifier))
+	if base64.RawURLEncoding.EncodeToString(sum[:]) != req.PKCEChallenge {
+		t.Fatalf("pkce challenge does not match verifier")
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	if u.Path != "/auth/slack" {
+		t.Fatalf("unexpected path: %s", u.Path)
+	}
+	q := u.Query()
+	for _, k := range []string{"session", "challenge", "relay_uuid", "sig", "timestamp", "scope"} {
+		if q.Get(k) == "" {
+			t.Fatalf("missing query param %s", k)
+		}
+	}
+	if q.Get("relay_uuid") != id.UUID {
+		t.Fatalf("relay_uuid mismatch")
+	}
+	if q.Get("scope") != "channels:read users:read" {
+		t.Fatalf("scope mismatch")
+	}
+
+	// Verify signature with the daemon's public key — exercising the same
+	// code path the relay broker uses.
+	payload, err := BuildAuthSignedPayload(q.Get("session"), q.Get("challenge"), q.Get("relay_uuid"), "slack", 1_700_000_000)
+	if err != nil {
+		t.Fatalf("rebuild payload: %v", err)
+	}
+	sigBytes, err := base64.StdEncoding.DecodeString(q.Get("sig"))
+	if err != nil {
+		t.Fatalf("decode sig: %v", err)
+	}
+	if !ecdsa.VerifyASN1(&id.PrivateKey.PublicKey, payload, sigBytes) {
+		t.Fatalf("signature verification failed")
+	}
+}
+
+func TestBuildAuthURL_OmitsEmptyScope(t *testing.T) {
+	id := newOAuthTestIdentity(t)
+	rawURL, _, err := BuildAuthURL("https://relay.dicode.app", id, "slack", "", 1)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	u, _ := url.Parse(rawURL)
+	if u.Query().Has("scope") {
+		t.Fatalf("expected no scope param when scope is empty")
+	}
+}
+
+// TestDecryptOAuthToken_RoundTrip generates an ephemeral keypair on the
+// "broker" side, encrypts a token payload exactly the way dicode-relay does,
+// then verifies the daemon-side DecryptOAuthToken recovers the plaintext.
+func TestDecryptOAuthToken_RoundTrip(t *testing.T) {
+	daemon := newOAuthTestIdentity(t)
+	plaintext := []byte(`{"access_token":"xoxb-test-token","scope":"channels:read"}`)
+	sessionID := "550e8400-e29b-41d4-a716-446655440000"
+
+	payload := encryptForDaemon(t, daemon, sessionID, plaintext)
+
+	got, err := DecryptOAuthToken(daemon, payload)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if string(got) != string(plaintext) {
+		t.Fatalf("plaintext mismatch:\n got=%q\nwant=%q", got, plaintext)
+	}
+}
+
+func TestDecryptOAuthToken_RejectsTamperedCiphertext(t *testing.T) {
+	daemon := newOAuthTestIdentity(t)
+	payload := encryptForDaemon(t, daemon, "550e8400-e29b-41d4-a716-446655440000", []byte("hello"))
+
+	// Flip a byte in the middle of the ciphertext.
+	ct, _ := base64.StdEncoding.DecodeString(payload.Ciphertext)
+	ct[0] ^= 0xFF
+	payload.Ciphertext = base64.StdEncoding.EncodeToString(ct)
+
+	if _, err := DecryptOAuthToken(daemon, payload); err == nil {
+		t.Fatalf("expected error on tampered ciphertext")
+	}
+}
+
+func TestDecryptOAuthToken_RejectsWrongSession(t *testing.T) {
+	daemon := newOAuthTestIdentity(t)
+	payload := encryptForDaemon(t, daemon, "550e8400-e29b-41d4-a716-446655440000", []byte("hello"))
+	payload.SessionID = "00000000-0000-0000-0000-000000000000"
+
+	if _, err := DecryptOAuthToken(daemon, payload); err == nil {
+		t.Fatalf("expected error when session id (HKDF salt) is wrong")
+	}
+}
+
+// encryptForDaemon mirrors dicode-relay src/broker/crypto.ts eciesEncrypt().
+func encryptForDaemon(t *testing.T, daemon *Identity, sessionID string, plaintext []byte) *OAuthTokenDeliveryPayload {
+	t.Helper()
+
+	// Daemon's long-lived public key as a crypto/ecdh peer key.
+	daemonPubBytes := daemon.UncompressedPublicKey()
+	daemonPub, err := ecdh.P256().NewPublicKey(daemonPubBytes)
+	if err != nil {
+		t.Fatalf("daemon pub: %v", err)
+	}
+
+	// Fresh ephemeral keypair on the broker side.
+	eph, err := ecdh.P256().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("eph keygen: %v", err)
+	}
+	shared, err := eph.ECDH(daemonPub)
+	if err != nil {
+		t.Fatalf("ecdh: %v", err)
+	}
+
+	encKey := make([]byte, 32)
+	kdf := hkdf.New(sha256.New, shared, []byte(sessionID), []byte(hkdfInfo))
+	if _, err := io.ReadFull(kdf, encKey); err != nil {
+		t.Fatalf("hkdf: %v", err)
+	}
+
+	iv := make([]byte, 12)
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		t.Fatalf("iv: %v", err)
+	}
+	block, _ := aes.NewCipher(encKey)
+	aead, _ := cipher.NewGCM(block)
+	ctWithTag := aead.Seal(nil, iv, plaintext, nil)
+
+	return &OAuthTokenDeliveryPayload{
+		Type:            "oauth_token_delivery",
+		SessionID:       sessionID,
+		EphemeralPubkey: base64.StdEncoding.EncodeToString(eph.PublicKey().Bytes()),
+		Ciphertext:      base64.StdEncoding.EncodeToString(ctWithTag),
+		Nonce:           base64.StdEncoding.EncodeToString(iv),
+	}
+}

--- a/pkg/relay/oauth_test.go
+++ b/pkg/relay/oauth_test.go
@@ -100,14 +100,8 @@ func TestBuildAuthURL_RoundTripVerify(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
-	if req.Provider != "slack" || req.SessionID == "" || req.PKCEVerifier == "" || req.PKCEChallenge == "" {
+	if req.Provider != "slack" || req.SessionID == "" || req.PKCEChallenge == "" {
 		t.Fatalf("incomplete AuthRequest: %+v", req)
-	}
-
-	// PKCE verifier → challenge consistency.
-	sum := sha256.Sum256([]byte(req.PKCEVerifier))
-	if base64.RawURLEncoding.EncodeToString(sum[:]) != req.PKCEChallenge {
-		t.Fatalf("pkce challenge does not match verifier")
 	}
 
 	u, err := url.Parse(rawURL)

--- a/pkg/relay/oauth_test.go
+++ b/pkg/relay/oauth_test.go
@@ -194,6 +194,38 @@ func TestDecryptOAuthToken_RejectsWrongSession(t *testing.T) {
 	}
 }
 
+// Envelopes with an empty Type must be rejected outright — the Type field
+// is the AAD, so accepting an empty value would silently disable domain
+// separation against any future ECIES-encrypted message type reusing this
+// key (see also the review notes in docs/design/oauth-broker if added).
+func TestDecryptOAuthToken_RejectsEmptyType(t *testing.T) {
+	daemon := newOAuthTestIdentity(t)
+	payload := encryptForDaemon(t, daemon, "550e8400-e29b-41d4-a716-446655440000", []byte("hello"))
+	payload.Type = ""
+
+	if _, err := DecryptOAuthToken(daemon, payload); err == nil {
+		t.Fatalf("expected error when Type is empty")
+	}
+}
+
+// Tampering with Type must invalidate the GCM tag because Type is bound as
+// AAD. This is the domain-separation guarantee in the positive direction:
+// not just "empty rejected" but "any mismatch rejected by the AEAD itself".
+func TestDecryptOAuthToken_RejectsTamperedType(t *testing.T) {
+	daemon := newOAuthTestIdentity(t)
+	payload := encryptForDaemon(t, daemon, "550e8400-e29b-41d4-a716-446655440000", []byte("hello"))
+	// A different non-empty type passes the explicit check but must fail
+	// aead.Open because the AAD no longer matches what was sealed.
+	// (We have to bypass the Type-required guard by sending a plausible-
+	//  looking alternative; since the current guard rejects anything not
+	//  equal to "oauth_token_delivery", this doubles as coverage for that.)
+	payload.Type = "wrong_type"
+
+	if _, err := DecryptOAuthToken(daemon, payload); err == nil {
+		t.Fatalf("expected error when Type is tampered")
+	}
+}
+
 // encryptForDaemon mirrors dicode-relay src/broker/crypto.ts eciesEncrypt().
 func encryptForDaemon(t *testing.T, daemon *Identity, sessionID string, plaintext []byte) *OAuthTokenDeliveryPayload {
 	t.Helper()
@@ -227,7 +259,7 @@ func encryptForDaemon(t *testing.T, daemon *Identity, sessionID string, plaintex
 	}
 	block, _ := aes.NewCipher(encKey)
 	aead, _ := cipher.NewGCM(block)
-	ctWithTag := aead.Seal(nil, iv, plaintext, nil)
+	ctWithTag := aead.Seal(nil, iv, plaintext, []byte("oauth_token_delivery"))
 
 	return &OAuthTokenDeliveryPayload{
 		Type:            "oauth_token_delivery",

--- a/pkg/relay/protocol.go
+++ b/pkg/relay/protocol.go
@@ -25,8 +25,9 @@ type helloMsg struct {
 }
 
 type welcomeMsg struct {
-	Type string `json:"type"`
-	URL  string `json:"url"`
+	Type         string `json:"type"`
+	URL          string `json:"url"`
+	BrokerPubkey string `json:"broker_pubkey,omitempty"` // base64 SPKI DER — TOFU-pinned by the daemon
 }
 
 type errorMsg struct {

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -21,6 +21,7 @@ import (
 	denopkg "github.com/dicode/dicode/pkg/deno"
 	"github.com/dicode/dicode/pkg/ipc"
 	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/relay"
 	pkgruntime "github.com/dicode/dicode/pkg/runtime"
 	"github.com/dicode/dicode/pkg/secrets"
 	"github.com/dicode/dicode/pkg/task"
@@ -80,6 +81,9 @@ type Runtime struct {
 	aiBaseURL      string
 	aiModel        string
 	aiAPIKey       string
+	oauthIdentity  *relay.Identity
+	oauthURL       string
+	oauthPending   *relay.PendingSessions
 }
 
 // New creates a Deno Runtime. It ensures the Deno binary is present in the
@@ -105,6 +109,17 @@ func (rt *Runtime) SetGateway(g *ipc.Gateway) { rt.gateway = g }
 // SetSecretsManager wires the secrets manager so tasks with permissions.dicode.secrets_write
 // can call dicode.secrets_set() and dicode.secrets_delete().
 func (rt *Runtime) SetSecretsManager(m secrets.Manager) { rt.secretsManager = m }
+
+// SetOAuthBroker wires the daemon's relay identity, broker base URL, and
+// the daemon-wide PendingSessions store so the auth-start and auth-relay
+// built-in tasks can use dicode.oauth.*. All three are required together;
+// passing nil leaves the oauth API inert and tasks will receive a
+// "not configured" error.
+func (rt *Runtime) SetOAuthBroker(id *relay.Identity, baseURL string, pending *relay.PendingSessions) {
+	rt.oauthIdentity = id
+	rt.oauthURL = baseURL
+	rt.oauthPending = pending
+}
 
 // SetAIConfig configures the AI provider details passed to tasks via dicode.get_config.
 func (rt *Runtime) SetAIConfig(baseURL, model, apiKey string) {
@@ -199,6 +214,9 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	srv := ipc.New(runID, spec.ID, rt.secret, rt.registry, rt.db, mergedParams, opts.Input, rt.log, spec, rt.engine, rt.aiBaseURL, rt.aiModel, rt.aiAPIKey)
 	srv.SetGateway(rt.gateway)
 	srv.SetSecrets(rt.secretsManager)
+	if rt.oauthIdentity != nil {
+		srv.SetOAuthBroker(rt.oauthIdentity, rt.oauthURL, rt.oauthPending)
+	}
 	socketPath, token, err := srv.Start(execCtx)
 	if err != nil {
 		status = registry.StatusFailure

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -84,6 +84,7 @@ type Runtime struct {
 	oauthIdentity  *relay.Identity
 	oauthURL       string
 	oauthPending   *relay.PendingSessions
+	brokerPubkeyFn func() string
 }
 
 // New creates a Deno Runtime. It ensures the Deno binary is present in the
@@ -115,10 +116,11 @@ func (rt *Runtime) SetSecretsManager(m secrets.Manager) { rt.secretsManager = m 
 // built-in tasks can use dicode.oauth.*. All three are required together;
 // passing nil leaves the oauth API inert and tasks will receive a
 // "not configured" error.
-func (rt *Runtime) SetOAuthBroker(id *relay.Identity, baseURL string, pending *relay.PendingSessions) {
+func (rt *Runtime) SetOAuthBroker(id *relay.Identity, baseURL string, pending *relay.PendingSessions, brokerPubkeyFn func() string) {
 	rt.oauthIdentity = id
 	rt.oauthURL = baseURL
 	rt.oauthPending = pending
+	rt.brokerPubkeyFn = brokerPubkeyFn
 }
 
 // SetAIConfig configures the AI provider details passed to tasks via dicode.get_config.
@@ -215,7 +217,7 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	srv.SetGateway(rt.gateway)
 	srv.SetSecrets(rt.secretsManager)
 	if rt.oauthIdentity != nil {
-		srv.SetOAuthBroker(rt.oauthIdentity, rt.oauthURL, rt.oauthPending)
+		srv.SetOAuthBroker(rt.oauthIdentity, rt.oauthURL, rt.oauthPending, rt.brokerPubkeyFn)
 	}
 	socketPath, token, err := srv.Start(execCtx)
 	if err != nil {

--- a/pkg/runtime/deno/sdk/sdk.d.ts
+++ b/pkg/runtime/deno/sdk/sdk.d.ts
@@ -32,6 +32,26 @@ declare interface MCP {
   call:       (name: string, tool: string, args?: Record<string, unknown>) => Promise<unknown>;
 }
 
+declare interface OAuthAuthURL {
+  url:        string;
+  session_id: string;
+  provider:   string;
+  timestamp:  number;
+  relay_uuid: string;
+}
+
+declare interface OAuthStoreResult {
+  provider: string;
+  secrets:  string[];
+}
+
+declare interface DicodeOAuth {
+  /** Requires permissions.dicode.oauth_init. Signs the daemon's side of a /auth/:provider URL via the relay broker. */
+  build_auth_url: (provider: string, scope?: string) => Promise<OAuthAuthURL>;
+  /** Requires permissions.dicode.oauth_store. Decrypts an incoming token envelope and writes the resulting credentials to secrets. Plaintext never crosses the IPC boundary. */
+  store_token:    (envelope: unknown)                => Promise<OAuthStoreResult>;
+}
+
 declare interface Dicode {
   /** Fully-namespaced id of the currently-running task (e.g. "buildin/ai-agent"). */
   task_id:        string;
@@ -43,6 +63,7 @@ declare interface Dicode {
   get_config:     (section: string)                                  => Promise<unknown>;
   secrets_set:    (key: string, value: string)                       => Promise<void>;
   secrets_delete: (key: string)                                       => Promise<void>;
+  oauth:          DicodeOAuth;
 }
 
 /** All SDK globals passed to your task's main() function. */

--- a/pkg/runtime/deno/sdk/shim.ts
+++ b/pkg/runtime/deno/sdk/shim.ts
@@ -65,6 +65,28 @@ export interface MCP {
   call:       (name: string, tool: string, args?: Record<string, unknown>) => Promise<unknown>;
 }
 
+export interface OAuthAuthURL {
+  url:        string;
+  session_id: string;
+  provider:   string;
+  timestamp:  number;
+  relay_uuid: string;
+}
+
+export interface OAuthStoreResult {
+  provider: string;
+  secrets:  string[];
+}
+
+// OAuth broker bridge — only functional inside the auth-start (oauth_init)
+// and auth-relay (oauth_store) built-in tasks. Plaintext tokens never cross
+// this boundary: store_token decrypts, parses, and writes to secrets
+// entirely daemon-side, and only returns which secret names were written.
+export interface DicodeOAuth {
+  build_auth_url: (provider: string, scope?: string) => Promise<OAuthAuthURL>;
+  store_token:    (envelope: unknown)                => Promise<OAuthStoreResult>;
+}
+
 export interface Dicode {
   // task_id: the fully-namespaced id of the currently-running task (e.g.
   // "buildin/ai-agent"). Populated from the IPC handshake so task code can
@@ -78,6 +100,7 @@ export interface Dicode {
   get_config:     (section: string)                                    => Promise<unknown>;
   secrets_set:    (key: string, value: string)                        => Promise<void>;
   secrets_delete: (key: string)                                        => Promise<void>;
+  oauth:          DicodeOAuth;
 }
 
 // ── connection ────────────────────────────────────────────────────────────────
@@ -232,6 +255,12 @@ const dicode: Dicode = {
   get_config:     (section)         => __call__({ method: "dicode.get_config",      section }),
   secrets_set:    (key, value)      => __call__({ method: "dicode.secrets_set",     key, stringValue: value }) as Promise<void>,
   secrets_delete: (key)             => __call__({ method: "dicode.secrets_delete",  key }) as Promise<void>,
+  oauth: {
+    build_auth_url: (provider, scope) =>
+      __call__({ method: "dicode.oauth.build_auth_url", provider, scope: scope ?? "" }) as Promise<OAuthAuthURL>,
+    store_token: (envelope) =>
+      __call__({ method: "dicode.oauth.store_token", envelope }) as Promise<OAuthStoreResult>,
+  },
 };
 
 // ── exports ───────────────────────────────────────────────────────────────────

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -244,6 +244,19 @@ type DicodePermissions struct {
 	// SecretsWrite enables dicode.secrets_set() and dicode.secrets_delete().
 	// Tasks may write or overwrite secrets but never read them back.
 	SecretsWrite bool `yaml:"secrets_write,omitempty" json:"secrets_write,omitempty"`
+	// OAuthInit enables dicode.oauth.build_auth_url(). Reserved for the
+	// auth-start built-in task. Granting this lets the task construct a
+	// signed /auth/:provider URL using the daemon's relay identity; the
+	// payload layout is hardcoded in Go so this primitive cannot be coaxed
+	// into producing signatures for other message types (e.g. WSS
+	// handshakes).
+	OAuthInit bool `yaml:"oauth_init,omitempty" json:"oauth_init,omitempty"`
+	// OAuthStore enables dicode.oauth.store_token(). Reserved for the
+	// auth-relay built-in task. The primitive decrypts an incoming token
+	// envelope and writes the resulting credentials directly into the
+	// secrets store — plaintext never reaches task code, so a careless
+	// console.log cannot leak a token.
+	OAuthStore bool `yaml:"oauth_store,omitempty" json:"oauth_store,omitempty"`
 }
 
 // Spec is parsed from task.yaml.

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -440,7 +440,20 @@ func (e *Engine) catchupMissedCronRuns(ctx context.Context) {
 	}
 }
 
+// reservedOAuthCompletePath is the webhook path the relay broker delivers
+// encrypted OAuth tokens to. Only buildin/auth-relay is allowed to bind it —
+// any other task that claims this path would be a drop-in exfiltration
+// sink for decrypted credentials once the built-in chains the data forward.
+const reservedOAuthCompletePath = "/hooks/oauth-complete"
+const oauthRelayBuiltinID = "buildin/auth-relay"
+
 func (e *Engine) registerWebhook(spec *task.Spec) {
+	if spec.Trigger.Webhook == reservedOAuthCompletePath && spec.ID != oauthRelayBuiltinID {
+		e.log.Warn("rejecting task that tries to shadow reserved OAuth delivery path",
+			zap.String("task", spec.ID),
+			zap.String("path", reservedOAuthCompletePath))
+		return
+	}
 	e.mu.Lock()
 	e.webhooks[spec.Trigger.Webhook] = spec.ID
 	e.mu.Unlock()

--- a/pkg/trigger/engine_test.go
+++ b/pkg/trigger/engine_test.go
@@ -234,6 +234,37 @@ func TestEngine_Register_Unregister(t *testing.T) {
 	}
 }
 
+func TestEngine_ReservesOAuthCompletePath(t *testing.T) {
+	// A non-buildin task must not be able to bind /hooks/oauth-complete —
+	// otherwise it becomes an exfiltration sink for decrypted OAuth tokens.
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	attacker := writeTask(t, dir, "sneaky", `return 1`, task.TriggerConfig{Webhook: "/hooks/oauth-complete"})
+	_ = e.reg.Register(attacker)
+	e.engine.Register(attacker)
+
+	e.engine.mu.Lock()
+	bound := e.engine.webhooks["/hooks/oauth-complete"]
+	e.engine.mu.Unlock()
+	if bound == "sneaky" {
+		t.Fatalf("non-buildin task was allowed to bind reserved OAuth delivery path")
+	}
+
+	// The legitimate built-in must still be able to claim the path.
+	builtin := writeTask(t, dir, "auth-relay", `return 1`, task.TriggerConfig{Webhook: "/hooks/oauth-complete"})
+	builtin.ID = "buildin/auth-relay"
+	_ = e.reg.Register(builtin)
+	e.engine.Register(builtin)
+
+	e.engine.mu.Lock()
+	bound = e.engine.webhooks["/hooks/oauth-complete"]
+	e.engine.mu.Unlock()
+	if bound != "buildin/auth-relay" {
+		t.Fatalf("buildin/auth-relay should own /hooks/oauth-complete; got %q", bound)
+	}
+}
+
 func TestEngine_Cron_Register(t *testing.T) {
 	dir := t.TempDir()
 	e := newTestEnv(t)

--- a/tasks/buildin/auth-relay/task.ts
+++ b/tasks/buildin/auth-relay/task.ts
@@ -1,0 +1,19 @@
+// buildin/auth-relay — OAuth token delivery sink.
+//
+// The relay broker POSTs an OAuthTokenDeliveryPayload JSON envelope to
+// /hooks/oauth-complete via the WSS tunnel. This task asks the daemon to
+// decrypt the envelope, parse the token bundle, and persist the fields to
+// secrets. The plaintext credentials are never returned to JS — the IPC
+// call only reports which secret names were written.
+
+export default async function main() {
+  // input is the decoded webhook request body; the relay broker always
+  // sends a JSON OAuthTokenDeliveryPayload, so trust the shape.
+  const envelope = input;
+  const result = await dicode.oauth.store_token(envelope);
+  return {
+    ok: true,
+    provider: result.provider,
+    secrets_written: result.secrets,
+  };
+}

--- a/tasks/buildin/auth-relay/task.yaml
+++ b/tasks/buildin/auth-relay/task.yaml
@@ -1,0 +1,27 @@
+apiVersion: dicode/v1
+kind: Task
+name: "OAuth — Token Relay Sink"
+description: >
+  Receives encrypted OAuth token deliveries from the dicode relay broker on
+  /hooks/oauth-complete, asks the daemon to decrypt + parse + persist the
+  token bundle via dicode.oauth.store_token, and returns. Plaintext tokens
+  never cross the JS boundary: the primitive writes straight to the
+  secrets store in Go-process memory, so a console.log mistake here cannot
+  leak a credential.
+
+  This path is reserved by the trigger engine — no other task can bind
+  /hooks/oauth-complete.
+runtime: deno
+
+trigger:
+  webhook: /hooks/oauth-complete
+
+permissions:
+  dicode:
+    oauth_store: true
+
+timeout: 10s
+
+notify:
+  on_success: false
+  on_failure: true

--- a/tasks/buildin/auth-start/task.ts
+++ b/tasks/buildin/auth-start/task.ts
@@ -1,0 +1,41 @@
+// buildin/auth-start — kicks off an OAuth flow via the dicode relay broker.
+//
+// The daemon-side dicode.oauth.build_auth_url primitive bakes the entire
+// /auth/:provider payload layout in Go (BuildAuthURL in pkg/relay/oauth.go),
+// so this task cannot be coaxed into signing a payload of the wrong shape.
+// It only gets to pick the provider and an optional scope override.
+
+export default async function main() {
+  const provider = (await params.get("provider")) ?? "";
+  const scope = (await params.get("scope")) ?? "";
+  if (!provider) throw new Error("provider parameter is required");
+
+  const result = await dicode.oauth.build_auth_url(provider, scope);
+
+  const lines = [
+    `OAuth flow started for ${result.provider}.`,
+    ``,
+    `Open this URL in a browser to authorize:`,
+    ``,
+    `  ${result.url}`,
+    ``,
+    `Once you complete the provider's consent screen, the dicode relay will`,
+    `deliver the encrypted token to this daemon. buildin/auth-relay will`,
+    `decrypt it and write the credentials to your secrets store under`,
+    `${result.provider.toUpperCase()}_ACCESS_TOKEN (and _REFRESH_TOKEN, _EXPIRES_AT if applicable).`,
+    ``,
+    `Session: ${result.session_id}`,
+  ];
+  const html = `<pre>${lines.map(escapeHtml).join("\n")}</pre>`;
+  await output.html(html);
+  return { url: result.url, session_id: result.session_id };
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
+}

--- a/tasks/buildin/auth-start/task.yaml
+++ b/tasks/buildin/auth-start/task.yaml
@@ -1,0 +1,36 @@
+apiVersion: dicode/v1
+kind: Task
+name: "OAuth — Start Flow"
+description: >
+  Starts an OAuth authorization flow by asking the dicode relay broker for a
+  signed /auth/:provider URL. The task prints the URL; the user opens it in
+  a browser and authorizes with the provider. The eventual token delivery
+  lands on /hooks/oauth-complete where buildin/auth-relay decrypts it and
+  writes the credentials to the secrets store.
+
+  This task requires the relay client to be enabled in dicode.yaml. If the
+  relay is not configured, dicode.oauth.build_auth_url returns an error.
+runtime: deno
+
+trigger:
+  manual: true
+
+params:
+  provider:
+    type: string
+    required: true
+    description: "OAuth provider key (slack, github, google, notion, ...)"
+  scope:
+    type: string
+    default: ""
+    description: "Optional space-separated scope override; empty uses broker default"
+
+permissions:
+  dicode:
+    oauth_init: true
+
+timeout: 10s
+
+notify:
+  on_success: false
+  on_failure: true

--- a/tasks/buildin/taskset.yaml
+++ b/tasks/buildin/taskset.yaml
@@ -27,3 +27,11 @@ spec:
     ai-agent:
       ref:
         path: ./ai-agent/task.yaml
+
+    auth-start:
+      ref:
+        path: ./auth-start/task.yaml
+
+    auth-relay:
+      ref:
+        path: ./auth-relay/task.yaml


### PR DESCRIPTION
## Summary

Ships the OAuth **relay broker flow** end-to-end on the daemon side: task-facing IPC primitives, two built-in tasks (`buildin/auth-start`, `buildin/auth-relay`) that drive the flow, the ECIES+AAD crypto path for token delivery, an audit-log hook, and the user-facing docs.

The goal is that a task author never handles tokens: they call `dicode.oauth.build_auth_url(...)`, hand the URL to the user, and the relay broker POSTs the encrypted token envelope back into `dicode.oauth.store_token(...)`, which writes the provider secrets directly to the secrets store. Plaintext tokens never cross the IPC boundary.

## What's in here

**New IPC primitives (`pkg/ipc`)**
- `dicode.oauth.build_auth_url(provider, scope)` — gated by `permissions.dicode.oauth_init`. Builds the `/auth/:provider` payload server-side so a task can't coerce the relay identity key into signing an arbitrary digest (e.g. a WSS-handshake-shaped payload). Registers an `AuthRequest` in the shared `PendingSessions` store.
- `dicode.oauth.store_token(envelope)` — gated by `permissions.dicode.oauth_store`. Looks up the pending session by session id, rejects unknown/expired sessions (closing the chosen-salt oracle on the identity key), ECIES-decrypts, parses, and writes `<PROVIDER>_ACCESS_TOKEN / _REFRESH_TOKEN / _EXPIRES_AT / _SCOPE / _TOKEN_TYPE` to the secrets store.

**Crypto hardening (`pkg/relay`)**
- `DecryptOAuthToken` requires an explicit `"oauth_token_delivery"` type tag and binds that tag into AES-256-GCM authenticated data. Any mismatch (or tampering with the envelope's `Type` field in transit) makes `aead.Open` fail, so the daemon identity key can never decrypt a future ciphertext that reuses this ECIES scheme under a different `Type` label. **Pairs with the coordinated change in dicode-relay `feat/oauth-aad-domain-sep` — merging only one side will cause token deliveries to fail to decrypt.**
- Empty-type guard fires before any crypto.
- `PendingSessions` has TTL-bounded `Add/Take/SweepExpired` and is shared daemon-wide across per-run `ipc.Server` instances so `auth-start` and `auth-relay` correlate by session id.
- `AuthRequest` no longer carries the unused PKCE verifier (the Grant step runs on the relay, not the daemon).

**Built-in tasks (`tasks/buildin/auth-{start,relay}`)**
- `auth-start` — manual-trigger task that calls `build_auth_url` and prints the URL for the user. `permissions.dicode.oauth_init` only.
- `auth-relay` — reserved-path webhook receiver that calls `store_token`. `permissions.dicode.oauth_store` only.
- Registered via `tasks/buildin/taskset.yaml`.

**Audit logging**
- `store_token` emits a metadata-only audit entry on success: task id, run id, provider, session id, and the list of secret names written. Plaintext tokens never reach the log pipeline.

**Deno runtime**
- `pkg/runtime/deno/sdk/*` gains `dicode.oauth.*` typings + shim wiring so TS tasks get the same surface as JS.

**Docs**
- `docs/oauth.md` gets a new top-level "Broker flow" section covering the task pair, secret naming convention, IPC primitives, security model, reserved delivery path, audit log, and failure modes. Existing local-flow content kept as the self-hosted alternative.
- `docs/relay.md` adds a short "OAuth broker" section pointing at `oauth.md`.
- `README.md`: project structure no longer says "broker mode planned"; Webhook Relay section gets a one-line `auth-start` example.
- `docs/followups/oauth-relay-rotation.md` tracks deferred identity-rotation hot-swap work (the follow-up PR on `feat/oauth-relay-rotation`).

## Tests

- `pkg/ipc/server_oauth_test.go` (337 LOC) — end-to-end coverage of `build_auth_url` and `store_token`: permission gating, unknown/expired session rejection, envelope validation, secrets-store writes, audit-log emission.
- `pkg/relay/oauth_test.go` (271 LOC) — ECIES round-trip, type-tag binding, tampered-type rejection, empty-type guard.
- `pkg/relay/oauth_pending_test.go` — TTL expiry and sweep.
- `pkg/trigger/engine_test.go` — reserved-path webhook routing for `auth-relay`.

## Merge coordination

⚠ **Must land roughly together with `dicode-ayo/dicode-relay#feat/oauth-aad-domain-sep`.** That branch adds the matching `setAAD(messageType)` calls on the broker side. Merging only one side will make OAuth token deliveries fail to decrypt (auth tag mismatch).

The `feat/oauth-relay-rotation` follow-up stacks on top of this PR and can merge afterwards on its own schedule.

## Test plan

- [ ] `make test` green on CI
- [ ] `make test-race` green
- [ ] `make lint` clean
- [ ] Manual end-to-end with a real provider after the coordinated dicode-relay PR is deployed: run `dicode run buildin/auth-start --param provider=github`, follow the URL, verify `GITHUB_ACCESS_TOKEN` lands in the secrets store and the audit log shows the delivery metadata
- [ ] Negative test: tamper with the `Type` field on the delivery envelope and confirm the daemon rejects it with an auth-tag error (no panic, no partial write)
- [ ] Verify permission gating: a task without `dicode.oauth_init` cannot call `build_auth_url`; a task without `dicode.oauth_store` cannot call `store_token`

🤖 Generated with [Claude Code](https://claude.com/claude-code)