### PR TITLE
test: mcp/client unit tests + fsnotify latency assertion (closes #37, partial #125)

### DIFF
--- a/pkg/mcp/client/client_test.go
+++ b/pkg/mcp/client/client_test.go
@@ -1,0 +1,191 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTestClient wires a Client to an httptest server. The client's baseURL is
+// the server's URL (the handler also handles the /mcp path the client POSTs to).
+func newTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("parse test server port: %v", err)
+	}
+	return New(port)
+}
+
+func TestListTools_Success(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/mcp" {
+			t.Errorf("path = %q, want /mcp", r.URL.Path)
+		}
+		var req rpcRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		if req.Method != "tools/list" {
+			t.Errorf("method = %q, want tools/list", req.Method)
+		}
+		_, _ = w.Write([]byte(`{
+			"jsonrpc":"2.0","id":1,
+			"result":{"tools":[
+				{"name":"add","description":"adds two ints"},
+				{"name":"echo","inputSchema":{"type":"object"}}
+			]}
+		}`))
+	})
+
+	tools, err := client.ListTools(context.Background())
+	if err != nil {
+		t.Fatalf("ListTools error: %v", err)
+	}
+	if len(tools) != 2 {
+		t.Fatalf("len(tools) = %d, want 2", len(tools))
+	}
+	if tools[0].Name != "add" || tools[0].Description != "adds two ints" {
+		t.Errorf("tool[0] = %+v, unexpected", tools[0])
+	}
+	if tools[1].Name != "echo" {
+		t.Errorf("tool[1].Name = %q, want echo", tools[1].Name)
+	}
+	if len(tools[1].InputSchema) == 0 {
+		t.Errorf("tool[1].InputSchema empty; want raw JSON passed through")
+	}
+}
+
+func TestListTools_RPCError(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found"}}`))
+	})
+
+	_, err := client.ListTools(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "-32601") || !strings.Contains(err.Error(), "method not found") {
+		t.Errorf("error = %v; want to contain both the code and message", err)
+	}
+}
+
+func TestListTools_HTTPError(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal", http.StatusInternalServerError)
+	})
+
+	_, err := client.ListTools(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// Plain "internal\n" is not valid JSON → decode error surfaces.
+	if !strings.Contains(err.Error(), "decode mcp response") {
+		t.Errorf("error = %v; want decode-response error on non-JSON body", err)
+	}
+}
+
+func TestListTools_Malformed(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`not json at all`))
+	})
+
+	_, err := client.ListTools(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "decode mcp response") {
+		t.Errorf("error = %v; want decode error", err)
+	}
+}
+
+func TestCall_Success(t *testing.T) {
+	var gotName string
+	var gotArgs map[string]any
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		var req rpcRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Method != "tools/call" {
+			t.Errorf("method = %q, want tools/call", req.Method)
+		}
+		// Params shape is a generic map in the request JSON.
+		params, _ := req.Params.(map[string]any)
+		gotName, _ = params["name"].(string)
+		gotArgs, _ = params["arguments"].(map[string]any)
+
+		_, _ = w.Write([]byte(`{
+			"jsonrpc":"2.0","id":1,
+			"result":{"content":[{"type":"text","text":"sum=7"}],"isError":false}
+		}`))
+	})
+
+	got, err := client.Call(context.Background(), "add", map[string]any{"a": 3, "b": 4})
+	if err != nil {
+		t.Fatalf("Call error: %v", err)
+	}
+	if gotName != "add" {
+		t.Errorf("server saw name=%q, want add", gotName)
+	}
+	if fmt.Sprint(gotArgs["a"]) != "3" || fmt.Sprint(gotArgs["b"]) != "4" {
+		t.Errorf("server saw args=%+v, want a=3 b=4", gotArgs)
+	}
+	// Result passed through as a generic value (expected to be a map with content/isError).
+	result, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("got %T, want map[string]any", got)
+	}
+	if _, ok := result["content"]; !ok {
+		t.Errorf("result missing `content` key: %+v", result)
+	}
+}
+
+func TestCall_RPCError(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"invalid params"}}`))
+	})
+
+	_, err := client.Call(context.Background(), "add", map[string]any{"a": "not-a-number"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "-32602") || !strings.Contains(err.Error(), "invalid params") {
+		t.Errorf("error = %v; want code + message propagated", err)
+	}
+}
+
+func TestCall_ConnectionRefused(t *testing.T) {
+	// Point at a port that's very unlikely to have a server on it. Using port
+	// 1 (tcpmux) on localhost is the closed-port standby in net tests — the
+	// kernel returns ECONNREFUSED immediately with no retry delay.
+	client := New(1)
+	// Short ctx deadline so a hypothetical firewall-drop doesn't stall us.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := client.ListTools(ctx)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "mcp request") {
+		t.Errorf("error = %v; want wrapped 'mcp request' error", err)
+	}
+}

--- a/pkg/mcp/client/client_test.go
+++ b/pkg/mcp/client/client_test.go
@@ -173,15 +173,26 @@ func TestCall_RPCError(t *testing.T) {
 }
 
 func TestCall_ConnectionRefused(t *testing.T) {
-	// Point at a port that's very unlikely to have a server on it. Using port
-	// 1 (tcpmux) on localhost is the closed-port standby in net tests — the
-	// kernel returns ECONNREFUSED immediately with no retry delay.
-	client := New(1)
-	// Short ctx deadline so a hypothetical firewall-drop doesn't stall us.
+	// Bind an httptest server to grab an ephemeral port, then close it so we
+	// point Client at a guaranteed-closed local port. More robust than
+	// hardcoding port 1 (tcpmux), which can return EACCES/EPERM on restricted
+	// CI sandboxes instead of the ECONNREFUSED we want.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("parse test server port: %v", err)
+	}
+	srv.Close()
+
+	client := New(port)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	_, err := client.ListTools(ctx)
+	_, err = client.ListTools(ctx)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/tests/e2e/file-change.spec.ts
+++ b/tests/e2e/file-change.spec.ts
@@ -139,6 +139,46 @@ test.describe('File Change Detection', () => {
     fs.writeFileSync(taskJsPath, originalJs, 'utf8');
   });
 
+  test('fsnotify pickup latency is within budget (< 1500 ms)', async ({ request }) => {
+    // dicode.app claims "Save a file — live in 100ms via fsnotify."
+    // Issue #125 wants <200ms, acknowledging CI jitter. We assert a looser
+    // <1500ms bound here as a regression gate — the actual measured delta
+    // is logged so the budget can be tightened once CI numbers stabilise.
+    const taskYamlPath = path.join(tasksDir(), 'hello-manual', 'task.yaml');
+    const originalYaml = fs.readFileSync(taskYamlPath, 'utf8');
+
+    const marker = `latency-probe-${Date.now()}`;
+    const updatedYaml = originalYaml.replace(
+      /description:.*$/m,
+      `description: ${marker}`,
+    );
+
+    const startedAt = Date.now();
+    fs.writeFileSync(taskYamlPath, updatedYaml, 'utf8');
+
+    const deadline = startedAt + 5_000;
+    let seenAt = 0;
+    while (Date.now() < deadline) {
+      const res = await request.get(`/api/tasks/${encodeURIComponent(MANUAL_TASK_ID)}`);
+      if (res.ok()) {
+        const body = await res.json() as { description?: string };
+        if (body.description?.includes(marker)) {
+          seenAt = Date.now();
+          break;
+        }
+      }
+      await new Promise((r) => setTimeout(r, 25));
+    }
+
+    // Restore before assertions so a failure doesn't leave the fixture mutated.
+    fs.writeFileSync(taskYamlPath, originalYaml, 'utf8');
+
+    expect(seenAt).toBeGreaterThan(0); // reconciler did pick it up
+    const latencyMs = seenAt - startedAt;
+    console.log(`[latency] fsnotify pickup: ${latencyMs}ms`);
+    expect(latencyMs).toBeLessThan(1500);
+  });
+
   test('file edit is idempotent — restoring original brings task back', async ({ request }) => {
     const taskYamlPath = path.join(tasksDir(), 'hello-manual', 'task.yaml');
     const originalYaml = fs.readFileSync(taskYamlPath, 'utf8');


### PR DESCRIPTION
Quick-fires off epic #127.

## Closes #37 — `pkg/mcp/client` unit tests

Adds [`pkg/mcp/client/client_test.go`](pkg/mcp/client/client_test.go). Seven table-driven tests against `httptest.NewServer` matching the matrix in the issue:

| Test | Covers |
|---|---|
| `TestListTools_Success` | Happy path — 2 tools parsed, `InputSchema` raw JSON passes through. |
| `TestListTools_RPCError` | `error: {code, message}` → wrapped Go error includes both. |
| `TestListTools_HTTPError` | HTTP 500 with non-JSON body surfaces as decode error. |
| `TestListTools_Malformed` | Garbage body surfaces as decode error. |
| `TestCall_Success` | `tools/call` happy path — args passed to server, generic result returned. |
| `TestCall_RPCError` | RPC error propagated on `tools/call`. |
| `TestCall_ConnectionRefused` | Server absent → `mcp request:` wrapped error. |

Verified green: `go test ./pkg/mcp/client/... -race -count=1` — all 7 pass in ~1s.

## Partial #125 — fsnotify latency assertion

Adds a regression gate to [`tests/e2e/file-change.spec.ts`](tests/e2e/file-change.spec.ts): writes a marker into `task.yaml`, polls `/api/tasks/{id}` every 25ms, asserts reconciler pickup within 1500ms, and logs the actual measured latency for future budget tightening.

**Local measurement:** 175 ms (target <200 ms per issue). The 1500ms bound is intentionally loose to survive CI jitter while still regression-gating — once we have a few CI runs of actual numbers, the budget can be tightened.

The git-poll branch of #125 still needs separate work; this is only the fsnotify-path item.

## Partial #124 — HMAC coverage noted

Commented on #124 to flag that item 1 (HMAC webhook verify) is already covered by the 7 tests in `tests/e2e/webhooks-secure.spec.ts` shipped by #150. ECDSA challenge and ECIES decrypt roundtrip still need Go unit tests under `pkg/relay/`.

## Test plan

- [x] `go test ./pkg/mcp/client/... -race -count=1 -timeout 30s -v` — 7/7 pass
- [x] `go test ./... -timeout 60s` — all packages still green
- [x] `make test-e2e-unauth` file-change.spec.ts — 5/5 pass, latency: 175ms
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)