### PR TITLE
feat(tasktest): CLI + IPC + MCP surface for running task tests (Phase 1, Deno)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ playwright-report/
 test-results/
 .playwright/
 tests/e2e/.auth-state.json
+# Top-level Deno lockfile — only tasks/deno.lock is authoritative.
+/deno.lock
 !.claude/memory/

--- a/README.md
+++ b/README.md
@@ -1124,10 +1124,10 @@ The testing and validation system is designed with four layers. Not all are impl
 |---|---|---|---|
 | E2E tests | Playwright | Full UI + API integration regressions | ✅ Implemented |
 | Static validation | `dicode task validate` | Schema errors, syntax, chain cycles | Planned |
-| Unit tests | `dicode task test` | Logic bugs, wrong HTTP calls, bad return values | Planned |
+| Unit tests | `dicode task test` | Logic bugs, wrong HTTP calls, bad return values | ✅ Implemented (Deno; Python/Docker/Podman tracked as #159) |
 | Dry run | `dicode task run --dry-run` | Secret resolution, correct endpoints | Planned |
 
-> **Note**: E2E tests use Playwright and cover core UI flows, file changes, webhooks, config, and auth. The CLI commands above (`task validate`, `task test`, `task run --dry-run`) are not yet implemented. Current CLI supports: `run`, `list`, `logs`, `status`, `secrets`, `version`.
+> **Note**: E2E tests use Playwright and cover core UI flows, file changes, webhooks, config, and auth. Unit tests run via `dicode task test <task-id>` or `make test-tasks` — the CLI routes through the same executor as the MCP `test_task` tool so any caller (human, built-in agent, third-party AI) gets the same results. `task validate` and `task run --dry-run` are not yet implemented. Current CLI supports: `run`, `list`, `logs`, `status`, `ai`, `task test`, `secrets`, `relay`, `version`.
 
 ---
 
@@ -1142,11 +1142,23 @@ Will check: `task.yaml` schema, script syntax, env var resolution, chain cycle d
 
 ---
 
-### Layers 2–4 — Unit tests, dry run, CI (planned)
+### Layer 2 — Unit tests (`dicode task test`)
 
-The test harness (`pkg/testing/`) is designed but not yet implemented. When built, it will support:
+Write a sibling `task.test.ts` (or `.js` / `.mjs`) and run it through the task's runtime:
 
-- **Unit tests**: `task.test.ts` files with mock globals (`http.mock`, `env.set`, `params.set`), `runTask()`, and assertion APIs
+```bash
+dicode task test buildin/webui           # via the daemon (CLI → IPC → executor)
+make test-tasks                          # or directly: every task.test.* in tasks/buildin/
+```
+
+The harness (`tasks/sdk-test.ts`) provides in-memory mocks for the production SDK: `params.set`, `env.set`, `kv.set/get`, `http.mock` / `mockOnce`, `assert.*`, plus `runTask()` which invokes the task's default export. Each `test()` case gets a fresh mock state. See [tasks/buildin/webui/task.test.ts](tasks/buildin/webui/task.test.ts) and [tasks/buildin/ai-agent/task.test.ts](tasks/buildin/ai-agent/task.test.ts) for working examples.
+
+The same executor is exposed as the `test_task` MCP tool, so any MCP-capable agent (Claude Code, Cursor) can drive testing without dicode-specific plumbing.
+
+Runtime support: **Deno ✅**. Python, Docker, Podman tracked as #159.
+
+### Layers 3–4 — Dry run, CI (planned)
+
 - **Dry run**: `dicode task run --dry-run` with intercepted HTTP calls
 - **CI integration**: `dicode ci init` to generate GitHub Actions / GitLab CI configs
 
@@ -1200,6 +1212,7 @@ When `server.auth: true`, add an API key from the Security page:
 | `list_tasks` | All registered tasks with id, trigger, status, last run time |
 | `get_task(id)` | Full task content: task.yaml + script source |
 | `run_task(id)` | Trigger a live run — returns run ID |
+| `test_task(id)` | Run the task's sibling `task.test.*` through its runtime. Returns pass/fail counts + full stdout. Deno supported; other runtimes return a clear "not yet supported" error (#159). |
 | `list_sources` | List configured task sources with dev mode status |
 | `switch_dev_mode(source, enabled, path?)` | Toggle dev mode for a source |
 
@@ -1208,7 +1221,6 @@ When `server.auth: true`, add an API key from the Security page:
 | Tool | Description |
 |---|---|
 | `validate_task(id)` | Static validation with structured errors |
-| `test_task(id)` | Run task tests |
 | `dry_run_task(id)` | Full execution with intercepted HTTP |
 | `commit_task(id, source_id)` | Promote local task to git repo |
 | `list_secrets` | Names of registered secrets |

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -14,6 +14,7 @@
 //	logs <run-id>                   fetch log lines for a run
 //	status [task-id]                daemon health or latest run for a task
 //	ai <prompt> [flags]             run the configured AI task with a prompt
+//	task test <task-id>             run the task's sibling task.test.* through its runtime
 //	secrets list                    list secret keys
 //	secrets set <key> <value>       store a secret
 //	secrets delete <key>            delete a secret
@@ -112,9 +113,58 @@ func dispatch(c *ipc.ControlClient, args []string) error {
 		return cmdRelay(c, args[1:])
 	case "ai":
 		return cmdAI(c, args[1:])
+	case "task":
+		if len(args) < 2 {
+			return fmt.Errorf("usage: dicode task <test> <task-id>")
+		}
+		return cmdTask(c, args[1:])
 	default:
 		return fmt.Errorf("unknown command %q — run 'dicode' for usage", args[0])
 	}
+}
+
+func cmdTask(c *ipc.ControlClient, args []string) error {
+	switch args[0] {
+	case "test":
+		if len(args) < 2 {
+			return fmt.Errorf("usage: dicode task test <task-id>")
+		}
+		return cmdTaskTest(c, args[1])
+	default:
+		return fmt.Errorf("unknown task subcommand %q — supported: test", args[0])
+	}
+}
+
+func cmdTaskTest(c *ipc.ControlClient, taskID string) error {
+	resp, err := c.Send(ipc.Request{Method: "cli.task.test", TaskID: taskID})
+	if err != nil {
+		return err
+	}
+	// Partial results come back even when the daemon reports an error
+	// (e.g. failing tests produce a populated Result with Error=""), so
+	// we print the payload first and surface the error only if no output.
+	var r ipc.TaskTestResult
+	if resp.Result != nil {
+		if rerr := remarshal(resp.Result, &r); rerr == nil && (r.Output != "" || r.Failed > 0 || r.Passed > 0) {
+			fmt.Print(r.Output)
+			if !strings.HasSuffix(r.Output, "\n") {
+				fmt.Println()
+			}
+			fmt.Printf("%s: %d passed, %d failed", r.TaskID, r.Passed, r.Failed)
+			if r.Skipped > 0 {
+				fmt.Printf(", %d skipped", r.Skipped)
+			}
+			fmt.Printf(" (runtime=%s, %dms)\n", r.Runtime, r.DurMs)
+			if r.Failed > 0 || r.ExitCode != 0 {
+				return fmt.Errorf("%d test(s) failed", r.Failed)
+			}
+			return nil
+		}
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	return nil
 }
 
 func cmdRelay(c *ipc.ControlClient, args []string) error {
@@ -508,6 +558,7 @@ Commands:
   status [task-id]                daemon health or task's latest run
   ai <prompt> [flags]             run the configured AI task with a prompt
                                   flags: --session-id ID, --task TASK_ID
+  task test <task-id>             run the task's sibling task.test.* through its runtime
   secrets list                    list secret keys
   secrets set <key> <value>       store a secret
   secrets delete <key>            delete a secret

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -140,29 +140,36 @@ func cmdTaskTest(c *ipc.ControlClient, taskID string) error {
 	if err != nil {
 		return err
 	}
-	// Partial results come back even when the daemon reports an error
-	// (e.g. failing tests produce a populated Result with Error=""), so
-	// we print the payload first and surface the error only if no output.
+
+	// The daemon returns a populated Result AND sometimes a non-empty
+	// resp.Error (e.g. failing tests produce real output but the handler
+	// flags them). Prefer the structured payload when we have one; fall
+	// back to the error string when we don't.
 	var r ipc.TaskTestResult
+	hasPayload := false
 	if resp.Result != nil {
-		if rerr := remarshal(resp.Result, &r); rerr == nil && (r.Output != "" || r.Failed > 0 || r.Passed > 0) {
-			fmt.Print(r.Output)
-			if !strings.HasSuffix(r.Output, "\n") {
-				fmt.Println()
-			}
-			fmt.Printf("%s: %d passed, %d failed", r.TaskID, r.Passed, r.Failed)
-			if r.Skipped > 0 {
-				fmt.Printf(", %d skipped", r.Skipped)
-			}
-			fmt.Printf(" (runtime=%s, %dms)\n", r.Runtime, r.DurMs)
-			if r.Failed > 0 || r.ExitCode != 0 {
-				return fmt.Errorf("%d test(s) failed", r.Failed)
-			}
-			return nil
+		if rerr := remarshal(resp.Result, &r); rerr == nil {
+			hasPayload = r.Output != "" || r.Failed > 0 || r.Passed > 0
 		}
 	}
-	if resp.Error != "" {
-		return fmt.Errorf("%s", resp.Error)
+	if !hasPayload {
+		if resp.Error != "" {
+			return fmt.Errorf("%s", resp.Error)
+		}
+		return nil
+	}
+
+	fmt.Print(r.Output)
+	if !strings.HasSuffix(r.Output, "\n") {
+		fmt.Println()
+	}
+	fmt.Printf("%s: %d passed, %d failed", r.TaskID, r.Passed, r.Failed)
+	if r.Skipped > 0 {
+		fmt.Printf(", %d skipped", r.Skipped)
+	}
+	fmt.Printf(" (runtime=%s, %dms)\n", r.Runtime, r.DurMs)
+	if r.Failed > 0 || r.ExitCode != 0 {
+		return fmt.Errorf("%d test(s) failed", r.Failed)
 	}
 	return nil
 }

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dicode/dicode/pkg/relay"
 	"github.com/dicode/dicode/pkg/secrets"
 	"github.com/dicode/dicode/pkg/task"
+	"github.com/dicode/dicode/pkg/tasktest"
 	"go.uber.org/zap"
 )
 
@@ -242,6 +243,9 @@ func (cs *ControlServer) dispatch(ctx context.Context, req Request) (any, error)
 
 	case "cli.relay.rotate_identity":
 		return cs.handleRelayRotate(ctx)
+
+	case "cli.task.test":
+		return cs.handleTaskTest(ctx, req)
 
 	default:
 		return nil, fmt.Errorf("unknown method: %s", req.Method)
@@ -530,6 +534,58 @@ func (cs *ControlServer) handleRelayRotate(ctx context.Context) (any, error) {
 		NewUUID: newUUID,
 		Warning: relayRotateWarning,
 	}, nil
+}
+
+// TaskTestResult mirrors pkg/tasktest.Result for the control-socket wire
+// shape. Defined here (not imported) so pkg/ipc has no dep on pkg/tasktest,
+// keeping the IPC message surface stable if the executor's internals evolve.
+type TaskTestResult struct {
+	TaskID   string `json:"taskID"`
+	Runtime  string `json:"runtime"`
+	TestFile string `json:"testFile"`
+	Passed   int    `json:"passed"`
+	Failed   int    `json:"failed"`
+	Skipped  int    `json:"skipped"`
+	DurMs    int64  `json:"durationMs"`
+	ExitCode int    `json:"exitCode"`
+	Output   string `json:"output"`
+	Error    string `json:"error,omitempty"`
+}
+
+// handleTaskTest resolves the task from the registry, locates its sibling
+// test file, and invokes the appropriate runtime's test runner. Phase 1
+// supports the Deno runtime only; other runtimes return a clear error.
+func (cs *ControlServer) handleTaskTest(ctx context.Context, req Request) (TaskTestResult, error) {
+	if req.TaskID == "" {
+		return TaskTestResult{}, errors.New("taskID required")
+	}
+	spec, ok := cs.reg.Get(req.TaskID)
+	if !ok {
+		return TaskTestResult{}, fmt.Errorf("task %q not found", req.TaskID)
+	}
+	// tasktest.Run returns both a partial Result and err on certain paths
+	// (e.g. unsupported runtime, deno-not-available). Convert the Result to
+	// the wire shape regardless so the CLI can surface the partial info.
+	res, err := tasktest.Run(ctx, spec)
+	wire := TaskTestResult{
+		TaskID:   res.TaskID,
+		Runtime:  res.Runtime,
+		TestFile: res.TestFile,
+		Passed:   res.Passed,
+		Failed:   res.Failed,
+		Skipped:  res.Skipped,
+		DurMs:    res.Duration.Milliseconds(),
+		ExitCode: res.ExitCode,
+		Output:   res.Output,
+		Error:    res.Error,
+	}
+	if err != nil {
+		if wire.Error == "" {
+			wire.Error = err.Error()
+		}
+		return wire, err
+	}
+	return wire, nil
 }
 
 // relayRotateWarning is the operator-facing message surfaced to the CLI after

--- a/pkg/ipc/control_task_test_test.go
+++ b/pkg/ipc/control_task_test_test.go
@@ -1,0 +1,145 @@
+package ipc
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
+)
+
+// Tests for the cli.task.test control-socket handler. Exercises the
+// method-dispatch path in isolation without going over the socket —
+// existing handler tests (control_test.go) cover the socket plumbing.
+
+func newControlServerForTaskTest(t *testing.T) (*ControlServer, *registry.Registry) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+
+	reg := registry.New(d)
+	cs := &ControlServer{reg: reg, log: zap.NewNop()}
+	return cs, reg
+}
+
+// registerTaskWithTest writes a minimal Deno task + passing test file
+// into a fresh temp dir and registers it.
+func registerTaskWithTest(t *testing.T, reg *registry.Registry, id string) *task.Spec {
+	t.Helper()
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "task.yaml"), []byte("name: "+id+"\ntrigger:\n  manual: true\nruntime: deno\n"), 0644)
+	_ = os.WriteFile(filepath.Join(dir, "task.ts"), []byte(`export default async function main() { return { ok: true } }`+"\n"), 0644)
+	_ = os.WriteFile(filepath.Join(dir, "task.test.ts"), []byte(`
+import { setupHarness } from "`+repoRootTasks(t)+`/sdk-test.ts";
+await setupHarness(import.meta.url);
+
+test("smoke", async () => {
+  const r = await runTask();
+  assert.equal(r.ok, true);
+});
+`), 0644)
+
+	spec := &task.Spec{
+		ID:      id,
+		Name:    id,
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Timeout: 5 * time.Second,
+		TaskDir: dir,
+	}
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	return spec
+}
+
+// repoRootTasks walks up from the CWD until it finds tasks/sdk-test.ts,
+// so the temp task's test file can import it. Keeps the test self-locating
+// regardless of where `go test` is invoked from.
+func repoRootTasks(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for dir := cwd; ; {
+		if _, err := os.Stat(filepath.Join(dir, "tasks", "sdk-test.ts")); err == nil {
+			return "file://" + filepath.Join(dir, "tasks")
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find tasks/sdk-test.ts walking up from %s", cwd)
+		}
+		dir = parent
+	}
+}
+
+func TestControl_TaskTest_MissingTaskID(t *testing.T) {
+	cs, _ := newControlServerForTaskTest(t)
+	_, err := cs.handleTaskTest(context.Background(), Request{})
+	if err == nil || !strings.Contains(err.Error(), "taskID required") {
+		t.Errorf("err = %v, want 'taskID required'", err)
+	}
+}
+
+func TestControl_TaskTest_UnknownTask(t *testing.T) {
+	cs, _ := newControlServerForTaskTest(t)
+	_, err := cs.handleTaskTest(context.Background(), Request{TaskID: "does/not/exist"})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("err = %v, want 'not found'", err)
+	}
+}
+
+func TestControl_TaskTest_NoTestFile(t *testing.T) {
+	cs, reg := newControlServerForTaskTest(t)
+	// Register a task without a test file.
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "task.yaml"), []byte("name: foo\ntrigger:\n  manual: true\nruntime: deno\n"), 0644)
+	_ = os.WriteFile(filepath.Join(dir, "task.ts"), []byte("export default () => ({})\n"), 0644)
+	spec := &task.Spec{
+		ID: "foo/no-test", Name: "foo", Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true}, Timeout: 5 * time.Second, TaskDir: dir,
+	}
+	_ = reg.Register(spec)
+
+	_, err := cs.handleTaskTest(context.Background(), Request{TaskID: "foo/no-test"})
+	if err == nil || !strings.Contains(err.Error(), "no test file") {
+		t.Errorf("err = %v, want ErrNoTestFile", err)
+	}
+}
+
+// TestControl_TaskTest_HappyPath runs a real Deno test end-to-end through
+// the handler. Slow (spawns Deno) but validates the full chain.
+func TestControl_TaskTest_HappyPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping deno-spawning test in -short mode")
+	}
+	cs, reg := newControlServerForTaskTest(t)
+	registerTaskWithTest(t, reg, "test/smoke")
+
+	res, err := cs.handleTaskTest(context.Background(), Request{TaskID: "test/smoke"})
+	if err != nil {
+		t.Fatalf("handleTaskTest: %v (output=%q)", err, res.Output)
+	}
+	if res.Passed != 1 || res.Failed != 0 {
+		t.Errorf("passed=%d failed=%d, want 1/0 (output=%q)", res.Passed, res.Failed, res.Output)
+	}
+	if res.Runtime != "deno" {
+		t.Errorf("runtime=%q, want deno", res.Runtime)
+	}
+	if res.ExitCode != 0 {
+		t.Errorf("exit=%d, want 0", res.ExitCode)
+	}
+	if res.DurMs <= 0 {
+		t.Errorf("duration not populated: %d", res.DurMs)
+	}
+}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 
 	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/tasktest"
 )
 
 // SourceLister is satisfied by *webui.SourceManager.
@@ -177,6 +178,13 @@ func (s *Server) methodToolsList(req rpcRequest) rpcResponse {
 				"id": map[string]any{"type": "string", "description": "Namespaced task ID"},
 			}, "id"),
 		},
+		{
+			Name:        "test_task",
+			Description: "Run the task's sibling test file (task.test.ts / .js / .mjs) through its runtime and return structured pass/fail counts plus the full stdout+stderr. Deno runtime only for now; other runtimes return a clear 'not yet supported' error.",
+			InputSchema: jsonSchema(map[string]any{
+				"id": map[string]any{"type": "string", "description": "Namespaced task ID (same as list_tasks returns)"},
+			}, "id"),
+		},
 	}
 	return rpcOK(req.ID, map[string]any{"tools": tools})
 }
@@ -201,6 +209,8 @@ func (s *Server) methodToolsCall(ctx context.Context, req rpcRequest) rpcRespons
 		return s.toolRunTask(ctx, req.ID, params.Arguments)
 	case "get_task":
 		return s.toolGetTask(req.ID, params.Arguments)
+	case "test_task":
+		return s.toolTestTask(ctx, req.ID, params.Arguments)
 	default:
 		return rpcErr(req.ID, -32601, fmt.Sprintf("unknown tool: %s", params.Name))
 	}
@@ -292,6 +302,46 @@ func (s *Server) toolGetTask(id any, raw json.RawMessage) rpcResponse {
 	}
 	b, _ := json.MarshalIndent(spec, "", "  ")
 	return textResult(id, string(b))
+}
+
+func (s *Server) toolTestTask(ctx context.Context, id any, raw json.RawMessage) rpcResponse {
+	var args struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return rpcErr(id, -32602, "invalid arguments: "+err.Error())
+	}
+	if args.ID == "" {
+		return rpcErr(id, -32602, "id is required")
+	}
+	if s.registry == nil {
+		return rpcErr(id, -32603, "registry not available")
+	}
+	spec, ok := s.registry.Get(args.ID)
+	if !ok {
+		return rpcErr(id, -32603, fmt.Sprintf("task %q not found", args.ID))
+	}
+	res, runErr := tasktest.Run(ctx, spec)
+	// Return structured JSON alongside the output text so MCP clients can
+	// read counts programmatically without having to re-parse the stdout.
+	payload := map[string]any{
+		"taskID":     res.TaskID,
+		"runtime":    res.Runtime,
+		"testFile":   res.TestFile,
+		"passed":     res.Passed,
+		"failed":     res.Failed,
+		"skipped":    res.Skipped,
+		"durationMs": res.Duration.Milliseconds(),
+		"exitCode":   res.ExitCode,
+	}
+	if res.Error != "" {
+		payload["error"] = res.Error
+	} else if runErr != nil {
+		payload["error"] = runErr.Error()
+	}
+	b, _ := json.MarshalIndent(payload, "", "  ")
+	text := fmt.Sprintf("%s\n\n--- summary ---\n%s\n", res.Output, string(b))
+	return textResult(id, text)
 }
 
 // --- helpers ---

--- a/pkg/mcp/test_task_tool_test.go
+++ b/pkg/mcp/test_task_tool_test.go
@@ -1,0 +1,151 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// Tests for the test_task MCP tool added in PR #160. The tool surfaces
+// pkg/tasktest.Run to any MCP-capable client; these tests verify the
+// listing, argument validation, and error paths are wired correctly.
+// The end-to-end happy path (spawning Deno) is covered by the parallel
+// test in pkg/ipc/control_task_test_test.go to avoid double-running
+// the slow test across packages.
+
+func newMCPServerForTest(t *testing.T) (*Server, *registry.Registry) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	reg := registry.New(d)
+	return New(reg, nil), reg
+}
+
+// TestToolsList_ExposesTestTask verifies the tool is advertised in the
+// tools/list response so MCP clients can discover it.
+func TestToolsList_ExposesTestTask(t *testing.T) {
+	s, _ := newMCPServerForTest(t)
+	resp := s.methodToolsList(rpcRequest{ID: 1})
+
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T, want map[string]any", resp.Result)
+	}
+	tools, _ := result["tools"].([]tool)
+	var found *tool
+	for i := range tools {
+		if tools[i].Name == "test_task" {
+			found = &tools[i]
+			break
+		}
+	}
+	if found == nil {
+		names := make([]string, 0, len(tools))
+		for _, t := range tools {
+			names = append(names, t.Name)
+		}
+		t.Fatalf("test_task not listed in tools/list (got: %v)", names)
+	}
+	if !strings.Contains(found.Description, "task.test") {
+		t.Errorf("description should mention task.test: %q", found.Description)
+	}
+	// Schema must require `id`. jsonSchema() stores the variadic
+	// []string directly, so assert the concrete slice type.
+	required, ok := found.InputSchema["required"].([]string)
+	if !ok {
+		t.Fatalf("required must be []string, got %T: %+v", found.InputSchema["required"], found.InputSchema)
+	}
+	foundID := false
+	for _, r := range required {
+		if r == "id" {
+			foundID = true
+		}
+	}
+	if !foundID {
+		t.Errorf("test_task schema must require 'id': %+v", found.InputSchema)
+	}
+}
+
+// TestToolTestTask_MissingID returns a JSON-RPC error when arguments omit id.
+func TestToolTestTask_MissingID(t *testing.T) {
+	s, _ := newMCPServerForTest(t)
+	resp := s.toolTestTask(context.Background(), 1, json.RawMessage(`{}`))
+	if resp.Error == nil {
+		t.Fatalf("expected error for missing id, got result=%v", resp.Result)
+	}
+	if !strings.Contains(resp.Error.Message, "id is required") {
+		t.Errorf("error msg = %q, want 'id is required'", resp.Error.Message)
+	}
+}
+
+// TestToolTestTask_MalformedArgs returns -32602 on invalid JSON.
+func TestToolTestTask_MalformedArgs(t *testing.T) {
+	s, _ := newMCPServerForTest(t)
+	resp := s.toolTestTask(context.Background(), 1, json.RawMessage(`not json`))
+	if resp.Error == nil {
+		t.Fatal("expected error for malformed args")
+	}
+	if resp.Error.Code != -32602 {
+		t.Errorf("code = %d, want -32602 (invalid params)", resp.Error.Code)
+	}
+}
+
+// TestToolTestTask_UnknownTask returns an error when the id doesn't
+// resolve to a registered task.
+func TestToolTestTask_UnknownTask(t *testing.T) {
+	s, _ := newMCPServerForTest(t)
+	resp := s.toolTestTask(context.Background(), 1, json.RawMessage(`{"id":"does/not/exist"}`))
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown task")
+	}
+	if !strings.Contains(resp.Error.Message, "not found") {
+		t.Errorf("error = %q, want to contain 'not found'", resp.Error.Message)
+	}
+}
+
+// TestToolTestTask_UnsupportedRuntime_StructuredSummary verifies the
+// summary block is emitted even when the underlying runner refuses the
+// runtime. MCP clients parse `--- summary ---` to pull structured counts.
+func TestToolTestTask_UnsupportedRuntime_StructuredSummary(t *testing.T) {
+	s, reg := newMCPServerForTest(t)
+
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "task.yaml"), []byte("name: x\ntrigger:\n  manual: true\nruntime: docker\n"), 0644)
+	_ = os.WriteFile(filepath.Join(dir, "task.test.ts"), []byte(""), 0644)
+	spec := &task.Spec{
+		ID: "x/docker", Name: "x", Runtime: task.RuntimeDocker,
+		Trigger: task.TriggerConfig{Manual: true}, Timeout: 5 * time.Second, TaskDir: dir,
+	}
+	_ = reg.Register(spec)
+
+	resp := s.toolTestTask(context.Background(), 1, json.RawMessage(`{"id":"x/docker"}`))
+	if resp.Error != nil {
+		t.Fatalf("tool call errored instead of returning partial result: %v", resp.Error)
+	}
+
+	// Response shape: content[0].text contains "<output>\n\n--- summary ---\n<json>"
+	result, _ := resp.Result.(map[string]any)
+	content, _ := result["content"].([]map[string]any)
+	if len(content) == 0 {
+		t.Fatalf("no content in response: %+v", resp.Result)
+	}
+	text, _ := content[0]["text"].(string)
+	if !strings.Contains(text, "--- summary ---") {
+		t.Errorf("response missing summary block: %q", text)
+	}
+	// The error field should mention the tracked issue for parity.
+	if !strings.Contains(text, "not yet supported") && !strings.Contains(text, "#159") {
+		t.Errorf("unsupported-runtime error not surfaced: %q", text)
+	}
+}

--- a/pkg/tasktest/tasktest.go
+++ b/pkg/tasktest/tasktest.go
@@ -64,6 +64,11 @@ func Run(ctx context.Context, spec *task.Spec) (Result, error) {
 	}
 
 	switch spec.Runtime {
+	// The "" and "js" aliases are defensive — pkg/task.applyDefaults
+	// normalizes both to RuntimeDeno at spec-load time, so the registry
+	// never hands us a non-normalized value. Keeping the aliases matches
+	// pkg/task/spec.go:validate and protects direct callers who construct
+	// a task.Spec without going through the loader.
 	case task.RuntimeDeno, "", "js":
 		return runDeno(ctx, spec, testFile)
 	default:
@@ -94,7 +99,7 @@ var denoSummaryRe = regexp.MustCompile(`(\d+)\s+passed(?:\s*\([\d\w]+\))?\s*\|\s
 // repo so `npm:...` imports resolve in-process.
 func denoConfigPath(taskDir string) string {
 	dir := filepath.Clean(taskDir)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		candidate := filepath.Join(dir, "tasks", "deno.json")
 		if _, err := os.Stat(candidate); err == nil {
 			return candidate

--- a/pkg/tasktest/tasktest.go
+++ b/pkg/tasktest/tasktest.go
@@ -26,16 +26,16 @@ import (
 // are parsed from Deno's summary line so machine callers don't have to
 // re-parse the text.
 type Result struct {
-	TaskID     string        `json:"taskID"`
-	Runtime    string        `json:"runtime"`
-	Passed     int           `json:"passed"`
-	Failed     int           `json:"failed"`
-	Skipped    int           `json:"skipped"`
-	Duration   time.Duration `json:"durationNs"`
-	ExitCode   int           `json:"exitCode"`
-	Output     string        `json:"output"`
-	TestFile   string        `json:"testFile"`
-	Error      string        `json:"error,omitempty"`
+	TaskID   string        `json:"taskID"`
+	Runtime  string        `json:"runtime"`
+	Passed   int           `json:"passed"`
+	Failed   int           `json:"failed"`
+	Skipped  int           `json:"skipped"`
+	Duration time.Duration `json:"durationNs"`
+	ExitCode int           `json:"exitCode"`
+	Output   string        `json:"output"`
+	TestFile string        `json:"testFile"`
+	Error    string        `json:"error,omitempty"`
 }
 
 // ErrNoTestFile signals that the task has no sibling test file.
@@ -90,8 +90,9 @@ func findTestFile(spec *task.Spec) (string, error) {
 }
 
 // denoSummaryRe matches Deno 2.x's summary line:
-//   "ok | 7 passed | 0 failed (80ms)"
-//   "FAILED | 5 passed | 2 failed | 1 ignored (2s)"
+//
+//	"ok | 7 passed | 0 failed (80ms)"
+//	"FAILED | 5 passed | 2 failed | 1 ignored (2s)"
 var denoSummaryRe = regexp.MustCompile(`(\d+)\s+passed(?:\s*\([\d\w]+\))?\s*\|\s*(\d+)\s+failed(?:\s*\|\s*(\d+)\s+ignored)?`)
 
 // denoConfigPath looks for tasks/deno.json walking up from the task dir

--- a/pkg/tasktest/tasktest.go
+++ b/pkg/tasktest/tasktest.go
@@ -1,0 +1,189 @@
+// Package tasktest runs a task's sibling test file (task.test.ts / .js / .mjs)
+// through the appropriate runtime and returns a structured result.
+//
+// Phase 1 supports the Deno runtime only — see issue #159 for Python,
+// Docker, and Podman parity.
+package tasktest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dicode/dicode/pkg/deno"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// Result summarises a task test run. Output is captured combined stdout +
+// stderr so callers (CLI, MCP) can display it verbatim; the integer fields
+// are parsed from Deno's summary line so machine callers don't have to
+// re-parse the text.
+type Result struct {
+	TaskID     string        `json:"taskID"`
+	Runtime    string        `json:"runtime"`
+	Passed     int           `json:"passed"`
+	Failed     int           `json:"failed"`
+	Skipped    int           `json:"skipped"`
+	Duration   time.Duration `json:"durationNs"`
+	ExitCode   int           `json:"exitCode"`
+	Output     string        `json:"output"`
+	TestFile   string        `json:"testFile"`
+	Error      string        `json:"error,omitempty"`
+}
+
+// ErrNoTestFile signals that the task has no sibling test file.
+var ErrNoTestFile = fmt.Errorf("task has no test file")
+
+// ErrUnsupportedRuntime signals a task whose runtime this package doesn't
+// yet cover. Phase 1 handles Deno only.
+type ErrUnsupportedRuntime struct{ Runtime string }
+
+func (e *ErrUnsupportedRuntime) Error() string {
+	return fmt.Sprintf("tasktest: runtime %q not yet supported (see #159)", e.Runtime)
+}
+
+// Run discovers the test file adjacent to spec.TaskDir, runs it through
+// the matching runtime, and returns a Result summarising the outcome.
+// Runtime errors (spawn, parse) surface as a non-nil error AND a partial
+// Result — callers can show whichever is useful.
+func Run(ctx context.Context, spec *task.Spec) (Result, error) {
+	if spec == nil || spec.TaskDir == "" {
+		return Result{}, fmt.Errorf("tasktest: spec or TaskDir is empty")
+	}
+
+	testFile, err := findTestFile(spec)
+	if err != nil {
+		return Result{TaskID: spec.ID}, err
+	}
+
+	switch spec.Runtime {
+	case task.RuntimeDeno, "", "js":
+		return runDeno(ctx, spec, testFile)
+	default:
+		return Result{TaskID: spec.ID, Runtime: string(spec.Runtime), TestFile: testFile},
+			&ErrUnsupportedRuntime{Runtime: string(spec.Runtime)}
+	}
+}
+
+// findTestFile picks the first task.test.* that exists in the task dir.
+// Mirrors the extension priority used by pkg/task.ScriptPath.
+func findTestFile(spec *task.Spec) (string, error) {
+	for _, ext := range []string{".ts", ".js", ".mjs"} {
+		p := filepath.Join(spec.TaskDir, "task.test"+ext)
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
+		}
+	}
+	return "", ErrNoTestFile
+}
+
+// denoSummaryRe matches Deno 2.x's summary line:
+//   "ok | 7 passed | 0 failed (80ms)"
+//   "FAILED | 5 passed | 2 failed | 1 ignored (2s)"
+var denoSummaryRe = regexp.MustCompile(`(\d+)\s+passed(?:\s*\([\d\w]+\))?\s*\|\s*(\d+)\s+failed(?:\s*\|\s*(\d+)\s+ignored)?`)
+
+// denoConfigPath looks for tasks/deno.json walking up from the task dir
+// up to a sensible ceiling. Matches the harness config that ships with the
+// repo so `npm:...` imports resolve in-process.
+func denoConfigPath(taskDir string) string {
+	dir := filepath.Clean(taskDir)
+	for i := 0; i < 10; i++ {
+		candidate := filepath.Join(dir, "tasks", "deno.json")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+	return ""
+}
+
+func runDeno(ctx context.Context, spec *task.Spec, testFile string) (Result, error) {
+	denoPath, err := deno.EnsureDeno(deno.DefaultVersion)
+	if err != nil {
+		return Result{TaskID: spec.ID, Runtime: "deno", TestFile: testFile, Error: err.Error()},
+			fmt.Errorf("tasktest: ensure deno: %w", err)
+	}
+
+	args := []string{"test", "--allow-all"}
+	if cfg := denoConfigPath(spec.TaskDir); cfg != "" {
+		args = append(args, "--config="+cfg)
+	}
+	args = append(args, testFile)
+
+	cmd := exec.CommandContext(ctx, denoPath, args...) //nolint:gosec
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	start := time.Now()
+	runErr := cmd.Run()
+	dur := time.Since(start)
+	exitCode := 0
+	if runErr != nil {
+		if ee, ok := runErr.(*exec.ExitError); ok {
+			exitCode = ee.ExitCode()
+		} else {
+			exitCode = -1
+		}
+	}
+
+	output := buf.String()
+	passed, failed, skipped := parseDenoSummary(output)
+
+	res := Result{
+		TaskID:   spec.ID,
+		Runtime:  "deno",
+		TestFile: testFile,
+		Passed:   passed,
+		Failed:   failed,
+		Skipped:  skipped,
+		Duration: dur,
+		ExitCode: exitCode,
+		Output:   output,
+	}
+	// Non-zero exit that we couldn't parse is a legit failure; return nil
+	// err but non-zero ExitCode — caller decides how to present it.
+	// Unparseable output (e.g. deno itself crashed before running tests)
+	// gets an Error string so the CLI can flag it.
+	if passed == 0 && failed == 0 && exitCode != 0 {
+		res.Error = fmt.Sprintf("deno test exited %d with no summary line", exitCode)
+	}
+	return res, nil
+}
+
+// parseDenoSummary extracts passed/failed/ignored counts from Deno test
+// output. Returns zeros if the summary line isn't found.
+func parseDenoSummary(output string) (passed, failed, skipped int) {
+	// Match against the last N lines — the summary is always at the tail.
+	lines := strings.Split(output, "\n")
+	for i := len(lines) - 1; i >= 0 && i >= len(lines)-20; i-- {
+		m := denoSummaryRe.FindStringSubmatch(stripANSI(lines[i]))
+		if m == nil {
+			continue
+		}
+		passed, _ = strconv.Atoi(m[1])
+		failed, _ = strconv.Atoi(m[2])
+		if m[3] != "" {
+			skipped, _ = strconv.Atoi(m[3])
+		}
+		return
+	}
+	return
+}
+
+// stripANSI removes ANSI color/control escapes so the regex can match
+// both `deno test` output (colored in terminals) and tee'd logs.
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
+
+func stripANSI(s string) string { return ansiRe.ReplaceAllString(s, "") }

--- a/pkg/tasktest/tasktest_test.go
+++ b/pkg/tasktest/tasktest_test.go
@@ -1,0 +1,95 @@
+package tasktest
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+func TestParseDenoSummary_Passed(t *testing.T) {
+	out := `Check file:///workspaces/dicode-core/tasks/buildin/webui/task.test.ts
+running 7 tests from ./tasks/buildin/webui/task.test.ts
+ping returns pong ... ok (1ms)
+
+ok | 7 passed | 0 failed (80ms)
+`
+	p, f, s := parseDenoSummary(out)
+	if p != 7 || f != 0 || s != 0 {
+		t.Errorf("passed=%d failed=%d skipped=%d; want 7/0/0", p, f, s)
+	}
+}
+
+func TestParseDenoSummary_Failed(t *testing.T) {
+	out := "FAILED | 5 passed | 2 failed | 1 ignored (1s)\n"
+	p, f, s := parseDenoSummary(out)
+	if p != 5 || f != 2 || s != 1 {
+		t.Errorf("passed=%d failed=%d skipped=%d; want 5/2/1", p, f, s)
+	}
+}
+
+func TestParseDenoSummary_WithANSI(t *testing.T) {
+	out := "\x1b[32mok\x1b[0m | \x1b[1m3 passed\x1b[0m | 0 failed (10ms)\n"
+	p, f, _ := parseDenoSummary(out)
+	if p != 3 || f != 0 {
+		t.Errorf("ANSI stripped incorrectly: passed=%d failed=%d; want 3/0", p, f)
+	}
+}
+
+func TestParseDenoSummary_Absent(t *testing.T) {
+	out := "deno: command failed\n"
+	p, f, s := parseDenoSummary(out)
+	if p != 0 || f != 0 || s != 0 {
+		t.Errorf("no-summary output should parse as zeros; got %d/%d/%d", p, f, s)
+	}
+}
+
+func TestFindTestFile_TsPreferred(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "task.test.ts"), []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "task.test.js"), []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	spec := &task.Spec{TaskDir: dir}
+	got, err := findTestFile(spec)
+	if err != nil {
+		t.Fatalf("findTestFile: %v", err)
+	}
+	if filepath.Base(got) != "task.test.ts" {
+		t.Errorf("got %q, want task.test.ts", got)
+	}
+}
+
+func TestFindTestFile_NoTest(t *testing.T) {
+	dir := t.TempDir()
+	spec := &task.Spec{TaskDir: dir}
+	_, err := findTestFile(spec)
+	if err != ErrNoTestFile {
+		t.Errorf("err = %v, want ErrNoTestFile", err)
+	}
+}
+
+func TestRun_UnsupportedRuntime(t *testing.T) {
+	spec := &task.Spec{ID: "foo", TaskDir: t.TempDir(), Runtime: task.RuntimeDocker}
+	_ = os.WriteFile(filepath.Join(spec.TaskDir, "task.test.ts"), []byte(""), 0644)
+
+	_, err := Run(context.Background(), spec)
+	if err == nil {
+		t.Fatal("expected ErrUnsupportedRuntime")
+	}
+	if _, ok := err.(*ErrUnsupportedRuntime); !ok {
+		t.Errorf("err = %T, want *ErrUnsupportedRuntime", err)
+	}
+}
+
+func TestRun_NoTestFile(t *testing.T) {
+	spec := &task.Spec{ID: "foo", TaskDir: t.TempDir(), Runtime: task.RuntimeDeno}
+	_, err := Run(context.Background(), spec)
+	if err != ErrNoTestFile {
+		t.Errorf("err = %v, want ErrNoTestFile", err)
+	}
+}


### PR DESCRIPTION
User ask: one uniform way to run a task's sibling test file whether the caller is a human (CLI), a buildin agent (IPC), or a third-party AI assistant (MCP). This is **Phase 1** — Deno runtime, which is 100% of the tasks we ship today. Phase 2 (Python + Docker/Podman parity) tracked as #159.

## Surface

All three entry points route through the same [`pkg/tasktest`](pkg/tasktest/tasktest.go) executor:

```
┌─ dicode task test <id>   (humans)
│
├─ cli.task.test IPC       (buildin agents, future webui button)
│
└─ test_task MCP tool      (Claude Code, Cursor, any MCP client)
        │
        ▼
   pkg/tasktest.Run(ctx, spec)
        │
        ├─ Deno  → deno test --allow-all --config=tasks/deno.json <task.test.ts>
        ├─ Python → stub (ErrUnsupportedRuntime #159)
        └─ Docker/Podman → stub (ErrUnsupportedRuntime #159)
```

Result shape is uniform: `{taskID, runtime, passed, failed, skipped, durationMs, exitCode, output, testFile, error?}`.

## What ships

### [`pkg/tasktest`](pkg/tasktest/tasktest.go) (new package)
- Discovers `task.test.{ts,js,mjs}` via `findTestFile`
- Dispatches on `spec.Runtime`; only Deno implemented, others return typed `ErrUnsupportedRuntime`
- Resolves Deno via `pkg/deno.EnsureDeno(DefaultVersion)` — same cached install the prod runtime uses
- Finds `tasks/deno.json` walking up so `npm:...` imports resolve
- Parses Deno's summary line for passed/failed/skipped counts (handles ANSI colour, `ignored`, `FAILED` prefix)

### [`pkg/ipc/control.go`](pkg/ipc/control.go)
- New method `cli.task.test` in the dispatch switch
- `TaskTestResult` wire type (stable surface; decoupled from `pkg/tasktest.Result` so the IPC shape can stay fixed as the executor evolves)
- `handleTaskTest(ctx, req)` resolves task from registry, delegates to `tasktest.Run`, converts to wire shape

### [`cmd/dicode/main.go`](cmd/dicode/main.go)
- New `dicode task test <task-id>` subcommand
- Prints runner output verbatim, then a one-line summary (`task/id: 7 passed, 0 failed (runtime=deno, 80ms)`)
- Exit non-zero on any failed test or parse error

### [`pkg/mcp/server.go`](pkg/mcp/server.go)
- New `test_task` tool listed in `tools/list`
- Input schema: `{id: string (required)}`
- Returns full runner output + a JSON summary block so MCP clients can read counts programmatically

## Tests

- **`pkg/tasktest`** — 8 unit tests covering the Deno summary regex (passed-only, failed-with-ignored, ANSI-coloured, no-summary), `findTestFile` extension priority, `ErrNoTestFile`, and `ErrUnsupportedRuntime`.
- **`pkg/ipc`** — 4 handler tests exercising `handleTaskTest` directly: missing taskID, unknown task, no test file, and an end-to-end happy path that spawns Deno against a tmp-generated task (0.5 s, skipped under `-short`).
- `go test ./... -race -count=1 -timeout 300s` — all packages green locally.

## Phase 2 (#159)

Out of scope for this PR — tracked as a follow-up:
- **Python:** `tasks/sdk_test.py` harness + `uv run pytest` dispatch
- **Docker/Podman:** requires a `Dockerfile` test-stage convention; needs a design doc before code

## Test plan

- [x] `go test ./pkg/tasktest/... -race` — 8/8 pass
- [x] `go test ./pkg/ipc/... -race` — 4 new tests pass, existing green
- [x] `go test ./... -race -count=1 -timeout 300s` — all packages green
- [x] `make build` — `dicode task test` appears in `dicode` usage
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)