### PR TITLE
test: secrets API write-only/keys-only + trigger engine WaitRun + on_failure_chain (closes #38, partial #126)

### DIFF
--- a/pkg/trigger/engine_failure_chain_test.go
+++ b/pkg/trigger/engine_failure_chain_test.go
@@ -1,0 +1,228 @@
+package trigger
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// waitForRunOfTask polls the registry's run list for a run of the given
+// task ID that reached a terminal state. Used to observe secondary runs
+// fired by the chain-dispatch path.
+func waitForRunOfTask(t *testing.T, e *Engine, taskID string, timeout time.Duration) *registry.Run {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		runs, err := e.registry.ListRuns(context.Background(), taskID, 5)
+		if err != nil {
+			t.Fatalf("ListRuns: %v", err)
+		}
+		for _, r := range runs {
+			if r.Status == registry.StatusSuccess || r.Status == registry.StatusFailure {
+				return r
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return nil
+}
+
+// ptrString is a helper because task.Spec.OnFailureChain is *string so ""
+// disables the default and nil uses the default.
+func ptrString(s string) *string { return &s }
+
+// TestEngine_SetDefaultsOnFailureChain_FiresFallbackOnFailure verifies that
+// after SetDefaultsOnFailureChain("fallback-task"), a failing run of any
+// other task dispatches the fallback.
+func TestEngine_SetDefaultsOnFailureChain_FiresFallbackOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	fallback := writeTask(t, dir, "fallback-task",
+		`export default async function main() { return "fallback-ran" }`,
+		task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(fallback)
+
+	failing := writeTask(t, dir, "failing-task",
+		`export default async function main() { throw new Error("boom") }`,
+		task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(failing)
+
+	e.engine.SetDefaultsOnFailureChain("fallback-task")
+
+	runID, err := e.engine.FireManual(context.Background(), "failing-task", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	failed := waitForTerminal(t, e.engine, runID, 30*time.Second)
+	if failed.Status != registry.StatusFailure {
+		t.Fatalf("primary run status = %q, want failure", failed.Status)
+	}
+
+	got := waitForRunOfTask(t, e.engine, "fallback-task", 15*time.Second)
+	if got == nil {
+		t.Fatal("fallback task never ran after primary failure")
+	}
+	if got.Status != registry.StatusSuccess {
+		t.Errorf("fallback status = %q, want success", got.Status)
+	}
+}
+
+// TestEngine_SetDefaultsOnFailureChain_NotFiredOnSuccess verifies the
+// default fallback does NOT run when the primary task succeeds.
+func TestEngine_SetDefaultsOnFailureChain_NotFiredOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	fallback := writeTask(t, dir, "noop-fallback",
+		`export default async function main() { return "fallback-ran" }`,
+		task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(fallback)
+
+	ok := writeTask(t, dir, "ok-task",
+		`export default async function main() { return "ok" }`,
+		task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(ok)
+
+	e.engine.SetDefaultsOnFailureChain("noop-fallback")
+
+	runID, err := e.engine.FireManual(context.Background(), "ok-task", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	run := waitForTerminal(t, e.engine, runID, 30*time.Second)
+	if run.Status != registry.StatusSuccess {
+		t.Fatalf("primary status = %q, want success", run.Status)
+	}
+
+	// Give the chain dispatcher a window to (incorrectly) fire. 2s is
+	// generous — chain dispatch is synchronous-in-goroutine post-completion.
+	time.Sleep(2 * time.Second)
+	runs, err := e.engine.registry.ListRuns(context.Background(), "noop-fallback", 5)
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) > 0 {
+		t.Errorf("noop-fallback should not have run on primary success, got %d runs", len(runs))
+	}
+}
+
+// TestEngine_OnFailureChain_PerTaskOverride verifies that a task with its
+// own `on_failure_chain` overrides the engine-level default.
+func TestEngine_OnFailureChain_PerTaskOverride(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	globalFallback := writeTask(t, dir, "global-fallback",
+		`export default async function main() { return "should-not-run" }`,
+		task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(globalFallback)
+
+	taskFallback := writeTask(t, dir, "task-fallback",
+		`export default async function main() { return "task-override-ran" }`,
+		task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(taskFallback)
+
+	failing := writeTask(t, dir, "failing-with-override",
+		`export default async function main() { throw new Error("boom") }`,
+		task.TriggerConfig{Manual: true})
+	failing.OnFailureChain = ptrString("task-fallback")
+	_ = e.reg.Register(failing)
+
+	e.engine.SetDefaultsOnFailureChain("global-fallback")
+
+	runID, err := e.engine.FireManual(context.Background(), "failing-with-override", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	waitForTerminal(t, e.engine, runID, 30*time.Second)
+
+	// Per-task override should have run.
+	got := waitForRunOfTask(t, e.engine, "task-fallback", 15*time.Second)
+	if got == nil {
+		t.Fatal("task-level fallback never ran")
+	}
+	if got.Status != registry.StatusSuccess {
+		t.Errorf("task-level fallback status = %q, want success", got.Status)
+	}
+
+	// Global fallback should NOT have run.
+	time.Sleep(1 * time.Second) // give stragglers time to land
+	globals, _ := e.engine.registry.ListRuns(context.Background(), "global-fallback", 5)
+	if len(globals) > 0 {
+		t.Errorf("global-fallback should not have run when per-task override is set; got %d runs", len(globals))
+	}
+}
+
+// TestEngine_OnFailureChain_EmptyStringDisablesDefault verifies that a
+// task with OnFailureChain = "" (pointer to empty string) opts OUT of the
+// engine-level default even when one is configured.
+func TestEngine_OnFailureChain_EmptyStringDisablesDefault(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	globalFallback := writeTask(t, dir, "global-fallback-disabled",
+		`export default async function main() { return "should-not-run" }`,
+		task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(globalFallback)
+
+	failing := writeTask(t, dir, "opt-out-task",
+		`export default async function main() { throw new Error("boom") }`,
+		task.TriggerConfig{Manual: true})
+	failing.OnFailureChain = ptrString("")
+	_ = e.reg.Register(failing)
+
+	e.engine.SetDefaultsOnFailureChain("global-fallback-disabled")
+
+	runID, err := e.engine.FireManual(context.Background(), "opt-out-task", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	waitForTerminal(t, e.engine, runID, 30*time.Second)
+
+	time.Sleep(2 * time.Second)
+	runs, _ := e.engine.registry.ListRuns(context.Background(), "global-fallback-disabled", 5)
+	if len(runs) > 0 {
+		t.Errorf("empty OnFailureChain should disable default, got %d runs", len(runs))
+	}
+}
+
+// TestEngine_OnFailureChain_NoLoopSelfReference verifies the engine refuses
+// to chain a task to itself on failure (infinite-loop guard in FireChain:
+// `targetID != completedTaskID`).
+func TestEngine_OnFailureChain_NoLoopSelfReference(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	self := writeTask(t, dir, "self-loop",
+		`export default async function main() { throw new Error("always fails") }`,
+		task.TriggerConfig{Manual: true})
+	self.OnFailureChain = ptrString("self-loop")
+	_ = e.reg.Register(self)
+
+	runID, err := e.engine.FireManual(context.Background(), "self-loop", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	waitForTerminal(t, e.engine, runID, 30*time.Second)
+
+	// Give the chain dispatcher a window — if the self-reference guard
+	// fails, this task would spawn additional runs of itself.
+	time.Sleep(2 * time.Second)
+	runs, err := e.engine.registry.ListRuns(context.Background(), "self-loop", 10)
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) != 1 {
+		// Surface IDs to help debug unexpected runs.
+		ids := make([]string, 0, len(runs))
+		for _, r := range runs {
+			ids = append(ids, r.ID)
+		}
+		t.Errorf("self-loop produced %d runs (want 1): %s", len(runs), strings.Join(ids, ", "))
+	}
+}

--- a/pkg/trigger/engine_waitrun_test.go
+++ b/pkg/trigger/engine_waitrun_test.go
@@ -1,0 +1,153 @@
+package trigger
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// waitForTerminal polls the registry until the run leaves the 'running'
+// state or the deadline elapses. Returns the final run record.
+func waitForTerminal(t *testing.T, e *Engine, runID string, timeout time.Duration) *registry.Run {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		run, err := e.registry.GetRun(context.Background(), runID)
+		if err != nil {
+			t.Fatalf("GetRun: %v", err)
+		}
+		if run.Status != registry.StatusRunning {
+			return run
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("run %s did not finish within %v", runID, timeout)
+	return nil
+}
+
+// TestEngine_WaitRun_ReturnsSuccessResult covers the happy path: fire a
+// short task, call WaitRun, expect status=success with the task's return
+// value decoded back into the ipc.RunResult.
+func TestEngine_WaitRun_ReturnsSuccessResult(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+	spec := writeTask(t, dir, "wait-success",
+		`export default async function main() { return { ok: true, n: 42 } }`,
+		task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(spec)
+
+	runID, err := e.engine.FireManual(context.Background(), "wait-success", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	result, err := e.engine.WaitRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("WaitRun: %v", err)
+	}
+	if result.RunID != runID {
+		t.Errorf("result.RunID = %q, want %q", result.RunID, runID)
+	}
+	if result.Status != registry.StatusSuccess {
+		t.Errorf("status = %q, want success", result.Status)
+	}
+	// ReturnValue is unmarshalled into interface{} — JSON object becomes map[string]any.
+	m, ok := result.ReturnValue.(map[string]interface{})
+	if !ok {
+		t.Fatalf("return value is %T, want map; value=%v", result.ReturnValue, result.ReturnValue)
+	}
+	if m["ok"] != true {
+		t.Errorf("return.ok = %v, want true", m["ok"])
+	}
+	if m["n"].(float64) != 42 {
+		t.Errorf("return.n = %v, want 42", m["n"])
+	}
+}
+
+// TestEngine_WaitRun_AlreadyFinished verifies the fast path: when the run
+// completed before WaitRun was called, it should skip the channel wait and
+// return the persisted record immediately.
+func TestEngine_WaitRun_AlreadyFinished(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+	spec := writeTask(t, dir, "wait-finished",
+		`export default async function main() { return "done" }`,
+		task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(spec)
+
+	runID, err := e.engine.FireManual(context.Background(), "wait-finished", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	waitForTerminal(t, e.engine, runID, 30*time.Second)
+
+	// Now WaitRun should return immediately without blocking.
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result, err := e.engine.WaitRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("WaitRun: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("WaitRun on finished run took %v, want <500ms", elapsed)
+	}
+	if result.Status != registry.StatusSuccess {
+		t.Errorf("status = %q, want success", result.Status)
+	}
+}
+
+// TestEngine_WaitRun_NotFound verifies that an unknown run ID returns
+// ErrRunNotFound rather than hanging or nil.
+func TestEngine_WaitRun_NotFound(t *testing.T) {
+	e := newTestEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := e.engine.WaitRun(ctx, "00000000-0000-0000-0000-000000000000")
+	if err == nil {
+		t.Fatal("expected error for unknown run, got nil")
+	}
+	if !errors.Is(err, ErrRunNotFound) {
+		t.Errorf("err = %v, want ErrRunNotFound", err)
+	}
+}
+
+// TestEngine_WaitRun_ContextCanceled verifies that cancelling the waiter's
+// context unblocks WaitRun with ctx.Err() while the run is still live.
+func TestEngine_WaitRun_ContextCanceled(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+	// Long-running task — sleeps 10s so we have time to cancel.
+	spec := writeTask(t, dir, "wait-slow",
+		`export default async function main() { await new Promise(r => setTimeout(r, 10_000)); return "ok" }`,
+		task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(spec)
+
+	runID, err := e.engine.FireManual(context.Background(), "wait-slow", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	_, err = e.engine.WaitRun(ctx, runID)
+	if err == nil {
+		t.Fatal("expected error for canceled context, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.DeadlineExceeded or Canceled", err)
+	}
+
+	// Clean up: kill the still-running task so the test teardown can close
+	// the DB without a live runner holding cursors.
+	e.engine.KillRun(runID)
+	waitForTerminal(t, e.engine, runID, 30*time.Second)
+}

--- a/pkg/webui/secrets_api_test.go
+++ b/pkg/webui/secrets_api_test.go
@@ -1,0 +1,264 @@
+package webui
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/config"
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/ipc"
+	"github.com/dicode/dicode/pkg/registry"
+	denoruntime "github.com/dicode/dicode/pkg/runtime/deno"
+	"github.com/dicode/dicode/pkg/secrets"
+	"github.com/dicode/dicode/pkg/trigger"
+	"go.uber.org/zap"
+)
+
+// inMemSecretsMgr is a minimal in-memory secrets.Manager for testing.
+// The real LocalProvider requires a master key on disk + Argon2id derivation,
+// which is overkill for API-surface tests — we only need the three CRUD
+// methods the handlers call through.
+type inMemSecretsMgr struct {
+	mu   sync.Mutex
+	data map[string]string
+}
+
+func (m *inMemSecretsMgr) List(_ context.Context) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	keys := make([]string, 0, len(m.data))
+	for k := range m.data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys, nil
+}
+
+func (m *inMemSecretsMgr) Set(_ context.Context, key, value string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.data == nil {
+		m.data = map[string]string{}
+	}
+	m.data[key] = value
+	return nil
+}
+
+func (m *inMemSecretsMgr) Delete(_ context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.data, key)
+	return nil
+}
+
+func (m *inMemSecretsMgr) get(key string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.data[key]
+}
+
+// newSecretsTestServer spins up a webui Server wired to an in-memory secrets
+// manager. server.auth is false, so the protected endpoints are reachable
+// without a session — this test targets the response shape, not auth.
+func newSecretsTestServer(t *testing.T) (*Server, *inMemSecretsMgr) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("db open: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+
+	reg := registry.New(d)
+	rt, err := denoruntime.New(reg, secrets.Chain{}, d, zap.NewNop())
+	if err != nil {
+		t.Skipf("deno runtime not available: %v", err)
+	}
+	eng := trigger.New(reg, rt, zap.NewNop())
+	mgr := &inMemSecretsMgr{}
+
+	var sm secrets.Manager = mgr
+	srv, err := New(
+		0, // port — unused (we call Handler() directly)
+		reg,
+		eng,
+		&config.Config{Server: config.ServerConfig{Port: 0, Auth: false}},
+		"", sm, nil, nil, "",
+		NewLogBroadcaster(),
+		zap.NewNop(),
+		d,
+		ipc.NewGateway(),
+	)
+	if err != nil {
+		t.Fatalf("New server: %v", err)
+	}
+	return srv, mgr
+}
+
+// TestAPI_ListSecrets_ReturnsKeysOnly verifies #126 item 1:
+// GET /api/secrets returns key names only — values must never appear in the
+// response body, even for authenticated admins.
+func TestAPI_ListSecrets_ReturnsKeysOnly(t *testing.T) {
+	srv, mgr := newSecretsTestServer(t)
+
+	// Seed with keys whose values contain distinctive markers that would be
+	// obvious if they leaked into the response body.
+	_ = mgr.Set(context.Background(), "api_key", "sk-LEAK-MARKER-AAA")
+	_ = mgr.Set(context.Background(), "db_password", "LEAK-MARKER-BBB")
+	_ = mgr.Set(context.Background(), "webhook_secret", "LEAK-MARKER-CCC")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/secrets", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+
+	body := w.Body.String()
+	for _, marker := range []string{"LEAK-MARKER-AAA", "LEAK-MARKER-BBB", "LEAK-MARKER-CCC", "sk-LEAK"} {
+		if strings.Contains(body, marker) {
+			t.Errorf("response body contains secret value marker %q\nfull body: %s", marker, body)
+		}
+	}
+
+	var keys []string
+	if err := json.Unmarshal(w.Body.Bytes(), &keys); err != nil {
+		t.Fatalf("decode body: %v (body=%q)", err, body)
+	}
+	sort.Strings(keys)
+	want := []string{"api_key", "db_password", "webhook_secret"}
+	if len(keys) != len(want) {
+		t.Fatalf("keys = %v, want %v", keys, want)
+	}
+	for i, k := range want {
+		if keys[i] != k {
+			t.Errorf("keys[%d] = %q, want %q", i, keys[i], k)
+		}
+	}
+}
+
+// TestAPI_ListSecrets_EmptyStore verifies an empty list returns JSON `[]`,
+// not `null` — consumers iterate the array and null would break them.
+func TestAPI_ListSecrets_EmptyStore(t *testing.T) {
+	srv, _ := newSecretsTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/secrets", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	// Either `[]` or `null` is JSON-valid; we want the empty-array form so
+	// the SPA can `.map(...)` without a null-guard.
+	body := strings.TrimSpace(w.Body.String())
+	if body != "[]" {
+		t.Errorf("empty list body = %q, want %q", body, "[]")
+	}
+}
+
+// TestAPI_SetSecret_IsWriteOnly verifies #126 item 2:
+// POST /api/secrets stores the value but does NOT echo it in the response.
+// The response body must only contain acknowledgement metadata.
+func TestAPI_SetSecret_IsWriteOnly(t *testing.T) {
+	srv, mgr := newSecretsTestServer(t)
+
+	const secretKey = "github_token"
+	const secretValue = "ghp_LEAK-MARKER-NEVER-ECHOED-12345"
+
+	body, _ := json.Marshal(map[string]string{"key": secretKey, "value": secretValue})
+	req := httptest.NewRequest(http.MethodPost, "/api/secrets", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+
+	respBody := w.Body.String()
+	if strings.Contains(respBody, "LEAK-MARKER") || strings.Contains(respBody, secretValue) {
+		t.Errorf("POST response echoes secret value\nbody: %s", respBody)
+	}
+
+	// Verify storage did happen — the value should be retrievable from the
+	// backing manager (the path the daemon uses internally), not via API.
+	stored := mgr.get(secretKey)
+	if stored != secretValue {
+		t.Errorf("stored value = %q, want %q", stored, secretValue)
+	}
+}
+
+// TestAPI_SetSecret_RejectsEmptyKey verifies the existing guard in
+// apiSetSecret. Included here because #126 asks for secret-handling
+// regression coverage and this path is adjacent.
+func TestAPI_SetSecret_RejectsEmptyKey(t *testing.T) {
+	srv, _ := newSecretsTestServer(t)
+
+	body, _ := json.Marshal(map[string]string{"key": "", "value": "v"})
+	req := httptest.NewRequest(http.MethodPost, "/api/secrets", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%q", w.Code, w.Body.String())
+	}
+}
+
+// TestAPI_ListSecrets_AfterSetDoesNotIncludeValues is the full round-trip:
+// POST a secret, then GET the list, verify only the key is visible and the
+// value never appears anywhere in the list response.
+func TestAPI_ListSecrets_AfterSetDoesNotIncludeValues(t *testing.T) {
+	srv, _ := newSecretsTestServer(t)
+
+	const secretValue = "oauth_LEAK-FOLLOWUP-MARKER"
+	body, _ := json.Marshal(map[string]string{"key": "oauth_token", "value": secretValue})
+	req := httptest.NewRequest(http.MethodPost, "/api/secrets", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	srv.Handler().ServeHTTP(httptest.NewRecorder(), req)
+
+	req = httptest.NewRequest(http.MethodGet, "/api/secrets", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("list status = %d, want 200", w.Code)
+	}
+	listBody := w.Body.String()
+	if strings.Contains(listBody, "LEAK-FOLLOWUP-MARKER") || strings.Contains(listBody, secretValue) {
+		t.Errorf("list response contains secret value after SET\nbody: %s", listBody)
+	}
+	if !strings.Contains(listBody, "oauth_token") {
+		t.Errorf("list response missing expected key\nbody: %s", listBody)
+	}
+}
+
+// sanity: ensure the Handler serves the secrets routes at all. Guards against
+// regressions where the group is mounted under a different path prefix.
+func TestAPI_SecretsRoute_Exists(t *testing.T) {
+	srv, _ := newSecretsTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/secrets", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code == http.StatusNotFound {
+		t.Fatalf("/api/secrets not routed — got 404")
+	}
+	// Verify content-type is JSON, not HTML.
+	if got := w.Header().Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+		t.Errorf("content-type = %q, want application/json", got)
+	}
+	// Touch the body so the test name still surfaces the method mismatch
+	// variant if someone accidentally flips the handler.
+	if w.Body.Len() == 0 {
+		t.Errorf("empty response body")
+	}
+}

--- a/pkg/webui/secrets_api_test.go
+++ b/pkg/webui/secrets_api_test.go
@@ -132,15 +132,21 @@ func TestAPI_ListSecrets_ReturnsKeysOnly(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &keys); err != nil {
 		t.Fatalf("decode body: %v (body=%q)", err, body)
 	}
-	sort.Strings(keys)
-	want := []string{"api_key", "db_password", "webhook_secret"}
+	// Set-based assertion — the real LocalProvider doesn't guarantee an
+	// ordering (SQLite scan order varies), so the test must not depend on
+	// the mock's `sort.Strings` helper.
+	want := map[string]bool{"api_key": true, "db_password": true, "webhook_secret": true}
 	if len(keys) != len(want) {
 		t.Fatalf("keys = %v, want %v", keys, want)
 	}
-	for i, k := range want {
-		if keys[i] != k {
-			t.Errorf("keys[%d] = %q, want %q", i, keys[i], k)
+	for _, k := range keys {
+		if !want[k] {
+			t.Errorf("unexpected key %q in response", k)
 		}
+		delete(want, k)
+	}
+	if len(want) > 0 {
+		t.Errorf("missing keys in response: %v", want)
 	}
 }
 


### PR DESCRIPTION
Next bundle off epic #127. 15 new tests, all green under `-race`.

## Closes #38 — Trigger engine: WaitRun, SetDefaultsOnFailureChain, on_failure_chain

Adds [`pkg/trigger/engine_waitrun_test.go`](pkg/trigger/engine_waitrun_test.go) and [`pkg/trigger/engine_failure_chain_test.go`](pkg/trigger/engine_failure_chain_test.go) covering the three methods listed in the issue:

| Test | Covers |
|---|---|
| `TestEngine_WaitRun_ReturnsSuccessResult` | Happy path — waits for a live run, verifies `Status=success`, `ReturnValue` JSON-decoded. |
| `TestEngine_WaitRun_AlreadyFinished` | Fast path — returns immediately (< 500 ms) when the run completed before `WaitRun` was called. |
| `TestEngine_WaitRun_NotFound` | `ErrRunNotFound` on an unknown run ID. |
| `TestEngine_WaitRun_ContextCanceled` | Canceling ctx unblocks `WaitRun` with `ctx.Err()`; test cleans up by killing the slow runner. |
| `TestEngine_SetDefaultsOnFailureChain_FiresFallbackOnFailure` | Primary task fails → fallback fires and reaches `success`. |
| `TestEngine_SetDefaultsOnFailureChain_NotFiredOnSuccess` | Primary succeeds → fallback does NOT fire (2 s guard window). |
| `TestEngine_OnFailureChain_PerTaskOverride` | Per-task `OnFailureChain` replaces the engine-level default. |
| `TestEngine_OnFailureChain_EmptyStringDisablesDefault` | `OnFailureChain = ""` opts the task OUT of the engine default. |
| `TestEngine_OnFailureChain_NoLoopSelfReference` | Self-referencing fallback is silently dropped (infinite-loop guard at `engine.go:663`). |

## Partial #126 items 1-2 — `/api/secrets` never leaks values

Adds [`pkg/webui/secrets_api_test.go`](pkg/webui/secrets_api_test.go) with six tests:

| Test | Covers |
|---|---|
| `TestAPI_ListSecrets_ReturnsKeysOnly` | Seeds three secrets with distinctive `LEAK-MARKER-*` values, verifies none appear in the list response body. |
| `TestAPI_ListSecrets_EmptyStore` | Empty list returns `[]` not `null` (SPA `.map()` safety). |
| `TestAPI_SetSecret_IsWriteOnly` | POST stores the value in the backing manager but does NOT echo it in the response. |
| `TestAPI_SetSecret_RejectsEmptyKey` | Empty key → 400. |
| `TestAPI_ListSecrets_AfterSetDoesNotIncludeValues` | Full round-trip: POST then GET — key visible, value invisible. |
| `TestAPI_SecretsRoute_Exists` | Route mounted, returns `application/json`. |

Uses an in-memory `secrets.Manager` mock — the real `LocalProvider` requires an Argon2id-derived master key on disk, overkill for API-surface tests.

Item 3 of #126 (log redaction of secret values in task stdout/stderr) is still open — it needs log capture plus a redaction check that crosses into `pkg/registry`'s logger.

## Test plan

- [x] `go test ./pkg/webui/... -run TestAPI_.*Secret -count=1` — 6/6 pass
- [x] `go test ./pkg/trigger/... -run TestEngine_WaitRun -count=1` — 4/4 pass
- [x] `go test ./pkg/trigger/... -run TestEngine_(SetDefaults|OnFailureChain) -count=1` — 5/5 pass
- [x] `go test ./... -race -count=1 -timeout 300s` — all packages green
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)