### PR TITLE
fix(buildin): restore auth-start + auth-relay to working order (#147)

### DIFF
--- a/tasks/buildin/auth-relay/task.ts
+++ b/tasks/buildin/auth-relay/task.ts
@@ -6,7 +6,7 @@
 // secrets. The plaintext credentials are never returned to JS — the IPC
 // call only reports which secret names were written.
 
-export default async function main() {
+export default async function main({ input, dicode }: DicodeSdk) {
   // input is the decoded webhook request body; the relay broker always
   // sends a JSON OAuthTokenDeliveryPayload, so trust the shape.
   const envelope = input;

--- a/tasks/buildin/auth-start/task.ts
+++ b/tasks/buildin/auth-start/task.ts
@@ -5,7 +5,7 @@
 // so this task cannot be coaxed into signing a payload of the wrong shape.
 // It only gets to pick the provider and an optional scope override.
 
-export default async function main() {
+export default async function main({ params, dicode, output }: DicodeSdk) {
   const provider = (await params.get("provider")) ?? "";
   const scope = (await params.get("scope")) ?? "";
   if (!provider) throw new Error("provider parameter is required");


### PR DESCRIPTION
Closes #147. Two-line fix — destructure the DicodeSdk arg in both auth-* buildins so they stop failing with \`ReferenceError: params is not defined\`.

## Summary

\`tasks/buildin/auth-start/task.ts\` and \`tasks/buildin/auth-relay/task.ts\` both still used pre-#70 SDK bare globals in \`main()\`. The current Deno runtime doesn't inject those globals — it passes a \`DicodeSdk\` object to \`main(...)\`. Every invocation of either task failed on the first \`params.get(...)\` or \`input\` reference.

Fix:

\`\`\`ts
// auth-start/task.ts
export default async function main({ params, dicode, output }: DicodeSdk) { ... }

// auth-relay/task.ts
export default async function main({ input, dicode }: DicodeSdk) { ... }
\`\`\`

Matches every other working buildin (notify, alert, tray, temp-cleanup).

## Impact

**Unblocks Lane 2 of the alpha epic [#82](https://github.com/dicode-ayo/dicode-core/issues/82)**. Every OAuth provider flow runs through these two tasks; without this they don't run at all. [#83](https://github.com/dicode-ayo/dicode-core/issues/83), [#84](https://github.com/dicode-ayo/dicode-core/issues/84), [#86](https://github.com/dicode-ayo/dicode-core/issues/86) all depend on these working.

## Test plan

- [x] \`go test ./... -race -count=1\` — unchanged (no Go code touched); still green
- [x] **Manual E2E** against a local dicode-relay broker:
  - Start relay on :5553, start daemon
  - \`./dicode run buildin/auth-start provider=slack\` — before fix: \`ReferenceError\` at line 9; after fix: returns signed URL + session_id cleanly (verified with the daemon's real \`dicode.oauth.build_auth_url\` IPC path, which is also gated by #104 protocol + #144 rotation flag)
- [ ] \`auth-relay\` end-to-end needs a real broker delivery to fully exercise — the signature fix is mechanical and matches the working-buildin pattern, so I'm confident it compiles and runs, but a full delivery test requires a provider with real creds. Tracked as part of #86.

## Why CI missed it

Unit tests in \`pkg/ipc/server_oauth_test.go\` exercise the IPC dispatch via mock clients, not through the Deno runtime. The runtime-level \`task.ts\` execution was never exercised in CI. This class of gap is what #127 (test coverage) and #136 (e2e) exist to close — #99 already tracks the missing Deno test harness for \`tasks/buildin/*/task.test.ts\`.

## Discovery

Surfaced during the PR #146 E2E smoke, where I tried to use \`auth-start\` to probe the rotation gate and had to fall back to a throwaway \`probe-oauth\` task because \`auth-start\` couldn't be invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)