### PR TITLE
ci: run e2e relay suite on relay-touching PRs (closes #138)

### DIFF
--- a/.github/workflows/e2e-relay.yml
+++ b/.github/workflows/e2e-relay.yml
@@ -1,0 +1,79 @@
+name: E2E Relay
+
+# Runs the Go + testcontainers-go relay e2e suite (tests/e2e/relay) only on
+# PRs that touch the relay surface. The relay image tag is pinned in
+# tests/e2e/relay/testdata/Dockerfile.relay (tracked by Dependabot) — this
+# workflow defers to that file and does not duplicate the version.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'pkg/relay/**'
+      - 'pkg/ipc/**'
+      - 'pkg/runtime/deno/**'
+      - 'cmd/dicode/**'
+      - 'tasks/buildin/auth-start/**'
+      - 'tasks/buildin/auth-relay/**'
+      - 'tests/e2e/relay/**'
+      - '.github/workflows/e2e-relay.yml'
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+# Least-privilege GITHUB_TOKEN. Only needs read access to check out source;
+# actions/upload-artifact uses its own implicit grant.
+permissions:
+  contents: read
+
+jobs:
+  e2e-relay:
+    name: E2E (relay)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Pre-pull relay image
+        # Parse the FROM line in Dockerfile.relay so docker's layer cache is
+        # warm before testcontainers-go builds the wrapper image. Keeps
+        # wall-clock timing predictable across runs.
+        run: |
+          set -euo pipefail
+          image=$(awk '/^FROM /{print $2; exit}' tests/e2e/relay/testdata/Dockerfile.relay)
+          echo "Pre-pulling ${image}"
+          docker pull "${image}"
+
+      - name: Run e2e relay suite
+        run: make test-e2e-relay
+
+      - name: Collect container logs
+        if: failure()
+        run: |
+          set -eu
+          mkdir -p /tmp/e2e-relay-logs
+          # testcontainers-go usually reaps containers on clean exit but
+          # leaves them around on failure; grab logs + inspect for each.
+          docker ps -a --format '{{.ID}} {{.Image}} {{.Names}}' \
+            | tee /tmp/e2e-relay-logs/containers.txt
+          while read -r id image name; do
+            [ -z "${id}" ] && continue
+            docker logs "${id}" > "/tmp/e2e-relay-logs/${id}-${name}.log" 2>&1 || true
+            docker inspect "${id}" > "/tmp/e2e-relay-logs/${id}-${name}.inspect.json" 2>&1 || true
+          done < <(docker ps -a --format '{{.ID}} {{.Image}} {{.Names}}')
+
+      - name: Upload container logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-relay-logs-${{ github.run_id }}
+          path: /tmp/e2e-relay-logs/
+          retention-days: 7
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Closes #138. Adds a dedicated CI workflow that runs the relay e2e suite (from #163) only on PRs that touch the relay surface, so the broader PR fleet doesn't pay Docker-pull cost on unrelated changes.

## Triggers

- `pull_request` on the paths listed in #138 (pkg/relay, pkg/ipc, pkg/runtime/deno, cmd/dicode, tasks/buildin/auth-*, tests/e2e/relay) + the workflow file itself
- `workflow_dispatch` for on-demand runs

## Job shape

- Runs `make test-e2e-relay` — canonical entrypoint from #163, no duplicate test invocation logic
- Pre-pulls the relay image by parsing the `FROM` line in `tests/e2e/relay/testdata/Dockerfile.relay` for predictable timing
- On failure: walks `docker ps -a`, captures `docker logs` + `docker inspect` per container, uploads as artifact `e2e-relay-logs-<run-id>` (7-day retention)
- Least-privilege `permissions: contents: read`
- Convention-matched with `ci.yml` / `e2e.yml` (Go version from `go.mod`, setup-go cache, `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env)
- Job / status-check name: `E2E (relay)` — matches the existing `Test` / `Lint` / `Playwright E2E` pattern

## Deviation from #138 body

The issue mentions pulling `dicodeayo/dicode-relay:main`, but we don't publish a rolling `:main` tag. The workflow defers to whatever is pinned in `Dockerfile.relay` (currently `:0.1.2`, Dependabot-bumped weekly) — no workflow change needed when the pin moves.

## Out of scope (deferred)

- **Nightly scheduled run** against an older image tag for scenario 4 (protocol version guard) — that scenario itself isn't shipped yet (Phase B of #137)
- **Branch protection / required-status** wiring — done via repo settings, not the workflow file

## Test plan

- [ ] This PR itself touches `.github/workflows/e2e-relay.yml` and should trigger the new workflow on its own creation (self-verifies the paths filter)
- [ ] A no-op docs-only PR should NOT trigger this workflow
- [ ] Forced-failure trial (break a test in a follow-up, revert) produces the `e2e-relay-logs-<run-id>` artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)