### PR TITLE
fix(relay): split Identity into SignKey + DecryptKey + require broker protocol 2 (#104)

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -201,7 +201,7 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 
 	// 11. Relay client — optional, enabled via config.
 	if cfg.Relay.Enabled && cfg.Relay.ServerURL != "" {
-		id, err := relay.LoadOrGenerateIdentity(ctx, database)
+		id, err := relay.LoadOrGenerateIdentity(ctx, database, log)
 		if err != nil {
 			log.Warn("relay: identity init failed, relay disabled", zap.Error(err))
 		} else {
@@ -213,9 +213,14 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 			// across runs so auth-start and auth-relay correlate by
 			// session id. The broker speaks HTTPS at the same host as the
 			// WSS relay endpoint.
+			//
+			// rc.SupportsOAuth is passed as a gating function (issue #104):
+			// pre-split brokers advertise protocol < 2, in which case the
+			// IPC layer refuses OAuth flows with a clear operator error
+			// rather than silently failing to decrypt the delivery.
 			pending := relay.NewPendingSessions()
 			if brokerURL := deriveBrokerBaseURL(cfg.Relay.ServerURL); brokerURL != "" {
-				denoRT.SetOAuthBroker(id, brokerURL, pending, rc.BrokerPubkey)
+				denoRT.SetOAuthBroker(id, brokerURL, pending, rc.BrokerPubkey, rc.SupportsOAuth)
 			} else {
 				log.Warn("relay: could not derive broker base URL from server_url — OAuth broker disabled",
 					zap.String("server_url", cfg.Relay.ServerURL),

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -18,6 +18,12 @@ import (
 	"go.uber.org/zap"
 )
 
+// oauthBrokerProtocolErr is the operator-facing error returned when a task
+// invokes dicode.oauth.* against a broker whose welcome message did not
+// advertise protocol >= 2 (issue #104). The message intentionally names
+// the fix so operators know what to upgrade without digging through logs.
+const oauthBrokerProtocolErr = "ipc: broker does not support split-key OAuth — upgrade dicode-relay to protocol >= 2"
+
 // Server is a per-run Unix socket server that bridges a task subprocess and
 // the Go host using the unified IPC protocol.
 //
@@ -28,18 +34,19 @@ type Server struct {
 	taskID string
 	secret []byte // daemon-level HMAC secret for token verification
 
-	registry       *registry.Registry
-	db             db.DB
-	params         map[string]string
-	input          any
-	spec           *task.Spec
-	engine         EngineRunner
-	secrets        secrets.Manager        // optional; enables dicode.secrets_set / dicode.secrets_delete
-	oauthID        *relay.Identity        // optional; enables dicode.oauth.* for the auth built-ins
-	oauthURL       string                 // broker base URL, e.g. "https://relay.dicode.app"
-	oauthPending   *relay.PendingSessions // tracks outstanding /auth/:provider flows by session id
-	brokerPubkeyFn func() string          // returns the TOFU-pinned broker pubkey (base64 SPKI DER)
-	log            *zap.Logger
+	registry        *registry.Registry
+	db              db.DB
+	params          map[string]string
+	input           any
+	spec            *task.Spec
+	engine          EngineRunner
+	secrets         secrets.Manager        // optional; enables dicode.secrets_set / dicode.secrets_delete
+	oauthID         *relay.Identity        // optional; enables dicode.oauth.* for the auth built-ins
+	oauthURL        string                 // broker base URL, e.g. "https://relay.dicode.app"
+	oauthPending    *relay.PendingSessions // tracks outstanding /auth/:provider flows by session id
+	brokerPubkeyFn  func() string          // returns the TOFU-pinned broker pubkey (base64 SPKI DER)
+	supportsOAuthFn func() bool            // issue #104: reports broker protocol >= 2; nil means unchecked
+	log             *zap.Logger
 
 	gateway *Gateway // optional; enables http.register for daemon tasks
 
@@ -115,11 +122,19 @@ func (s *Server) SetSecrets(m secrets.Manager) { s.secrets = m }
 // pending is shared across all per-run ipc.Server instances so that an
 // auth-start run and the subsequent auth-complete webhook run can correlate
 // on session id.
-func (s *Server) SetOAuthBroker(id *relay.Identity, baseURL string, pending *relay.PendingSessions, brokerPubkeyFn func() string) {
+//
+// supportsOAuthFn (issue #104) is consulted immediately before every OAuth
+// IPC dispatch. If non-nil and it returns false, dicode.oauth.build_auth_url
+// and dicode.oauth.store_token are refused with a clear operator error
+// rather than silently failing at decrypt time. Passing nil leaves the IPC
+// path unchecked — appropriate for test fixtures that don't run a full
+// relay client.
+func (s *Server) SetOAuthBroker(id *relay.Identity, baseURL string, pending *relay.PendingSessions, brokerPubkeyFn func() string, supportsOAuthFn func() bool) {
 	s.oauthID = id
 	s.oauthURL = baseURL
 	s.oauthPending = pending
 	s.brokerPubkeyFn = brokerPubkeyFn
+	s.supportsOAuthFn = supportsOAuthFn
 }
 
 // Start creates the Unix socket and begins accepting connections.
@@ -571,6 +586,17 @@ func (s *Server) handleConn(conn net.Conn) {
 				reply(req.ID, nil, "ipc: oauth broker not configured on this daemon")
 				continue
 			}
+			// Issue #104: refuse OAuth flows when the connected broker has not
+			// advertised protocol >= 2. A pre-split broker would encrypt the
+			// delivery to the SignKey pubkey, which DecryptOAuthToken cannot
+			// open with the DecryptKey — the failure would only surface on
+			// the callback, after the user has already completed the upstream
+			// consent. Refusing here turns a silent crypto failure into an
+			// actionable operator message.
+			if s.supportsOAuthFn != nil && !s.supportsOAuthFn() {
+				reply(req.ID, nil, oauthBrokerProtocolErr)
+				continue
+			}
 			if req.Provider == "" {
 				reply(req.ID, nil, "ipc: provider required")
 				continue
@@ -598,6 +624,14 @@ func (s *Server) handleConn(conn net.Conn) {
 			}
 			if s.oauthID == nil || s.oauthPending == nil {
 				reply(req.ID, nil, "ipc: oauth broker not configured on this daemon")
+				continue
+			}
+			// Issue #104 — see the note on dicode.oauth.build_auth_url.
+			// Reject store_token against a pre-split broker so a stale
+			// session delivered just after a downgrade can't coerce a
+			// mismatched-key decrypt attempt.
+			if s.supportsOAuthFn != nil && !s.supportsOAuthFn() {
+				reply(req.ID, nil, oauthBrokerProtocolErr)
 				continue
 			}
 			if s.secrets == nil {

--- a/pkg/ipc/server_oauth_test.go
+++ b/pkg/ipc/server_oauth_test.go
@@ -5,16 +5,14 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/ecdh"
-	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -47,15 +45,12 @@ func (m *memSecrets) Name() string { return "mem" }
 
 var _ secrets.Manager = (*memSecrets)(nil)
 
+// newOAuthIdentity delegates to relay.NewTestIdentity so the struct shape of
+// relay.Identity stays an implementation detail of the relay package (see
+// issue #104).
 func newOAuthIdentity(t *testing.T) *relay.Identity {
 	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatalf("keygen: %v", err)
-	}
-	pubBytes := append([]byte{0x04}, append(key.PublicKey.X.FillBytes(make([]byte, 32)), key.PublicKey.Y.FillBytes(make([]byte, 32))...)...)
-	sum := sha256.Sum256(pubBytes)
-	return &relay.Identity{PrivateKey: key, UUID: hex.EncodeToString(sum[:])}
+	return relay.NewTestIdentity(t)
 }
 
 type oauthEnv struct {
@@ -80,7 +75,9 @@ func startOAuthServer(t *testing.T) *oauthEnv {
 	identity := newOAuthIdentity(t)
 	pending := relay.NewPendingSessions()
 	secretsMgr := newMemSecrets()
-	srv.SetOAuthBroker(identity, "https://relay.dicode.app", pending, nil)
+	// supportsOAuthFn=nil so existing tests that pre-date #104 still exercise
+	// the happy path without having to fake a handshake.
+	srv.SetOAuthBroker(identity, "https://relay.dicode.app", pending, nil, nil)
 	srv.SetSecrets(secretsMgr)
 
 	socketPath, token, err := srv.Start(context.Background())
@@ -144,7 +141,7 @@ func TestServer_OAuth_BuildAuthURL_DeniedWithoutInit(t *testing.T) {
 	spec := specWithDicode("leaky", &task.DicodePermissions{OAuthStore: true})
 	runID := fmt.Sprintf("test-%d", time.Now().UnixNano())
 	srv := New(runID, spec.ID, env.secret, env.reg, env.db, nil, nil, zap.NewNop(), spec, nil)
-	srv.SetOAuthBroker(newOAuthIdentity(t), "https://relay.dicode.app", relay.NewPendingSessions(), nil)
+	srv.SetOAuthBroker(newOAuthIdentity(t), "https://relay.dicode.app", relay.NewPendingSessions(), nil, nil)
 	socketPath, token, err := srv.Start(context.Background())
 	if err != nil {
 		t.Fatalf("Start: %v", err)
@@ -301,10 +298,73 @@ func TestServer_OAuth_NotConfigured(t *testing.T) {
 	}
 }
 
+// TestServer_OAuth_RefusesWhenBrokerProtocolOld covers decision 3 of the
+// issue #104 review: when the connected broker has advertised a protocol
+// version < 2 (captured here by supportsOAuthFn=false), both
+// dicode.oauth.build_auth_url and dicode.oauth.store_token must refuse
+// the request with the clear "upgrade dicode-relay to protocol >= 2"
+// error rather than silently proceeding to a mismatched-key decrypt.
+func TestServer_OAuth_RefusesWhenBrokerProtocolOld(t *testing.T) {
+	env := newTestEnv(t)
+	spec := specWithDicode("auth-relay", &task.DicodePermissions{OAuthInit: true, OAuthStore: true})
+	runID := fmt.Sprintf("test-%d", time.Now().UnixNano())
+	srv := New(runID, spec.ID, env.secret, env.reg, env.db, nil, nil, zap.NewNop(), spec, nil)
+
+	id := newOAuthIdentity(t)
+	pending := relay.NewPendingSessions()
+	secretsMgr := newMemSecrets()
+	// supportsOAuthFn always false — simulating a broker still on protocol 1.
+	srv.SetOAuthBroker(id, "https://relay.dicode.app", pending, nil, func() bool { return false })
+	srv.SetSecrets(secretsMgr)
+
+	socketPath, token, err := srv.Start(context.Background())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(srv.Stop)
+	conn := dial(t, socketPath)
+	t.Cleanup(func() { conn.Close() })
+	doHandshake(t, conn, token)
+
+	// build_auth_url must be refused with the clear upgrade message.
+	sendMsg(t, conn, map[string]any{"id": "1", "method": "dicode.oauth.build_auth_url", "provider": "slack"})
+	resp := recvMsg(t, conn)
+	errStr, _ := resp["error"].(string)
+	if errStr == "" {
+		t.Fatal("expected broker-protocol error, got none")
+	}
+	if !strings.Contains(errStr, "protocol") || !strings.Contains(errStr, "2") {
+		t.Fatalf("expected operator-actionable protocol error, got: %q", errStr)
+	}
+	// The pending store must not have grown — the gate is pre-enqueue.
+	if pending.Len() != 0 {
+		t.Fatalf("pending session unexpectedly registered: len=%d", pending.Len())
+	}
+
+	// store_token is also refused, even before decryption is attempted. We
+	// pass a deliberately malformed envelope — the gate must short-circuit
+	// before any decode happens.
+	sendMsg(t, conn, map[string]any{
+		"id":       "2",
+		"method":   "dicode.oauth.store_token",
+		"envelope": json.RawMessage(`{}`),
+	})
+	resp2 := recvMsg(t, conn)
+	errStr2, _ := resp2["error"].(string)
+	if errStr2 == "" {
+		t.Fatal("expected broker-protocol error on store_token, got none")
+	}
+	if !strings.Contains(errStr2, "protocol") {
+		t.Fatalf("expected protocol error on store_token, got: %q", errStr2)
+	}
+}
+
 // sealForDaemon mirrors dicode-relay src/broker/crypto.ts eciesEncrypt.
+// Post-#104 the broker encrypts against the daemon's DecryptKey pubkey —
+// mirror that here so the test actually exercises the production code path.
 func sealForDaemon(t *testing.T, identity *relay.Identity, sessionID string, plaintext []byte) *relay.OAuthTokenDeliveryPayload {
 	t.Helper()
-	daemonPub, err := ecdh.P256().NewPublicKey(identity.UncompressedPublicKey())
+	daemonPub, err := ecdh.P256().NewPublicKey(identity.DecryptPublicKey())
 	if err != nil {
 		t.Fatalf("daemon pub: %v", err)
 	}

--- a/pkg/relay/broker_protocol_test.go
+++ b/pkg/relay/broker_protocol_test.go
@@ -15,23 +15,21 @@ import (
 	"github.com/coder/websocket"
 )
 
-// TestClient_RefusesOAuth_WhenBrokerProtocolOld covers the daemon-side half of
-// the version gate from decision 3 in the #104 review: the client reads the
-// broker's `protocol` field in the welcome message and only reports
-// SupportsOAuth when it is >= 2.
+// TestClient_RefusesConnection_WhenBrokerProtocolOld covers the daemon-side
+// half of the version gate from decision 3 in the #104 review: the client
+// reads the broker's `protocol` field in the welcome message and refuses the
+// connection outright when it is below 2. No silent fallback — the broker must
+// be upgraded to honour the split sign/decrypt key model.
 //
-// The test drives three variants of the welcome message through a minimal
-// test broker:
-//   - no protocol field at all (legacy pre-#104 broker)
-//   - protocol: 1 (explicit pre-split)
-//   - protocol: 2 (post-split)
-//
-// SupportsOAuth must be false for the first two and true for the last.
-func TestClient_RefusesOAuth_WhenBrokerProtocolOld(t *testing.T) {
+// Three welcome variants:
+//   - no protocol field at all (legacy pre-#104 broker) → connection refused
+//   - protocol: 1 (explicit pre-split)                  → connection refused
+//   - protocol: 2 (post-split)                          → connection accepted
+func TestClient_RefusesConnection_WhenBrokerProtocolOld(t *testing.T) {
 	cases := []struct {
-		name    string
-		welcome welcomeMsg
-		want    bool
+		name          string
+		welcome       welcomeMsg
+		wantHandshake bool // true = runOnce should complete the handshake successfully
 	}{
 		{"no protocol field", welcomeMsg{Type: msgWelcome, URL: "https://x/u/x/hooks/"}, false},
 		{"protocol 1", welcomeMsg{Type: msgWelcome, URL: "https://x/u/x/hooks/", Protocol: 1}, false},
@@ -53,21 +51,16 @@ func TestClient_RefusesOAuth_WhenBrokerProtocolOld(t *testing.T) {
 
 				ctx := r.Context()
 
-				// Send a dummy challenge. We don't verify the hello; we
-				// only care that the client processes our welcome.
 				nonce := make([]byte, 32)
 				_, _ = rand.Read(nonce)
 				ch, _ := encodeMsg(challengeMsg{Type: msgChallenge, Nonce: hex.EncodeToString(nonce)})
 				_ = conn.Write(ctx, websocket.MessageText, ch)
 
-				// Drain the hello message so the client is ready for welcome.
 				_, _, _ = conn.Read(ctx)
 
 				w2, _ := encodeMsg(welcome)
 				_ = conn.Write(ctx, websocket.MessageText, w2)
 
-				// Keep the connection alive briefly so Client.serve doesn't
-				// race us to Read before we've returned.
 				time.Sleep(150 * time.Millisecond)
 			}))
 			defer ts.Close()
@@ -84,44 +77,54 @@ func TestClient_RefusesOAuth_WhenBrokerProtocolOld(t *testing.T) {
 
 			client := NewClient(wsURL, id, port, nil, noopLogger())
 
-			// Precondition: SupportsOAuth must be false before any handshake.
 			if client.SupportsOAuth() {
 				t.Fatal("SupportsOAuth should be false before handshake")
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
-			done := make(chan struct{})
+			errCh := make(chan error, 1)
 			go func() {
-				_ = client.runOnce(ctx)
-				close(done)
+				errCh <- client.runOnce(ctx)
 			}()
 
-			// Wait for the welcome to be processed (poll SupportsOAuth).
-			deadline := time.After(2 * time.Second)
-			var settled bool
-			for !settled {
-				select {
-				case <-deadline:
-					t.Fatal("handshake did not settle within 2s")
-				case <-time.After(25 * time.Millisecond):
-					// Cheap way to detect "the welcome has been applied":
-					// once client.hookBaseURL is non-empty it means
-					// Client.handshake returned, which means brokerProtocol
-					// has been recorded.
-					if client.HookBaseURL() != "" {
-						settled = true
+			if tc.wantHandshake {
+				// protocol 2 — wait for the handshake to complete, confirmed by
+				// the hookBaseURL being set and SupportsOAuth flipping to true.
+				deadline := time.After(2 * time.Second)
+				for {
+					select {
+					case <-deadline:
+						t.Fatal("handshake did not settle within 2s")
+					case <-time.After(25 * time.Millisecond):
+						if client.HookBaseURL() != "" {
+							if !client.SupportsOAuth() {
+								t.Fatalf("protocol 2 broker: SupportsOAuth should be true after handshake")
+							}
+							cancel()
+							<-errCh
+							return
+						}
 					}
 				}
+			} else {
+				// protocol < 2 — runOnce must return an error containing the
+				// "upgrade dicode-relay" hint; SupportsOAuth must stay false.
+				select {
+				case err := <-errCh:
+					if err == nil {
+						t.Fatalf("expected connection refusal error, got nil")
+					}
+					if !strings.Contains(err.Error(), "upgrade dicode-relay") {
+						t.Fatalf("error should mention upgrade dicode-relay: got %v", err)
+					}
+				case <-time.After(2 * time.Second):
+					t.Fatal("runOnce did not return within 2s")
+				}
+				if client.SupportsOAuth() {
+					t.Fatalf("SupportsOAuth must remain false when broker protocol < 2")
+				}
 			}
-
-			if got := client.SupportsOAuth(); got != tc.want {
-				t.Fatalf("SupportsOAuth = %v, want %v (protocol=%d)",
-					got, tc.want, welcome.Protocol)
-			}
-
-			cancel()
-			<-done
 		})
 	}
 }

--- a/pkg/relay/broker_protocol_test.go
+++ b/pkg/relay/broker_protocol_test.go
@@ -1,0 +1,127 @@
+package relay
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// TestClient_RefusesOAuth_WhenBrokerProtocolOld covers the daemon-side half of
+// the version gate from decision 3 in the #104 review: the client reads the
+// broker's `protocol` field in the welcome message and only reports
+// SupportsOAuth when it is >= 2.
+//
+// The test drives three variants of the welcome message through a minimal
+// test broker:
+//   - no protocol field at all (legacy pre-#104 broker)
+//   - protocol: 1 (explicit pre-split)
+//   - protocol: 2 (post-split)
+//
+// SupportsOAuth must be false for the first two and true for the last.
+func TestClient_RefusesOAuth_WhenBrokerProtocolOld(t *testing.T) {
+	cases := []struct {
+		name    string
+		welcome welcomeMsg
+		want    bool
+	}{
+		{"no protocol field", welcomeMsg{Type: msgWelcome, URL: "https://x/u/x/hooks/"}, false},
+		{"protocol 1", welcomeMsg{Type: msgWelcome, URL: "https://x/u/x/hooks/", Protocol: 1}, false},
+		{"protocol 2", welcomeMsg{Type: msgWelcome, URL: "https://x/u/x/hooks/", Protocol: 2}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			welcome := tc.welcome
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+					InsecureSkipVerify: true,
+				})
+				if err != nil {
+					return
+				}
+				defer conn.CloseNow()
+
+				ctx := r.Context()
+
+				// Send a dummy challenge. We don't verify the hello; we
+				// only care that the client processes our welcome.
+				nonce := make([]byte, 32)
+				_, _ = rand.Read(nonce)
+				ch, _ := encodeMsg(challengeMsg{Type: msgChallenge, Nonce: hex.EncodeToString(nonce)})
+				_ = conn.Write(ctx, websocket.MessageText, ch)
+
+				// Drain the hello message so the client is ready for welcome.
+				_, _, _ = conn.Read(ctx)
+
+				w2, _ := encodeMsg(welcome)
+				_ = conn.Write(ctx, websocket.MessageText, w2)
+
+				// Keep the connection alive briefly so Client.serve doesn't
+				// race us to Read before we've returned.
+				time.Sleep(150 * time.Millisecond)
+			}))
+			defer ts.Close()
+
+			id := NewTestIdentity(t)
+			wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+			localSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer localSrv.Close()
+			_, portStr, _ := net.SplitHostPort(localSrv.Listener.Addr().String())
+			port, _ := strconv.Atoi(portStr)
+
+			client := NewClient(wsURL, id, port, nil, noopLogger())
+
+			// Precondition: SupportsOAuth must be false before any handshake.
+			if client.SupportsOAuth() {
+				t.Fatal("SupportsOAuth should be false before handshake")
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			done := make(chan struct{})
+			go func() {
+				_ = client.runOnce(ctx)
+				close(done)
+			}()
+
+			// Wait for the welcome to be processed (poll SupportsOAuth).
+			deadline := time.After(2 * time.Second)
+			var settled bool
+			for !settled {
+				select {
+				case <-deadline:
+					t.Fatal("handshake did not settle within 2s")
+				case <-time.After(25 * time.Millisecond):
+					// Cheap way to detect "the welcome has been applied":
+					// once client.hookBaseURL is non-empty it means
+					// Client.handshake returned, which means brokerProtocol
+					// has been recorded.
+					if client.HookBaseURL() != "" {
+						settled = true
+					}
+				}
+			}
+
+			if got := client.SupportsOAuth(); got != tc.want {
+				t.Fatalf("SupportsOAuth = %v, want %v (protocol=%d)",
+					got, tc.want, welcome.Protocol)
+			}
+
+			cancel()
+			<-done
+		})
+	}
+}

--- a/pkg/relay/client.go
+++ b/pkg/relay/client.go
@@ -245,20 +245,17 @@ func (c *Client) handshake(ctx context.Context, conn *websocket.Conn, sendMu *sy
 		c.hookBaseURL = w.URL
 		c.hookMu.Unlock()
 
-		// Broker protocol version (issue #104). An advertised protocol < 2
-		// (or an absent field) means the broker does not understand the
-		// split sign/decrypt key and will encrypt OAuth deliveries to the
-		// SignKey pubkey, which the daemon cannot decrypt with DecryptKey.
-		// The WSS relay path is unaffected — it only uses SignKey for the
-		// ECDSA handshake, which the broker can still verify.
+		// Broker protocol version (issue #104). Protocol 2 commits the broker
+		// to honouring the split sign/decrypt keys. Refuse the connection
+		// outright if the broker advertises anything lower — encrypting OAuth
+		// deliveries to the SignKey pubkey would silently produce undecryptable
+		// payloads.
+		if w.Protocol < 2 {
+			return fmt.Errorf("broker protocol %d too old — require >= 2 (upgrade dicode-relay)", w.Protocol)
+		}
 		c.protoMu.Lock()
 		c.brokerProtocol = w.Protocol
 		c.protoMu.Unlock()
-		if w.Protocol < 2 {
-			c.log.Warn("relay: broker advertises pre-split protocol — OAuth IPC paths disabled",
-				zap.Int("broker_protocol", w.Protocol),
-				zap.Int("required", 2))
-		}
 
 		// TOFU broker pubkey pinning: on first connect, store the broker's
 		// signing pubkey. On reconnect, verify it hasn't changed.

--- a/pkg/relay/client.go
+++ b/pkg/relay/client.go
@@ -53,6 +53,26 @@ type Client struct {
 
 	brokerMu     sync.RWMutex
 	brokerPubkey string // cached pinned broker pubkey (base64 SPKI DER)
+
+	// protoMu guards brokerProtocol. The value is 0 until the first successful
+	// handshake; after that it reflects the broker's advertised `protocol`
+	// field in the welcome message. A value < 2 means the broker has not
+	// been upgraded for issue #104 and OAuth IPC paths must be refused.
+	protoMu        sync.RWMutex
+	brokerProtocol int
+}
+
+// SupportsOAuth reports whether the currently connected broker has announced
+// a protocol version recent enough for the split sign/decrypt key scheme
+// (issue #104). The OAuth IPC dispatch in pkg/ipc consults this before
+// handing out auth URLs or accepting token-delivery envelopes so the daemon
+// never decrypts against the wrong key on an out-of-date broker.
+//
+// Returns false until the first successful handshake completes.
+func (c *Client) SupportsOAuth() bool {
+	c.protoMu.RLock()
+	defer c.protoMu.RUnlock()
+	return c.brokerProtocol >= 2
 }
 
 // BrokerPubkey returns the currently pinned broker public key (base64 SPKI DER).
@@ -136,6 +156,13 @@ func (c *Client) runOnce(ctx context.Context) error {
 	c.hookBaseURL = ""
 	c.hookMu.Unlock()
 
+	// Reset the broker protocol version on every reconnect so SupportsOAuth
+	// only returns true while a broker is actually connected and after the
+	// handshake has observed its advertised protocol.
+	c.protoMu.Lock()
+	c.brokerProtocol = 0
+	c.protoMu.Unlock()
+
 	// Apply a timeout to the dial + handshake phase.
 	dialCtx, cancel := context.WithTimeout(ctx, dialTimeout)
 	defer cancel()
@@ -176,19 +203,21 @@ func (c *Client) handshake(ctx context.Context, conn *websocket.Conn, sendMu *sy
 	}
 
 	ts := time.Now().Unix()
-	sig, err := signChallenge(c.identity.PrivateKey, nonceBytes, ts)
+	sig, err := signChallenge(c.identity.SignKey, nonceBytes, ts)
 	if err != nil {
 		return fmt.Errorf("sign challenge: %w", err)
 	}
 
-	pubKeyB64 := base64.StdEncoding.EncodeToString(c.identity.UncompressedPublicKey())
+	signPubB64 := base64.StdEncoding.EncodeToString(c.identity.SignPublicKey())
+	decryptPubB64 := base64.StdEncoding.EncodeToString(c.identity.DecryptPublicKey())
 
 	hello, err := encodeMsg(helloMsg{
-		Type:      msgHello,
-		UUID:      c.identity.UUID,
-		PubKey:    pubKeyB64,
-		Sig:       base64.StdEncoding.EncodeToString(sig),
-		Timestamp: ts,
+		Type:          msgHello,
+		UUID:          c.identity.UUID,
+		PubKey:        signPubB64,
+		DecryptPubKey: decryptPubB64,
+		Sig:           base64.StdEncoding.EncodeToString(sig),
+		Timestamp:     ts,
 	})
 	if err != nil {
 		return fmt.Errorf("encode hello: %w", err)
@@ -215,6 +244,21 @@ func (c *Client) handshake(ctx context.Context, conn *websocket.Conn, sendMu *sy
 		c.hookMu.Lock()
 		c.hookBaseURL = w.URL
 		c.hookMu.Unlock()
+
+		// Broker protocol version (issue #104). An advertised protocol < 2
+		// (or an absent field) means the broker does not understand the
+		// split sign/decrypt key and will encrypt OAuth deliveries to the
+		// SignKey pubkey, which the daemon cannot decrypt with DecryptKey.
+		// The WSS relay path is unaffected — it only uses SignKey for the
+		// ECDSA handshake, which the broker can still verify.
+		c.protoMu.Lock()
+		c.brokerProtocol = w.Protocol
+		c.protoMu.Unlock()
+		if w.Protocol < 2 {
+			c.log.Warn("relay: broker advertises pre-split protocol — OAuth IPC paths disabled",
+				zap.Int("broker_protocol", w.Protocol),
+				zap.Int("required", 2))
+		}
 
 		// TOFU broker pubkey pinning: on first connect, store the broker's
 		// signing pubkey. On reconnect, verify it hasn't changed.

--- a/pkg/relay/client_test.go
+++ b/pkg/relay/client_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+	"go.uber.org/zap"
 )
 
 // newTestServer starts an in-process relay server and returns its URL and a
@@ -40,7 +41,7 @@ func newTestIdentity(t *testing.T) *Identity {
 	t.Helper()
 	ctx := context.Background()
 	database := openTestDB(t)
-	id, err := LoadOrGenerateIdentity(ctx, database)
+	id, err := LoadOrGenerateIdentity(ctx, database, zap.NewNop())
 	if err != nil {
 		t.Fatalf("generate identity: %v", err)
 	}
@@ -91,7 +92,8 @@ func TestHandshakeWrongKey(t *testing.T) {
 	// ...then create a different identity and use its key but id1's UUID.
 	id2 := newTestIdentity(t)
 	tamperedID := &Identity{
-		PrivateKey: id2.PrivateKey, // wrong key
+		SignKey:    id2.SignKey,    // wrong sign key
+		DecryptKey: id2.DecryptKey, // any valid decrypt key; irrelevant for handshake
 		UUID:       id1.UUID,       // mismatched UUID
 	}
 
@@ -152,7 +154,7 @@ func TestHandshakeReplayedTimestamp(t *testing.T) {
 
 	// Use a timestamp 60 seconds in the past (outside ±30 s window).
 	staleTS := time.Now().Unix() - 60
-	sig, err := signChallenge(id.PrivateKey, nonceBytes, staleTS)
+	sig, err := signChallenge(id.SignKey, nonceBytes, staleTS)
 	if err != nil {
 		t.Fatalf("sign: %v", err)
 	}
@@ -160,7 +162,7 @@ func TestHandshakeReplayedTimestamp(t *testing.T) {
 	hello, _ := encodeMsg(helloMsg{
 		Type:      msgHello,
 		UUID:      id.UUID,
-		PubKey:    base64.StdEncoding.EncodeToString(id.UncompressedPublicKey()),
+		PubKey:    base64.StdEncoding.EncodeToString(id.SignPublicKey()),
 		Sig:       base64.StdEncoding.EncodeToString(sig),
 		Timestamp: staleTS,
 	})
@@ -394,11 +396,11 @@ func TestNonceReplay(t *testing.T) {
 	nonce1, _ := hex.DecodeString(ch1.Nonce)
 
 	ts1 := time.Now().Unix()
-	sig1, _ := signChallenge(id.PrivateKey, nonce1, ts1)
+	sig1, _ := signChallenge(id.SignKey, nonce1, ts1)
 	hello1, _ := encodeMsg(helloMsg{
 		Type:      msgHello,
 		UUID:      id.UUID,
-		PubKey:    base64.StdEncoding.EncodeToString(id.UncompressedPublicKey()),
+		PubKey:    base64.StdEncoding.EncodeToString(id.SignPublicKey()),
 		Sig:       base64.StdEncoding.EncodeToString(sig1),
 		Timestamp: ts1,
 	})
@@ -430,11 +432,11 @@ func TestNonceReplay(t *testing.T) {
 
 	// Re-use nonce1 (which was already consumed).
 	ts2 := time.Now().Unix()
-	sig2, _ := signChallenge(id.PrivateKey, nonce1, ts2)
+	sig2, _ := signChallenge(id.SignKey, nonce1, ts2)
 	hello2, _ := encodeMsg(helloMsg{
 		Type:      msgHello,
 		UUID:      id.UUID,
-		PubKey:    base64.StdEncoding.EncodeToString(id.UncompressedPublicKey()),
+		PubKey:    base64.StdEncoding.EncodeToString(id.SignPublicKey()),
 		Sig:       base64.StdEncoding.EncodeToString(sig2),
 		Timestamp: ts2,
 	})
@@ -560,13 +562,13 @@ func TestWrongUUID(t *testing.T) {
 	nonceBytes, _ := hex.DecodeString(ch.Nonce)
 
 	ts2 := time.Now().Unix()
-	sig, _ := signChallenge(id.PrivateKey, nonceBytes, ts2)
+	sig, _ := signChallenge(id.SignKey, nonceBytes, ts2)
 
 	// Send a valid pubkey but a wrong UUID (all-zeros).
 	hello, _ := encodeMsg(helloMsg{
 		Type:      msgHello,
 		UUID:      strings.Repeat("0", 64),
-		PubKey:    base64.StdEncoding.EncodeToString(id.UncompressedPublicKey()),
+		PubKey:    base64.StdEncoding.EncodeToString(id.SignPublicKey()),
 		Sig:       base64.StdEncoding.EncodeToString(sig),
 		Timestamp: ts2,
 	})

--- a/pkg/relay/hello_wire_test.go
+++ b/pkg/relay/hello_wire_test.go
@@ -1,0 +1,114 @@
+package relay
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// TestHello_AdvertisesBothKeys drives Client.handshake against a minimal
+// inspector server that captures the hello message. We assert that both
+// `pubkey` (SignKey) and `decrypt_pubkey` (DecryptKey) are populated and
+// match the daemon's keys — this is the wire-level guarantee of the
+// #104 split on the daemon-to-broker side.
+func TestHello_AdvertisesBothKeys(t *testing.T) {
+	captured := make(chan helloMsg, 1)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+		})
+		if err != nil {
+			t.Errorf("ws accept: %v", err)
+			return
+		}
+		defer conn.CloseNow()
+
+		ctx := r.Context()
+
+		// Send a minimal challenge so the client proceeds to send hello.
+		nonce := make([]byte, 32)
+		_, _ = rand.Read(nonce)
+		ch, _ := encodeMsg(challengeMsg{Type: msgChallenge, Nonce: hex.EncodeToString(nonce)})
+		if err := conn.Write(ctx, websocket.MessageText, ch); err != nil {
+			return
+		}
+
+		// Read the hello and forward it to the test goroutine.
+		_, data, err := conn.Read(ctx)
+		if err != nil {
+			return
+		}
+		var h helloMsg
+		if err := json.Unmarshal(data, &h); err != nil {
+			t.Errorf("parse hello: %v", err)
+			return
+		}
+		select {
+		case captured <- h:
+		default:
+		}
+
+		// Send a welcome with protocol 2 so Client.SupportsOAuth would be true.
+		w2, _ := encodeMsg(welcomeMsg{Type: msgWelcome, URL: "https://example.test/u/x/hooks/", Protocol: 2})
+		_ = conn.Write(ctx, websocket.MessageText, w2)
+
+		// Keep the connection up briefly so the client settles past handshake.
+		time.Sleep(100 * time.Millisecond)
+	}))
+	defer ts.Close()
+
+	id := NewTestIdentity(t)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+
+	// A harmless local HTTP server so NewClient has a port to target.
+	localSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer localSrv.Close()
+	_, portStr, _ := net.SplitHostPort(localSrv.Listener.Addr().String())
+	port, _ := strconv.Atoi(portStr)
+
+	client := NewClient(wsURL, id, port, nil, noopLogger())
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	go func() { _ = client.runOnce(ctx) }()
+
+	select {
+	case h := <-captured:
+		// Verify pubkey matches SignPublicKey.
+		wantSign := base64.StdEncoding.EncodeToString(id.SignPublicKey())
+		if h.PubKey != wantSign {
+			t.Fatalf("hello.pubkey does not match SignPublicKey\n got=%s\nwant=%s",
+				h.PubKey, wantSign)
+		}
+		// Verify decrypt_pubkey matches DecryptPublicKey and is not empty.
+		wantDecrypt := base64.StdEncoding.EncodeToString(id.DecryptPublicKey())
+		if h.DecryptPubKey == "" {
+			t.Fatal("hello.decrypt_pubkey is empty — new daemons must advertise it")
+		}
+		if h.DecryptPubKey != wantDecrypt {
+			t.Fatalf("hello.decrypt_pubkey does not match DecryptPublicKey\n got=%s\nwant=%s",
+				h.DecryptPubKey, wantDecrypt)
+		}
+		// And crucially, the two fields must be different values: if they
+		// were equal the split would have been silently defeated (two
+		// references to the same key).
+		if h.PubKey == h.DecryptPubKey {
+			t.Fatal("hello.pubkey == hello.decrypt_pubkey — SignKey and DecryptKey collapsed to one key")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for client hello")
+	}
+}

--- a/pkg/relay/keys.go
+++ b/pkg/relay/keys.go
@@ -14,20 +14,51 @@ import (
 	"math/big"
 
 	"github.com/dicode/dicode/pkg/db"
+	"go.uber.org/zap"
 )
 
-const kvKeyRelayPrivateKey = "relay.private_key"
+// kvKeyRelayPrivateKey is the legacy (pre-#104) KV row that stored the single
+// dual-use ECDSA private key. After #104 the same row stores the SignKey only
+// — the DecryptKey lives at kvKeyRelayDecryptPrivateKey. On upgrade the old row
+// is reused as-is so the UUID (derived from the SignKey pubkey) stays stable
+// and existing webhook URLs keep working.
+const (
+	kvKeyRelayPrivateKey        = "relay.private_key"
+	kvKeyRelayDecryptPrivateKey = "relay.decrypt_private_key"
+)
 
-// Identity holds the relay keypair and the derived stable UUID.
+// Identity holds the relay keypairs and the derived stable UUID.
+//
+// Issue #104 split the single dual-use relay key into two keys with disjoint
+// roles:
+//
+//   - SignKey    — ECDSA P-256, used for WSS handshake signatures and for
+//     /auth/:provider query-string signatures. Never participates in ECDH.
+//   - DecryptKey — ECDH P-256, used as the ECIES recipient key when the
+//     broker delivers an encrypted OAuth token envelope.
+//
+// UUID remains derived from the SignKey uncompressed pubkey (sha256, hex) so
+// daemons upgrading to #104 keep the same UUID and their shared webhook URLs
+// (/u/<uuid>/hooks/...) do not break.
 type Identity struct {
-	PrivateKey *ecdsa.PrivateKey
-	UUID       string // hex(sha256(uncompressed pubkey)) — 64 chars
+	SignKey    *ecdsa.PrivateKey // ECDSA P-256: WSS handshake + /auth/:provider sig
+	DecryptKey *ecdsa.PrivateKey // ECDH P-256: OAuth token delivery (ECIES recipient)
+	UUID       string            // hex(sha256(uncompressed SignKey pubkey)) — 64 chars
 }
 
-// UncompressedPublicKey returns the 65-byte uncompressed P-256 public key.
-func (id *Identity) UncompressedPublicKey() []byte {
-	pub := &id.PrivateKey.PublicKey
-	return marshalUncompressed(pub)
+// SignPublicKey returns the 65-byte uncompressed P-256 public key for the
+// SignKey. This is what the daemon advertises as `pubkey` in the WSS hello
+// message and what the broker uses to verify ECDSA signatures.
+func (id *Identity) SignPublicKey() []byte {
+	return marshalUncompressed(&id.SignKey.PublicKey)
+}
+
+// DecryptPublicKey returns the 65-byte uncompressed P-256 public key for the
+// DecryptKey. This is what the daemon advertises as `decrypt_pubkey` in the
+// WSS hello message and what the broker uses as the ECIES recipient key when
+// encrypting OAuth token deliveries.
+func (id *Identity) DecryptPublicKey() []byte {
+	return marshalUncompressed(&id.DecryptKey.PublicKey)
 }
 
 // marshalUncompressed serializes a P-256 public key as a 65-byte uncompressed
@@ -63,12 +94,73 @@ func deriveUUID(pub *ecdsa.PublicKey) string {
 }
 
 // LoadOrGenerateIdentity loads the relay identity from the database.
-// If no key exists yet, a new P-256 keypair is generated and stored.
-func LoadOrGenerateIdentity(ctx context.Context, database db.DB) (*Identity, error) {
+//
+// Migration behaviour (issue #104):
+//
+//   - If the legacy relay.private_key row is present it becomes the SignKey.
+//     The UUID is derived from its pubkey — bytes-identical to the pre-#104
+//     UUID, so webhook URLs stay stable.
+//   - If relay.decrypt_private_key is present it is parsed as the DecryptKey.
+//   - If relay.decrypt_private_key is missing the function generates a fresh
+//     P-256 key, inserts it (plain INSERT; never OR REPLACE, so an existing
+//     row is never silently overwritten) and logs at INFO.
+//   - If both rows are missing (fresh daemon) both keys are generated and
+//     stored in a single call.
+func LoadOrGenerateIdentity(ctx context.Context, database db.DB, log *zap.Logger) (*Identity, error) {
+	if log == nil {
+		log = zap.NewNop()
+	}
+
+	signPEM, err := loadKVKey(ctx, database, kvKeyRelayPrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("load relay sign key: %w", err)
+	}
+
+	var signKey *ecdsa.PrivateKey
+	if signPEM != "" {
+		signKey, err = parseECPrivateKeyPEM(signPEM)
+		if err != nil {
+			return nil, fmt.Errorf("parse relay sign key: %w", err)
+		}
+	} else {
+		signKey, err = generateAndStoreSignKey(ctx, database)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	decryptPEM, err := loadKVKey(ctx, database, kvKeyRelayDecryptPrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("load relay decrypt key: %w", err)
+	}
+
+	var decryptKey *ecdsa.PrivateKey
+	if decryptPEM != "" {
+		decryptKey, err = parseECPrivateKeyPEM(decryptPEM)
+		if err != nil {
+			return nil, fmt.Errorf("parse relay decrypt key: %w", err)
+		}
+	} else {
+		decryptKey, err = generateAndStoreDecryptKey(ctx, database)
+		if err != nil {
+			return nil, err
+		}
+		log.Info("relay: generated fresh decrypt key (issue #104 split)")
+	}
+
+	return &Identity{
+		SignKey:    signKey,
+		DecryptKey: decryptKey,
+		UUID:       deriveUUID(&signKey.PublicKey),
+	}, nil
+}
+
+// loadKVKey reads a single KV row. Returns "" (no error) if the row is absent.
+func loadKVKey(ctx context.Context, database db.DB, key string) (string, error) {
 	var pemData string
 	err := database.Query(ctx,
 		`SELECT value FROM kv WHERE key = ?`,
-		[]any{kvKeyRelayPrivateKey},
+		[]any{key},
 		func(rows db.Scanner) error {
 			if rows.Next() {
 				return rows.Scan(&pemData)
@@ -76,56 +168,72 @@ func LoadOrGenerateIdentity(ctx context.Context, database db.DB) (*Identity, err
 			return nil
 		},
 	)
-	if err != nil {
-		return nil, fmt.Errorf("load relay key: %w", err)
-	}
-
-	if pemData != "" {
-		return parseIdentity(pemData)
-	}
-
-	return generateAndStore(ctx, database)
+	return pemData, err
 }
 
-func parseIdentity(pemData string) (*Identity, error) {
+// parseECPrivateKeyPEM decodes a PEM-encoded "EC PRIVATE KEY" block.
+func parseECPrivateKeyPEM(pemData string) (*ecdsa.PrivateKey, error) {
 	block, _ := pem.Decode([]byte(pemData))
 	if block == nil {
-		return nil, fmt.Errorf("relay key: invalid PEM")
+		return nil, fmt.Errorf("invalid PEM")
 	}
 	key, err := x509.ParseECPrivateKey(block.Bytes)
 	if err != nil {
-		return nil, fmt.Errorf("relay key: parse EC private key: %w", err)
+		return nil, fmt.Errorf("parse EC private key: %w", err)
 	}
-	return &Identity{
-		PrivateKey: key,
-		UUID:       deriveUUID(&key.PublicKey),
-	}, nil
+	return key, nil
 }
 
-func generateAndStore(ctx context.Context, database db.DB) (*Identity, error) {
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		return nil, fmt.Errorf("generate relay keypair: %w", err)
-	}
-
+// encodeECPrivateKeyPEM encodes a P-256 private key as an "EC PRIVATE KEY" PEM
+// block — the format both pre- and post-#104 rows share.
+func encodeECPrivateKeyPEM(key *ecdsa.PrivateKey) (string, error) {
 	der, err := x509.MarshalECPrivateKey(key)
 	if err != nil {
-		return nil, fmt.Errorf("marshal relay key: %w", err)
+		return "", fmt.Errorf("marshal EC private key: %w", err)
 	}
-	pemData := string(pem.EncodeToMemory(&pem.Block{
+	return string(pem.EncodeToMemory(&pem.Block{
 		Type:  "EC PRIVATE KEY",
 		Bytes: der,
-	}))
+	})), nil
+}
 
+func generateAndStoreSignKey(ctx context.Context, database db.DB) (*ecdsa.PrivateKey, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate relay sign key: %w", err)
+	}
+	pemData, err := encodeECPrivateKeyPEM(key)
+	if err != nil {
+		return nil, err
+	}
+	// INSERT OR REPLACE is safe here: we only reach this path when the row is
+	// absent. The fresh-daemon case wants to write it; a concurrent writer
+	// writing the same key would race but that's a pathological scenario.
 	if err := database.Exec(ctx,
 		`INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)`,
 		kvKeyRelayPrivateKey, pemData,
 	); err != nil {
-		return nil, fmt.Errorf("store relay key: %w", err)
+		return nil, fmt.Errorf("store relay sign key: %w", err)
 	}
+	return key, nil
+}
 
-	return &Identity{
-		PrivateKey: key,
-		UUID:       deriveUUID(&key.PublicKey),
-	}, nil
+func generateAndStoreDecryptKey(ctx context.Context, database db.DB) (*ecdsa.PrivateKey, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate relay decrypt key: %w", err)
+	}
+	pemData, err := encodeECPrivateKeyPEM(key)
+	if err != nil {
+		return nil, err
+	}
+	// Plain INSERT (not OR REPLACE) so we never silently overwrite an existing
+	// decrypt key — if one exists, we should have read it above.
+	if err := database.Exec(ctx,
+		`INSERT INTO kv (key, value) VALUES (?, ?)`,
+		kvKeyRelayDecryptPrivateKey, pemData,
+	); err != nil {
+		return nil, fmt.Errorf("store relay decrypt key: %w", err)
+	}
+	return key, nil
 }

--- a/pkg/relay/keys_test.go
+++ b/pkg/relay/keys_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/dicode/dicode/pkg/db"
+	"go.uber.org/zap"
 )
 
 func openTestDB(t *testing.T) db.DB {
@@ -27,13 +28,16 @@ func TestGenerateIdentity(t *testing.T) {
 	ctx := context.Background()
 	database := openTestDB(t)
 
-	id, err := LoadOrGenerateIdentity(ctx, database)
+	id, err := LoadOrGenerateIdentity(ctx, database, zap.NewNop())
 	if err != nil {
 		t.Fatalf("generate identity: %v", err)
 	}
 
-	if id.PrivateKey == nil {
-		t.Fatal("nil private key")
+	if id.SignKey == nil {
+		t.Fatal("nil sign key")
+	}
+	if id.DecryptKey == nil {
+		t.Fatal("nil decrypt key")
 	}
 	if id.UUID == "" {
 		t.Fatal("empty UUID")
@@ -47,13 +51,13 @@ func TestUUIDDeterministic(t *testing.T) {
 	ctx := context.Background()
 	database := openTestDB(t)
 
-	id1, err := LoadOrGenerateIdentity(ctx, database)
+	id1, err := LoadOrGenerateIdentity(ctx, database, zap.NewNop())
 	if err != nil {
 		t.Fatalf("first load: %v", err)
 	}
 
 	// Load again — must return the same UUID.
-	id2, err := LoadOrGenerateIdentity(ctx, database)
+	id2, err := LoadOrGenerateIdentity(ctx, database, zap.NewNop())
 	if err != nil {
 		t.Fatalf("second load: %v", err)
 	}
@@ -67,35 +71,37 @@ func TestKeyRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	database := openTestDB(t)
 
-	id1, err := LoadOrGenerateIdentity(ctx, database)
+	id1, err := LoadOrGenerateIdentity(ctx, database, zap.NewNop())
 	if err != nil {
 		t.Fatalf("generate: %v", err)
 	}
 
-	id2, err := LoadOrGenerateIdentity(ctx, database)
+	id2, err := LoadOrGenerateIdentity(ctx, database, zap.NewNop())
 	if err != nil {
 		t.Fatalf("reload: %v", err)
 	}
 
-	// Public keys must match.
-	pub1 := id1.PrivateKey.PublicKey
-	pub2 := id2.PrivateKey.PublicKey
-
-	if pub1.X.Cmp(pub2.X) != 0 || pub1.Y.Cmp(pub2.Y) != 0 {
-		t.Fatal("public key changed after round-trip")
+	// Both public keys (sign and decrypt) must round-trip identically.
+	if id1.SignKey.PublicKey.X.Cmp(id2.SignKey.PublicKey.X) != 0 ||
+		id1.SignKey.PublicKey.Y.Cmp(id2.SignKey.PublicKey.Y) != 0 {
+		t.Fatal("sign public key changed after round-trip")
+	}
+	if id1.DecryptKey.PublicKey.X.Cmp(id2.DecryptKey.PublicKey.X) != 0 ||
+		id1.DecryptKey.PublicKey.Y.Cmp(id2.DecryptKey.PublicKey.Y) != 0 {
+		t.Fatal("decrypt public key changed after round-trip")
 	}
 }
 
-func TestUncompressedPublicKey(t *testing.T) {
+func TestSignPublicKey(t *testing.T) {
 	ctx := context.Background()
 	database := openTestDB(t)
 
-	id, err := LoadOrGenerateIdentity(ctx, database)
+	id, err := LoadOrGenerateIdentity(ctx, database, zap.NewNop())
 	if err != nil {
 		t.Fatalf("generate: %v", err)
 	}
 
-	raw := id.UncompressedPublicKey()
+	raw := id.SignPublicKey()
 	if len(raw) != 65 {
 		t.Fatalf("uncompressed key must be 65 bytes, got %d", len(raw))
 	}
@@ -103,13 +109,39 @@ func TestUncompressedPublicKey(t *testing.T) {
 		t.Fatalf("uncompressed key must start with 0x04, got 0x%02x", raw[0])
 	}
 
-	// Must round-trip through unmarshalUncompressed.
+	// Must round-trip through unmarshalUncompressed and match SignKey.
 	pub, err := unmarshalUncompressed(raw)
 	if err != nil {
 		t.Fatalf("unmarshalUncompressed failed: %v", err)
 	}
-	if pub.X.Cmp(id.PrivateKey.PublicKey.X) != 0 || pub.Y.Cmp(id.PrivateKey.PublicKey.Y) != 0 {
-		t.Fatal("round-trip public key mismatch")
+	if pub.X.Cmp(id.SignKey.PublicKey.X) != 0 || pub.Y.Cmp(id.SignKey.PublicKey.Y) != 0 {
+		t.Fatal("round-trip sign public key mismatch")
+	}
+}
+
+func TestDecryptPublicKey(t *testing.T) {
+	ctx := context.Background()
+	database := openTestDB(t)
+
+	id, err := LoadOrGenerateIdentity(ctx, database, zap.NewNop())
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	raw := id.DecryptPublicKey()
+	if len(raw) != 65 {
+		t.Fatalf("uncompressed key must be 65 bytes, got %d", len(raw))
+	}
+	if raw[0] != 0x04 {
+		t.Fatalf("uncompressed key must start with 0x04, got 0x%02x", raw[0])
+	}
+
+	pub, err := unmarshalUncompressed(raw)
+	if err != nil {
+		t.Fatalf("unmarshalUncompressed failed: %v", err)
+	}
+	if pub.X.Cmp(id.DecryptKey.PublicKey.X) != 0 || pub.Y.Cmp(id.DecryptKey.PublicKey.Y) != 0 {
+		t.Fatal("round-trip decrypt public key mismatch")
 	}
 }
 
@@ -117,13 +149,14 @@ func TestDeriveUUID(t *testing.T) {
 	ctx := context.Background()
 	database := openTestDB(t)
 
-	id, err := LoadOrGenerateIdentity(ctx, database)
+	id, err := LoadOrGenerateIdentity(ctx, database, zap.NewNop())
 	if err != nil {
 		t.Fatalf("generate: %v", err)
 	}
 
-	// Recompute UUID manually.
-	expected := deriveUUID(&id.PrivateKey.PublicKey)
+	// The UUID is derived from the SignKey pubkey only — the DecryptKey
+	// has no effect on the URL prefix (issue #104).
+	expected := deriveUUID(&id.SignKey.PublicKey)
 	if id.UUID != expected {
 		t.Fatalf("UUID mismatch: got %s, want %s", id.UUID, expected)
 	}

--- a/pkg/relay/migration_test.go
+++ b/pkg/relay/migration_test.go
@@ -1,0 +1,135 @@
+package relay
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestIdentity_KeysAreDistinct locks in the post-#104 invariant: a freshly
+// generated identity never reuses the same key for both roles. If the two
+// fields aliased the same *ecdsa.PrivateKey the whole point of the split
+// (domain separation between ECDSA sign and ECDH decrypt) would be lost.
+func TestIdentity_KeysAreDistinct(t *testing.T) {
+	ctx := context.Background()
+	database := openTestDB(t)
+
+	id, err := LoadOrGenerateIdentity(ctx, database, zap.NewNop())
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	if id.SignKey == id.DecryptKey {
+		t.Fatal("SignKey and DecryptKey are the same *ecdsa.PrivateKey pointer")
+	}
+	if id.SignKey.D.Cmp(id.DecryptKey.D) == 0 {
+		t.Fatal("SignKey.D == DecryptKey.D — keys are not independently generated")
+	}
+	if id.SignKey.PublicKey.X.Cmp(id.DecryptKey.PublicKey.X) == 0 &&
+		id.SignKey.PublicKey.Y.Cmp(id.DecryptKey.PublicKey.Y) == 0 {
+		t.Fatal("SignKey public point == DecryptKey public point")
+	}
+}
+
+// TestMigration_OldKeyBecomesSignKey exercises the upgrade path: a daemon
+// booting on post-#104 code against a database that only has the legacy
+// relay.private_key row must reuse that key as the SignKey (preserving the
+// UUID and therefore the shared webhook URLs) and generate a fresh
+// DecryptKey, persisting it in a new relay.decrypt_private_key row.
+func TestMigration_OldKeyBecomesSignKey(t *testing.T) {
+	ctx := context.Background()
+	database := openTestDB(t)
+
+	// Simulate a pre-#104 daemon: generate an identity and keep only the
+	// sign key row. (LoadOrGenerateIdentity on the new code always writes
+	// both rows, so we seed manually by deleting the decrypt row it wrote.)
+	seeded, err := LoadOrGenerateIdentity(ctx, database, zap.NewNop())
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	originalUUID := seeded.UUID
+	originalSignD := seeded.SignKey.D.String()
+	if err := database.Exec(ctx,
+		`DELETE FROM kv WHERE key = ?`, kvKeyRelayDecryptPrivateKey,
+	); err != nil {
+		t.Fatalf("delete decrypt row (pre-104 seeding): %v", err)
+	}
+	// Sanity: the decrypt row should now be absent.
+	if v, _ := loadKVKey(ctx, database, kvKeyRelayDecryptPrivateKey); v != "" {
+		t.Fatalf("precondition: decrypt row should be empty after seeding, got %q", v)
+	}
+
+	// Run the loader again — the migration path should kick in.
+	migrated, err := LoadOrGenerateIdentity(ctx, database, zap.NewNop())
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// 1. SignKey must be byte-identical to the seeded one.
+	if migrated.SignKey.D.String() != originalSignD {
+		t.Fatalf("SignKey changed across migration: want D=%s got D=%s",
+			originalSignD, migrated.SignKey.D.String())
+	}
+	// 2. UUID must be stable (webhook URL invariant).
+	if migrated.UUID != originalUUID {
+		t.Fatalf("UUID changed across migration: want %s got %s", originalUUID, migrated.UUID)
+	}
+	// 3. The KV row for the decrypt key must now exist.
+	decryptPEM, err := loadKVKey(ctx, database, kvKeyRelayDecryptPrivateKey)
+	if err != nil {
+		t.Fatalf("load decrypt row after migration: %v", err)
+	}
+	if decryptPEM == "" {
+		t.Fatal("migration did not insert relay.decrypt_private_key row")
+	}
+	// 4. The new DecryptKey must differ from SignKey (distinctness invariant).
+	if migrated.DecryptKey.D.Cmp(migrated.SignKey.D) == 0 {
+		t.Fatal("migration reused SignKey as DecryptKey — split is defeated")
+	}
+}
+
+// TestMigration_Idempotent verifies that running the loader twice on a
+// migrated database is a no-op on the DB side and returns identical keys.
+// This guards against a regression where the decrypt-key row is
+// accidentally rewritten (and therefore rotated) on every daemon start.
+func TestMigration_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	database := openTestDB(t)
+
+	first, err := LoadOrGenerateIdentity(ctx, database, zap.NewNop())
+	if err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+
+	// Capture the raw PEM rows so we can compare byte-for-byte.
+	firstSignPEM, err := loadKVKey(ctx, database, kvKeyRelayPrivateKey)
+	if err != nil {
+		t.Fatalf("read sign row: %v", err)
+	}
+	firstDecryptPEM, err := loadKVKey(ctx, database, kvKeyRelayDecryptPrivateKey)
+	if err != nil {
+		t.Fatalf("read decrypt row: %v", err)
+	}
+
+	second, err := LoadOrGenerateIdentity(ctx, database, zap.NewNop())
+	if err != nil {
+		t.Fatalf("second load: %v", err)
+	}
+
+	if first.SignKey.D.Cmp(second.SignKey.D) != 0 {
+		t.Fatal("SignKey.D changed on second load — migration is not idempotent")
+	}
+	if first.DecryptKey.D.Cmp(second.DecryptKey.D) != 0 {
+		t.Fatal("DecryptKey.D changed on second load — migration is not idempotent")
+	}
+
+	secondSignPEM, _ := loadKVKey(ctx, database, kvKeyRelayPrivateKey)
+	secondDecryptPEM, _ := loadKVKey(ctx, database, kvKeyRelayDecryptPrivateKey)
+	if firstSignPEM != secondSignPEM {
+		t.Fatal("relay.private_key PEM rewritten on second load")
+	}
+	if firstDecryptPEM != secondDecryptPEM {
+		t.Fatal("relay.decrypt_private_key PEM rewritten on second load")
+	}
+}

--- a/pkg/relay/oauth.go
+++ b/pkg/relay/oauth.go
@@ -115,7 +115,7 @@ func generatePKCEChallenge() (string, error) {
 //	baseURL  e.g. "https://relay.dicode.app"
 //	scope    optional space-separated scope override (empty = use broker default)
 func BuildAuthURL(baseURL string, identity *Identity, provider, scope string, now int64) (string, *AuthRequest, error) {
-	if identity == nil || identity.PrivateKey == nil {
+	if identity == nil || identity.SignKey == nil {
 		return "", nil, fmt.Errorf("identity required")
 	}
 	if provider == "" {
@@ -133,7 +133,7 @@ func BuildAuthURL(baseURL string, identity *Identity, provider, scope string, no
 	if err != nil {
 		return "", nil, err
 	}
-	sig, err := SignAuthPayload(identity.PrivateKey, payload)
+	sig, err := SignAuthPayload(identity.SignKey, payload)
 	if err != nil {
 		return "", nil, err
 	}
@@ -186,7 +186,7 @@ type OAuthTokenDeliveryPayload struct {
 // decrypts the payload. The 16-byte GCM auth tag is appended to the ciphertext
 // per the broker convention; this function splits it back off.
 func DecryptOAuthToken(identity *Identity, payload *OAuthTokenDeliveryPayload) ([]byte, error) {
-	if identity == nil || identity.PrivateKey == nil {
+	if identity == nil || identity.DecryptKey == nil {
 		return nil, fmt.Errorf("identity required")
 	}
 	if payload == nil {
@@ -211,8 +211,11 @@ func DecryptOAuthToken(identity *Identity, payload *OAuthTokenDeliveryPayload) (
 		return nil, fmt.Errorf("parse ephemeral pubkey: %w", err)
 	}
 
-	// Convert the long-lived ECDSA key to an ECDH key on the same curve.
-	daemonECDH, err := ecdsaToECDH(identity.PrivateKey)
+	// Convert the long-lived DecryptKey (ECDSA type, P-256 curve) to an ECDH
+	// key so it can participate in ECDH against the broker's ephemeral key.
+	// #104: the SignKey must never take this code path — ECDSA-only domain
+	// separation is exactly what the split buys us.
+	daemonECDH, err := ecdsaToECDH(identity.DecryptKey)
 	if err != nil {
 		return nil, fmt.Errorf("convert daemon key: %w", err)
 	}

--- a/pkg/relay/oauth_split_test.go
+++ b/pkg/relay/oauth_split_test.go
@@ -1,0 +1,187 @@
+package relay
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdh"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"io"
+	"net/url"
+	"testing"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	return u
+}
+
+// ecdsaVerify parses a 65-byte uncompressed P-256 pubkey and checks sig.
+func ecdsaVerify(uncompressedPub, digest, sig []byte) bool {
+	pub, err := unmarshalUncompressed(uncompressedPub)
+	if err != nil {
+		return false
+	}
+	return ecdsa.VerifyASN1(pub, digest, sig)
+}
+
+// TestOAuth_UsesDecryptKey is the positive/negative canary for the split:
+// encrypting under the SignKey pubkey must fail to decrypt (because the
+// daemon now opens with DecryptKey), while encrypting under the DecryptKey
+// pubkey must succeed. Accidentally re-wiring DecryptOAuthToken back to
+// identity.SignKey — or teaching the broker to encrypt under the SignKey
+// pubkey — would flip either half of this assertion.
+func TestOAuth_UsesDecryptKey(t *testing.T) {
+	id := NewTestIdentity(t)
+	plaintext := []byte(`{"access_token":"xoxb-test"}`)
+	sessionID := "550e8400-e29b-41d4-a716-446655440000"
+
+	t.Run("encrypted to SignKey pubkey fails to decrypt", func(t *testing.T) {
+		payload := encryptTo(t, id.SignPublicKey(), sessionID, plaintext)
+		if _, err := DecryptOAuthToken(id, payload); err == nil {
+			t.Fatal("expected decrypt to fail when broker encrypted under the SignKey pubkey; " +
+				"this is the whole point of the #104 split — if this succeeds, DecryptOAuthToken " +
+				"is still using the sign key or the broker is encrypting to the wrong key")
+		}
+	})
+
+	t.Run("encrypted to DecryptKey pubkey succeeds", func(t *testing.T) {
+		payload := encryptTo(t, id.DecryptPublicKey(), sessionID, plaintext)
+		got, err := DecryptOAuthToken(id, payload)
+		if err != nil {
+			t.Fatalf("decrypt with DecryptKey should succeed: %v", err)
+		}
+		if string(got) != string(plaintext) {
+			t.Fatalf("plaintext mismatch: got %q want %q", got, plaintext)
+		}
+	})
+}
+
+// TestAuthURL_UsesSignKey confirms that BuildAuthURL signs with the SignKey,
+// not the DecryptKey. We verify the signature against id.SignKey.PublicKey.
+// If BuildAuthURL were wired to DecryptKey the verification would fail even
+// though the URL fields are all well-formed.
+func TestAuthURL_UsesSignKey(t *testing.T) {
+	id := NewTestIdentity(t)
+
+	rawURL, _, err := BuildAuthURL("https://relay.dicode.app", id, "slack", "", 1_700_000_000)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	// Parse out session/challenge/sig (minimal parsing — we own the format).
+	// BuildAuthURL's own round-trip test already exercises the verify path;
+	// here we re-verify explicitly with id.SignKey to lock in the invariant.
+	u := mustParseURL(t, rawURL)
+	payload, err := BuildAuthSignedPayload(
+		u.Query().Get("session"),
+		u.Query().Get("challenge"),
+		u.Query().Get("relay_uuid"),
+		"slack",
+		1_700_000_000,
+	)
+	if err != nil {
+		t.Fatalf("rebuild payload: %v", err)
+	}
+	sig, err := base64.StdEncoding.DecodeString(u.Query().Get("sig"))
+	if err != nil {
+		t.Fatalf("decode sig: %v", err)
+	}
+	if !ecdsaVerify(id.SignPublicKey(), payload, sig) {
+		t.Fatal("URL signature does not verify under SignKey — BuildAuthURL may be signing with DecryptKey")
+	}
+	// And crucially: it must NOT verify under DecryptKey. This is the
+	// distinctness invariant on the sign side of the split.
+	if ecdsaVerify(id.DecryptPublicKey(), payload, sig) {
+		t.Fatal("URL signature unexpectedly verifies under DecryptKey — SignKey and DecryptKey may be aliased")
+	}
+}
+
+// TestWSS_UsesSignKey verifies the handshake code path only touches SignKey:
+// the daemon must be able to connect with DecryptKey left nil, and must
+// refuse to sign the handshake if SignKey is nil.
+func TestWSS_UsesSignKey(t *testing.T) {
+	t.Run("signChallenge succeeds with only SignKey populated", func(t *testing.T) {
+		id := NewTestIdentity(t)
+		id.DecryptKey = nil // prove the handshake doesn't read DecryptKey
+		nonce := make([]byte, 32)
+		if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+			t.Fatalf("rand: %v", err)
+		}
+		if _, err := signChallenge(id.SignKey, nonce, 1_700_000_000); err != nil {
+			t.Fatalf("signChallenge should not need DecryptKey: %v", err)
+		}
+		// And the SignPublicKey accessor must still work.
+		if got := id.SignPublicKey(); len(got) != 65 {
+			t.Fatalf("SignPublicKey len=%d", len(got))
+		}
+	})
+
+	t.Run("BuildAuthURL rejects identity with nil SignKey", func(t *testing.T) {
+		id := NewTestIdentity(t)
+		id.SignKey = nil
+		if _, _, err := BuildAuthURL("https://r", id, "slack", "", 1); err == nil {
+			t.Fatal("expected BuildAuthURL to refuse an identity with nil SignKey")
+		}
+	})
+
+	t.Run("DecryptOAuthToken rejects identity with nil DecryptKey", func(t *testing.T) {
+		id := NewTestIdentity(t)
+		id.DecryptKey = nil
+		if _, err := DecryptOAuthToken(id, &OAuthTokenDeliveryPayload{
+			Type: OAuthDeliveryType,
+		}); err == nil {
+			t.Fatal("expected DecryptOAuthToken to refuse an identity with nil DecryptKey")
+		}
+	})
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// encryptTo mirrors dicode-relay's eciesEncrypt exactly, but lets the caller
+// pick *which* daemon pubkey to encrypt against — so we can verify the
+// daemon's Decrypt function is keyed to DecryptKey and not SignKey.
+func encryptTo(t *testing.T, daemonPubUncompressed []byte, sessionID string, plaintext []byte) *OAuthTokenDeliveryPayload {
+	t.Helper()
+	daemonPub, err := ecdh.P256().NewPublicKey(daemonPubUncompressed)
+	if err != nil {
+		t.Fatalf("daemon pub: %v", err)
+	}
+	eph, err := ecdh.P256().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("eph: %v", err)
+	}
+	shared, err := eph.ECDH(daemonPub)
+	if err != nil {
+		t.Fatalf("ecdh: %v", err)
+	}
+	encKey := make([]byte, 32)
+	if _, err := io.ReadFull(
+		hkdf.New(sha256.New, shared, []byte(sessionID), []byte(hkdfInfo)),
+		encKey,
+	); err != nil {
+		t.Fatalf("hkdf: %v", err)
+	}
+	iv := make([]byte, 12)
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		t.Fatalf("iv: %v", err)
+	}
+	block, _ := aes.NewCipher(encKey)
+	aead, _ := cipher.NewGCM(block)
+	ct := aead.Seal(nil, iv, plaintext, []byte(OAuthDeliveryType))
+	return &OAuthTokenDeliveryPayload{
+		Type:            OAuthDeliveryType,
+		SessionID:       sessionID,
+		EphemeralPubkey: base64.StdEncoding.EncodeToString(eph.PublicKey().Bytes()),
+		Ciphertext:      base64.StdEncoding.EncodeToString(ct),
+		Nonce:           base64.StdEncoding.EncodeToString(iv),
+	}
+}

--- a/pkg/relay/oauth_test.go
+++ b/pkg/relay/oauth_test.go
@@ -19,16 +19,24 @@ import (
 	"golang.org/x/crypto/hkdf"
 )
 
-// newOAuthTestIdentity creates a fresh in-memory P-256 identity (no DB writes).
+// newOAuthTestIdentity creates a fresh in-memory split-key identity
+// (no DB writes). SignKey and DecryptKey are deliberately independent so
+// tests exercise the post-#104 invariant that signing and decryption happen
+// under disjoint keys.
 func newOAuthTestIdentity(t *testing.T) *Identity {
 	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	signKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		t.Fatalf("generate key: %v", err)
+		t.Fatalf("generate sign key: %v", err)
+	}
+	decryptKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate decrypt key: %v", err)
 	}
 	return &Identity{
-		PrivateKey: key,
-		UUID:       deriveUUID(&key.PublicKey),
+		SignKey:    signKey,
+		DecryptKey: decryptKey,
+		UUID:       deriveUUID(&signKey.PublicKey),
 	}
 }
 
@@ -134,7 +142,7 @@ func TestBuildAuthURL_RoundTripVerify(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decode sig: %v", err)
 	}
-	if !ecdsa.VerifyASN1(&id.PrivateKey.PublicKey, payload, sigBytes) {
+	if !ecdsa.VerifyASN1(&id.SignKey.PublicKey, payload, sigBytes) {
 		t.Fatalf("signature verification failed")
 	}
 }
@@ -230,8 +238,9 @@ func TestDecryptOAuthToken_RejectsTamperedType(t *testing.T) {
 func encryptForDaemon(t *testing.T, daemon *Identity, sessionID string, plaintext []byte) *OAuthTokenDeliveryPayload {
 	t.Helper()
 
-	// Daemon's long-lived public key as a crypto/ecdh peer key.
-	daemonPubBytes := daemon.UncompressedPublicKey()
+	// Daemon's DecryptKey public key as a crypto/ecdh peer key (post-#104
+	// the broker encrypts against DecryptKey, not SignKey).
+	daemonPubBytes := daemon.DecryptPublicKey()
 	daemonPub, err := ecdh.P256().NewPublicKey(daemonPubBytes)
 	if err != nil {
 		t.Fatalf("daemon pub: %v", err)

--- a/pkg/relay/protocol.go
+++ b/pkg/relay/protocol.go
@@ -17,17 +17,31 @@ type challengeMsg struct {
 }
 
 type helloMsg struct {
-	Type      string `json:"type"`
-	UUID      string `json:"uuid"`
-	PubKey    string `json:"pubkey"`
-	Sig       string `json:"sig"`
-	Timestamp int64  `json:"timestamp"`
+	Type string `json:"type"`
+	UUID string `json:"uuid"`
+	// PubKey is the base64-encoded uncompressed SignKey public key (65 bytes).
+	// The broker uses it both to verify the ECDSA handshake signature and —
+	// on pre-#104 brokers — as the ECIES recipient for OAuth deliveries.
+	PubKey string `json:"pubkey"`
+	// DecryptPubKey is the base64-encoded uncompressed DecryptKey public key
+	// (65 bytes). Post-#104 brokers encrypt OAuth deliveries against this
+	// key instead of PubKey. The field is always populated by post-#104
+	// daemons; pre-#104 brokers ignore it and fall back to PubKey.
+	DecryptPubKey string `json:"decrypt_pubkey,omitempty"`
+	Sig           string `json:"sig"`
+	Timestamp     int64  `json:"timestamp"`
 }
 
 type welcomeMsg struct {
 	Type         string `json:"type"`
 	URL          string `json:"url"`
 	BrokerPubkey string `json:"broker_pubkey,omitempty"` // base64 SPKI DER — TOFU-pinned by the daemon
+	// Protocol is the broker's wire-protocol version. A value >= 2 means the
+	// broker understands the split sign/decrypt key scheme (issue #104) and
+	// will encrypt OAuth deliveries to the daemon's DecryptKey pubkey.
+	// Protocol 1 (or an absent field) means the broker is pre-#104 and the
+	// daemon must refuse OAuth IPC flows to avoid silent decrypt failures.
+	Protocol int `json:"protocol,omitempty"`
 }
 
 type errorMsg struct {

--- a/pkg/relay/server.go
+++ b/pkg/relay/server.go
@@ -107,7 +107,7 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 	}
 
 	welcomeURL := fmt.Sprintf("%s/u/%s/hooks/", s.host, sc.uuid)
-	welcomeData, _ := encodeMsg(welcomeMsg{Type: msgWelcome, URL: welcomeURL})
+	welcomeData, _ := encodeMsg(welcomeMsg{Type: msgWelcome, URL: welcomeURL, Protocol: 2})
 	if err := sc.write(ctx, welcomeData); err != nil {
 		return
 	}

--- a/pkg/relay/testing.go
+++ b/pkg/relay/testing.go
@@ -1,0 +1,44 @@
+package relay
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+)
+
+// NewTestIdentity returns a fresh in-memory *Identity suitable for unit tests
+// that need a valid signing and decryption keypair but don't want the weight
+// of a SQLite round-trip through LoadOrGenerateIdentity.
+//
+// The helper exists because the Identity struct layout is an implementation
+// detail of the relay package — tests in other packages (e.g. pkg/ipc) would
+// otherwise have to know the field names and reach into the struct literally,
+// which makes the split-key refactor (issue #104) a mechanical churn across
+// the whole repo every time the shape changes.
+//
+// Two distinct keys are generated to exercise the post-#104 invariant that
+// SignKey and DecryptKey are independent. The UUID is derived from the
+// SignKey public key exactly as in LoadOrGenerateIdentity.
+//
+// Naming note: this file lives in the production build (Go test helpers in
+// same-package must be in _test.go files; to share with other packages we
+// need a regular file). The cost is the stdlib "testing" import linking
+// into the daemon binary — acceptable for dicode's scale. See the issue
+// #104 design doc §4.1, decision 5, for the rationale.
+func NewTestIdentity(t *testing.T) *Identity {
+	t.Helper()
+	signKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("relay: generate sign key: %v", err)
+	}
+	decryptKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("relay: generate decrypt key: %v", err)
+	}
+	return &Identity{
+		SignKey:    signKey,
+		DecryptKey: decryptKey,
+		UUID:       deriveUUID(&signKey.PublicKey),
+	}
+}

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -69,19 +69,20 @@ type RunResult struct {
 
 // Runtime executes task scripts with Deno.
 type Runtime struct {
-	registry       *registry.Registry
-	secrets        secrets.Chain
-	secretsManager secrets.Manager // optional; wired for dicode.secrets_set/delete
-	db             db.DB
-	log            *zap.Logger
-	denoPath       string
-	secret         []byte
-	engine         ipc.EngineRunner
-	gateway        *ipc.Gateway
-	oauthIdentity  *relay.Identity
-	oauthURL       string
-	oauthPending   *relay.PendingSessions
-	brokerPubkeyFn func() string
+	registry        *registry.Registry
+	secrets         secrets.Chain
+	secretsManager  secrets.Manager // optional; wired for dicode.secrets_set/delete
+	db              db.DB
+	log             *zap.Logger
+	denoPath        string
+	secret          []byte
+	engine          ipc.EngineRunner
+	gateway         *ipc.Gateway
+	oauthIdentity   *relay.Identity
+	oauthURL        string
+	oauthPending    *relay.PendingSessions
+	brokerPubkeyFn  func() string
+	supportsOAuthFn func() bool
 }
 
 // New creates a Deno Runtime. It ensures the Deno binary is present in the
@@ -113,11 +114,20 @@ func (rt *Runtime) SetSecretsManager(m secrets.Manager) { rt.secretsManager = m 
 // built-in tasks can use dicode.oauth.*. All three are required together;
 // passing nil leaves the oauth API inert and tasks will receive a
 // "not configured" error.
-func (rt *Runtime) SetOAuthBroker(id *relay.Identity, baseURL string, pending *relay.PendingSessions, brokerPubkeyFn func() string) {
+//
+// supportsOAuthFn (issue #104) is an optional predicate reporting whether
+// the currently-connected broker advertises a protocol version new enough
+// to understand the split sign/decrypt key scheme. If nil the OAuth IPC
+// paths are always enabled (suitable for test harnesses that don't have a
+// real relay.Client). In production the daemon wires rc.SupportsOAuth so
+// that an old broker cleanly disables the OAuth flows instead of silently
+// failing to decrypt.
+func (rt *Runtime) SetOAuthBroker(id *relay.Identity, baseURL string, pending *relay.PendingSessions, brokerPubkeyFn func() string, supportsOAuthFn func() bool) {
 	rt.oauthIdentity = id
 	rt.oauthURL = baseURL
 	rt.oauthPending = pending
 	rt.brokerPubkeyFn = brokerPubkeyFn
+	rt.supportsOAuthFn = supportsOAuthFn
 }
 
 // Run executes a task script and returns the result.
@@ -207,7 +217,7 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	srv.SetGateway(rt.gateway)
 	srv.SetSecrets(rt.secretsManager)
 	if rt.oauthIdentity != nil {
-		srv.SetOAuthBroker(rt.oauthIdentity, rt.oauthURL, rt.oauthPending, rt.brokerPubkeyFn)
+		srv.SetOAuthBroker(rt.oauthIdentity, rt.oauthURL, rt.oauthPending, rt.brokerPubkeyFn, rt.supportsOAuthFn)
 	}
 	socketPath, token, err := srv.Start(execCtx)
 	if err != nil {


### PR DESCRIPTION
Closes #104. Companion to [dicode-relay#29](https://github.com/dicode-ayo/dicode-relay/pull/29) — that PR must land + deploy first.

## Problem

The daemon's long-lived P-256 identity key was reused for three distinct crypto operations:
1. ECDSA signing of WSS handshake challenges
2. ECDSA signing of \`/auth/:provider\` payloads
3. ECDH key agreement for ECIES OAuth token decryption

Cross-protocol key reuse is a well-known footgun — any future primitive exposing a partial signing or decryption oracle cross-contaminates the other schemes.

## Solution

Two independent P-256 keys:
- **SignKey** — ECDSA for WSS handshake + \`/auth/:provider\` sigs
- **DecryptKey** — ECDH for OAuth token delivery (ECIES recipient)

**UUID stays derived from SignKey pubkey.** Webhook URLs shared by existing deployments (\`/u/<uuid>/hooks/...\`) survive the upgrade bytes-identically.

**Migration on first boot of new code**: existing \`relay.private_key\` DB row becomes SignKey; a fresh \`relay.decrypt_private_key\` row is inserted and persisted. Idempotent. Logged at INFO. No operator action required.

**Wire**: daemon always advertises \`decrypt_pubkey\` alongside \`pubkey\` in hello. Welcome must announce \`protocol: 2\` — daemons on new code that hit an old broker detect \`protocol < 2\` and disable their OAuth IPC paths with a clear \"upgrade dicode-relay\" error, rather than silently failing to decrypt against SignKey-encrypted deliveries. WSS relay (the tunnel itself) works against any broker version.

**IPC gate** (\`pkg/ipc/server.go\`): \`dicode.oauth.build_auth_url\` and \`dicode.oauth.store_token\` refuse when \`Client.SupportsOAuth()\` is false.

## Rollout

1. Merge + deploy [dicode-relay#29](https://github.com/dicode-ayo/dicode-relay/pull/29) to the hosted broker
2. Merge this PR
3. Rebase [PR #101](https://github.com/dicode-ayo/dicode-core/pull/101) (rotate-identity) onto the new struct — will rotate both keys atomically in one tx
4. Re-open #82 review for the other alpha items

## Test plan

Every existing test still green; plus new dedicated coverage.

- [x] \`TestIdentity_KeysAreDistinct\` — SignKey.D != DecryptKey.D
- [x] \`TestMigration_OldKeyBecomesSignKey\` — seed pre-#104 \`relay.private_key\`; assert SignKey matches, UUID stable, fresh DecryptKey generated, \`relay.decrypt_private_key\` row inserted
- [x] \`TestMigration_Idempotent\` — second load does not rewrite
- [x] \`TestOAuth_UsesDecryptKey\` — encrypting to SignKey pubkey → decrypt fails; encrypting to DecryptKey pubkey → succeeds (catches wiring regressions)
- [x] \`TestWSS_UsesSignKey\` — Identity with nil DecryptKey still handshakes
- [x] \`TestAuthURL_UsesSignKey\` — auth-payload sig verifies under SignKey.PublicKey
- [x] \`TestHello_AdvertisesBothKeys\` — hello message carries both \`pubkey\` and \`decrypt_pubkey\`
- [x] \`TestClient_RefusesOAuth_WhenBrokerProtocolOld\` — three welcome variants (no field / protocol=1 / protocol=2), SupportsOAuth() flips only at ≥ 2
- [x] \`TestServer_OAuth_RefusesWhenBrokerProtocolOld\` — both IPC methods return the actionable upgrade error; pending store untouched
- [x] \`go test ./... -race -count=1\` — all green
- [x] \`go vet ./...\` — clean
- [x] \`gofmt -l .\` — clean

## Design

Full spec: [docs/design/104-design.md](https://github.com/dicode-ayo/dicode-core/blob/fix/104-split-identity-keys/docs/design/104-design.md) — no, not in this PR (the design was a working doc at /tmp/104-design.md during implementation). Key decisions captured here:
- UUID stays SignKey-derived (webhook URL stability)
- Two KV rows, additive migration
- \`decrypt_pubkey\` additive on hello
- Broker-first rollout + \`protocol: 2\` version guard
- PEM \`EC PRIVATE KEY\` format for both keys
- \`NewTestIdentity(t)\` test helper

## Diff surface

- \`pkg/relay/keys.go\` — struct change, new accessors, migration (with \*zap.Logger plumbed through \`LoadOrGenerateIdentity\`)
- \`pkg/relay/protocol.go\` — \`DecryptPubKey\` in hello, \`Protocol\` in welcome
- \`pkg/relay/client.go\` — send both pubkeys; read \`brokerProtocol\` on welcome; expose \`Client.SupportsOAuth()\`; reset on reconnect
- \`pkg/relay/oauth.go\` — SignKey for signing, DecryptKey for decryption
- \`pkg/relay/testing.go\` — new \`NewTestIdentity(t)\` helper
- \`pkg/ipc/server.go\` — \`SetOAuthBroker\` takes a \`supportsOAuthFn func() bool\`; both OAuth IPC methods gate on it
- \`pkg/runtime/deno/runtime.go\` — thread the predicate through
- \`pkg/daemon/daemon.go\` — logger for migration; wire \`SupportsOAuth\`
- Tests: 8 new + mechanical updates to 4 existing test files

~1000 LOC total (≈570 production + 430 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)