### PR TITLE
feat(config,runtime): add RelayConfig.BrokerURL + inject DICODE_BROKER_URL (#84)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,32 @@ type ExecutionConfig struct {
 type RelayConfig struct {
 	Enabled   bool   `yaml:"enabled"`
 	ServerURL string `yaml:"server_url"` // wss://relay.dicode.app
+	// BrokerURL overrides the OAuth broker base URL. When empty, the daemon
+	// derives it from ServerURL by swapping the scheme (wss://host →
+	// https://host). Set this when the broker runs on a different host than
+	// the WSS relay endpoint, or during local development to point at a
+	// broker on a non-TLS port (e.g. http://localhost:5553). Must be http://
+	// or https:// when set.
+	BrokerURL string `yaml:"broker_url,omitempty"`
+}
+
+// ResolvedBrokerURL returns the HTTP(S) OAuth broker base URL that the
+// daemon should use for signing /auth URLs and receiving ECIES-encrypted
+// token deliveries. If BrokerURL is set it wins; otherwise the URL is
+// derived from ServerURL. Returns empty when neither yields a usable URL —
+// the daemon treats that as "OAuth broker disabled".
+func (r RelayConfig) ResolvedBrokerURL() string {
+	if r.BrokerURL != "" {
+		return r.BrokerURL
+	}
+	switch {
+	case strings.HasPrefix(r.ServerURL, "wss://"):
+		return "https://" + strings.TrimPrefix(r.ServerURL, "wss://")
+	case strings.HasPrefix(r.ServerURL, "ws://"):
+		return "http://" + strings.TrimPrefix(r.ServerURL, "ws://")
+	default:
+		return ""
+	}
 }
 
 // AIConfig points the WebUI and CLI at a single task for AI operations.
@@ -317,6 +343,12 @@ func (cfg *Config) validate() error {
 			return fmt.Errorf("sources[%d]: type is required (git or local)", i)
 		default:
 			return fmt.Errorf("sources[%d]: unknown type %q (valid: git, local)", i, s.Type)
+		}
+	}
+	if cfg.Relay.BrokerURL != "" {
+		if !strings.HasPrefix(cfg.Relay.BrokerURL, "http://") &&
+			!strings.HasPrefix(cfg.Relay.BrokerURL, "https://") {
+			return fmt.Errorf("relay.broker_url: must start with http:// or https://, got %q", cfg.Relay.BrokerURL)
 		}
 	}
 	return nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,18 +60,24 @@ type RelayConfig struct {
 // token deliveries. If BrokerURL is set it wins; otherwise the URL is
 // derived from ServerURL. Returns empty when neither yields a usable URL —
 // the daemon treats that as "OAuth broker disabled".
+//
+// The returned URL never has a trailing slash so callers can safely
+// concatenate `+ "/auth/" + provider` without producing a "//" double-
+// slash. Operators writing broker_url: https://host/ in dicode.yaml get
+// the slash stripped here.
 func (r RelayConfig) ResolvedBrokerURL() string {
-	if r.BrokerURL != "" {
-		return r.BrokerURL
-	}
+	var raw string
 	switch {
+	case r.BrokerURL != "":
+		raw = r.BrokerURL
 	case strings.HasPrefix(r.ServerURL, "wss://"):
-		return "https://" + strings.TrimPrefix(r.ServerURL, "wss://")
+		raw = "https://" + strings.TrimPrefix(r.ServerURL, "wss://")
 	case strings.HasPrefix(r.ServerURL, "ws://"):
-		return "http://" + strings.TrimPrefix(r.ServerURL, "ws://")
+		raw = "http://" + strings.TrimPrefix(r.ServerURL, "ws://")
 	default:
 		return ""
 	}
+	return strings.TrimRight(raw, "/")
 }
 
 // AIConfig points the WebUI and CLI at a single task for AI operations.
@@ -346,9 +353,15 @@ func (cfg *Config) validate() error {
 		}
 	}
 	if cfg.Relay.BrokerURL != "" {
-		if !strings.HasPrefix(cfg.Relay.BrokerURL, "http://") &&
-			!strings.HasPrefix(cfg.Relay.BrokerURL, "https://") {
-			return fmt.Errorf("relay.broker_url: must start with http:// or https://, got %q", cfg.Relay.BrokerURL)
+		u, err := url.Parse(cfg.Relay.BrokerURL)
+		if err != nil {
+			return fmt.Errorf("relay.broker_url: %w", err)
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return fmt.Errorf("relay.broker_url: must use http:// or https://, got scheme %q", u.Scheme)
+		}
+		if u.Host == "" {
+			return fmt.Errorf("relay.broker_url: missing host in %q", cfg.Relay.BrokerURL)
 		}
 	}
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -158,6 +158,29 @@ func TestResolvedBrokerURL_Override(t *testing.T) {
 	}
 }
 
+// TestResolvedBrokerURL_StripsTrailingSlash ensures callers can safely
+// concatenate "/auth/..." onto the returned URL without producing a "//"
+// double-slash, regardless of whether the operator put a trailing slash
+// in broker_url: or the derivation path happens to introduce one.
+func TestResolvedBrokerURL_StripsTrailingSlash(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		r    RelayConfig
+		want string
+	}{
+		{"override with trailing slash", RelayConfig{BrokerURL: "https://broker.dicode.app/"}, "https://broker.dicode.app"},
+		{"override with multiple trailing slashes", RelayConfig{BrokerURL: "https://broker.dicode.app///"}, "https://broker.dicode.app"},
+		{"derived: wss with trailing slash", RelayConfig{ServerURL: "wss://relay.dicode.app/"}, "https://relay.dicode.app"},
+		{"override without trailing slash unchanged", RelayConfig{BrokerURL: "https://broker.dicode.app"}, "https://broker.dicode.app"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.r.ResolvedBrokerURL(); got != tc.want {
+				t.Errorf("ResolvedBrokerURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestResolvedBrokerURL_DerivesFromServerURL covers the default path:
 // BrokerURL empty → swap ws[s] → http[s] on the ServerURL host.
 func TestResolvedBrokerURL_DerivesFromServerURL(t *testing.T) {
@@ -211,12 +234,15 @@ relay:
 }
 
 // TestLoad_RelayBrokerURL_RejectsMalformed covers the validator: anything
-// that's not http:// or https:// fails at Load() time with a clear error.
+// that's not http:// or https://, or missing a host, fails at Load() time
+// with a clear error.
 func TestLoad_RelayBrokerURL_RejectsMalformed(t *testing.T) {
 	for _, bad := range []string{
 		"broker.dicode.app",       // no scheme
 		"ftp://broker.dicode.app", // non-http scheme
 		"wss://broker.dicode.app", // WSS — user probably meant server_url
+		"https://",                // missing host
+		"http://",                 // missing host
 	} {
 		t.Run(bad, func(t *testing.T) {
 			dir := t.TempDir()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -142,6 +143,99 @@ sources:
 	}
 	if cfg.AI.Task != "examples/ai-agent-ollama" {
 		t.Errorf("AI.Task = %q, want %q", cfg.AI.Task, "examples/ai-agent-ollama")
+	}
+}
+
+// TestResolvedBrokerURL_Override exercises the explicit RelayConfig.BrokerURL
+// path: when set it wins over any derivation from ServerURL.
+func TestResolvedBrokerURL_Override(t *testing.T) {
+	r := RelayConfig{
+		ServerURL: "wss://relay.dicode.app",
+		BrokerURL: "https://oauth.dicode.app",
+	}
+	if got := r.ResolvedBrokerURL(); got != "https://oauth.dicode.app" {
+		t.Errorf("ResolvedBrokerURL() = %q, want override https://oauth.dicode.app", got)
+	}
+}
+
+// TestResolvedBrokerURL_DerivesFromServerURL covers the default path:
+// BrokerURL empty → swap ws[s] → http[s] on the ServerURL host.
+func TestResolvedBrokerURL_DerivesFromServerURL(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		serverURL string
+		want      string
+	}{
+		{"wss → https", "wss://relay.dicode.app", "https://relay.dicode.app"},
+		{"ws → http", "ws://localhost:5553", "http://localhost:5553"},
+		{"empty server_url → empty", "", ""},
+		{"http scheme rejected at derivation", "http://oops", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := RelayConfig{ServerURL: tc.serverURL}
+			if got := r.ResolvedBrokerURL(); got != tc.want {
+				t.Errorf("ResolvedBrokerURL(%q) = %q, want %q", tc.serverURL, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoad_RelayBrokerURL_Roundtrip ensures the BrokerURL field parses from
+// YAML and survives through Load() validation.
+func TestLoad_RelayBrokerURL_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+
+	content := `
+sources:
+  - type: local
+    path: ${CONFIGDIR}/tasks
+relay:
+  enabled: true
+  server_url: wss://relay.example.com
+  broker_url: https://broker.example.com
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Relay.BrokerURL != "https://broker.example.com" {
+		t.Errorf("Relay.BrokerURL = %q, want https://broker.example.com", cfg.Relay.BrokerURL)
+	}
+	if got := cfg.Relay.ResolvedBrokerURL(); got != "https://broker.example.com" {
+		t.Errorf("ResolvedBrokerURL() = %q, want the explicit broker_url", got)
+	}
+}
+
+// TestLoad_RelayBrokerURL_RejectsMalformed covers the validator: anything
+// that's not http:// or https:// fails at Load() time with a clear error.
+func TestLoad_RelayBrokerURL_RejectsMalformed(t *testing.T) {
+	for _, bad := range []string{
+		"broker.dicode.app",       // no scheme
+		"ftp://broker.dicode.app", // non-http scheme
+		"wss://broker.dicode.app", // WSS — user probably meant server_url
+	} {
+		t.Run(bad, func(t *testing.T) {
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "dicode.yaml")
+			content := fmt.Sprintf(`
+sources:
+  - type: local
+    path: ${CONFIGDIR}/tasks
+relay:
+  enabled: true
+  broker_url: %q
+`, bad)
+			if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Load(cfgPath); err == nil {
+				t.Errorf("Load(broker_url=%q): expected error, got nil", bad)
+			}
+		})
 	}
 }
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -230,12 +230,13 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 			pending := relay.NewPendingSessions()
 			var rotationActive atomic.Bool
 			rotationActiveFn := func() bool { return rotationActive.Load() }
-			if brokerURL := deriveBrokerBaseURL(cfg.Relay.ServerURL); brokerURL != "" {
+			if brokerURL := cfg.Relay.ResolvedBrokerURL(); brokerURL != "" {
 				denoRT.SetOAuthBroker(id, brokerURL, pending, rc.BrokerPubkey, rc.SupportsOAuth, rotationActiveFn)
 			} else {
-				log.Warn("relay: could not derive broker base URL from server_url — OAuth broker disabled",
+				log.Warn("relay: no broker URL (neither relay.broker_url nor a parsable relay.server_url) — OAuth broker disabled",
 					zap.String("server_url", cfg.Relay.ServerURL),
-					zap.String("expected_scheme", "wss:// or ws://"))
+					zap.String("broker_url", cfg.Relay.BrokerURL),
+					zap.String("hint", "set relay.broker_url: https://... in dicode.yaml, or use server_url: wss://..."))
 			}
 			g.Go(func() error { pending.StartSweep(ctx); return nil })
 			// Identity rotation via `dicode relay rotate-identity`. The
@@ -394,20 +395,6 @@ func buildRuntimes(
 	}
 
 	return managed, eng, denoRT, nil
-}
-
-// deriveBrokerBaseURL converts a relay WSS URL (e.g. wss://relay.dicode.app)
-// into the matching HTTPS broker base URL. Returns empty if the input scheme
-// is not ws/wss.
-func deriveBrokerBaseURL(wsURL string) string {
-	switch {
-	case strings.HasPrefix(wsURL, "wss://"):
-		return "https://" + strings.TrimPrefix(wsURL, "wss://")
-	case strings.HasPrefix(wsURL, "ws://"):
-		return "http://" + strings.TrimPrefix(wsURL, "ws://")
-	default:
-		return ""
-	}
 }
 
 func buildSecretsChain(cfg *config.Config, dataDir string, database db.DB, log *zap.Logger) (secrets.Chain, secrets.Manager) {

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -301,9 +301,9 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	}
 	runnerFile.Close()
 
-	args := buildDenoArgs(spec, socketPath, shimPath, runnerPath)
+	args := buildDenoArgs(spec, socketPath, shimPath, runnerPath, rt.oauthURL)
 	cmd := exec.CommandContext(execCtx, rt.denoPath, args...) //nolint:gosec
-	cmd.Env = buildEnv(resolved, socketPath, token)
+	cmd.Env = buildEnv(resolved, socketPath, token, rt.oauthURL)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -413,7 +413,7 @@ func expandHome(p string) string {
 	return p
 }
 
-func buildDenoArgs(spec *task.Spec, socketPath, shimPath, runnerPath string) []string {
+func buildDenoArgs(spec *task.Spec, socketPath, shimPath, runnerPath, brokerURL string) []string {
 	args := []string{"run"}
 
 	// Network: omit = unrestricted (--allow-net); empty list = deny all; named hosts = allowlist.
@@ -432,7 +432,13 @@ func buildDenoArgs(spec *task.Spec, socketPath, shimPath, runnerPath string) []s
 
 	// Env: always allow the internal IPC vars plus HOME/DENO_DIR/XDG_CACHE_HOME
 	// (required by deno.land/x/cache for vendored binary downloads).
+	// DICODE_BROKER_URL (issue #84) is daemon-provided infrastructure —
+	// auto-allowed when a broker URL is configured so auth tasks don't
+	// need to redeclare it in permissions.env.
 	envVars := []string{"DICODE_SOCKET", "DICODE_TOKEN", "HOME", "DENO_DIR", "XDG_CACHE_HOME"}
+	if brokerURL != "" {
+		envVars = append(envVars, "DICODE_BROKER_URL")
+	}
 	for _, e := range spec.Permissions.Env {
 		envVars = append(envVars, e.Name)
 	}
@@ -480,10 +486,16 @@ func buildDenoArgs(spec *task.Spec, socketPath, shimPath, runnerPath string) []s
 	return args
 }
 
-func buildEnv(resolved map[string]string, socketPath, token string) []string {
+func buildEnv(resolved map[string]string, socketPath, token, brokerURL string) []string {
 	// Inherit the host environment so Deno can locate its cache (DENO_DIR etc).
 	// The --allow-env flag separately controls which vars the JS script can read.
 	env := append(os.Environ(), "DICODE_SOCKET="+socketPath, "DICODE_TOKEN="+token)
+	// DICODE_BROKER_URL (issue #84) — daemon-resolved OAuth broker base URL.
+	// Injected only when configured so tasks can distinguish "broker disabled"
+	// from "broker at the default".
+	if brokerURL != "" {
+		env = append(env, "DICODE_BROKER_URL="+brokerURL)
+	}
 	for k, v := range resolved {
 		env = append(env, k+"="+v)
 	}

--- a/pkg/runtime/deno/runtime_test.go
+++ b/pkg/runtime/deno/runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -453,6 +454,71 @@ func TestRuntime_Timeout(t *testing.T) {
 	if r.Error == nil {
 		t.Fatal("expected timeout error")
 	}
+}
+
+// TestBuildEnv_InjectsBrokerURL covers issue #84: when the daemon has a
+// resolved broker URL, buildEnv must export it to the Deno subprocess as
+// DICODE_BROKER_URL. When empty (relay disabled or ServerURL unparsable),
+// the variable must NOT be present — tasks then distinguish "broker
+// disabled" from "broker at default" by checking Deno.env.get().
+func TestBuildEnv_InjectsBrokerURL(t *testing.T) {
+	t.Run("injected when non-empty", func(t *testing.T) {
+		env := buildEnv(nil, "/tmp/sock", "tok", "https://broker.dicode.app")
+		var found string
+		for _, kv := range env {
+			if strings.HasPrefix(kv, "DICODE_BROKER_URL=") {
+				found = kv
+				break
+			}
+		}
+		if found != "DICODE_BROKER_URL=https://broker.dicode.app" {
+			t.Errorf("expected DICODE_BROKER_URL injection, got %q among env", found)
+		}
+	})
+
+	t.Run("omitted when empty", func(t *testing.T) {
+		env := buildEnv(nil, "/tmp/sock", "tok", "")
+		for _, kv := range env {
+			if strings.HasPrefix(kv, "DICODE_BROKER_URL=") {
+				t.Errorf("DICODE_BROKER_URL must not be injected when broker URL is empty, got %q", kv)
+			}
+		}
+	})
+}
+
+// TestBuildDenoArgs_AllowsBrokerURL ensures DICODE_BROKER_URL is added to
+// --allow-env (auto-granted, like DICODE_SOCKET) when configured, so auth
+// tasks can Deno.env.get() it without declaring it in permissions.env.
+func TestBuildDenoArgs_AllowsBrokerURL(t *testing.T) {
+	spec := &task.Spec{
+		ID:      "probe",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+	}
+	findAllowEnv := func(args []string) string {
+		for _, a := range args {
+			if strings.HasPrefix(a, "--allow-env=") {
+				return a
+			}
+		}
+		return ""
+	}
+
+	t.Run("allowlist includes DICODE_BROKER_URL when set", func(t *testing.T) {
+		args := buildDenoArgs(spec, "/tmp/sock", "/tmp/shim", "/tmp/runner", "https://b")
+		allow := findAllowEnv(args)
+		if !strings.Contains(allow, "DICODE_BROKER_URL") {
+			t.Errorf("--allow-env must include DICODE_BROKER_URL when broker URL set, got %q", allow)
+		}
+	})
+
+	t.Run("allowlist omits DICODE_BROKER_URL when empty", func(t *testing.T) {
+		args := buildDenoArgs(spec, "/tmp/sock", "/tmp/shim", "/tmp/runner", "")
+		allow := findAllowEnv(args)
+		if strings.Contains(allow, "DICODE_BROKER_URL") {
+			t.Errorf("--allow-env must not include DICODE_BROKER_URL when unset, got %q", allow)
+		}
+	})
 }
 
 // mockSecretProvider for env tests.


### PR DESCRIPTION
Closes #84. First step of Lane 2 in [#82](https://github.com/dicode-ayo/dicode-core/issues/82) (OAuth broker E2E vertical).

## Summary

Tasks that initiate OAuth flows (\`tasks/auth/_oauth-app/task.ts\`, \`tasks/auth/openrouter-oauth/task.ts\`, etc.) need the broker base URL to build their own /auth/:provider URLs. The daemon already derives one from \`relay.server_url\` (\`wss://host\` → \`https://host\`) and passes it into its internal IPC, but tasks have no way to reach it without ad-hoc config parsing.

This PR:

1. Adds \`RelayConfig.BrokerURL\` — an explicit override for the derived URL. Useful when the broker runs on a different host than the WSS relay (e.g. local dev: \`ws://localhost:5553\` for relay, \`http://localhost:5553\` for broker — the derivation already handles this, so the override is mostly for split-host setups).
2. Adds \`RelayConfig.ResolvedBrokerURL()\` — single source of truth for "what broker do we point at". Explicit > derived > empty. Replaces \`pkg/daemon/daemon.go\`'s inline \`deriveBrokerBaseURL\` helper.
3. Injects the resolved URL into every Deno task as \`DICODE_BROKER_URL\`, auto-allowed via \`--allow-env\` alongside \`DICODE_SOCKET\`/\`DICODE_TOKEN\`. Tasks don't need to declare it in \`permissions.env\`.
4. Validates \`broker_url\` at \`Load()\` time — must be \`http://\` or \`https://\` when set; catches the common mistake of putting a \`wss://\` URL in the broker slot.

## Why auto-inject vs. opt-in

Mirrors the existing \`DICODE_SOCKET\`/\`DICODE_TOKEN\` pattern — these are daemon-provided infrastructure, not task secrets. The broker URL is derivable from config, so there's no operational reason for every auth task to redeclare it in \`permissions.env\` (unlike \`DICODE_BASE_URL\`, which is still operator-set and intentionally opt-in).

## Test plan

- [x] \`TestResolvedBrokerURL_Override\` — explicit \`BrokerURL\` wins over derived
- [x] \`TestResolvedBrokerURL_DerivesFromServerURL\` — wss→https, ws→http, empty / non-scheme → empty
- [x] \`TestLoad_RelayBrokerURL_Roundtrip\` — YAML parse + validation preserves the field
- [x] \`TestLoad_RelayBrokerURL_RejectsMalformed\` — validator rejects no-scheme, \`ftp://\`, \`wss://\` (the common slot-confusion)
- [x] \`TestBuildEnv_InjectsBrokerURL\` — injected when set, omitted when empty (distinguishes "broker at default" from "broker disabled")
- [x] \`TestBuildDenoArgs_AllowsBrokerURL\` — auto-added to \`--allow-env\` when set, absent when empty
- [x] \`go test ./... -race -count=1 -timeout 300s\` — 15/15 packages green
- [x] \`go vet ./...\` and \`gofmt -l .\` clean

## Rollout

Fully backward-compatible: existing \`dicode.yaml\` files with only \`relay.server_url\` set continue to work (the derivation produces the same result the old code did). New \`broker_url\` field is optional.

## Unblocks

- [#83](https://github.com/dicode-ayo/dicode-core/issues/83) — OAuth delivery handler: tasks can now find the broker without hardcoding.
- [#86](https://github.com/dicode-ayo/dicode-core/issues/86) — e2e test: can configure a local broker URL for integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)