### PR TITLE
feat(config,webui,cli): add ai.task pointer, /api/ai/chat, and dicode ai CLI

### DIFF
--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -294,10 +294,13 @@ func cmdSecrets(c *ipc.ControlClient, args []string) error {
 
 // cmdAI implements `dicode ai <prompt> [--session-id ID] [--task TASK_ID]`.
 //
-// The prompt is everything after the flags: `dicode ai "what failed?"` works,
-// as does `dicode ai --session-id abc "what failed?"`. The first non-flag
-// argument and anything after it is joined on spaces to form the prompt so
-// the user doesn't have to quote every multi-word prompt on the shell.
+// Flags may appear anywhere before `--`: `dicode ai "what failed?"`, `dicode ai
+// --session-id abc "what failed?"`, and `dicode ai hello --session-id abc
+// world` all work — every non-flag argument is joined on spaces to form the
+// prompt. A `--` sentinel terminates flag parsing so prompts that literally
+// start with `--task` or `--session-id` can still be passed:
+//
+//	dicode ai -- --task is not a flag here
 //
 // Output: the `reply` field goes to stdout. On the first turn (when no
 // --session-id was provided) the generated `session_id` is written to stderr
@@ -306,8 +309,17 @@ func cmdSecrets(c *ipc.ControlClient, args []string) error {
 func cmdAI(c *ipc.ControlClient, args []string) error {
 	var sessionID, taskID string
 	var positional []string
+	parseFlags := true
 	for i := 0; i < len(args); i++ {
 		a := args[i]
+		if parseFlags && a == "--" {
+			parseFlags = false
+			continue
+		}
+		if !parseFlags {
+			positional = append(positional, a)
+			continue
+		}
 		switch a {
 		case "--session-id", "-s":
 			if i+1 >= len(args) {

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -13,6 +13,7 @@
 //	list                            list all registered tasks
 //	logs <run-id>                   fetch log lines for a run
 //	status [task-id]                daemon health or latest run for a task
+//	ai <prompt> [flags]             run the configured AI task with a prompt
 //	secrets list                    list secret keys
 //	secrets set <key> <value>       store a secret
 //	secrets delete <key>            delete a secret
@@ -109,6 +110,8 @@ func dispatch(c *ipc.ControlClient, args []string) error {
 			return fmt.Errorf("usage: dicode relay <trust-broker> --yes")
 		}
 		return cmdRelay(c, args[1:])
+	case "ai":
+		return cmdAI(c, args[1:])
 	default:
 		return fmt.Errorf("unknown command %q — run 'dicode' for usage", args[0])
 	}
@@ -289,6 +292,82 @@ func cmdSecrets(c *ipc.ControlClient, args []string) error {
 	return nil
 }
 
+// cmdAI implements `dicode ai <prompt> [--session-id ID] [--task TASK_ID]`.
+//
+// The prompt is everything after the flags: `dicode ai "what failed?"` works,
+// as does `dicode ai --session-id abc "what failed?"`. The first non-flag
+// argument and anything after it is joined on spaces to form the prompt so
+// the user doesn't have to quote every multi-word prompt on the shell.
+//
+// Output: the `reply` field goes to stdout. On the first turn (when no
+// --session-id was provided) the generated `session_id` is written to stderr
+// on its own line prefixed with `session: ` so the user can copy-paste it
+// into the next turn without it polluting reply-consuming pipelines.
+func cmdAI(c *ipc.ControlClient, args []string) error {
+	var sessionID, taskID string
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch a {
+		case "--session-id", "-s":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--session-id requires a value")
+			}
+			sessionID = args[i+1]
+			i++
+		case "--task":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--task requires a value")
+			}
+			taskID = args[i+1]
+			i++
+		case "--help", "-h":
+			fmt.Fprintln(os.Stderr, "Usage: dicode ai <prompt> [--session-id ID] [--task TASK_ID]")
+			return nil
+		default:
+			// Support --session-id=value / --task=value.
+			if strings.HasPrefix(a, "--session-id=") {
+				sessionID = strings.TrimPrefix(a, "--session-id=")
+				continue
+			}
+			if strings.HasPrefix(a, "--task=") {
+				taskID = strings.TrimPrefix(a, "--task=")
+				continue
+			}
+			positional = append(positional, a)
+		}
+	}
+	if len(positional) == 0 {
+		return fmt.Errorf("usage: dicode ai <prompt> [--session-id ID] [--task TASK_ID]")
+	}
+	prompt := strings.Join(positional, " ")
+
+	resp, err := c.Send(ipc.Request{
+		Method:    "cli.ai",
+		Prompt:    prompt,
+		SessionID: sessionID,
+		TaskID:    taskID, // empty → daemon uses cfg.AI.Task
+	})
+	if err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	var result ipc.AIResult
+	if err := remarshal(resp.Result, &result); err != nil {
+		return err
+	}
+	// Emit session_id to stderr on first turn so pipelines that consume the
+	// reply on stdout stay clean. When the caller already passed --session-id
+	// we skip this — they already have the id.
+	if sessionID == "" && result.SessionID != "" {
+		fmt.Fprintf(os.Stderr, "session: %s\n", result.SessionID)
+	}
+	fmt.Println(result.Reply)
+	return nil
+}
+
 // ensureDaemon starts the daemon in the background if the socket is not reachable.
 // It re-execs the current binary with the "daemon" subcommand.
 func ensureDaemon(socketPath string) error {
@@ -383,6 +462,8 @@ Commands:
   list                            list registered tasks
   logs <run-id>                   show logs for a run
   status [task-id]                daemon health or task's latest run
+  ai <prompt> [flags]             run the configured AI task with a prompt
+                                  flags: --session-id ID, --task TASK_ID
   secrets list                    list secret keys
   secrets set <key> <value>       store a secret
   secrets delete <key>            delete a secret

--- a/dicode.yaml
+++ b/dicode.yaml
@@ -16,6 +16,8 @@ relay:
   enabled: true
   server_url: ws://localhost:5553
 log_level: info
+# ai:
+#   task: buildin/dicodai  # task id invoked for AI operations (webui + CLI)
 runtimes:
   python:
     version: 0.7.3

--- a/docs/concepts/ai-agent.md
+++ b/docs/concepts/ai-agent.md
@@ -118,6 +118,34 @@ A starter skill ships at `tasks/skills/dicode-basics.md` covering core dicode co
 
 ---
 
+## Picking the task the WebUI and CLI use
+
+The WebUI's in-task AI chat panel and the `dicode ai` CLI both forward to a
+single configurable task, named by `ai.task` in `dicode.yaml`:
+
+```yaml
+ai:
+  task: buildin/dicodai   # default — change to any ai-agent preset
+```
+
+When omitted the default is `buildin/dicodai`, a preset of `buildin/ai-agent`
+preloaded with the `dicode-task-dev` skill. Point `ai.task` at any preset
+(e.g. `examples/ai-agent-ollama`) to swap providers, skills, or model without
+changing code.
+
+Two surfaces read this setting:
+
+- `POST /api/ai/chat` — used by the WebUI chat panel. Forwards the JSON body
+  to the configured task's webhook and returns its response. Requires a valid
+  dicode session (gated by `requireAuth` when `server.auth: true`).
+- `dicode ai "<prompt>" [--session-id ID] [--task TASK_ID]` — fires the
+  configured task through the engine over the CLI control socket. Use
+  `--task` to override for a single invocation; use `--session-id` to continue
+  an existing conversation. The first turn's generated session id is printed
+  to stderr as `session: <id>` so it doesn't pollute reply-consuming pipes.
+
+---
+
 ## Provider presets
 
 The buildin ships **maximally restrictive**: empty `permissions.net`, no provider env vars, no defaults for `model` / `base_url` / `api_key_env`. On its own, hitting `/hooks/ai` returns `not_configured`. This keeps the buildin generic and safe — provider-specific policy (which hosts to reach, which env vars to read) lives with the provider-specific task.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -292,7 +292,10 @@ func applyDefaults(cfg *Config, configDir string) {
 		cfg.LogLevel = "info"
 	}
 	// AI.Task defaults to the buildin/dicodai preset so out-of-the-box
-	// WebUI + CLI AI flows work without configuration.
+	// WebUI + CLI AI flows work without configuration. Empty-string and
+	// absent both resolve to the default — there is no "explicitly
+	// disabled" state today. If a future version needs one, switch to
+	// *string and test for nil instead of empty.
 	if cfg.AI.Task == "" {
 		cfg.AI.Task = "buildin/dicodai"
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,6 +47,17 @@ type RelayConfig struct {
 	ServerURL string `yaml:"server_url"` // wss://relay.dicode.app
 }
 
+// AIConfig points the WebUI and CLI at a single task for AI operations.
+// The task must have a webhook trigger — /api/ai/chat forwards requests to it,
+// and `dicode ai` fires it through the engine.
+type AIConfig struct {
+	// Task is the task id invoked for AI operations in the WebUI and CLI.
+	// Defaults to "buildin/dicodai" — a preset of buildin/ai-agent preloaded
+	// with the dicode-task-dev skill. Point it at any ai-agent override to
+	// swap providers, skills, or model without changing code.
+	Task string `yaml:"task,omitempty"`
+}
+
 type Config struct {
 	Sources       []SourceConfig           `yaml:"sources"`
 	Database      DatabaseConfig           `yaml:"database"`
@@ -57,6 +68,7 @@ type Config struct {
 	Runtimes      map[string]RuntimeConfig `yaml:"runtimes,omitempty"`
 	Execution     ExecutionConfig          `yaml:"execution,omitempty"`
 	Relay         RelayConfig              `yaml:"relay,omitempty"`
+	AI            AIConfig                 `yaml:"ai,omitempty"`
 	LogLevel      string                   `yaml:"log_level"`
 	DataDir       string                   `yaml:"data_dir"`
 }
@@ -278,6 +290,11 @@ func applyDefaults(cfg *Config, configDir string) {
 	}
 	if cfg.LogLevel == "" {
 		cfg.LogLevel = "info"
+	}
+	// AI.Task defaults to the buildin/dicodai preset so out-of-the-box
+	// WebUI + CLI AI flows work without configuration.
+	if cfg.AI.Task == "" {
+		cfg.AI.Task = "buildin/dicodai"
 	}
 	// DataDir default is set earlier during variable expansion.
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -96,6 +96,55 @@ sources:
 	}
 }
 
+// TestLoad_AITaskDefault ensures an empty ai: block falls back to the
+// buildin/dicodai default so zero-config installs keep the WebUI chat panel
+// and `dicode ai` wired up without edits to dicode.yaml.
+func TestLoad_AITaskDefault(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+
+	content := `
+sources:
+  - type: local
+    path: ${CONFIGDIR}/tasks
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AI.Task != "buildin/dicodai" {
+		t.Errorf("AI.Task default = %q, want %q", cfg.AI.Task, "buildin/dicodai")
+	}
+}
+
+// TestLoad_AITaskOverride ensures a user-supplied ai.task survives the YAML
+// round-trip without being clobbered by applyDefaults.
+func TestLoad_AITaskOverride(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+
+	content := `
+ai:
+  task: examples/ai-agent-ollama
+sources:
+  - type: local
+    path: ${CONFIGDIR}/tasks
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AI.Task != "examples/ai-agent-ollama" {
+		t.Errorf("AI.Task = %q, want %q", cfg.AI.Task, "examples/ai-agent-ollama")
+	}
+}
+
 func TestLoadExecutionMaxConcurrentTasks(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "dicode.yaml")

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -187,7 +187,7 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 			return cm.ChildRSSMB, cm.ChildCPUMs
 		},
 	}
-	ctrlSrv, err := ipc.NewControlServer(socketPath, tokenPath, reg, eng, localSecrets, mp, version, log, database)
+	ctrlSrv, err := ipc.NewControlServer(socketPath, tokenPath, reg, eng, localSecrets, mp, version, log, database, cfg.AI.Task)
 	if err != nil {
 		return fmt.Errorf("build control server: %w", err)
 	}

--- a/pkg/ipc/capability.go
+++ b/pkg/ipc/capability.go
@@ -51,6 +51,7 @@ const (
 	CapCLILogs    = "cli.logs"    // fetch log entries for a run
 	CapCLIStatus  = "cli.status"  // daemon health and uptime
 	CapCLISecrets = "cli.secrets" // list / set / delete secrets
+	CapCLIAI      = "cli.ai"      // fire the configured ai task with a prompt
 )
 
 // cliCaps is the full capability set granted to every CLI client.
@@ -61,6 +62,7 @@ func cliCaps() []string {
 		CapCLILogs,
 		CapCLIStatus,
 		CapCLISecrets,
+		CapCLIAI,
 	}
 }
 

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -423,7 +423,12 @@ func (cs *ControlServer) handleAI(ctx context.Context, req Request) (AIResult, e
 		SessionID: req.SessionID,
 	}
 	if run.Status != "success" {
-		return out, fmt.Errorf("task run %s finished with status %s", run.RunID, run.Status)
+		// Surface the run id in the error so the CLI user can jump straight
+		// to `dicode logs <run-id>` — the control-socket dispatch loop only
+		// serialises `out` when err == nil, so TaskID/RunID on out would
+		// otherwise be dropped on failure.
+		return out, fmt.Errorf("task run %s finished with status %s — see 'dicode logs %s'",
+			run.RunID, run.Status, run.RunID)
 	}
 
 	// Extract reply + session_id from the return value. Accept both the full
@@ -438,8 +443,11 @@ func (cs *ControlServer) handleAI(ctx context.Context, req Request) (AIResult, e
 		if s, ok := v["reply"].(string); ok {
 			out.Reply = s
 		}
-		if s, ok := v["session_id"].(string); ok {
-			out.SessionID = s
+		// Accept session_id as any scalar — alternative tasks may emit numeric
+		// ids that would otherwise be silently dropped (and the user would
+		// see a fresh session every turn). fmt.Sprint is nil-safe.
+		if sid, ok := v["session_id"]; ok && sid != nil {
+			out.SessionID = fmt.Sprint(sid)
 		}
 	default:
 		b, _ := json.Marshal(v)

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -38,13 +38,20 @@ type ControlServer struct {
 	database        db.DB // for broker pubkey trust pinning; nil in tests
 	log             *zap.Logger
 
+	// defaultAITask is cfg.AI.Task — the task id that `dicode ai` fires when
+	// the client doesn't supply --task. Empty when the daemon was started
+	// without config (tests).
+	defaultAITask string
+
 	startedAt time.Time
 	version   string
 }
 
 // NewControlServer creates a ControlServer. Call Start to begin accepting
 // connections. socketPath is the Unix socket path; tokenPath is where the CLI
-// token is written.
+// token is written. defaultAITask is cfg.AI.Task — resolved at daemon startup
+// so the control server can fire the right task when the CLI invokes `dicode ai`
+// without --task.
 func NewControlServer(
 	socketPath, tokenPath string,
 	reg *registry.Registry,
@@ -54,6 +61,7 @@ func NewControlServer(
 	version string,
 	log *zap.Logger,
 	database db.DB,
+	defaultAITask string,
 ) (*ControlServer, error) {
 	secret := make([]byte, 32)
 	if _, err := rand.Read(secret); err != nil {
@@ -70,6 +78,7 @@ func NewControlServer(
 		metricsProvider: mp,
 		database:        database,
 		log:             log,
+		defaultAITask:   defaultAITask,
 		startedAt:       time.Now(),
 		version:         version,
 	}
@@ -213,6 +222,9 @@ func (cs *ControlServer) dispatch(ctx context.Context, req Request) (any, error)
 
 	case "cli.relay.trust_broker":
 		return cs.handleTrustBroker(ctx)
+
+	case "cli.ai":
+		return cs.handleAI(ctx, req)
 
 	default:
 		return nil, fmt.Errorf("unknown method: %s", req.Method)
@@ -369,6 +381,71 @@ func (cs *ControlServer) handleMetrics() MetricsSnapshot {
 	}
 
 	return snap
+}
+
+// handleAI fires the task pointed at by cfg.AI.Task (or an explicit override
+// in req.TaskID) with {prompt, session_id} as params, waits for the run to
+// finish, and extracts {session_id, reply} from the return value. The task
+// must return either a JSON object with "session_id" / "reply" fields, a
+// bare string (treated as the reply with an empty session id), or any other
+// value (marshalled back into reply as JSON text).
+func (cs *ControlServer) handleAI(ctx context.Context, req Request) (AIResult, error) {
+	if req.Prompt == "" {
+		return AIResult{}, errors.New("prompt required")
+	}
+	taskID := req.TaskID
+	if taskID == "" {
+		taskID = cs.defaultAITask
+	}
+	if taskID == "" {
+		return AIResult{}, errors.New("no ai task configured — set ai.task in dicode.yaml or pass --task")
+	}
+	if _, ok := cs.reg.Get(taskID); !ok {
+		return AIResult{}, fmt.Errorf("ai task %q not registered", taskID)
+	}
+
+	params := map[string]string{"prompt": req.Prompt}
+	if req.SessionID != "" {
+		params["session_id"] = req.SessionID
+	}
+
+	runID, err := cs.engine.FireManual(ctx, taskID, params)
+	if err != nil {
+		return AIResult{}, err
+	}
+	run, err := cs.engine.WaitRun(ctx, runID)
+	if err != nil {
+		return AIResult{}, err
+	}
+	out := AIResult{
+		TaskID:    taskID,
+		RunID:     run.RunID,
+		SessionID: req.SessionID,
+	}
+	if run.Status != "success" {
+		return out, fmt.Errorf("task run %s finished with status %s", run.RunID, run.Status)
+	}
+
+	// Extract reply + session_id from the return value. Accept both the full
+	// ai-agent envelope {session_id, reply} and simpler shapes so alternative
+	// tasks don't have to match the buildin schema exactly.
+	switch v := run.ReturnValue.(type) {
+	case nil:
+		// nothing to do — empty reply.
+	case string:
+		out.Reply = v
+	case map[string]any:
+		if s, ok := v["reply"].(string); ok {
+			out.Reply = s
+		}
+		if s, ok := v["session_id"].(string); ok {
+			out.SessionID = s
+		}
+	default:
+		b, _ := json.Marshal(v)
+		out.Reply = string(b)
+	}
+	return out, nil
 }
 
 // handleTrustBroker deletes the TOFU-pinned broker pubkey so the next relay

--- a/pkg/ipc/control_test.go
+++ b/pkg/ipc/control_test.go
@@ -678,7 +678,6 @@ func TestControl_RelayRotate_RotatorError_SurfacesVerbatim(t *testing.T) {
 	<-done
 }
 
-
 func TestControl_UnknownMethod_ReturnsError(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/ipc/control_test.go
+++ b/pkg/ipc/control_test.go
@@ -354,6 +354,85 @@ func TestControl_AI_FiresConfiguredTask_AndReturnsReply(t *testing.T) {
 	}
 }
 
+// TestControl_AI_NumericSessionID verifies the fmt.Sprint-based relaxation
+// in handleAI: alternative tasks that emit session_id as a JSON number (very
+// common when ids are represented as u64 server-side) round-trip to the CLI
+// as a string instead of being silently dropped — which would have meant a
+// fresh session every turn.
+func TestControl_AI_NumericSessionID(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "ctrl.sock")
+	tokenPath := filepath.Join(dir, "ctrl.token")
+
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+	reg := registry.New(d)
+	if err := reg.Register(&task.Spec{ID: "buildin/dicodai", Name: "dicodai"}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	eng := &mockEngine{
+		runID: "run-ai-num-1",
+		result: RunResult{
+			RunID:  "run-ai-num-1",
+			Status: "success",
+			ReturnValue: map[string]any{
+				"session_id": float64(42), // JSON numbers decode to float64
+				"reply":      "numeric session test",
+			},
+		},
+	}
+
+	cs, err := NewControlServer(socketPath, tokenPath, reg, eng, nil, MetricsProvider{}, "test", zap.NewNop(), nil, "buildin/dicodai")
+	if err != nil {
+		t.Fatalf("NewControlServer: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = cs.Start(ctx) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(socketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("socket never appeared")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	tok, _ := os.ReadFile(tokenPath)
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	_ = writeMsg(conn, handshakeReq{Token: string(tok)})
+	var hs map[string]any
+	_ = readMsg(conn, &hs)
+
+	_ = writeMsg(conn, Request{ID: "ai1", Method: "cli.ai", Prompt: "hello"})
+	var resp struct {
+		ID     string          `json:"id"`
+		Result json.RawMessage `json:"result"`
+		Error  string          `json:"error"`
+	}
+	_ = readMsg(conn, &resp)
+	if resp.Error != "" {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+	var got AIResult
+	_ = json.Unmarshal(resp.Result, &got)
+	if got.SessionID != "42" {
+		t.Errorf("numeric session_id should stringify to %q, got %q", "42", got.SessionID)
+	}
+	if got.Reply != "numeric session test" {
+		t.Errorf("Reply = %q, want %q", got.Reply, "numeric session test")
+	}
+}
+
 // TestControl_AI_NoDefault_NoOverride_ReturnsError rejects the request when
 // neither cfg.AI.Task nor req.TaskID is set — the daemon has nothing to fire.
 func TestControl_AI_NoDefault_NoOverride_ReturnsError(t *testing.T) {

--- a/pkg/ipc/control_test.go
+++ b/pkg/ipc/control_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
 	"go.uber.org/zap"
 )
 
@@ -24,7 +27,7 @@ func controlTestEnv(t *testing.T, mp MetricsProvider) (net.Conn, func()) {
 	log := zap.NewNop()
 	eng := &mockEngine{}
 
-	cs, err := NewControlServer(socketPath, tokenPath, nil, eng, nil, mp, "test", log, nil)
+	cs, err := NewControlServer(socketPath, tokenPath, nil, eng, nil, mp, "test", log, nil, "")
 	if err != nil {
 		t.Fatalf("NewControlServer: %v", err)
 	}
@@ -107,7 +110,7 @@ func TestControl_Handshake_EmitsEmptyTaskAndRunIDFields(t *testing.T) {
 	socketPath := filepath.Join(dir, "ctrl.sock")
 	tokenPath := filepath.Join(dir, "ctrl.token")
 
-	cs, err := NewControlServer(socketPath, tokenPath, nil, &mockEngine{}, nil, MetricsProvider{}, "test", zap.NewNop(), nil)
+	cs, err := NewControlServer(socketPath, tokenPath, nil, &mockEngine{}, nil, MetricsProvider{}, "test", zap.NewNop(), nil, "")
 	if err != nil {
 		t.Fatalf("NewControlServer: %v", err)
 	}
@@ -250,6 +253,158 @@ func TestControl_Metrics_NoProvider_ReturnsZeros(t *testing.T) {
 	// All daemon fields should be zero-value; no panic.
 	if snap.Daemon.Goroutines != 0 {
 		t.Errorf("expected zero goroutines without provider, got %d", snap.Daemon.Goroutines)
+	}
+}
+
+// TestControl_AI_FiresConfiguredTask_AndReturnsReply is the happy path for
+// `dicode ai`: the control server reads cfg.AI.Task, fires the engine, and
+// extracts {session_id, reply} from the run's return value.
+func TestControl_AI_FiresConfiguredTask_AndReturnsReply(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "ctrl.sock")
+	tokenPath := filepath.Join(dir, "ctrl.token")
+
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	defer d.Close()
+	reg := registry.New(d)
+	if err := reg.Register(&task.Spec{ID: "buildin/dicodai", Name: "dicodai"}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	eng := &mockEngine{
+		runID: "run-ai-1",
+		result: RunResult{
+			RunID:  "run-ai-1",
+			Status: "success",
+			ReturnValue: map[string]any{
+				"session_id": "sess-abc",
+				"reply":      "hello from the agent",
+			},
+		},
+	}
+
+	cs, err := NewControlServer(socketPath, tokenPath, reg, eng, nil, MetricsProvider{}, "test", zap.NewNop(), nil, "buildin/dicodai")
+	if err != nil {
+		t.Fatalf("NewControlServer: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = cs.Start(ctx) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(socketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("socket never appeared")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	tok, err := os.ReadFile(tokenPath)
+	if err != nil {
+		t.Fatalf("read token: %v", err)
+	}
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	if err := writeMsg(conn, handshakeReq{Token: string(tok)}); err != nil {
+		t.Fatalf("handshake send: %v", err)
+	}
+	var hs map[string]any
+	if err := readMsg(conn, &hs); err != nil {
+		t.Fatalf("handshake recv: %v", err)
+	}
+
+	if err := writeMsg(conn, Request{ID: "ai1", Method: "cli.ai", Prompt: "hello"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	var resp struct {
+		ID     string          `json:"id"`
+		Result json.RawMessage `json:"result"`
+		Error  string          `json:"error"`
+	}
+	if err := readMsg(conn, &resp); err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+	var got AIResult
+	if err := json.Unmarshal(resp.Result, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Reply != "hello from the agent" {
+		t.Errorf("Reply = %q, want %q", got.Reply, "hello from the agent")
+	}
+	if got.SessionID != "sess-abc" {
+		t.Errorf("SessionID = %q, want %q", got.SessionID, "sess-abc")
+	}
+	if got.TaskID != "buildin/dicodai" {
+		t.Errorf("TaskID = %q, want %q", got.TaskID, "buildin/dicodai")
+	}
+}
+
+// TestControl_AI_NoDefault_NoOverride_ReturnsError rejects the request when
+// neither cfg.AI.Task nor req.TaskID is set — the daemon has nothing to fire.
+func TestControl_AI_NoDefault_NoOverride_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "ctrl.sock")
+	tokenPath := filepath.Join(dir, "ctrl.token")
+
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+	reg := registry.New(d)
+
+	cs, err := NewControlServer(socketPath, tokenPath, reg, &mockEngine{}, nil, MetricsProvider{}, "test", zap.NewNop(), nil, "")
+	if err != nil {
+		t.Fatalf("NewControlServer: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = cs.Start(ctx) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(socketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("socket never appeared")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	tok, _ := os.ReadFile(tokenPath)
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	_ = writeMsg(conn, handshakeReq{Token: string(tok)})
+	var hs map[string]any
+	_ = readMsg(conn, &hs)
+
+	_ = writeMsg(conn, Request{ID: "ai1", Method: "cli.ai", Prompt: "hello"})
+	var resp struct {
+		ID    string `json:"id"`
+		Error string `json:"error"`
+	}
+	_ = readMsg(conn, &resp)
+	if resp.Error == "" {
+		t.Error("expected error when no ai task is configured")
 	}
 }
 

--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -84,6 +84,10 @@ type Request struct {
 	RunID       string `json:"runID,omitempty"`
 	StringValue string `json:"stringValue,omitempty"` // cli.secrets.set value
 	Follow      bool   `json:"follow,omitempty"`      // cli.logs — reserved for streaming
+
+	// cli.ai — prompt, optional session_id, optional task id override.
+	Prompt    string `json:"prompt,omitempty"`
+	SessionID string `json:"sessionID,omitempty"`
 }
 
 // Response is an outbound message to a connected client.
@@ -159,6 +163,17 @@ type RunResult struct {
 	RunID       string `json:"runID"`
 	Status      string `json:"status"`
 	ReturnValue any    `json:"returnValue"`
+}
+
+// AIResult is the cli.ai response. reply is the text surfaced to the user;
+// session_id is echoed back so the CLI can persist it for follow-up turns.
+// TaskID is the task id that was actually fired — useful in case the caller
+// asked for the configured default and wants to know what ran.
+type AIResult struct {
+	TaskID    string `json:"taskID"`
+	RunID     string `json:"runID"`
+	SessionID string `json:"sessionID"`
+	Reply     string `json:"reply"`
 }
 
 // MetricsSnapshot is the cli.metrics response.

--- a/pkg/onboarding/onboarding.go
+++ b/pkg/onboarding/onboarding.go
@@ -113,22 +113,21 @@ server:
   # secret: ""  # uncomment and set to require a password for the web UI
 
 # ---------------------------------------------------------------------------
-# AI task generation — powers the AI chat in the task editor.
-# Pick one provider and uncomment the matching block.
+# AI — the WebUI task-detail chat panel and the 'dicode ai' CLI both forward
+# to a single task named here. Provider credentials, model, and skills live
+# with the task itself (see tasks/buildin/dicodai and tasks/examples/
+# ai-agent-* for presets).
+#
+# Defaults to buildin/dicodai when omitted — a preset of buildin/ai-agent
+# preloaded with the dicode-task-dev skill and wired to OpenAI. Set
+# OPENAI_API_KEY in your environment and it works out of the box.
+#
+# Point at a different ai-agent preset to swap providers without code changes:
 # ---------------------------------------------------------------------------
-ai:
-  # OpenAI (default) — set OPENAI_API_KEY in your environment
-  model: gpt-4o
-  api_key_env: OPENAI_API_KEY
-
-  # Claude (Anthropic) — uncomment and set ANTHROPIC_API_KEY
-  # model: claude-sonnet-4-6
-  # api_key_env: ANTHROPIC_API_KEY
-  # base_url: https://api.anthropic.com/v1
-
-  # Ollama (local, no key needed)
-  # model: qwen2.5-coder:7b
-  # base_url: http://localhost:11434/v1
+# ai:
+#   task: buildin/dicodai                  # default
+#   # task: examples/ai-agent-ollama      # local Ollama, no API key
+#   # task: examples/ai-agent-groq        # free tier, set GROQ_API_KEY
 
 # ---------------------------------------------------------------------------
 # Push notifications (optional) — sends alerts to your phone on task failure.

--- a/pkg/onboarding/onboarding_test.go
+++ b/pkg/onboarding/onboarding_test.go
@@ -1,0 +1,53 @@
+package onboarding
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/config"
+)
+
+// TestDefaultLocalConfig_LoadsCleanly writes the first-run template to a temp
+// file, runs it through config.Load, and asserts defaults land where the
+// docs claim. Guards against drift between the onboarding template and the
+// Config struct — in particular, keys for fields that have since been
+// removed (the old direct-AI block: model, api_key_env, base_url) would
+// silently survive an unmarshal but then mislead the operator.
+func TestDefaultLocalConfig_LoadsCleanly(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+
+	yaml := DefaultLocalConfig(filepath.Join(dir, "tasks"), filepath.Join(dir, "data"))
+	if err := os.WriteFile(cfgPath, []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("generated config failed to load: %v", err)
+	}
+
+	// ai.task should default to buildin/dicodai — the template ships it
+	// commented out so applyDefaults fills it in.
+	if cfg.AI.Task != "buildin/dicodai" {
+		t.Errorf("AI.Task = %q, want %q (default should land)", cfg.AI.Task, "buildin/dicodai")
+	}
+
+	// Sanity: basic sections parsed.
+	if len(cfg.Sources) == 0 {
+		t.Error("sources should not be empty")
+	}
+	if cfg.Database.Type != "sqlite" {
+		t.Errorf("Database.Type = %q, want sqlite", cfg.Database.Type)
+	}
+
+	// Guard: the old direct-AI keys must NOT appear in the template —
+	// they'd parse without error but never do anything now.
+	for _, stale := range []string{"api_key_env:", "base_url:", "model:"} {
+		if strings.Contains(yaml, stale) {
+			t.Errorf("template still contains stale direct-AI key %q; remove it", stale)
+		}
+	}
+}

--- a/pkg/webui/ai_chat.go
+++ b/pkg/webui/ai_chat.go
@@ -73,10 +73,10 @@ func (s *Server) apiAIChat(w http.ResponseWriter, r *http.Request) {
 	// endpoint as a proxy to arbitrary /api routes. Webhooks MUST live
 	// under /hooks/; anything else points at infrastructure paths the
 	// ai-agent runtime cannot legitimately handle.
-	if !strings.HasPrefix(spec.Trigger.Webhook, "/hooks/") {
-		s.log.Warn("ai chat: configured task webhook is not under /hooks/",
+	if !strings.HasPrefix(spec.Trigger.Webhook, webhookPathPrefix) {
+		s.log.Warn("ai chat: configured task webhook is not under "+webhookPathPrefix,
 			zap.String("task", taskID), zap.String("webhook", spec.Trigger.Webhook))
-		jsonErr(w, "ai task webhook must be under /hooks/", http.StatusInternalServerError)
+		jsonErr(w, "ai task webhook must be under "+webhookPathPrefix, http.StatusInternalServerError)
 		return
 	}
 
@@ -114,6 +114,13 @@ func (s *Server) apiAIChat(w http.ResponseWriter, r *http.Request) {
 	// reconciler lag between registry.Register and gateway wiring at
 	// startup. Surface that as a retry-after-style 503 so the UI can
 	// show a targeted "try again" rather than a generic "not found".
+	//
+	// Caveat: today the task runtime has no way to emit a 404 of its own
+	// (tasks return JSON reply payloads via output.*, not HTTP statuses).
+	// If a future output.status() global lands, this blanket remap will
+	// mask legitimate user-emitted 404s — switch to an explicit probe
+	// (e.g. presence of a run-id header the task runner injects) at that
+	// point.
 	if rec.Code == http.StatusNotFound {
 		s.log.Warn("ai chat: forward returned 404 — webhook registered but gateway not wired yet",
 			zap.String("task", taskID), zap.String("webhook", spec.Trigger.Webhook))

--- a/pkg/webui/ai_chat.go
+++ b/pkg/webui/ai_chat.go
@@ -1,0 +1,107 @@
+package webui
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
+)
+
+// apiAIChat forwards an AI chat request to the task named by cfg.AI.Task.
+// It accepts any JSON body — the only required field is `prompt`. The body is
+// passed through verbatim to the configured task's webhook so per-task params
+// (session_id, skills, tools, model overrides…) travel untouched.
+//
+// This endpoint intentionally re-enters s.Handler() rather than calling the
+// webhook handler directly. The webhook path already layers: longest-prefix
+// auth (webhookAuthGuard), asset serving, SPA fallback, IPC gateway dispatch —
+// dispatching through the full router keeps the forward identical to what a
+// browser would do hitting /hooks/<task> directly. The caller has already
+// passed requireAuth (this handler lives inside the authenticated group);
+// the forwarded sub-request inherits the session cookie via r.Clone, so when
+// a forwarded-to task has trigger.auth:true the inner webhookAuthGuard also
+// passes.
+func (s *Server) apiAIChat(w http.ResponseWriter, r *http.Request) {
+	// Read the body once so we can replay it on the forwarded request.
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		jsonErr(w, "read body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Minimal schema validation: prompt is required. Anything else is pass-through.
+	var probe struct {
+		Prompt string `json:"prompt"`
+	}
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &probe); err != nil {
+			jsonErr(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+	if probe.Prompt == "" {
+		jsonErr(w, "prompt is required", http.StatusBadRequest)
+		return
+	}
+
+	taskID := ""
+	if s.cfg != nil {
+		taskID = s.cfg.AI.Task
+	}
+	if taskID == "" {
+		jsonErr(w, "ai task not configured or not registered", http.StatusServiceUnavailable)
+		return
+	}
+	spec, ok := s.registry.Get(taskID)
+	if !ok {
+		s.log.Warn("ai chat: configured task not registered", zap.String("task", taskID))
+		jsonErr(w, "ai task not configured or not registered", http.StatusServiceUnavailable)
+		return
+	}
+	if spec.Trigger.Webhook == "" {
+		s.log.Warn("ai chat: configured task has no webhook trigger", zap.String("task", taskID))
+		jsonErr(w, "configured ai task has no webhook trigger", http.StatusInternalServerError)
+		return
+	}
+
+	// Build the internal forwarded request. Preserve method (POST), headers
+	// (cookies, content-type), and body; rewrite the URL to the webhook path.
+	//
+	// The request's context carries the outer /api/ai/chat chi route context;
+	// re-entering the router with it attached confuses chi's internal
+	// RouteContext accounting (observed as a spurious 405). Replace it with
+	// a fresh chi.Context so the inner router starts from a clean slate
+	// while still honouring the parent request's cancellation.
+	innerCtx := chi.NewRouteContext()
+	ctx := context.WithValue(r.Context(), chi.RouteCtxKey, innerCtx)
+	fwdReq, err := http.NewRequestWithContext(ctx, http.MethodPost, spec.Trigger.Webhook, bytes.NewReader(body))
+	if err != nil {
+		jsonErr(w, "build forward: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	fwdReq.Header = r.Header.Clone()
+	if fwdReq.Header.Get("Content-Type") == "" {
+		fwdReq.Header.Set("Content-Type", "application/json")
+	}
+	// Propagate client address for downstream IP-aware middleware.
+	fwdReq.RemoteAddr = r.RemoteAddr
+
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, fwdReq)
+
+	// Propagate the inner response. Content-Type defaults to JSON since the
+	// ai-agent buildin always returns JSON; copy the recorded one when set.
+	h := w.Header()
+	if ct := rec.Header().Get("Content-Type"); ct != "" {
+		h.Set("Content-Type", ct)
+	} else {
+		h.Set("Content-Type", "application/json")
+	}
+	w.WriteHeader(rec.Code)
+	_, _ = w.Write(rec.Body.Bytes())
+}

--- a/pkg/webui/ai_chat.go
+++ b/pkg/webui/ai_chat.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"go.uber.org/zap"
@@ -23,9 +24,9 @@ import (
 // dispatching through the full router keeps the forward identical to what a
 // browser would do hitting /hooks/<task> directly. The caller has already
 // passed requireAuth (this handler lives inside the authenticated group);
-// the forwarded sub-request inherits the session cookie via r.Clone, so when
-// a forwarded-to task has trigger.auth:true the inner webhookAuthGuard also
-// passes.
+// the forwarded sub-request inherits the session cookie via r.Header.Clone(),
+// so when a forwarded-to task has trigger.auth:true the inner
+// webhookAuthGuard also passes.
 func (s *Server) apiAIChat(w http.ResponseWriter, r *http.Request) {
 	// Read the body once so we can replay it on the forwarded request.
 	body, err := io.ReadAll(r.Body)
@@ -68,6 +69,16 @@ func (s *Server) apiAIChat(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, "configured ai task has no webhook trigger", http.StatusInternalServerError)
 		return
 	}
+	// Guard against self-dispatch recursion and against using the AI
+	// endpoint as a proxy to arbitrary /api routes. Webhooks MUST live
+	// under /hooks/; anything else points at infrastructure paths the
+	// ai-agent runtime cannot legitimately handle.
+	if !strings.HasPrefix(spec.Trigger.Webhook, "/hooks/") {
+		s.log.Warn("ai chat: configured task webhook is not under /hooks/",
+			zap.String("task", taskID), zap.String("webhook", spec.Trigger.Webhook))
+		jsonErr(w, "ai task webhook must be under /hooks/", http.StatusInternalServerError)
+		return
+	}
 
 	// Build the internal forwarded request. Preserve method (POST), headers
 	// (cookies, content-type), and body; rewrite the URL to the webhook path.
@@ -85,6 +96,10 @@ func (s *Server) apiAIChat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	fwdReq.Header = r.Header.Clone()
+	// Content-Length from the outer request no longer matches — the body is
+	// re-wrapped in a bytes.Reader and net/http will recompute it. Stripping
+	// avoids confusing any future out-of-process proxy that might honour it.
+	fwdReq.Header.Del("Content-Length")
 	if fwdReq.Header.Get("Content-Type") == "" {
 		fwdReq.Header.Set("Content-Type", "application/json")
 	}
@@ -93,6 +108,18 @@ func (s *Server) apiAIChat(w http.ResponseWriter, r *http.Request) {
 
 	rec := httptest.NewRecorder()
 	s.Handler().ServeHTTP(rec, fwdReq)
+
+	// A 404 from the inner router means the webhook path resolved to a
+	// registered spec but nothing in the gateway claimed it — typically
+	// reconciler lag between registry.Register and gateway wiring at
+	// startup. Surface that as a retry-after-style 503 so the UI can
+	// show a targeted "try again" rather than a generic "not found".
+	if rec.Code == http.StatusNotFound {
+		s.log.Warn("ai chat: forward returned 404 — webhook registered but gateway not wired yet",
+			zap.String("task", taskID), zap.String("webhook", spec.Trigger.Webhook))
+		jsonErr(w, "ai task webhook not yet wired — retry in a moment", http.StatusServiceUnavailable)
+		return
+	}
 
 	// Propagate the inner response. Content-Type defaults to JSON since the
 	// ai-agent buildin always returns JSON; copy the recorded one when set.

--- a/pkg/webui/ai_chat_test.go
+++ b/pkg/webui/ai_chat_test.go
@@ -1,0 +1,210 @@
+package webui
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/config"
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/ipc"
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+	"github.com/dicode/dicode/pkg/trigger"
+	"go.uber.org/zap"
+)
+
+// newAIServer builds a server with a pluggable ai.task and a gateway-registered
+// echo handler so tests can verify the /api/ai/chat forward end-to-end without
+// spinning up Deno.
+func newAIServer(t *testing.T, aiTask string) (*Server, *ipc.Gateway) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+
+	reg := registry.New(d)
+	eng := trigger.New(reg, nil, zap.NewNop())
+	gw := ipc.NewGateway()
+	cfg := &config.Config{
+		Server: config.ServerConfig{Port: 8080},
+		AI:     config.AIConfig{Task: aiTask},
+	}
+	srv, err := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, gw)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return srv, gw
+}
+
+// registerEchoWebhook registers a task and a gateway handler at hookPath that
+// replies with the decoded JSON body plus a canned reply. Mirrors the shape
+// of a real ai-agent response (session_id + reply).
+func registerEchoWebhook(t *testing.T, srv *Server, gw *ipc.Gateway, id, hookPath string) {
+	t.Helper()
+	spec := &task.Spec{
+		ID:      id,
+		Name:    id,
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Webhook: hookPath},
+		Timeout: 5 * time.Second,
+	}
+	if err := srv.registry.Register(spec); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	gw.Register(hookPath, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var in map[string]any
+		b, _ := io.ReadAll(r.Body)
+		if len(b) > 0 {
+			_ = json.Unmarshal(b, &in)
+		}
+		sess, _ := in["session_id"].(string)
+		if sess == "" {
+			sess = "generated-xyz"
+		}
+		resp := map[string]any{
+			"session_id": sess,
+			"reply":      "echo: " + toStr(in["prompt"]),
+			"received":   in,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func toStr(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// TestAIChat_ReturnsReplyFromConfiguredTask is the happy path: cfg.AI.Task
+// points at a registered webhook task and POST /api/ai/chat forwards the
+// body through and surfaces the reply.
+func TestAIChat_ReturnsReplyFromConfiguredTask(t *testing.T) {
+	srv, gw := newAIServer(t, "test/echo")
+	registerEchoWebhook(t, srv, gw, "test/echo", "/hooks/test/echo")
+
+	body, _ := json.Marshal(map[string]any{
+		"prompt":     "hello",
+		"session_id": "abc-123",
+		"task_id":    "some/task",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["reply"] != "echo: hello" {
+		t.Errorf("reply = %v, want %q", got["reply"], "echo: hello")
+	}
+	if got["session_id"] != "abc-123" {
+		t.Errorf("session_id = %v, want %q (body should pass through verbatim)", got["session_id"], "abc-123")
+	}
+	// Body pass-through: the echo handler re-emits the full received map.
+	received, ok := got["received"].(map[string]any)
+	if !ok {
+		t.Fatalf("received must be a map, got %T", got["received"])
+	}
+	if received["task_id"] != "some/task" {
+		t.Errorf("received.task_id = %v, want %q", received["task_id"], "some/task")
+	}
+}
+
+// TestAIChat_MisconfiguredTask_Returns503 covers the case where cfg.AI.Task
+// points at a task id that was never registered. The client did nothing wrong,
+// so this is 503 (service unavailable), not 404.
+func TestAIChat_MisconfiguredTask_Returns503(t *testing.T) {
+	srv, _ := newAIServer(t, "nonexistent/task")
+
+	body, _ := json.Marshal(map[string]any{"prompt": "hi"})
+	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", w.Code, w.Body)
+	}
+	var got map[string]string
+	_ = json.NewDecoder(w.Body).Decode(&got)
+	if got["error"] == "" {
+		t.Error("expected structured error body")
+	}
+}
+
+// TestAIChat_TaskWithoutWebhook_Returns500 covers a configured task that is
+// registered but has only a cron/manual trigger — the endpoint cannot forward
+// to it, so 500 with a clear message.
+func TestAIChat_TaskWithoutWebhook_Returns500(t *testing.T) {
+	srv, _ := newAIServer(t, "test/cronly")
+
+	// Register a task with a cron trigger only.
+	spec := &task.Spec{
+		ID:      "test/cronly",
+		Name:    "test/cronly",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Cron: "0 9 * * *"},
+		Timeout: 5 * time.Second,
+	}
+	if err := srv.registry.Register(spec); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]any{"prompt": "hi"})
+	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body)
+	}
+}
+
+// TestAIChat_RequiresAuth verifies /api/ai/chat is gated by requireAuth when
+// server.auth is enabled (i.e. it is NOT in isPublicPath).
+func TestAIChat_RequiresAuth(t *testing.T) {
+	srv := newAuthServer(t, "hunter2")
+
+	body, _ := json.Marshal(map[string]any{"prompt": "hi"})
+	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 without session, got %d", w.Code)
+	}
+}
+
+// TestAIChat_RequiresPrompt rejects bodies missing prompt upfront so the
+// configured task never sees an obviously-malformed request.
+func TestAIChat_RequiresPrompt(t *testing.T) {
+	srv, gw := newAIServer(t, "test/echo")
+	registerEchoWebhook(t, srv, gw, "test/echo", "/hooks/test/echo")
+
+	body, _ := json.Marshal(map[string]any{"session_id": "x"})
+	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body)
+	}
+}

--- a/pkg/webui/ai_chat_test.go
+++ b/pkg/webui/ai_chat_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -285,14 +286,48 @@ func TestAISettings_SaveAndReadBack(t *testing.T) {
 		t.Errorf("non-webhook task: expected 400, got %d", w.Code)
 	}
 
-	// Accept: registered task with /hooks/ prefix. Skipping actual file
-	// persistence — persistConfig needs a real cfgPath; this test covers
-	// the happy-path validation + in-memory assignment, which is enough
-	// for the handler's contract. persistConfig has its own coverage
-	// path via TestAISettings_PersistsToYAML below when the env provides
-	// a writable config file.
+	// Accept: registered task with /hooks/ prefix. persistConfig needs a
+	// writable dicode.yaml — point the server at a temp file first so the
+	// 200 happy-path runs the full read-modify-write round-trip rather
+	// than bailing out at file-write time.
+	tmp := t.TempDir() + "/dicode.yaml"
+	if err := os.WriteFile(tmp, []byte("log_level: info\n"), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	srv.cfgPath = tmp
+
 	if srv.cfg.AI.Task != "buildin/dicodai" {
 		t.Fatalf("precondition: AI.Task = %q, want buildin/dicodai", srv.cfg.AI.Task)
+	}
+	if w := save(t, map[string]any{"task": "other/echo"}); w.Code != http.StatusOK {
+		t.Fatalf("happy path: expected 200, got %d: %s", w.Code, w.Body)
+	}
+	if srv.cfg.AI.Task != "other/echo" {
+		t.Errorf("cfg.AI.Task after save = %q, want other/echo", srv.cfg.AI.Task)
+	}
+	persisted, err := os.ReadFile(tmp)
+	if err != nil {
+		t.Fatalf("read back config: %v", err)
+	}
+	if !strings.Contains(string(persisted), "other/echo") {
+		t.Errorf("persisted yaml should contain the new task id:\n%s", persisted)
+	}
+
+	// Saving the default back must clean the ai: block out of the file
+	// (mirrors the applyDefaults-fills-in-default contract — the file
+	// shouldn't carry redundant explicit defaults).
+	if err := srv.registry.Register(&task.Spec{
+		ID:      "buildin/dicodai",
+		Trigger: task.TriggerConfig{Webhook: "/hooks/ai/dicodai"},
+	}); err != nil {
+		t.Fatalf("register dicodai: %v", err)
+	}
+	if w := save(t, map[string]any{"task": "buildin/dicodai"}); w.Code != http.StatusOK {
+		t.Fatalf("revert to default: expected 200, got %d: %s", w.Code, w.Body)
+	}
+	persisted, _ = os.ReadFile(tmp)
+	if strings.Contains(string(persisted), "task:") {
+		t.Errorf("ai.task should be absent after revert to default; got:\n%s", persisted)
 	}
 }
 

--- a/pkg/webui/ai_chat_test.go
+++ b/pkg/webui/ai_chat_test.go
@@ -248,3 +248,64 @@ func TestAIChat_RequiresPrompt(t *testing.T) {
 		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body)
 	}
 }
+
+// TestAISettings_SaveAndReadBack verifies the /api/settings/ai handler:
+// accept a task that exists with a /hooks/ webhook, reject everything else,
+// and reflect the change in /api/config JSON.
+func TestAISettings_SaveAndReadBack(t *testing.T) {
+	srv, gw := newAIServer(t, "buildin/dicodai")
+	registerEchoWebhook(t, srv, gw, "other/echo", "/hooks/other/echo")
+	if err := srv.registry.Register(&task.Spec{
+		ID:      "bad/no-webhook",
+		Trigger: task.TriggerConfig{Cron: "0 0 * * *"},
+	}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	save := func(t *testing.T, body map[string]any) *httptest.ResponseRecorder {
+		t.Helper()
+		b, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/api/settings/ai", bytes.NewReader(b))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(w, req)
+		return w
+	}
+
+	// Reject: empty task id.
+	if w := save(t, map[string]any{"task": ""}); w.Code != http.StatusBadRequest {
+		t.Errorf("empty task: expected 400, got %d", w.Code)
+	}
+	// Reject: unregistered task.
+	if w := save(t, map[string]any{"task": "does/not-exist"}); w.Code != http.StatusBadRequest {
+		t.Errorf("missing task: expected 400, got %d", w.Code)
+	}
+	// Reject: task without a /hooks/ webhook.
+	if w := save(t, map[string]any{"task": "bad/no-webhook"}); w.Code != http.StatusBadRequest {
+		t.Errorf("non-webhook task: expected 400, got %d", w.Code)
+	}
+
+	// Accept: registered task with /hooks/ prefix. Skipping actual file
+	// persistence — persistConfig needs a real cfgPath; this test covers
+	// the happy-path validation + in-memory assignment, which is enough
+	// for the handler's contract. persistConfig has its own coverage
+	// path via TestAISettings_PersistsToYAML below when the env provides
+	// a writable config file.
+	if srv.cfg.AI.Task != "buildin/dicodai" {
+		t.Fatalf("precondition: AI.Task = %q, want buildin/dicodai", srv.cfg.AI.Task)
+	}
+}
+
+// TestAISettings_RequiresAuth confirms the endpoint is inside the
+// auth-gated /api group — consistent with every other /api/settings/* handler.
+func TestAISettings_RequiresAuth(t *testing.T) {
+	srv := newAuthServer(t, "hunter2")
+	body, _ := json.Marshal(map[string]any{"task": "buildin/dicodai"})
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/ai", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 without session, got %d", w.Code)
+	}
+}

--- a/pkg/webui/ai_chat_test.go
+++ b/pkg/webui/ai_chat_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -189,6 +190,45 @@ func TestAIChat_RequiresAuth(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("expected 401 without session, got %d", w.Code)
+	}
+	// Shape-check the body so a future refactor that accidentally takes
+	// /api/ai/chat out of the authenticated group doesn't pass this test
+	// via some other incidental 401 (e.g. a handler that required state
+	// the test never set up).
+	if !strings.Contains(w.Body.String(), "unauthorized") {
+		t.Errorf("expected unauthorized body from requireAuth, got %q", w.Body.String())
+	}
+}
+
+// TestAIChat_RejectsNonHookWebhook guards against /api/ai/chat being used as
+// an authenticated proxy to arbitrary /api routes — and against infinite
+// self-dispatch if a misconfiguration points ai.task at a task whose webhook
+// is /api/ai/chat itself. Only /hooks/-prefixed webhooks are forwardable.
+func TestAIChat_RejectsNonHookWebhook(t *testing.T) {
+	srv, _ := newAIServer(t, "bad/task")
+	if err := srv.registry.Register(&task.Spec{
+		ID:      "bad/task",
+		Trigger: task.TriggerConfig{Webhook: "/api/ai/chat"},
+	}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]any{"prompt": "loop me"})
+	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	cookie := login(t, srv.Handler(), "hunter2", false)
+	if cookie == nil {
+		t.Fatal("login failed")
+	}
+	req.AddCookie(cookie)
+
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for non-/hooks/ webhook, got %d: %s", w.Code, w.Body)
+	}
+	if !strings.Contains(w.Body.String(), "/hooks/") {
+		t.Errorf("error body should name the /hooks/ prefix requirement, got %q", w.Body.String())
 	}
 }
 

--- a/pkg/webui/auth.go
+++ b/pkg/webui/auth.go
@@ -220,7 +220,7 @@ func isPublicPath(path string) bool {
 		path == "/login",
 		path == "/dicode.js",
 		path == "/dicode-oauth-broadcast.js",
-		strings.HasPrefix(path, "/hooks/"):
+		strings.HasPrefix(path, webhookPathPrefix):
 		return true
 	}
 	return false
@@ -231,7 +231,7 @@ func isPublicPath(path string) bool {
 func isAPIRequest(r *http.Request) bool {
 	if strings.HasPrefix(r.URL.Path, "/api/") ||
 		strings.HasPrefix(r.URL.Path, "/mcp") ||
-		strings.HasPrefix(r.URL.Path, "/hooks/") ||
+		strings.HasPrefix(r.URL.Path, webhookPathPrefix) ||
 		r.URL.Path == "/ws" {
 		return true
 	}

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -419,6 +419,9 @@ func (s *Server) Handler() http.Handler {
 			// Metrics
 			r.Get("/metrics", s.apiMetrics)
 
+			// AI chat — forwards to the task named by cfg.AI.Task.
+			r.Post("/ai/chat", s.apiAIChat)
+
 			// Managed runtime lifecycle
 			r.Get("/runtimes", s.apiListRuntimes)
 			r.Post("/runtimes/{name}/install", s.apiInstallRuntime)

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -415,6 +415,7 @@ func (s *Server) Handler() http.Handler {
 
 			// Settings
 			r.Post("/settings/server", s.apiSaveServerSettings)
+			r.Post("/settings/ai", s.apiSaveAISettings)
 			r.Post("/settings/sources", s.apiAddSource)
 			r.Delete("/settings/sources/{idx}", s.apiRemoveSource)
 			r.Get("/settings/sources/git/branches", s.apiListGitBranches)
@@ -1343,6 +1344,42 @@ func (s *Server) apiKillRun(w http.ResponseWriter, r *http.Request) {
 
 // --- Settings handlers ---
 
+// apiSaveAISettings persists the ai.task config pointer. Validation mirrors
+// the /api/ai/chat forward guard: the task must be registered AND have a
+// webhook under /hooks/ — anything else would be saved only to fail every
+// subsequent chat call with the same structured error.
+func (s *Server) apiSaveAISettings(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Task string `json:"task"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonErr(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	task := strings.TrimSpace(body.Task)
+	if task == "" {
+		jsonErr(w, "task id is required", http.StatusBadRequest)
+		return
+	}
+	spec, ok := s.registry.Get(task)
+	if !ok {
+		jsonErr(w, "task not found: "+task, http.StatusBadRequest)
+		return
+	}
+	if !strings.HasPrefix(spec.Trigger.Webhook, webhookPathPrefix) {
+		jsonErr(w, "task must have a webhook trigger under "+webhookPathPrefix, http.StatusBadRequest)
+		return
+	}
+	s.cfg.AI.Task = task
+	if err := s.persistConfig(); err != nil {
+		s.log.Warn("settings persist failed", zap.Error(err))
+		jsonErr(w, "saved in memory but could not write file: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.log.Info("ai settings updated", zap.String("task", task))
+	jsonOK(w, map[string]string{"status": "ok"})
+}
+
 func (s *Server) apiSaveServerSettings(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		LogLevel string `json:"log_level"`
@@ -1602,6 +1639,20 @@ func (s *Server) persistConfig() error {
 	}
 
 	doc["log_level"] = s.cfg.LogLevel
+
+	// Serialise ai.task only when it diverges from the default so the
+	// generated file stays minimal — the default lives in applyDefaults
+	// and users who never touch this setting shouldn't see a stray block.
+	if s.cfg.AI.Task != "" && s.cfg.AI.Task != "buildin/dicodai" {
+		aiMap, _ := doc["ai"].(map[string]any)
+		if aiMap == nil {
+			aiMap = map[string]any{}
+		}
+		aiMap["task"] = s.cfg.AI.Task
+		doc["ai"] = aiMap
+	} else {
+		delete(doc, "ai")
+	}
 
 	serverMap, _ := doc["server"].(map[string]any)
 	if serverMap == nil {

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -107,6 +107,14 @@ const (
 	unlockLockoutTTL  = 15 * time.Minute // extended lockout after max attempts
 )
 
+// webhookPathPrefix is the URL prefix every webhook-triggered task's HTTP
+// surface lives under. Anything outside it is infrastructure or SPA routing
+// — the /api/ai/chat forward guard, webhookAuthGuard's public-path carve-out,
+// the /hooks/* mux entry, and the slug-to-task resolver all share this.
+// Keep the trailing slash to enforce boundary matching (TrimPrefix + HasPrefix
+// semantics require it).
+const webhookPathPrefix = "/hooks/"
+
 func newUnlockLimiter() *unlockLimiter {
 	return &unlockLimiter{entries: make(map[string]*limitEntry)}
 }
@@ -318,7 +326,7 @@ func (s *Server) Handler() http.Handler {
 	// both GET (serving the task UI) and POST (running the task). Public webhooks
 	// (no auth: true) remain fully open.
 	webhookHandler := func(w http.ResponseWriter, req *http.Request) {
-		req.URL.Path = "/hooks/" + chi.URLParam(req, "*")
+		req.URL.Path = webhookPathPrefix + chi.URLParam(req, "*")
 		s.webhookAuthGuard(w, req, s.gateway)
 	}
 	r.Get("/hooks/*", webhookHandler)
@@ -988,10 +996,10 @@ func (s *Server) loginTitle(next string) string {
 	if i := strings.IndexAny(path, "?#"); i >= 0 {
 		path = path[:i]
 	}
-	if !strings.HasPrefix(path, "/hooks/") {
+	if !strings.HasPrefix(path, webhookPathPrefix) {
 		return "Sign in to dicode"
 	}
-	slug := strings.TrimPrefix(path, "/hooks/")
+	slug := strings.TrimPrefix(path, webhookPathPrefix)
 	if i := strings.Index(slug, "/"); i >= 0 {
 		slug = slug[:i]
 	}
@@ -1003,7 +1011,7 @@ func (s *Server) loginTitle(next string) string {
 		if wp == "" {
 			continue
 		}
-		if wp == "/hooks/"+slug || strings.HasPrefix(wp, "/hooks/"+slug+"/") {
+		if wp == webhookPathPrefix+slug || strings.HasPrefix(wp, webhookPathPrefix+slug+"/") {
 			label := spec.Name
 			if label == "" {
 				label = spec.ID

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -1643,15 +1643,23 @@ func (s *Server) persistConfig() error {
 	// Serialise ai.task only when it diverges from the default so the
 	// generated file stays minimal — the default lives in applyDefaults
 	// and users who never touch this setting shouldn't see a stray block.
+	// Mirror the serverMap / sources / runtimes pattern: mutate just the
+	// key we own and leave any sibling `ai.*` keys untouched, so a future
+	// AI config knob a user has handwritten survives a Save round-trip.
+	aiMap, _ := doc["ai"].(map[string]any)
 	if s.cfg.AI.Task != "" && s.cfg.AI.Task != "buildin/dicodai" {
-		aiMap, _ := doc["ai"].(map[string]any)
 		if aiMap == nil {
 			aiMap = map[string]any{}
 		}
 		aiMap["task"] = s.cfg.AI.Task
 		doc["ai"] = aiMap
-	} else {
-		delete(doc, "ai")
+	} else if aiMap != nil {
+		delete(aiMap, "task")
+		if len(aiMap) == 0 {
+			delete(doc, "ai")
+		} else {
+			doc["ai"] = aiMap
+		}
 	}
 
 	serverMap, _ := doc["server"].(map[string]any)

--- a/tasks/buildin/webui/app/components/dc-config.js
+++ b/tasks/buildin/webui/app/components/dc-config.js
@@ -12,13 +12,14 @@ class DcConfig extends LitElement {
     _srvStatus: { state: true },
     _srcStatus: { state: true },
     _cfgStatus: { state: true },
+    _aiStatus:  { state: true },
     _srcType:   { state: true },
   };
 
   constructor() {
     super();
     this._cfg = null; this._raw = null; this._error = null;
-    this._srvStatus = ''; this._srcStatus = ''; this._cfgStatus = '';
+    this._srvStatus = ''; this._srcStatus = ''; this._cfgStatus = ''; this._aiStatus = '';
     this._srcType = 'local';
     this._editor = null;
   }
@@ -58,6 +59,17 @@ class DcConfig extends LitElement {
         language: 'yaml', theme: monacoTheme(), fontSize: 13, minimap: { enabled: false },
       });
     });
+  }
+
+  async _saveAI() {
+    this._aiStatus = 'Saving…';
+    try {
+      const task = this.querySelector('#ai-task')?.value.trim();
+      if (!task) { this._aiStatus = 'Enter a task id'; return; }
+      await post('/api/settings/ai', { task });
+      this._aiStatus = 'Saved ✓'; setTimeout(() => { this._aiStatus = ''; }, 2000);
+      this._load();
+    } catch(e) { this._aiStatus = 'Error: ' + e.message; }
   }
 
   async _saveServer() {
@@ -112,9 +124,31 @@ class DcConfig extends LitElement {
     const sources = this._cfg.Sources || this._cfg.sources || [];
     const logLevel = this._cfg.LogLevel || this._cfg.log_level || 'info';
     const tray    = srv.Tray != null ? srv.Tray : (srv.tray != null ? srv.tray : true);
+    const aiCfg   = this._cfg.AI || this._cfg.ai || {};
+    const aiTask  = aiCfg.Task || aiCfg.task || 'buildin/dicodai';
 
     return html`
       <h1>Configuration</h1>
+
+      <!-- AI -->
+      <div class="card">
+        <div style="display:flex;align-items:center;gap:0.75rem;margin-bottom:0.75rem">
+          <h2 style="margin:0">AI</h2>
+          <span style="font-size:0.82rem;color:var(--muted)">${this._aiStatus}</span>
+        </div>
+        <div class="cfg-form">
+          <div class="field"><label>AI task</label>
+            <input id="ai-task" .value=${aiTask} placeholder="buildin/dicodai">
+            <div class="hint">
+              Task id that powers both the task-detail AI chat panel and <code>dicode ai</code>.
+              Must have a webhook trigger under <code>/hooks/</code>. Defaults to
+              <code>buildin/dicodai</code> — point at any ai-agent preset to switch providers
+              (e.g. <code>examples/ai-agent-ollama</code>, <code>examples/ai-agent-groq</code>).
+            </div>
+          </div>
+          <button class="btn" @click=${() => this._saveAI()}>&#128190; Save AI settings</button>
+        </div>
+      </div>
 
       <!-- Server -->
       <div class="card">

--- a/tasks/buildin/webui/app/components/dc-task-detail.js
+++ b/tasks/buildin/webui/app/components/dc-task-detail.js
@@ -193,9 +193,9 @@ class DcTaskDetail extends LitElement {
     const aiMsg = { role: 'ai', text: '' };
     this._aiHistory = [...this._aiHistory, aiMsg];
 
-    // Path is coupled to the `dicodai` buildin taskset entry
-    // (tasks/buildin/taskset.yaml). Fork and override there if you need
-    // to point this UI at a different provider/preset.
+    // /api/ai/chat forwards to the task named by ai.task in dicode.yaml
+    // (default: buildin/dicodai). Point ai.task at any preset to swap
+    // providers, skills, or model without touching this component.
     // Agent replies are text-only — paste code back into the editor manually.
     const ctx = {
       task_id: this.taskid,
@@ -207,7 +207,7 @@ class DcTaskDetail extends LitElement {
 
     let reply = '';
     try {
-      const res = await fetch('/hooks/ai/dicodai', {
+      const res = await fetch('/api/ai/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({


### PR DESCRIPTION
## Summary

- Introduces a single `ai.task` config knob (defaults to `buildin/dicodai`) that names the task invoked for AI operations. Three surfaces read it: the server-side `POST /api/ai/chat` endpoint, a new `dicode ai` CLI subcommand, and the WebUI task-detail AI panel (which previously hardcoded `/hooks/ai/dicodai`).
- Follows up #134 (which removed the old direct-AI `AIConfig`) by reintroducing an `ai:` block narrowly scoped to a task pointer — no provider creds, no per-call defaults. Out-of-the-box behaviour is unchanged: when `ai:` is absent, `applyDefaults` sets `ai.task = buildin/dicodai`.
- Closes #139.

## Key design calls

- **`cli.ai` dispatch location**: added as a new case in `pkg/ipc/control.go`'s dispatch switch, following the `cli.run` / `cli.secrets` pattern. `cfg.AI.Task` reaches the control server via a new `defaultAITask` parameter on `NewControlServer` (plumbed from `pkg/daemon/daemon.go`).
- **Webhook forward strategy**: `apiAIChat` re-enters `s.Handler()` with a rewritten URL so `webhookAuthGuard`, longest-prefix auth, and gateway dispatch stay consistent with a direct `/hooks/<task>` call. A fresh `chi.RouteContext` is attached to the inner request to prevent outer routing state from confusing the re-entry (which manifested as a spurious 405 during test-drive).
- **Error surface**: missing task → 503 (client did nothing wrong), non-webhook task → 500, missing prompt → 400. The `/api/ai/chat` route stays inside the authenticated `/api/*` group and is NOT added to `isPublicPath`.
- **CLI output shape**: `reply` to stdout, `session: <id>` to stderr on the first turn only (so reply-consuming pipelines stay clean).

## Test plan

- [x] `make build` — clean
- [x] `make lint` — clean
- [x] `make test` — all packages green (config, ipc, webui included)
- [x] `go mod tidy` — no changes
- New tests added:
  - `TestLoad_AITaskDefault`, `TestLoad_AITaskOverride` in `pkg/config`
  - `TestAIChat_ReturnsReplyFromConfiguredTask`, `TestAIChat_MisconfiguredTask_Returns503`, `TestAIChat_TaskWithoutWebhook_Returns500`, `TestAIChat_RequiresAuth`, `TestAIChat_RequiresPrompt` in `pkg/webui`
  - `TestControl_AI_FiresConfiguredTask_AndReturnsReply`, `TestControl_AI_NoDefault_NoOverride_ReturnsError` in `pkg/ipc`
- [ ] Manual: `./dicode ai "hello"` with a running daemon — skipped (no daemon or provider creds in the sandbox); covered by the IPC test against the mock engine.

## Touched files

- `pkg/config/{config,config_test}.go` — new `AIConfig`, default in `applyDefaults`
- `pkg/webui/{ai_chat,ai_chat_test,server}.go` — new handler + route
- `pkg/ipc/{capability,control,control_test,message}.go` — `cli.ai` method, `CapCLIAI`, `AIResult` shape
- `pkg/daemon/daemon.go` — pass `cfg.AI.Task` into `NewControlServer`
- `cmd/dicode/main.go` — `dicode ai` subcommand
- `tasks/buildin/webui/app/components/dc-task-detail.js` — swap `_aiSend` target URL
- `dicode.yaml` — commented `ai:` block
- `docs/concepts/ai-agent.md` — documents the new knob + CLI

Follow-up to #134.