### PR TITLE
feat(relay): rotate-identity CLI — split-key aware (replaces #101)

### DIFF
--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -106,7 +106,7 @@ func dispatch(c *ipc.ControlClient, args []string) error {
 		return cmdSecrets(c, args[1:])
 	case "relay":
 		if len(args) < 2 {
-			return fmt.Errorf("usage: dicode relay <trust-broker> --yes")
+			return fmt.Errorf("usage: dicode relay <trust-broker|rotate-identity> [--yes]")
 		}
 		return cmdRelay(c, args[1:])
 	default:
@@ -140,6 +140,35 @@ func cmdRelay(c *ipc.ControlClient, args []string) error {
 			return fmt.Errorf("%s", resp.Error)
 		}
 		fmt.Println("Broker pubkey pin cleared. Restart the daemon to accept the new broker key.")
+		return nil
+	case "rotate-identity":
+		force := false
+		for _, a := range args[1:] {
+			if a == "--yes" || a == "-y" {
+				force = true
+			}
+		}
+		if !force {
+			fmt.Fprintln(os.Stderr, "This will permanently invalidate the current relay identity.")
+			fmt.Fprintln(os.Stderr, "Any public webhook URLs under the old UUID will stop working.")
+			fmt.Fprintln(os.Stderr, "Re-run with --yes to confirm.")
+			return fmt.Errorf("aborted")
+		}
+		resp, err := c.Send(ipc.Request{Method: "cli.relay.rotate_identity"})
+		if err != nil {
+			return err
+		}
+		if resp.Error != "" {
+			return fmt.Errorf("%s", resp.Error)
+		}
+		var result ipc.RelayRotateResult
+		if err := remarshal(resp.Result, &result); err != nil {
+			return err
+		}
+		fmt.Printf("new relay uuid: %s\n", result.NewUUID)
+		if result.Warning != "" {
+			fmt.Fprintln(os.Stderr, result.Warning)
+		}
 		return nil
 	default:
 		return fmt.Errorf("unknown relay subcommand %q", args[0])
@@ -386,6 +415,7 @@ Commands:
   secrets list                    list secret keys
   secrets set <key> <value>       store a secret
   secrets delete <key>            delete a secret
+  relay rotate-identity --yes     rotate the daemon's relay identity (irreversible)
   version                         print version
 `)
 }

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -144,8 +144,11 @@ func cmdRelay(c *ipc.ControlClient, args []string) error {
 	case "rotate-identity":
 		force := false
 		for _, a := range args[1:] {
-			if a == "--yes" || a == "-y" {
+			switch a {
+			case "--yes", "-y":
 				force = true
+			default:
+				return fmt.Errorf("unknown flag %q — usage: dicode relay rotate-identity --yes", a)
 			}
 		}
 		if !force {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -227,6 +227,21 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 					zap.String("expected_scheme", "wss:// or ws://"))
 			}
 			g.Go(func() error { pending.StartSweep(ctx); return nil })
+			// Identity rotation via `dicode relay rotate-identity`. The
+			// callback regenerates BOTH the sign and decrypt keypairs
+			// atomically (split identity, issue #104) and invalidates any
+			// outstanding OAuth sessions (they were encrypted to the old
+			// DecryptKey). The running relay WSS connection keeps the old
+			// in-memory identity until the daemon restarts — documented
+			// in the RelayRotateResult warning returned to the CLI.
+			ctrlSrv.SetRelayIdentityRotator(func(ctx context.Context) (string, error) {
+				newID, err := relay.RotateIdentity(ctx, database)
+				if err != nil {
+					return "", err
+				}
+				pending.Clear()
+				return newID.UUID, nil
+			})
 			g.Go(func() error { return rc.Run(ctx) })
 		}
 	}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -235,11 +235,17 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 			// in-memory identity until the daemon restarts — documented
 			// in the RelayRotateResult warning returned to the CLI.
 			ctrlSrv.SetRelayIdentityRotator(func(ctx context.Context) (string, error) {
-				// Clear pending sessions first: a post-rotation daemon
-				// cannot decrypt them (encrypted to the old pubkey), so
-				// dropping them is the only honest outcome. If the DB
-				// write then fails, we've lost in-flight flows but that
-				// is correct — they'd fail to decrypt anyway.
+				// Invariant: pending.Clear() MUST run before
+				// relay.RotateIdentity(). A post-rotation daemon cannot
+				// decrypt envelopes bound to the old DecryptKey, so dropping
+				// them up front is the only honest outcome — a partial-
+				// success state where the DB still has old rows and pending
+				// is already empty is still correct (next rotate retry will
+				// converge). Swapping this order would leave a window where
+				// rotation succeeds in the DB but an in-flight delivery
+				// arrives against the NEW DecryptKey while pending still
+				// references the old session, producing a silent decrypt
+				// failure rather than a clear "session expired" retry path.
 				dropped := pending.Clear()
 				oldUUID := id.UUID
 				newID, err := relay.RotateIdentity(ctx, database)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -235,11 +235,22 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 			// in-memory identity until the daemon restarts — documented
 			// in the RelayRotateResult warning returned to the CLI.
 			ctrlSrv.SetRelayIdentityRotator(func(ctx context.Context) (string, error) {
+				// Clear pending sessions first: a post-rotation daemon
+				// cannot decrypt them (encrypted to the old pubkey), so
+				// dropping them is the only honest outcome. If the DB
+				// write then fails, we've lost in-flight flows but that
+				// is correct — they'd fail to decrypt anyway.
+				dropped := pending.Clear()
+				oldUUID := id.UUID
 				newID, err := relay.RotateIdentity(ctx, database)
 				if err != nil {
 					return "", err
 				}
-				pending.Clear()
+				log.Warn("relay identity rotated",
+					zap.String("old_uuid", oldUUID),
+					zap.String("new_uuid", newID.UUID),
+					zap.Int("dropped_sessions", dropped),
+				)
 				return newID.UUID, nil
 			})
 			g.Go(func() error { return rc.Run(ctx) })

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -235,17 +235,23 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 			// in-memory identity until the daemon restarts — documented
 			// in the RelayRotateResult warning returned to the CLI.
 			ctrlSrv.SetRelayIdentityRotator(func(ctx context.Context) (string, error) {
-				// Invariant: pending.Clear() MUST run before
-				// relay.RotateIdentity(). A post-rotation daemon cannot
-				// decrypt envelopes bound to the old DecryptKey, so dropping
-				// them up front is the only honest outcome — a partial-
-				// success state where the DB still has old rows and pending
-				// is already empty is still correct (next rotate retry will
-				// converge). Swapping this order would leave a window where
-				// rotation succeeds in the DB but an in-flight delivery
-				// arrives against the NEW DecryptKey while pending still
-				// references the old session, producing a silent decrypt
-				// failure rather than a clear "session expired" retry path.
+				// Invariant: pending.Clear() runs BEFORE relay.RotateIdentity().
+				// Operator intent of rotation is "the old identity is dead from
+				// this point forward", so every in-flight flow issued against
+				// the old identity must be invalidated at the same moment as
+				// the DB swap. If Rotate ran first, the window between Rotate
+				// and Clear would leave in-flight flows still completing
+				// against the old DecryptKey (the broker has it in
+				// session.pubkey, unchanged by DB rotation) — inconsistent
+				// with the operator's mental model of rotation as a hard
+				// cutover.
+				//
+				// Note: the `id` pointer captured in denoRT.SetOAuthBroker
+				// above is NOT replaced here. The running daemon continues
+				// using the old in-memory identity for WSS + ECIES decrypt
+				// until a restart. This is the hazard relayRotateWarning
+				// calls out — the rotation point is "DB + pending cutover";
+				// the running-connection cutover is at restart.
 				dropped := pending.Clear()
 				oldUUID := id.UUID
 				newID, err := relay.RotateIdentity(ctx, database)

--- a/pkg/ipc/capability.go
+++ b/pkg/ipc/capability.go
@@ -46,11 +46,12 @@ const (
 	CapSecretsWrite  = "secrets.write"
 
 	// CLI capabilities — granted to dicode CLI clients on the control socket.
-	CapCLIRun     = "cli.run"     // trigger a task run and stream its output
-	CapCLIList    = "cli.list"    // list tasks and their last-run status
-	CapCLILogs    = "cli.logs"    // fetch log entries for a run
-	CapCLIStatus  = "cli.status"  // daemon health and uptime
-	CapCLISecrets = "cli.secrets" // list / set / delete secrets
+	CapCLIRun         = "cli.run"          // trigger a task run and stream its output
+	CapCLIList        = "cli.list"         // list tasks and their last-run status
+	CapCLILogs        = "cli.logs"         // fetch log entries for a run
+	CapCLIStatus      = "cli.status"       // daemon health and uptime
+	CapCLISecrets     = "cli.secrets"      // list / set / delete secrets
+	CapCLIRelayRotate = "cli.relay.rotate" // rotate the relay identity (irreversible)
 )
 
 // cliCaps is the full capability set granted to every CLI client.
@@ -61,6 +62,7 @@ func cliCaps() []string {
 		CapCLILogs,
 		CapCLIStatus,
 		CapCLISecrets,
+		CapCLIRelayRotate,
 	}
 }
 

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -19,6 +19,19 @@ import (
 	"go.uber.org/zap"
 )
 
+// RelayIdentityRotator rotates the daemon's relay identity on demand.
+// It is implemented by main.go (which owns the db handle, the pending
+// store, and the running relay client) and passed into ControlServer so
+// the cli.relay.rotate_identity handler can trigger a rotation without
+// ControlServer needing direct access to any of those pieces.
+//
+// The returned string is the new UUID. The rotator is responsible for:
+//   - generating + persisting a fresh keypair in the daemon DB
+//   - invalidating any in-memory state tied to the old key (pending
+//     OAuth sessions, running relay WSS connection)
+//   - returning cleanly even if the relay client is currently dialing
+type RelayIdentityRotator func(ctx context.Context) (newUUID string, err error)
+
 // ControlServer is the daemon's persistent control socket. It listens at a
 // fixed path (dataDir/daemon.sock) and accepts connections from the dicode CLI.
 //
@@ -35,7 +48,8 @@ type ControlServer struct {
 	engine          EngineRunner
 	secrets         secrets.Manager // nil if no local provider configured
 	metricsProvider MetricsProvider
-	database        db.DB // for broker pubkey trust pinning; nil in tests
+	database        db.DB                // for broker pubkey trust pinning; nil in tests
+	rotateRelay     RelayIdentityRotator // nil if relay not enabled
 	log             *zap.Logger
 
 	startedAt time.Time
@@ -214,6 +228,9 @@ func (cs *ControlServer) dispatch(ctx context.Context, req Request) (any, error)
 	case "cli.relay.trust_broker":
 		return cs.handleTrustBroker(ctx)
 
+	case "cli.relay.rotate_identity":
+		return cs.handleRelayRotate(ctx)
+
 	default:
 		return nil, fmt.Errorf("unknown method: %s", req.Method)
 	}
@@ -385,6 +402,41 @@ func (cs *ControlServer) handleTrustBroker(ctx context.Context) (any, error) {
 	return map[string]string{
 		"status":  "ok",
 		"message": "Broker pubkey pin cleared. Restart the daemon (or wait for reconnect) to accept the new broker key.",
+	}, nil
+}
+
+// SetRelayIdentityRotator wires the rotation callback. The ControlServer
+// owns nothing except the function; main.go constructs a closure that holds
+// the db, pending store, and relay client, and passes it in after relay
+// initialization. Passing nil (or not calling this at all) leaves
+// cli.relay.rotate_identity disabled.
+func (cs *ControlServer) SetRelayIdentityRotator(fn RelayIdentityRotator) {
+	cs.rotateRelay = fn
+}
+
+// RelayRotateResult is returned over the control socket after a successful
+// rotation. The new UUID is surfaced so the CLI can print it; the warning
+// reminds the operator that live webhook URLs pointing at the old UUID are
+// now dead.
+type RelayRotateResult struct {
+	NewUUID string `json:"new_uuid"`
+	Warning string `json:"warning"`
+}
+
+func (cs *ControlServer) handleRelayRotate(ctx context.Context) (any, error) {
+	if cs.rotateRelay == nil {
+		return nil, fmt.Errorf("relay not enabled on this daemon")
+	}
+	newUUID, err := cs.rotateRelay(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("rotate: %w", err)
+	}
+	cs.log.Warn("relay identity rotated",
+		zap.String("new_uuid", newUUID),
+	)
+	return RelayRotateResult{
+		NewUUID: newUUID,
+		Warning: "Old UUID is permanently invalidated. Any public webhook URLs you previously shared under the old UUID will stop working. Restart the daemon to activate the new identity on the WSS relay connection.",
 	}, nil
 }
 

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -410,6 +410,10 @@ func (cs *ControlServer) handleTrustBroker(ctx context.Context) (any, error) {
 // the db, pending store, and relay client, and passes it in after relay
 // initialization. Passing nil (or not calling this at all) leaves
 // cli.relay.rotate_identity disabled.
+//
+// Must be called before Start(). There is no synchronisation on the field;
+// swapping the rotator after the control socket is accepting connections is
+// not supported.
 func (cs *ControlServer) SetRelayIdentityRotator(fn RelayIdentityRotator) {
 	cs.rotateRelay = fn
 }
@@ -439,9 +443,20 @@ func (cs *ControlServer) handleRelayRotate(ctx context.Context) (any, error) {
 	)
 	return RelayRotateResult{
 		NewUUID: newUUID,
-		Warning: "Old UUID is permanently invalidated. Any public webhook URLs you previously shared under the old UUID will stop working. IMPORTANT: the running relay WSS connection still uses the old key in memory. An attacker who has the old key can impersonate this daemon until you restart. Restart the daemon now to complete the rotation.",
+		Warning: relayRotateWarning,
 	}, nil
 }
+
+// relayRotateWarning is the operator-facing message surfaced to the CLI after
+// a successful rotation. It documents the two non-obvious consequences:
+// (a) UUID invalidation breaks every shared webhook URL, and (b) the still-
+// connected WSS session holds the OLD identity in memory until the daemon is
+// restarted, so a stolen old key remains impersonation-capable for that window.
+const relayRotateWarning = "Old UUID is permanently invalidated. " +
+	"Any public webhook URLs you previously shared under the old UUID will stop working. " +
+	"IMPORTANT: the running relay WSS connection still uses the old key in memory. " +
+	"An attacker who has the old key can impersonate this daemon until you restart. " +
+	"Restart the daemon now to complete the rotation."
 
 // triggerLabel returns a human-readable trigger description for a task spec.
 func triggerLabel(s *task.Spec) string {

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -431,12 +431,15 @@ func (cs *ControlServer) handleRelayRotate(ctx context.Context) (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("rotate: %w", err)
 	}
-	cs.log.Warn("relay identity rotated",
+	// The rotator closure in main.go emits a detailed audit entry with
+	// old_uuid, new_uuid, and dropped_sessions. We log here too for the
+	// control-socket-level audit trail (separate from the relay-level one).
+	cs.log.Warn("relay identity rotated via control socket",
 		zap.String("new_uuid", newUUID),
 	)
 	return RelayRotateResult{
 		NewUUID: newUUID,
-		Warning: "Old UUID is permanently invalidated. Any public webhook URLs you previously shared under the old UUID will stop working. Restart the daemon to activate the new identity on the WSS relay connection.",
+		Warning: "Old UUID is permanently invalidated. Any public webhook URLs you previously shared under the old UUID will stop working. IMPORTANT: the running relay WSS connection still uses the old key in memory. An attacker who has the old key can impersonate this daemon until you restart. Restart the daemon now to complete the rotation.",
 	}, nil
 }
 

--- a/pkg/ipc/control_test.go
+++ b/pkg/ipc/control_test.go
@@ -3,9 +3,11 @@ package ipc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -351,6 +353,91 @@ func TestControl_RelayRotate_InvokesRotator(t *testing.T) {
 	}
 	if called != 1 {
 		t.Errorf("rotator called %d times, expected 1", called)
+	}
+
+	cancel()
+	<-done
+}
+
+// TestControl_RelayRotate_RotatorError_SurfacesVerbatim ensures that when the
+// injected rotator returns an error, the control socket surfaces the error
+// string to the client (wrapped as "rotate: <err>") and does NOT populate
+// RelayRotateResult.NewUUID. Catches regressions in handleRelayRotate's
+// error-wrapping path.
+func TestControl_RelayRotate_RotatorError_SurfacesVerbatim(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "ctrl.sock")
+	tokenPath := filepath.Join(dir, "ctrl.token")
+
+	cs, err := NewControlServer(socketPath, tokenPath, nil, &mockEngine{}, nil, MetricsProvider{}, "test", zap.NewNop(), nil)
+	if err != nil {
+		t.Fatalf("NewControlServer: %v", err)
+	}
+
+	cs.SetRelayIdentityRotator(func(_ context.Context) (string, error) {
+		return "", errors.New("db locked")
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { defer close(done); _ = cs.Start(ctx) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(socketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("control socket never appeared")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	tok, err := os.ReadFile(tokenPath)
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	if err := writeMsg(conn, handshakeReq{Token: string(tok)}); err != nil {
+		t.Fatalf("handshake send: %v", err)
+	}
+	var hs struct {
+		Proto int `json:"proto"`
+	}
+	if err := readMsg(conn, &hs); err != nil {
+		t.Fatalf("handshake recv: %v", err)
+	}
+
+	if err := writeMsg(conn, Request{ID: "r1", Method: "cli.relay.rotate_identity"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	var resp struct {
+		ID     string            `json:"id"`
+		Error  string            `json:"error"`
+		Result RelayRotateResult `json:"result"`
+	}
+	if err := readMsg(conn, &resp); err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+	if resp.Error == "" {
+		t.Fatal("expected error when rotator returns an error")
+	}
+	if !strings.Contains(resp.Error, "db locked") {
+		t.Errorf("error should surface rotator error verbatim, got %q", resp.Error)
+	}
+	if resp.Result.NewUUID != "" {
+		t.Errorf("result should be empty on rotator error, got NewUUID=%q", resp.Result.NewUUID)
+	}
+	if resp.Result.Warning != "" {
+		t.Errorf("result should be empty on rotator error, got Warning=%q", resp.Result.Warning)
 	}
 
 	cancel()

--- a/pkg/ipc/control_test.go
+++ b/pkg/ipc/control_test.go
@@ -253,6 +253,110 @@ func TestControl_Metrics_NoProvider_ReturnsZeros(t *testing.T) {
 	}
 }
 
+func TestControl_RelayRotate_NotEnabled(t *testing.T) {
+	t.Parallel()
+
+	conn, cleanup := controlTestEnv(t, MetricsProvider{})
+	defer cleanup()
+
+	// No rotator wired → expect a clear error, not a crash.
+	if err := writeMsg(conn, Request{ID: "r1", Method: "cli.relay.rotate_identity"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	var resp struct {
+		ID    string `json:"id"`
+		Error string `json:"error"`
+	}
+	if err := readMsg(conn, &resp); err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+	if resp.Error == "" {
+		t.Error("expected error when no rotator is wired")
+	}
+}
+
+func TestControl_RelayRotate_InvokesRotator(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "ctrl.sock")
+	tokenPath := filepath.Join(dir, "ctrl.token")
+
+	cs, err := NewControlServer(socketPath, tokenPath, nil, &mockEngine{}, nil, MetricsProvider{}, "test", zap.NewNop(), nil)
+	if err != nil {
+		t.Fatalf("NewControlServer: %v", err)
+	}
+
+	called := 0
+	cs.SetRelayIdentityRotator(func(_ context.Context) (string, error) {
+		called++
+		return "newuuid123", nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { defer close(done); _ = cs.Start(ctx) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(socketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("control socket never appeared")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	tok, err := os.ReadFile(tokenPath)
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	if err := writeMsg(conn, handshakeReq{Token: string(tok)}); err != nil {
+		t.Fatalf("handshake send: %v", err)
+	}
+	var hs struct {
+		Proto int `json:"proto"`
+	}
+	if err := readMsg(conn, &hs); err != nil {
+		t.Fatalf("handshake recv: %v", err)
+	}
+
+	if err := writeMsg(conn, Request{ID: "r1", Method: "cli.relay.rotate_identity"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	var resp struct {
+		ID     string            `json:"id"`
+		Error  string            `json:"error"`
+		Result RelayRotateResult `json:"result"`
+	}
+	if err := readMsg(conn, &resp); err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("unexpected error: %s", resp.Error)
+	}
+	if resp.Result.NewUUID != "newuuid123" {
+		t.Fatalf("new uuid mismatch: %+v", resp.Result)
+	}
+	if resp.Result.Warning == "" {
+		t.Error("expected a warning message to be surfaced")
+	}
+	if called != 1 {
+		t.Errorf("rotator called %d times, expected 1", called)
+	}
+
+	cancel()
+	<-done
+}
+
 func TestControl_UnknownMethod_ReturnsError(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/relay/keys.go
+++ b/pkg/relay/keys.go
@@ -216,6 +216,12 @@ func encodeECPrivateKeyPEM(key *ecdsa.PrivateKey) (string, error) {
 // process — the caller is responsible for tearing them down and
 // re-connecting with the new identity (typically by restarting the daemon).
 func RotateIdentity(ctx context.Context, database db.DB) (*Identity, error) {
+	// Order is deliberate: generate both keys and encode both PEMs BEFORE
+	// opening the transaction, so the tx only wraps DB writes. Moving the
+	// ecdsa.GenerateKey or PEM encoding inside the tx would hold the SQLite
+	// write lock across entropy reads and CPU-bound ASN.1 marshalling, which
+	// blocks concurrent readers for no reason. Fail-fast on generation is
+	// also cheaper than opening a tx we'd then have to roll back.
 	signKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("generate relay sign key: %w", err)
@@ -234,6 +240,9 @@ func RotateIdentity(ctx context.Context, database db.DB) (*Identity, error) {
 		return nil, err
 	}
 
+	// Atomicity: both INSERT OR REPLACEs share one transaction. On any DB
+	// error, neither row is updated — the daemon never loads a mixed
+	// old/new identity on next boot. Do not split these into separate tx's.
 	if err := database.Tx(ctx, func(tx db.DB) error {
 		if err := tx.Exec(ctx,
 			`INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)`,

--- a/pkg/relay/keys.go
+++ b/pkg/relay/keys.go
@@ -197,6 +197,68 @@ func encodeECPrivateKeyPEM(key *ecdsa.PrivateKey) (string, error) {
 	})), nil
 }
 
+// RotateIdentity generates a fresh pair of P-256 keypairs (SignKey +
+// DecryptKey), overwrites BOTH stored identity rows in a single transaction,
+// and returns the new Identity.
+//
+// Both keys are rotated atomically: if one leaks, the other must be assumed
+// leaked too (same process memory, same SQLite file, same backup). Rotating
+// only one would leave a half-compromised surface with no operator-visible
+// signal. The tx guarantees either both rows are replaced or neither is —
+// the Identity the daemon will load on next boot is never a mix of old/new.
+//
+// The old keys are unrecoverable after this call. The UUID changes (it is
+// derived from the new SignKey pubkey), so any public webhook URL the
+// operator previously shared under the old UUID becomes permanently invalid;
+// downstream consumers must be re-wired to the new
+// relay.dicode.app/u/<new-uuid> base. Live WSS connections held by an
+// in-memory Identity from before the rotation are not affected in this
+// process — the caller is responsible for tearing them down and
+// re-connecting with the new identity (typically by restarting the daemon).
+func RotateIdentity(ctx context.Context, database db.DB) (*Identity, error) {
+	signKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate relay sign key: %w", err)
+	}
+	decryptKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate relay decrypt key: %w", err)
+	}
+
+	signPEM, err := encodeECPrivateKeyPEM(signKey)
+	if err != nil {
+		return nil, err
+	}
+	decryptPEM, err := encodeECPrivateKeyPEM(decryptKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := database.Tx(ctx, func(tx db.DB) error {
+		if err := tx.Exec(ctx,
+			`INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)`,
+			kvKeyRelayPrivateKey, signPEM,
+		); err != nil {
+			return fmt.Errorf("store relay sign key: %w", err)
+		}
+		if err := tx.Exec(ctx,
+			`INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)`,
+			kvKeyRelayDecryptPrivateKey, decryptPEM,
+		); err != nil {
+			return fmt.Errorf("store relay decrypt key: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return &Identity{
+		SignKey:    signKey,
+		DecryptKey: decryptKey,
+		UUID:       deriveUUID(&signKey.PublicKey),
+	}, nil
+}
+
 func generateAndStoreSignKey(ctx context.Context, database db.DB) (*ecdsa.PrivateKey, error) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {

--- a/pkg/relay/keys_test.go
+++ b/pkg/relay/keys_test.go
@@ -149,7 +149,7 @@ func TestRotateIdentity(t *testing.T) {
 	ctx := context.Background()
 	database := openTestDB(t)
 
-	orig, err := LoadOrGenerateIdentity(ctx, database)
+	orig, err := LoadOrGenerateIdentity(ctx, database, nil)
 	if err != nil {
 		t.Fatalf("initial load: %v", err)
 	}
@@ -161,18 +161,30 @@ func TestRotateIdentity(t *testing.T) {
 	if rotated.UUID == orig.UUID {
 		t.Fatalf("rotation produced the same UUID")
 	}
-	if rotated.PrivateKey.D.Cmp(orig.PrivateKey.D) == 0 {
-		t.Fatalf("rotation kept the same private scalar")
+	if rotated.SignKey.D.Cmp(orig.SignKey.D) == 0 {
+		t.Fatalf("rotation kept the same SignKey scalar")
+	}
+	if rotated.DecryptKey.D.Cmp(orig.DecryptKey.D) == 0 {
+		t.Fatalf("rotation kept the same DecryptKey scalar")
+	}
+	if rotated.SignKey.D.Cmp(rotated.DecryptKey.D) == 0 {
+		t.Fatalf("rotated SignKey and DecryptKey are the same scalar")
 	}
 
-	// A subsequent LoadOrGenerate must return the rotated key, not the
-	// original — the rotation is persistent.
-	reloaded, err := LoadOrGenerateIdentity(ctx, database)
+	// A subsequent LoadOrGenerate must return the rotated keys, not the
+	// originals — the rotation is persistent on both rows.
+	reloaded, err := LoadOrGenerateIdentity(ctx, database, nil)
 	if err != nil {
 		t.Fatalf("reload: %v", err)
 	}
 	if reloaded.UUID != rotated.UUID {
-		t.Fatalf("reload returned %s, expected rotated %s", reloaded.UUID, rotated.UUID)
+		t.Fatalf("reload returned UUID %s, expected rotated %s", reloaded.UUID, rotated.UUID)
+	}
+	if reloaded.SignKey.D.Cmp(rotated.SignKey.D) != 0 {
+		t.Fatalf("reload returned a different SignKey than rotated")
+	}
+	if reloaded.DecryptKey.D.Cmp(rotated.DecryptKey.D) != 0 {
+		t.Fatalf("reload returned a different DecryptKey than rotated")
 	}
 }
 

--- a/pkg/relay/keys_test.go
+++ b/pkg/relay/keys_test.go
@@ -145,6 +145,37 @@ func TestDecryptPublicKey(t *testing.T) {
 	}
 }
 
+func TestRotateIdentity(t *testing.T) {
+	ctx := context.Background()
+	database := openTestDB(t)
+
+	orig, err := LoadOrGenerateIdentity(ctx, database)
+	if err != nil {
+		t.Fatalf("initial load: %v", err)
+	}
+
+	rotated, err := RotateIdentity(ctx, database)
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	if rotated.UUID == orig.UUID {
+		t.Fatalf("rotation produced the same UUID")
+	}
+	if rotated.PrivateKey.D.Cmp(orig.PrivateKey.D) == 0 {
+		t.Fatalf("rotation kept the same private scalar")
+	}
+
+	// A subsequent LoadOrGenerate must return the rotated key, not the
+	// original — the rotation is persistent.
+	reloaded, err := LoadOrGenerateIdentity(ctx, database)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if reloaded.UUID != rotated.UUID {
+		t.Fatalf("reload returned %s, expected rotated %s", reloaded.UUID, rotated.UUID)
+	}
+}
+
 func TestDeriveUUID(t *testing.T) {
 	ctx := context.Background()
 	database := openTestDB(t)

--- a/pkg/relay/oauth_pending.go
+++ b/pkg/relay/oauth_pending.go
@@ -118,3 +118,15 @@ func (s *PendingSessions) StartSweep(ctx context.Context) {
 		}
 	}
 }
+
+// Clear drops every pending session. Called on relay-identity rotation:
+// the outstanding flows were issued under the old DecryptKey and any
+// arriving token delivery will be encrypted to that key, so the rotated
+// daemon identity cannot decrypt them.
+func (s *PendingSessions) Clear() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := len(s.byID)
+	s.byID = make(map[string]*AuthRequest)
+	return n
+}


### PR DESCRIPTION
Closes #101. Supersedes [PR #101](https://github.com/dicode-ayo/dicode-core/pull/101) which was stacked on top of the original OAuth broker PR and predated #104's identity split.

## Summary

Adds \`dicode relay rotate-identity --yes\` — regenerates the daemon's relay identity on demand (laptop stolen / key leaked scenarios).

After #104 the identity is two keys, not one, so rotation rewrites BOTH rows atomically:
- \`relay.private_key\` — SignKey (ECDSA for WSS handshake + /auth URL sigs)
- \`relay.decrypt_private_key\` — DecryptKey (ECDH for OAuth ECIES recipient)

A single \`database.Tx\` wraps both \`INSERT OR REPLACE\` writes; if one fails, neither is committed. The daemon never loads a mixed old/new identity on next boot.

## Design decisions

- **Both keys rotate together.** Rotating only one leaves half the attack surface and no operator signal. If one key is assumed compromised, the other likely is too (same process memory, same SQLite file, same backup).
- **UUID changes on rotation** (derived from the new SignKey pubkey). Any shared \`/u/<uuid>/hooks/...\` webhook URL is permanently invalidated — documented in the CLI warning and in the RelayRotateResult return value.
- **Outstanding OAuth sessions are cleared** (\`PendingSessions.Clear()\`) since they were encrypted to the old DecryptKey and the rotated daemon can no longer decrypt them.
- **Running WSS connection keeps the old in-memory identity** until daemon restart. The CLI warning calls this out — operator is expected to restart to complete the rotation cleanly.

## Test plan

- [x] \`go test ./... -race -count=1\` — all 14 packages green
- [x] \`TestRotateIdentity\` updated for the split-key model: asserts SignKey.D, DecryptKey.D, and UUID all change; asserts the two rotated keys are distinct from each other; asserts reload returns both rotated keys (not the originals)
- [x] Manual E2E: started strict relay + strict daemon on localhost; verified pre-rotation DB state (two keys, known hashes); ran \`dicode relay rotate-identity --yes\`; verified both keys changed hash after rotation; new UUID returned by CLI

## Rollout

Ships after #104 (merged). No wire change — the daemon advertises the rotated SignKey/DecryptKey on its next handshake; the broker handles them like any fresh pair.

## What's different from #101

- Supersedes — this PR is a clean rebase on current \`main\` instead of the stacked branch.
- \`RotateIdentity\` now rotates both keys atomically (was single-key).
- \`PendingSessions.Clear()\` docstring notes it clears "old DecryptKey"-encrypted deliveries.
- Test updated to assert split-key rotation semantics.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)