### PR TITLE
fix(relay): refuse OAuth IPC during rotation + doc cleanup (#144 + #143 + #145)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1304,9 +1304,13 @@ curl http://localhost:8080/api/runs/<run-id>
 # Stream live logs for a running task
 curl http://localhost:8080/api/runs/<run-id>/stream   # Server-Sent Events
 
-# Generate a task from a prompt
-curl -X POST http://localhost:8080/api/ai/generate \
+# Ask the configured AI task (default: buildin/dicodai) to generate a task
+# Requires an authenticated session cookie — easier via the CLI:
+#   dicode ai "ping my API every 5 minutes"
+# Or the REST API once logged in:
+curl -X POST http://localhost:8080/api/ai/chat \
   -H "Content-Type: application/json" \
+  -H "Cookie: dicode_secrets_sess=<your-session>" \
   -d '{"prompt": "ping my API every 5 minutes"}'
 
 # Force an immediate git sync

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -511,6 +511,7 @@ Commands:
   secrets list                    list secret keys
   secrets set <key> <value>       store a secret
   secrets delete <key>            delete a secret
+  relay trust-broker --yes        clear the pinned broker signing key (TOFU re-pin on reconnect)
   relay rotate-identity --yes     rotate the daemon's relay identity (irreversible)
   version                         print version
 `)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -268,6 +268,15 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 				// succeeds so the IPC layer starts refusing dicode.oauth.*
 				// immediately. A failed rotation leaves the flag clear,
 				// keeping OAuth flows working against the unchanged identity.
+				//
+				// Trade-off: there is a sub-microsecond window between
+				// RotateIdentity returning nil and Store(true) below where
+				// a concurrent OAuth IPC call could pass the gate and get a
+				// URL signed under the old identity. Flipping the flag first
+				// would require rolling back on error (re-setting to false);
+				// the current order trades that race for simpler failure
+				// semantics. Do not move the Store earlier without adding
+				// the rollback path.
 				dropped := pending.Clear()
 				oldUUID := id.UUID
 				newID, err := relay.RotateIdentity(ctx, database)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 
 	"github.com/dicode/dicode/pkg/config"
@@ -218,9 +219,19 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 			// pre-split brokers advertise protocol < 2, in which case the
 			// IPC layer refuses OAuth flows with a clear operator error
 			// rather than silently failing to decrypt the delivery.
+			//
+			// rotationActive (issue #144) is flipped true by the rotator
+			// closure below after `relay.RotateIdentity` succeeds. Until
+			// the daemon restarts (which reconstructs denoRT and re-reads
+			// Identity), the in-memory `id` still points at the OLD keys;
+			// the IPC layer refuses new OAuth flows so the operator isn't
+			// silently handed URLs signed under the identity they just
+			// retired.
 			pending := relay.NewPendingSessions()
+			var rotationActive atomic.Bool
+			rotationActiveFn := func() bool { return rotationActive.Load() }
 			if brokerURL := deriveBrokerBaseURL(cfg.Relay.ServerURL); brokerURL != "" {
-				denoRT.SetOAuthBroker(id, brokerURL, pending, rc.BrokerPubkey, rc.SupportsOAuth)
+				denoRT.SetOAuthBroker(id, brokerURL, pending, rc.BrokerPubkey, rc.SupportsOAuth, rotationActiveFn)
 			} else {
 				log.Warn("relay: could not derive broker base URL from server_url — OAuth broker disabled",
 					zap.String("server_url", cfg.Relay.ServerURL),
@@ -252,12 +263,18 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 				// until a restart. This is the hazard relayRotateWarning
 				// calls out — the rotation point is "DB + pending cutover";
 				// the running-connection cutover is at restart.
+				//
+				// rotationActive (issue #144) flips true AFTER the DB swap
+				// succeeds so the IPC layer starts refusing dicode.oauth.*
+				// immediately. A failed rotation leaves the flag clear,
+				// keeping OAuth flows working against the unchanged identity.
 				dropped := pending.Clear()
 				oldUUID := id.UUID
 				newID, err := relay.RotateIdentity(ctx, database)
 				if err != nil {
 					return "", err
 				}
+				rotationActive.Store(true)
 				log.Warn("relay identity rotated",
 					zap.String("old_uuid", oldUUID),
 					zap.String("new_uuid", newID.UUID),

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -533,14 +533,17 @@ func (cs *ControlServer) handleRelayRotate(ctx context.Context) (any, error) {
 }
 
 // relayRotateWarning is the operator-facing message surfaced to the CLI after
-// a successful rotation. It documents the two non-obvious consequences:
-// (a) UUID invalidation breaks every shared webhook URL, and (b) the still-
+// a successful rotation. It documents the three non-obvious consequences:
+// (a) UUID invalidation breaks every shared webhook URL, (b) the still-
 // connected WSS session holds the OLD identity in memory until the daemon is
-// restarted, so a stolen old key remains impersonation-capable for that window.
+// restarted (so a stolen old key remains impersonation-capable for that
+// window), and (c) dicode.oauth.* IPC is now refused until restart (issue
+// #144) to avoid handing out new URLs signed under the retired identity.
 const relayRotateWarning = "Old UUID is permanently invalidated. " +
 	"Any public webhook URLs you previously shared under the old UUID will stop working. " +
 	"IMPORTANT: the running relay WSS connection still uses the old key in memory. " +
 	"An attacker who has the old key can impersonate this daemon until you restart. " +
+	"dicode.oauth.build_auth_url / store_token are refused until the daemon restarts. " +
 	"Restart the daemon now to complete the rotation."
 
 // triggerLabel returns a human-readable trigger description for a task spec.

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -30,7 +30,11 @@ const oauthBrokerProtocolErr = "ipc: broker does not support split-key OAuth —
 // holds the OLD in-memory Identity pointer, so a new flow would be issued
 // under the old SignKey — contradicting the rotation contract. Refuse here
 // and tell the operator exactly what to do.
-const oauthRotationInProgressErr = "ipc: relay rotation in progress — restart the daemon to complete rotation before issuing new OAuth URLs"
+//
+// Covers both build_auth_url (would sign a URL under the old key) and
+// store_token (would persist a token that was encrypted to the old
+// DecryptKey by the mid-flight broker session).
+const oauthRotationInProgressErr = "ipc: relay rotation in progress — restart the daemon to complete rotation before issuing or accepting OAuth tokens"
 
 // Server is a per-run Unix socket server that bridges a task subprocess and
 // the Go host using the unified IPC protocol.
@@ -603,6 +607,20 @@ func (s *Server) handleConn(conn net.Conn) {
 				reply(req.ID, nil, "ipc: oauth broker not configured on this daemon")
 				continue
 			}
+			// Issue #144: refuse after `dicode relay rotate-identity` has
+			// swapped the DB keys. The in-memory s.oauthID still points at
+			// the OLD SignKey until the daemon restarts; issuing a new
+			// URL under it would contradict the rotation contract the
+			// operator just signed off on.
+			//
+			// Checked BEFORE the #104 protocol gate because rotation-in-
+			// progress is the more immediate actionable condition (restart
+			// the daemon) — telling the operator to "upgrade dicode-relay"
+			// when they've just run `rotate-identity` would be misleading.
+			if s.rotationActiveFn != nil && s.rotationActiveFn() {
+				reply(req.ID, nil, oauthRotationInProgressErr)
+				continue
+			}
 			// Issue #104: refuse OAuth flows when the connected broker has not
 			// advertised protocol >= 2. A pre-split broker would encrypt the
 			// delivery to the SignKey pubkey, which DecryptOAuthToken cannot
@@ -612,15 +630,6 @@ func (s *Server) handleConn(conn net.Conn) {
 			// actionable operator message.
 			if s.supportsOAuthFn != nil && !s.supportsOAuthFn() {
 				reply(req.ID, nil, oauthBrokerProtocolErr)
-				continue
-			}
-			// Issue #144: refuse after `dicode relay rotate-identity` has
-			// swapped the DB keys. The in-memory s.oauthID still points at
-			// the OLD SignKey until the daemon restarts; issuing a new
-			// URL under it would contradict the rotation contract the
-			// operator just signed off on.
-			if s.rotationActiveFn != nil && s.rotationActiveFn() {
-				reply(req.ID, nil, oauthRotationInProgressErr)
 				continue
 			}
 			if req.Provider == "" {
@@ -652,20 +661,22 @@ func (s *Server) handleConn(conn net.Conn) {
 				reply(req.ID, nil, "ipc: oauth broker not configured on this daemon")
 				continue
 			}
+			// Issue #144: refuse delivery after rotation. A post-rotation
+			// delivery was issued under the old SignKey and encrypted to
+			// the old DecryptKey; accepting it here would persist a token
+			// tied to an identity the operator has explicitly retired.
+			// Checked before the #104 protocol gate — see the rationale on
+			// build_auth_url above.
+			if s.rotationActiveFn != nil && s.rotationActiveFn() {
+				reply(req.ID, nil, oauthRotationInProgressErr)
+				continue
+			}
 			// Issue #104 — see the note on dicode.oauth.build_auth_url.
 			// Reject store_token against a pre-split broker so a stale
 			// session delivered just after a downgrade can't coerce a
 			// mismatched-key decrypt attempt.
 			if s.supportsOAuthFn != nil && !s.supportsOAuthFn() {
 				reply(req.ID, nil, oauthBrokerProtocolErr)
-				continue
-			}
-			// Issue #144: refuse delivery after rotation. A post-rotation
-			// delivery was issued under the old SignKey and encrypted to
-			// the old DecryptKey; accepting it here would persist a token
-			// tied to an identity the operator has explicitly retired.
-			if s.rotationActiveFn != nil && s.rotationActiveFn() {
-				reply(req.ID, nil, oauthRotationInProgressErr)
 				continue
 			}
 			if s.secrets == nil {

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -24,6 +24,14 @@ import (
 // the fix so operators know what to upgrade without digging through logs.
 const oauthBrokerProtocolErr = "ipc: broker does not support split-key OAuth — upgrade dicode-relay to protocol >= 2"
 
+// oauthRotationInProgressErr is the operator-facing error returned when a task
+// invokes dicode.oauth.* after `dicode relay rotate-identity` has swapped the
+// DB keys but the daemon has not yet been restarted. The rotated daemon still
+// holds the OLD in-memory Identity pointer, so a new flow would be issued
+// under the old SignKey — contradicting the rotation contract. Refuse here
+// and tell the operator exactly what to do.
+const oauthRotationInProgressErr = "ipc: relay rotation in progress — restart the daemon to complete rotation before issuing new OAuth URLs"
+
 // Server is a per-run Unix socket server that bridges a task subprocess and
 // the Go host using the unified IPC protocol.
 //
@@ -34,19 +42,20 @@ type Server struct {
 	taskID string
 	secret []byte // daemon-level HMAC secret for token verification
 
-	registry        *registry.Registry
-	db              db.DB
-	params          map[string]string
-	input           any
-	spec            *task.Spec
-	engine          EngineRunner
-	secrets         secrets.Manager        // optional; enables dicode.secrets_set / dicode.secrets_delete
-	oauthID         *relay.Identity        // optional; enables dicode.oauth.* for the auth built-ins
-	oauthURL        string                 // broker base URL, e.g. "https://relay.dicode.app"
-	oauthPending    *relay.PendingSessions // tracks outstanding /auth/:provider flows by session id
-	brokerPubkeyFn  func() string          // returns the TOFU-pinned broker pubkey (base64 SPKI DER)
-	supportsOAuthFn func() bool            // issue #104: reports broker protocol >= 2; nil means unchecked
-	log             *zap.Logger
+	registry         *registry.Registry
+	db               db.DB
+	params           map[string]string
+	input            any
+	spec             *task.Spec
+	engine           EngineRunner
+	secrets          secrets.Manager        // optional; enables dicode.secrets_set / dicode.secrets_delete
+	oauthID          *relay.Identity        // optional; enables dicode.oauth.* for the auth built-ins
+	oauthURL         string                 // broker base URL, e.g. "https://relay.dicode.app"
+	oauthPending     *relay.PendingSessions // tracks outstanding /auth/:provider flows by session id
+	brokerPubkeyFn   func() string          // returns the TOFU-pinned broker pubkey (base64 SPKI DER)
+	supportsOAuthFn  func() bool            // issue #104: reports broker protocol >= 2; nil means unchecked
+	rotationActiveFn func() bool            // issue #144: reports whether a relay-identity rotation has started; nil means unchecked
+	log              *zap.Logger
 
 	gateway *Gateway // optional; enables http.register for daemon tasks
 
@@ -129,12 +138,20 @@ func (s *Server) SetSecrets(m secrets.Manager) { s.secrets = m }
 // rather than silently failing at decrypt time. Passing nil leaves the IPC
 // path unchecked — appropriate for test fixtures that don't run a full
 // relay client.
-func (s *Server) SetOAuthBroker(id *relay.Identity, baseURL string, pending *relay.PendingSessions, brokerPubkeyFn func() string, supportsOAuthFn func() bool) {
+//
+// rotationActiveFn (issue #144) is consulted alongside supportsOAuthFn. If
+// non-nil and it returns true, the same two OAuth methods are refused with
+// an error telling the operator to restart the daemon to complete the
+// rotation. Lives on the daemon (not the per-run Server) because Servers
+// are recreated per task invocation but the rotation state persists for
+// the daemon process lifetime.
+func (s *Server) SetOAuthBroker(id *relay.Identity, baseURL string, pending *relay.PendingSessions, brokerPubkeyFn func() string, supportsOAuthFn func() bool, rotationActiveFn func() bool) {
 	s.oauthID = id
 	s.oauthURL = baseURL
 	s.oauthPending = pending
 	s.brokerPubkeyFn = brokerPubkeyFn
 	s.supportsOAuthFn = supportsOAuthFn
+	s.rotationActiveFn = rotationActiveFn
 }
 
 // Start creates the Unix socket and begins accepting connections.
@@ -597,6 +614,15 @@ func (s *Server) handleConn(conn net.Conn) {
 				reply(req.ID, nil, oauthBrokerProtocolErr)
 				continue
 			}
+			// Issue #144: refuse after `dicode relay rotate-identity` has
+			// swapped the DB keys. The in-memory s.oauthID still points at
+			// the OLD SignKey until the daemon restarts; issuing a new
+			// URL under it would contradict the rotation contract the
+			// operator just signed off on.
+			if s.rotationActiveFn != nil && s.rotationActiveFn() {
+				reply(req.ID, nil, oauthRotationInProgressErr)
+				continue
+			}
 			if req.Provider == "" {
 				reply(req.ID, nil, "ipc: provider required")
 				continue
@@ -632,6 +658,14 @@ func (s *Server) handleConn(conn net.Conn) {
 			// mismatched-key decrypt attempt.
 			if s.supportsOAuthFn != nil && !s.supportsOAuthFn() {
 				reply(req.ID, nil, oauthBrokerProtocolErr)
+				continue
+			}
+			// Issue #144: refuse delivery after rotation. A post-rotation
+			// delivery was issued under the old SignKey and encrypted to
+			// the old DecryptKey; accepting it here would persist a token
+			// tied to an identity the operator has explicitly retired.
+			if s.rotationActiveFn != nil && s.rotationActiveFn() {
+				reply(req.ID, nil, oauthRotationInProgressErr)
 				continue
 			}
 			if s.secrets == nil {

--- a/pkg/ipc/server_oauth_test.go
+++ b/pkg/ipc/server_oauth_test.go
@@ -76,8 +76,9 @@ func startOAuthServer(t *testing.T) *oauthEnv {
 	pending := relay.NewPendingSessions()
 	secretsMgr := newMemSecrets()
 	// supportsOAuthFn=nil so existing tests that pre-date #104 still exercise
-	// the happy path without having to fake a handshake.
-	srv.SetOAuthBroker(identity, "https://relay.dicode.app", pending, nil, nil)
+	// the happy path without having to fake a handshake. rotationActiveFn=nil
+	// leaves the #144 gate unchecked for the same reason.
+	srv.SetOAuthBroker(identity, "https://relay.dicode.app", pending, nil, nil, nil)
 	srv.SetSecrets(secretsMgr)
 
 	socketPath, token, err := srv.Start(context.Background())
@@ -141,7 +142,7 @@ func TestServer_OAuth_BuildAuthURL_DeniedWithoutInit(t *testing.T) {
 	spec := specWithDicode("leaky", &task.DicodePermissions{OAuthStore: true})
 	runID := fmt.Sprintf("test-%d", time.Now().UnixNano())
 	srv := New(runID, spec.ID, env.secret, env.reg, env.db, nil, nil, zap.NewNop(), spec, nil)
-	srv.SetOAuthBroker(newOAuthIdentity(t), "https://relay.dicode.app", relay.NewPendingSessions(), nil, nil)
+	srv.SetOAuthBroker(newOAuthIdentity(t), "https://relay.dicode.app", relay.NewPendingSessions(), nil, nil, nil)
 	socketPath, token, err := srv.Start(context.Background())
 	if err != nil {
 		t.Fatalf("Start: %v", err)
@@ -314,7 +315,7 @@ func TestServer_OAuth_RefusesWhenBrokerProtocolOld(t *testing.T) {
 	pending := relay.NewPendingSessions()
 	secretsMgr := newMemSecrets()
 	// supportsOAuthFn always false — simulating a broker still on protocol 1.
-	srv.SetOAuthBroker(id, "https://relay.dicode.app", pending, nil, func() bool { return false })
+	srv.SetOAuthBroker(id, "https://relay.dicode.app", pending, nil, func() bool { return false }, nil)
 	srv.SetSecrets(secretsMgr)
 
 	socketPath, token, err := srv.Start(context.Background())
@@ -356,6 +357,70 @@ func TestServer_OAuth_RefusesWhenBrokerProtocolOld(t *testing.T) {
 	}
 	if !strings.Contains(errStr2, "protocol") {
 		t.Fatalf("expected protocol error on store_token, got: %q", errStr2)
+	}
+}
+
+// TestServer_OAuth_RefusesWhenRotationInProgress covers issue #144: after
+// `dicode relay rotate-identity --yes` swaps the DB keys, the daemon's
+// in-memory Identity still points at the OLD SignKey/DecryptKey until the
+// process restarts. Issuing a new /auth URL under that identity would
+// contradict the rotation contract (operator was told the old identity is
+// dead). The IPC layer must refuse both OAuth methods with a clear
+// "restart required" error until the daemon cycles.
+func TestServer_OAuth_RefusesWhenRotationInProgress(t *testing.T) {
+	env := newTestEnv(t)
+	spec := specWithDicode("auth-relay", &task.DicodePermissions{OAuthInit: true, OAuthStore: true})
+	runID := fmt.Sprintf("test-%d", time.Now().UnixNano())
+	srv := New(runID, spec.ID, env.secret, env.reg, env.db, nil, nil, zap.NewNop(), spec, nil)
+
+	id := newOAuthIdentity(t)
+	pending := relay.NewPendingSessions()
+	secretsMgr := newMemSecrets()
+	// supportsOAuthFn returns true (broker is protocol-2); rotationActiveFn
+	// returns true (rotation has happened, daemon hasn't restarted).
+	srv.SetOAuthBroker(id, "https://relay.dicode.app", pending, nil,
+		func() bool { return true },
+		func() bool { return true },
+	)
+	srv.SetSecrets(secretsMgr)
+
+	socketPath, token, err := srv.Start(context.Background())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(srv.Stop)
+	conn := dial(t, socketPath)
+	t.Cleanup(func() { conn.Close() })
+	doHandshake(t, conn, token)
+
+	// build_auth_url must be refused with the rotation-in-progress message.
+	sendMsg(t, conn, map[string]any{"id": "1", "method": "dicode.oauth.build_auth_url", "provider": "slack"})
+	resp := recvMsg(t, conn)
+	errStr, _ := resp["error"].(string)
+	if errStr == "" {
+		t.Fatal("expected rotation-in-progress error, got none")
+	}
+	if !strings.Contains(errStr, "rotation") || !strings.Contains(errStr, "restart") {
+		t.Fatalf("expected operator-actionable rotation error, got: %q", errStr)
+	}
+	// Gate must be pre-enqueue — no pending session added.
+	if pending.Len() != 0 {
+		t.Fatalf("pending session unexpectedly registered during rotation: len=%d", pending.Len())
+	}
+
+	// store_token must also refuse, short-circuiting before any decrypt.
+	sendMsg(t, conn, map[string]any{
+		"id":       "2",
+		"method":   "dicode.oauth.store_token",
+		"envelope": json.RawMessage(`{}`),
+	})
+	resp2 := recvMsg(t, conn)
+	errStr2, _ := resp2["error"].(string)
+	if errStr2 == "" {
+		t.Fatal("expected rotation-in-progress error on store_token, got none")
+	}
+	if !strings.Contains(errStr2, "rotation") {
+		t.Fatalf("expected rotation error on store_token, got: %q", errStr2)
 	}
 }
 

--- a/pkg/ipc/server_oauth_test.go
+++ b/pkg/ipc/server_oauth_test.go
@@ -424,6 +424,59 @@ func TestServer_OAuth_RefusesWhenRotationInProgress(t *testing.T) {
 	}
 }
 
+// TestServer_OAuth_RotationErrorOutranksProtocolError verifies the gate
+// priority documented on build_auth_url: when a daemon is mid-rotation AND
+// connected to a broker on an old protocol, the operator sees the rotation
+// error (the actionable one — restart the daemon) rather than the protocol
+// error (true but misleading — "upgrade dicode-relay" is not the fix).
+// Mirrors TestServer_OAuth_RefusesWhenRotationInProgress but with
+// supportsOAuthFn=false so both gates would fire on their own.
+func TestServer_OAuth_RotationErrorOutranksProtocolError(t *testing.T) {
+	env := newTestEnv(t)
+	spec := specWithDicode("auth-relay", &task.DicodePermissions{OAuthInit: true, OAuthStore: true})
+	runID := fmt.Sprintf("test-%d", time.Now().UnixNano())
+	srv := New(runID, spec.ID, env.secret, env.reg, env.db, nil, nil, zap.NewNop(), spec, nil)
+
+	id := newOAuthIdentity(t)
+	pending := relay.NewPendingSessions()
+	secretsMgr := newMemSecrets()
+	// Both gates would refuse independently. Rotation must win.
+	srv.SetOAuthBroker(id, "https://relay.dicode.app", pending, nil,
+		func() bool { return false }, // supportsOAuthFn — would trip the #104 gate
+		func() bool { return true },  // rotationActiveFn — would trip the #144 gate
+	)
+	srv.SetSecrets(secretsMgr)
+
+	socketPath, token, err := srv.Start(context.Background())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(srv.Stop)
+	conn := dial(t, socketPath)
+	t.Cleanup(func() { conn.Close() })
+	doHandshake(t, conn, token)
+
+	for _, method := range []string{"dicode.oauth.build_auth_url", "dicode.oauth.store_token"} {
+		sendMsg(t, conn, map[string]any{
+			"id":       method,
+			"method":   method,
+			"provider": "slack",
+			"envelope": json.RawMessage(`{}`),
+		})
+		resp := recvMsg(t, conn)
+		errStr, _ := resp["error"].(string)
+		if errStr == "" {
+			t.Fatalf("%s: expected refusal, got none", method)
+		}
+		if !strings.Contains(errStr, "rotation") {
+			t.Fatalf("%s: expected rotation error to outrank protocol error, got: %q", method, errStr)
+		}
+		if strings.Contains(errStr, "upgrade dicode-relay") {
+			t.Fatalf("%s: rotation should win over protocol gate, got protocol error: %q", method, errStr)
+		}
+	}
+}
+
 // sealForDaemon mirrors dicode-relay src/broker/crypto.ts eciesEncrypt.
 // Post-#104 the broker encrypts against the daemon's DecryptKey pubkey —
 // mirror that here so the test actually exercises the production code path.

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -69,20 +69,21 @@ type RunResult struct {
 
 // Runtime executes task scripts with Deno.
 type Runtime struct {
-	registry        *registry.Registry
-	secrets         secrets.Chain
-	secretsManager  secrets.Manager // optional; wired for dicode.secrets_set/delete
-	db              db.DB
-	log             *zap.Logger
-	denoPath        string
-	secret          []byte
-	engine          ipc.EngineRunner
-	gateway         *ipc.Gateway
-	oauthIdentity   *relay.Identity
-	oauthURL        string
-	oauthPending    *relay.PendingSessions
-	brokerPubkeyFn  func() string
-	supportsOAuthFn func() bool
+	registry         *registry.Registry
+	secrets          secrets.Chain
+	secretsManager   secrets.Manager // optional; wired for dicode.secrets_set/delete
+	db               db.DB
+	log              *zap.Logger
+	denoPath         string
+	secret           []byte
+	engine           ipc.EngineRunner
+	gateway          *ipc.Gateway
+	oauthIdentity    *relay.Identity
+	oauthURL         string
+	oauthPending     *relay.PendingSessions
+	brokerPubkeyFn   func() string
+	supportsOAuthFn  func() bool
+	rotationActiveFn func() bool
 }
 
 // New creates a Deno Runtime. It ensures the Deno binary is present in the
@@ -122,12 +123,20 @@ func (rt *Runtime) SetSecretsManager(m secrets.Manager) { rt.secretsManager = m 
 // real relay.Client). In production the daemon wires rc.SupportsOAuth so
 // that an old broker cleanly disables the OAuth flows instead of silently
 // failing to decrypt.
-func (rt *Runtime) SetOAuthBroker(id *relay.Identity, baseURL string, pending *relay.PendingSessions, brokerPubkeyFn func() string, supportsOAuthFn func() bool) {
+//
+// rotationActiveFn (issue #144) is an optional predicate reporting whether
+// a `dicode relay rotate-identity` has swapped the DB keys. The in-memory
+// Identity passed here is NOT replaced by rotation; until the daemon
+// restarts, signing a new auth URL under it would contradict the operator's
+// stated intent. Non-nil + true refuses the OAuth IPC methods with an
+// actionable error. Nil leaves the path unchecked (test fixtures).
+func (rt *Runtime) SetOAuthBroker(id *relay.Identity, baseURL string, pending *relay.PendingSessions, brokerPubkeyFn func() string, supportsOAuthFn func() bool, rotationActiveFn func() bool) {
 	rt.oauthIdentity = id
 	rt.oauthURL = baseURL
 	rt.oauthPending = pending
 	rt.brokerPubkeyFn = brokerPubkeyFn
 	rt.supportsOAuthFn = supportsOAuthFn
+	rt.rotationActiveFn = rotationActiveFn
 }
 
 // Run executes a task script and returns the result.
@@ -217,7 +226,7 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	srv.SetGateway(rt.gateway)
 	srv.SetSecrets(rt.secretsManager)
 	if rt.oauthIdentity != nil {
-		srv.SetOAuthBroker(rt.oauthIdentity, rt.oauthURL, rt.oauthPending, rt.brokerPubkeyFn, rt.supportsOAuthFn)
+		srv.SetOAuthBroker(rt.oauthIdentity, rt.oauthURL, rt.oauthPending, rt.brokerPubkeyFn, rt.supportsOAuthFn, rt.rotationActiveFn)
 	}
 	socketPath, token, err := srv.Start(execCtx)
 	if err != nil {


### PR DESCRIPTION
Bundles three issues surfaced by the post-#141 gap analysis. #144 is the real work; #143 and #145 are ≤5-line doc cleanups riding along because the \`relayRotateWarning\` update in #144 already touches the same user-facing narrative.

Closes #144, #143, #145.

## #144 (P1) — rotation IPC gate

### Problem

After \`dicode relay rotate-identity --yes\`:
- DB rows (\`relay.private_key\` + \`relay.decrypt_private_key\`) are atomically swapped
- \`pending.Clear()\` drops in-flight OAuth sessions
- \`relayRotateWarning\` tells the operator \"restart the daemon to complete the rotation\"

But the in-memory \`*Identity\` pointer captured in \`denoRT.SetOAuthBroker(id, ...)\` is NOT replaced. Until the operator actually restarts, a task calling \`dicode.oauth.build_auth_url\` succeeds and returns a URL signed under the OLD SignKey. The broker still has the OLD UUID → pubkey mapping (WSS connection unchanged), so the URL works — a new OAuth flow completes under the identity the operator just retired.

### Fix

- \`pkg/daemon/daemon.go\` owns an \`atomic.Bool\` flipped by the rotator closure after \`relay.RotateIdentity\` succeeds. Predicate closure over it plumbs to denoRT.
- \`pkg/runtime/deno/runtime.go\` → \`pkg/ipc/server.go\`: new \`rotationActiveFn func() bool\` parameter on \`SetOAuthBroker\` (6th arg), consulted in both \`dicode.oauth.build_auth_url\` and \`dicode.oauth.store_token\` alongside the existing \`supportsOAuthFn\` (#104) gate.
- Refusal error: \`ipc: relay rotation in progress — restart the daemon to complete rotation before issuing new OAuth URLs\`. Actionable operator message, same shape as the #104 protocol-version refusal.
- \`relayRotateWarning\` updated to mention the OAuth refusal.

### Test

New \`TestServer_OAuth_RefusesWhenRotationInProgress\` in \`pkg/ipc/server_oauth_test.go\`, mirroring \`TestServer_OAuth_RefusesWhenBrokerProtocolOld\`. Asserts:
- \`build_auth_url\` returns the rotation-in-progress error
- \`pending\` store not touched (gate is pre-enqueue)
- \`store_token\` also refuses, short-circuiting before decrypt

## #143 (P2) — README stale \`/api/ai/generate\` example

#134 removed \`/api/ai/*\`; #140 reintroduced \`/api/ai/chat\` with a new shape (auth required, \`{prompt, session_id?, task?}\`). Swapped the dead curl for one pointing at the new endpoint, with \`dicode ai \"...\"\` CLI reference as the more ergonomic alternative.

## #145 (P2) — CLI \`usage()\` omits \`trust-broker\`

The \`relay\` namespace has both \`trust-broker\` and \`rotate-identity\`; \`usage()\` only listed the latter. Added a one-line row for \`trust-broker\` so operators who are told to run it (e.g. by the broker-pin-mismatch log message) can confirm it's a real subcommand.

## Test plan

- [x] \`go vet ./...\` — clean
- [x] \`go test ./... -race -count=1 -timeout 300s\` — all 15 packages green
- [x] \`make build\` — clean
- [x] New test asserts rotation-gate refusal on both OAuth IPC methods
- [x] Existing \`TestServer_OAuth_RefusesWhenBrokerProtocolOld\` still passes (same \`SetOAuthBroker\` shape, just one more param)

🤖 Generated with [Claude Code](https://claude.com/claude-code)