### PR TITLE
test(relay): WSS reconnect + broker TOFU pin + key-rotation (closes #122)

### DIFF
--- a/docs/superpowers/specs/2026-04-22-http-request-log-levels-design.md
+++ b/docs/superpowers/specs/2026-04-22-http-request-log-levels-design.md
@@ -1,0 +1,124 @@
+# HTTP request log levels — design
+
+Addresses [#23](https://github.com/dicode-ayo/dicode-core/issues/23). The chi `middleware.Logger` at [pkg/webui/server.go:322](../../../pkg/webui/server.go#L322) emits every HTTP request at the default (info) level, drowning application-level log lines. This spec replaces it with a zap-based middleware that routes by status code and adds a per-request correlation ID.
+
+## Acceptance (copied from #23, plus one adjacent)
+
+- 2xx/3xx request lines logged at **debug**
+- 4xx logged at **warn**
+- 5xx logged at **error**
+- No change to existing structured log fields *outside the request logger*
+- **Adjacent:** every request carries a `req_id` field for correlation (requires `middleware.RequestID`)
+
+## Design
+
+### New file: `pkg/webui/log_middleware.go`
+
+Two types implementing chi's `middleware.LogFormatter` / `middleware.LogEntry` interfaces:
+
+```go
+type zapLogFormatter struct{ log *zap.Logger }
+
+func (f *zapLogFormatter) NewLogEntry(r *http.Request) middleware.LogEntry {
+    return &zapLogEntry{
+        log:    f.log,
+        method: r.Method,
+        path:   r.URL.Path,
+        remote: r.RemoteAddr,
+        reqID:  middleware.GetReqID(r.Context()),
+    }
+}
+
+type zapLogEntry struct {
+    log                          *zap.Logger
+    method, path, remote, reqID  string
+}
+
+func (e *zapLogEntry) Write(status, bytes int, _ http.Header, elapsed time.Duration, _ interface{}) {
+    fields := []zap.Field{
+        zap.String("method", e.method),
+        zap.String("path",   e.path),
+        zap.Int("status",    status),
+        zap.Int("bytes",     bytes),
+        zap.Duration("dur",  elapsed),
+        zap.String("remote", e.remote),
+        zap.String("req_id", e.reqID),
+    }
+    switch {
+    case status >= 500:
+        e.log.Error("http", fields...)
+    case status >= 400:
+        e.log.Warn("http", fields...)
+    default:
+        e.log.Debug("http", fields...)
+    }
+}
+
+func (e *zapLogEntry) Panic(v interface{}, stack []byte) {
+    e.log.Error("http panic",
+        zap.String("method", e.method),
+        zap.String("path",   e.path),
+        zap.String("req_id", e.reqID),
+        zap.Any("panic",     v),
+        zap.ByteString("stack", stack),
+    )
+}
+```
+
+### Wire-up in `pkg/webui/server.go`
+
+Replace line 322:
+
+```go
+r.Use(middleware.Logger)
+```
+
+with:
+
+```go
+r.Use(middleware.RequestID)
+r.Use(middleware.RequestLogger(&zapLogFormatter{log: s.log}))
+```
+
+`RequestID` must precede `RequestLogger` so `GetReqID` resolves inside `NewLogEntry`. Both sit *after* `middleware.Recoverer` — the recoverer calls our `Panic` via the formatter.
+
+### Level semantics
+
+| Status | Level | Rationale |
+|---|---|---|
+| 1xx/2xx/3xx | Debug | Normal traffic, silenced by default, visible under `--log-level debug`. |
+| 4xx | Warn | Client errors — usually the caller's fault but worth seeing. Matches existing `s.log.Warn` usage for auth rejections. |
+| 5xx | Error | Server-side failure, always surfaced. |
+| panic | Error | Captured via `Panic(v, stack)`, includes the stack bytes. |
+
+### What stays unchanged
+
+- Existing `s.log.Info/Warn/Error` call sites inside handlers (login flow, config save, etc.) — untouched.
+- `middleware.Recoverer` ordering — remains first; our logger entry's `Panic` gets called by it.
+- `securityHeaders` and the rest of the chain — unchanged.
+
+## Testing
+
+New file: `pkg/webui/log_middleware_test.go`.
+
+Use `go.uber.org/zap/zaptest/observer` to build an in-memory logger, run httptest requests, assert level + fields.
+
+| Test | Setup | Asserts |
+|---|---|---|
+| `TestRequestLogger_2xx_Debug` | handler returns 200 | one observed entry at `DebugLevel` with `status=200`, `method`, `path` |
+| `TestRequestLogger_4xx_Warn`  | handler returns 404 | one entry at `WarnLevel`, `status=404` |
+| `TestRequestLogger_5xx_Error` | handler returns 500 | one entry at `ErrorLevel`, `status=500` |
+| `TestRequestLogger_ReqID_Propagates` | stack with `middleware.RequestID` + formatter | entry's `req_id` field is non-empty and matches `X-Request-Id` response header |
+| `TestRequestLogger_Panic_Logged` | handler panics, stack has `Recoverer` then our formatter | entry at `ErrorLevel` with `msg="http panic"` and a `panic` field |
+
+No change to existing tests.
+
+## Migration / rollout
+
+Zero-config. Behaviour change: previously-visible request lines disappear at default log level. Docs already mention `log_level: debug` as the way to re-enable verbose output — no README edit required.
+
+## Out of scope
+
+- Request ID in response header for client-side correlation — `middleware.RequestID` already sets `X-Request-Id` automatically; no extra work.
+- Structured-only output format (JSON). Zap's configured encoder (currently console) governs the on-wire format; we're only emitting fields.
+- Sampling / rate-limiting of high-volume debug lines — not needed while debug is off by default.

--- a/pkg/relay/helpers_test.go
+++ b/pkg/relay/helpers_test.go
@@ -15,3 +15,21 @@ func noopLogger() *zap.Logger {
 func dialWS(ctx context.Context, url string) (*websocket.Conn, *http.Response, error) {
 	return websocket.Dial(ctx, url, nil)
 }
+
+// severAllWS closes every active WebSocket connection currently tracked by
+// the Server. Used by reconnect tests — httptest.Server.CloseClientConnections
+// is a no-op on hijacked (upgraded) connections, so it does NOT force a
+// daemon-side reconnect on its own. Reaching into the server's client map
+// and closing each WS forces the daemon's read loop to return and runOnce
+// to exit, which is what triggers Run's reconnect cycle.
+func severAllWS(s *Server) {
+	s.mu.Lock()
+	conns := make([]*websocket.Conn, 0, len(s.clients))
+	for _, sc := range s.clients {
+		conns = append(conns, sc.conn)
+	}
+	s.mu.Unlock()
+	for _, c := range conns {
+		_ = c.CloseNow()
+	}
+}

--- a/pkg/relay/reconnect_tofu_test.go
+++ b/pkg/relay/reconnect_tofu_test.go
@@ -7,6 +7,9 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
@@ -44,27 +47,6 @@ func generateBrokerPubkeyB64(t *testing.T) string {
 	return base64.StdEncoding.EncodeToString(der)
 }
 
-// newTOFUTestDB opens an in-memory SQLite DB with the kv table the
-// CheckAndPinBrokerPubkey / ReplaceBrokerPubkey helpers operate on.
-// Returns the DB plus a cleanup registered via t.Cleanup.
-func newTOFUTestDB(t *testing.T) db.DB {
-	t.Helper()
-	database, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
-	if err != nil {
-		t.Fatalf("open sqlite: %v", err)
-	}
-	t.Cleanup(func() { _ = database.Close() })
-
-	// The kv table is created by the daemon's migrations, but pkg/relay
-	// tests don't run them — create the minimal schema inline.
-	if err := database.Exec(context.Background(),
-		`CREATE TABLE IF NOT EXISTS kv (key TEXT PRIMARY KEY, value TEXT NOT NULL)`,
-	); err != nil {
-		t.Fatalf("create kv table: %v", err)
-	}
-	return database
-}
-
 // setupTOFURelay spins up a relay Server advertising the given broker pubkey
 // and returns the httptest wrapper + the ws:// URL the client should dial.
 func setupTOFURelay(t *testing.T, brokerPubB64 string) (*httptest.Server, string, *Server) {
@@ -92,26 +74,29 @@ func waitForPubkey(t *testing.T, c *Client, want string, deadline time.Duration,
 	t.Fatalf("%s: BrokerPubkey() = %q, want %q after %s", msg, c.BrokerPubkey(), want, deadline)
 }
 
-// localLoopback runs a trivial HTTP server on a random local port and
-// returns its port. Used as the daemon's forwarding target — we only
-// care that the daemon's relay.Client is up, not about request handling.
+// loopbackPort extracts the port number from an httptest.Server listener
+// address. Unlike a bare string split this handles IPv6 literals correctly.
+func loopbackPort(t *testing.T, addr string) int {
+	t.Helper()
+	_, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("split host/port %q: %v", addr, err)
+	}
+	p, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("parse port %q: %v", portStr, err)
+	}
+	return p
+}
+
+// localLoopback runs a trivial no-op HTTP server on a random local port and
+// returns the port. For tests that just need the daemon's relay.Client to
+// have a forwarding target but don't care about request handling.
 func localLoopback(t *testing.T) int {
 	t.Helper()
 	ls := httptest.NewServer(nil)
 	t.Cleanup(ls.Close)
-	_, portStr, _ := splitHostPort(ls.Listener.Addr().String())
-	p, _ := strconv.Atoi(portStr)
-	return p
-}
-
-// splitHostPort is a local alias so we don't drag net.SplitHostPort through
-// every test body.
-func splitHostPort(addr string) (string, string, error) {
-	parts := strings.SplitN(addr, ":", 2)
-	if len(parts) != 2 {
-		return addr, "", nil
-	}
-	return parts[0], parts[1], nil
+	return loopbackPort(t, ls.Listener.Addr().String())
 }
 
 // ---------------------------------------------------------------------------
@@ -121,7 +106,7 @@ func splitHostPort(addr string) (string, string, error) {
 func TestTOFU_PinOnFirstConnect(t *testing.T) {
 	brokerPub := generateBrokerPubkeyB64(t)
 	_, wsURL, _ := setupTOFURelay(t, brokerPub)
-	database := newTOFUTestDB(t)
+	database := openTestDB(t)
 
 	// Pre-assertion: no pin.
 	got, err := LoadBrokerPubkey(context.Background(), database)
@@ -155,41 +140,106 @@ func TestTOFU_PinOnFirstConnect(t *testing.T) {
 // Scenario 3: reconnect after network drop succeeds without re-pinning
 // ---------------------------------------------------------------------------
 
+// TestTOFU_PinPreservedAcrossReconnects proves two things that have to hold
+// together: (a) the daemon successfully re-handshakes after a dropped
+// connection, and (b) the TOFU pin is not re-written on that successful
+// reconnect. Proving a reconnect *happened* matters — the client's
+// in-memory BrokerPubkey and the DB pin both survive disconnect on their
+// own, so asserting on their values alone is a trivial passing test.
+// Following the `TestAutoReconnect` pattern we ping through the relay's
+// public webhook URL; the local daemon-side handler signals a fresh hit,
+// confirming the full WS tunnel is live end-to-end on each iteration.
 func TestTOFU_PinPreservedAcrossReconnects(t *testing.T) {
 	brokerPub := generateBrokerPubkeyB64(t)
-	ts, wsURL, _ := setupTOFURelay(t, brokerPub)
-	database := newTOFUTestDB(t)
+	ts, wsURL, srv := setupTOFURelay(t, brokerPub)
+	database := openTestDB(t)
 
-	client := NewClient(wsURL, newTestIdentity(t), localLoopback(t), database, noopLogger())
+	// Local daemon-side HTTP server: signals on every /hooks/ping hit so
+	// the test can observe when a fresh WS tunnel actually carries
+	// traffic end-to-end (not just when a welcome was received).
+	pinged := make(chan struct{}, 10)
+	localSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/hooks/ping" {
+			select {
+			case pinged <- struct{}{}:
+			default:
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(localSrv.Close)
+	port := loopbackPort(t, localSrv.Listener.Addr().String())
+
+	id := newTestIdentity(t)
+	client := NewClient(wsURL, id, port, database, noopLogger())
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	go func() { _ = client.Run(ctx) }()
 
 	waitForPubkey(t, client, brokerPub, 5*time.Second, "initial connect")
 
-	// Snapshot the DB pin — must not change on reconnect.
-	before, err := LoadBrokerPubkey(context.Background(), database)
-	if err != nil {
-		t.Fatalf("load pin: %v", err)
+	// pingUntilDelivered polls /hooks/ping through the public relay URL
+	// until the daemon-local handler signals receipt, confirming a live
+	// WS tunnel. Fails the test on deadline.
+	pingUntilDelivered := func(label string) {
+		t.Helper()
+		hookURL := fmt.Sprintf("%s/u/%s/hooks/ping", ts.URL, id.UUID)
+		deadline := time.After(5 * time.Second)
+		for {
+			select {
+			case <-deadline:
+				t.Fatalf("%s: webhook never reached daemon via relay", label)
+			case <-pinged:
+				return
+			default:
+			}
+			resp, err := http.Post(hookURL, "application/json", strings.NewReader("{}"))
+			if resp != nil {
+				resp.Body.Close()
+			}
+			_ = err
+			time.Sleep(100 * time.Millisecond)
+		}
 	}
 
-	// Drop the active connection; httptest.Server stays up, so the
-	// daemon's backoff reconnect lands a fresh handshake.
-	ts.CloseClientConnections()
+	// First iteration: prove the tunnel is live.
+	pingUntilDelivered("pre-drop")
 
-	// Wait for the client to reconnect — BrokerPubkey is cleared to ""
-	// between connections? No — client.go only sets it on welcome, and
-	// doesn't clear on disconnect. So we watch for a log-level signal
-	// that reconnect happened. Simplest: poll the stored pin is still
-	// the same value and wait a short while to confirm no regression.
-	time.Sleep(1500 * time.Millisecond) // past the 1s initial backoff
+	// Drain any stragglers from the first ping before we measure the
+	// second — `pingUntilDelivered` loops until it sees at least one
+	// signal, but extra retries may have queued up.
+	for {
+		select {
+		case <-pinged:
+			continue
+		default:
+		}
+		break
+	}
 
-	after, err := LoadBrokerPubkey(context.Background(), database)
+	// Drop the tunnel. httptest.Server.CloseClientConnections is a no-op
+	// on hijacked WS connections; severAllWS reaches into the server's
+	// client registry and closes each active ws.Conn directly, forcing
+	// the daemon's read loop to return and runOnce to exit. Run's
+	// backoff-and-retry cycle then lands a fresh handshake.
+	severAllWS(srv)
+
+	// Second iteration: prove the tunnel comes back. The fact that a
+	// NEW ping propagates (after the old connection was severed) is the
+	// cross-component signal that a reconnect actually happened.
+	pingUntilDelivered("post-drop — reconnect must have completed")
+
+	// Invariant under test: the TOFU pin must have stayed put across
+	// the reconnect. CheckAndPinBrokerPubkey should have returned
+	// BrokerPubkeyPinMatch (not PinNew) — a stored value of anything
+	// other than brokerPub would mean the DB was re-written on the
+	// re-handshake, which breaks the whole TOFU guarantee.
+	stored, err := LoadBrokerPubkey(context.Background(), database)
 	if err != nil {
 		t.Fatalf("load pin after reconnect: %v", err)
 	}
-	if before != after {
-		t.Fatalf("pin changed across reconnect: before=%q after=%q", before, after)
+	if stored != brokerPub {
+		t.Fatalf("pin changed across reconnect: got %q, want %q", stored, brokerPub)
 	}
 	if client.BrokerPubkey() != brokerPub {
 		t.Fatalf("client.BrokerPubkey() = %q after reconnect, want %q",
@@ -228,7 +278,7 @@ func TestTOFU_RefusesAfterBrokerKeyRotation(t *testing.T) {
 		t.Fatal("freshly generated keys should differ; test assumption violated")
 	}
 	_, wsURL, srv := setupTOFURelay(t, origPub)
-	database := newTOFUTestDB(t)
+	database := openTestDB(t)
 
 	// Daemon 1 pins origPub.
 	_, cancel1 := startDaemonAndWait(t, wsURL, database, origPub, 5*time.Second)
@@ -274,7 +324,7 @@ func TestTOFU_TrustBrokerClearsPinAndRepins(t *testing.T) {
 	origPub := generateBrokerPubkeyB64(t)
 	newPub := generateBrokerPubkeyB64(t)
 	_, wsURL, srv := setupTOFURelay(t, origPub)
-	database := newTOFUTestDB(t)
+	database := openTestDB(t)
 
 	// Daemon 1 pins origPub.
 	_, cancel1 := startDaemonAndWait(t, wsURL, database, origPub, 5*time.Second)

--- a/pkg/relay/reconnect_tofu_test.go
+++ b/pkg/relay/reconnect_tofu_test.go
@@ -1,0 +1,306 @@
+package relay
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+)
+
+// Tests in this file address issue #122: WSS reconnect + broker TOFU pin
+// + key-rotation verification. Scenarios 1 (ECDSA challenge-response) and
+// 6 (timestamp / nonce replay protection) are already covered by
+// client_test.go and challenge_sig_test.go; these tests cover the TOFU
+// lifecycle gaps (2, 3, 4, 5 from the issue acceptance).
+//
+// Design note: instead of hand-rolling a stub broker, these tests drive
+// the real in-repo Server (pkg/relay.Server) and use the new
+// SetBrokerPubkey hook to simulate key rotation across reconnects. That
+// keeps the production wire protocol as the single source of truth —
+// no risk of a divergent stub implementation covering up a real drift.
+
+// generateBrokerPubkeyB64 returns a fresh ECDSA P-256 public key encoded
+// as base64 SPKI DER — the same shape dicode-relay advertises in its
+// welcome messages.
+func generateBrokerPubkeyB64(t *testing.T) string {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate broker key: %v", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	if err != nil {
+		t.Fatalf("marshal SPKI: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(der)
+}
+
+// newTOFUTestDB opens an in-memory SQLite DB with the kv table the
+// CheckAndPinBrokerPubkey / ReplaceBrokerPubkey helpers operate on.
+// Returns the DB plus a cleanup registered via t.Cleanup.
+func newTOFUTestDB(t *testing.T) db.DB {
+	t.Helper()
+	database, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	// The kv table is created by the daemon's migrations, but pkg/relay
+	// tests don't run them — create the minimal schema inline.
+	if err := database.Exec(context.Background(),
+		`CREATE TABLE IF NOT EXISTS kv (key TEXT PRIMARY KEY, value TEXT NOT NULL)`,
+	); err != nil {
+		t.Fatalf("create kv table: %v", err)
+	}
+	return database
+}
+
+// setupTOFURelay spins up a relay Server advertising the given broker pubkey
+// and returns the httptest wrapper + the ws:// URL the client should dial.
+func setupTOFURelay(t *testing.T, brokerPubB64 string) (*httptest.Server, string, *Server) {
+	t.Helper()
+	log := noopLogger()
+	srv := NewServer("https://example.com", log)
+	srv.SetBrokerPubkey(brokerPubB64)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws"
+	return ts, wsURL, srv
+}
+
+// waitForPubkey polls c.BrokerPubkey() until it returns want or deadline
+// elapses. Fails the test if the poll times out.
+func waitForPubkey(t *testing.T, c *Client, want string, deadline time.Duration, msg string) {
+	t.Helper()
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		if c.BrokerPubkey() == want {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("%s: BrokerPubkey() = %q, want %q after %s", msg, c.BrokerPubkey(), want, deadline)
+}
+
+// localLoopback runs a trivial HTTP server on a random local port and
+// returns its port. Used as the daemon's forwarding target — we only
+// care that the daemon's relay.Client is up, not about request handling.
+func localLoopback(t *testing.T) int {
+	t.Helper()
+	ls := httptest.NewServer(nil)
+	t.Cleanup(ls.Close)
+	_, portStr, _ := splitHostPort(ls.Listener.Addr().String())
+	p, _ := strconv.Atoi(portStr)
+	return p
+}
+
+// splitHostPort is a local alias so we don't drag net.SplitHostPort through
+// every test body.
+func splitHostPort(addr string) (string, string, error) {
+	parts := strings.SplitN(addr, ":", 2)
+	if len(parts) != 2 {
+		return addr, "", nil
+	}
+	return parts[0], parts[1], nil
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2: broker pubkey is pinned on first connection
+// ---------------------------------------------------------------------------
+
+func TestTOFU_PinOnFirstConnect(t *testing.T) {
+	brokerPub := generateBrokerPubkeyB64(t)
+	_, wsURL, _ := setupTOFURelay(t, brokerPub)
+	database := newTOFUTestDB(t)
+
+	// Pre-assertion: no pin.
+	got, err := LoadBrokerPubkey(context.Background(), database)
+	if err != nil {
+		t.Fatalf("LoadBrokerPubkey before connect: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("pre-connect pin = %q, want empty", got)
+	}
+
+	client := NewClient(wsURL, newTestIdentity(t), localLoopback(t), database, noopLogger())
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	runErr := make(chan error, 1)
+	go func() { runErr <- client.Run(ctx) }()
+
+	waitForPubkey(t, client, brokerPub, 5*time.Second,
+		"first connect should pin the broker pubkey")
+
+	// And the DB-side pin matches.
+	got, err = LoadBrokerPubkey(context.Background(), database)
+	if err != nil {
+		t.Fatalf("LoadBrokerPubkey after connect: %v", err)
+	}
+	if got != brokerPub {
+		t.Fatalf("stored pin = %q, want %q", got, brokerPub)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3: reconnect after network drop succeeds without re-pinning
+// ---------------------------------------------------------------------------
+
+func TestTOFU_PinPreservedAcrossReconnects(t *testing.T) {
+	brokerPub := generateBrokerPubkeyB64(t)
+	ts, wsURL, _ := setupTOFURelay(t, brokerPub)
+	database := newTOFUTestDB(t)
+
+	client := NewClient(wsURL, newTestIdentity(t), localLoopback(t), database, noopLogger())
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	go func() { _ = client.Run(ctx) }()
+
+	waitForPubkey(t, client, brokerPub, 5*time.Second, "initial connect")
+
+	// Snapshot the DB pin — must not change on reconnect.
+	before, err := LoadBrokerPubkey(context.Background(), database)
+	if err != nil {
+		t.Fatalf("load pin: %v", err)
+	}
+
+	// Drop the active connection; httptest.Server stays up, so the
+	// daemon's backoff reconnect lands a fresh handshake.
+	ts.CloseClientConnections()
+
+	// Wait for the client to reconnect — BrokerPubkey is cleared to ""
+	// between connections? No — client.go only sets it on welcome, and
+	// doesn't clear on disconnect. So we watch for a log-level signal
+	// that reconnect happened. Simplest: poll the stored pin is still
+	// the same value and wait a short while to confirm no regression.
+	time.Sleep(1500 * time.Millisecond) // past the 1s initial backoff
+
+	after, err := LoadBrokerPubkey(context.Background(), database)
+	if err != nil {
+		t.Fatalf("load pin after reconnect: %v", err)
+	}
+	if before != after {
+		t.Fatalf("pin changed across reconnect: before=%q after=%q", before, after)
+	}
+	if client.BrokerPubkey() != brokerPub {
+		t.Fatalf("client.BrokerPubkey() = %q after reconnect, want %q",
+			client.BrokerPubkey(), brokerPub)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios 4 & 5 use the sequential-daemons pattern: pin under broker K1,
+// then start a fresh daemon against broker K2, sharing the same DB. This
+// avoids waiting for the real client's exponential-backoff reconnect loop
+// to catch up after a mid-connection rotation — we already have #137's
+// testcontainers suite for the "live reconnect under load" flavor; here
+// we isolate the TOFU state-machine transitions and drive them directly.
+// ---------------------------------------------------------------------------
+
+func startDaemonAndWait(t *testing.T, wsURL string, database db.DB, wantPub string, stable time.Duration) (*Client, context.CancelFunc) {
+	t.Helper()
+	client := NewClient(wsURL, newTestIdentity(t), localLoopback(t), database, noopLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = client.Run(ctx) }()
+	if wantPub != "" {
+		waitForPubkey(t, client, wantPub, stable, "handshake completion")
+	}
+	return client, cancel
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 4: reconnect fails hard when the broker presents a different key
+// ---------------------------------------------------------------------------
+
+func TestTOFU_RefusesAfterBrokerKeyRotation(t *testing.T) {
+	origPub := generateBrokerPubkeyB64(t)
+	newPub := generateBrokerPubkeyB64(t)
+	if origPub == newPub {
+		t.Fatal("freshly generated keys should differ; test assumption violated")
+	}
+	_, wsURL, srv := setupTOFURelay(t, origPub)
+	database := newTOFUTestDB(t)
+
+	// Daemon 1 pins origPub.
+	_, cancel1 := startDaemonAndWait(t, wsURL, database, origPub, 5*time.Second)
+	cancel1()
+
+	// Broker rotates. Daemon 2 reconnects and must NOT accept the new
+	// welcome.broker_pubkey: the stored pin is still origPub, so
+	// CheckAndPinBrokerPubkey returns Mismatch and the handshake aborts.
+	srv.SetBrokerPubkey(newPub)
+
+	client2, cancel2 := startDaemonAndWait(t, wsURL, database, "", 0)
+	defer cancel2()
+
+	// Give the client a handful of handshake cycles. Each attempt hits
+	// the mismatch branch — none should update state. The pin must stay
+	// origPub on disk and the in-memory cache must not report newPub.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := client2.BrokerPubkey(); got == newPub {
+			t.Fatalf("client accepted rotated broker pubkey: BrokerPubkey() = %q; "+
+				"mismatch path must abort the handshake before updating the cache", got)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	stored, err := LoadBrokerPubkey(context.Background(), database)
+	if err != nil {
+		t.Fatalf("load pin: %v", err)
+	}
+	if stored != origPub {
+		t.Fatalf("DB pin overwritten on mismatch: got %q, want %q; "+
+			"CheckAndPinBrokerPubkey must NOT overwrite on mismatch — that would "+
+			"silently accept a rotated broker key and defeat TOFU", stored, origPub)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 5: `dicode relay trust-broker --yes` clears the pin and the next
+// TOFU succeeds against the new key.
+// ---------------------------------------------------------------------------
+
+func TestTOFU_TrustBrokerClearsPinAndRepins(t *testing.T) {
+	origPub := generateBrokerPubkeyB64(t)
+	newPub := generateBrokerPubkeyB64(t)
+	_, wsURL, srv := setupTOFURelay(t, origPub)
+	database := newTOFUTestDB(t)
+
+	// Daemon 1 pins origPub.
+	_, cancel1 := startDaemonAndWait(t, wsURL, database, origPub, 5*time.Second)
+	cancel1()
+
+	// Broker rotates to newPub. Daemon 2 would fail with mismatch (tested
+	// separately in TestTOFU_RefusesAfterBrokerKeyRotation), so skip it
+	// here — go directly to the operator intervention.
+	srv.SetBrokerPubkey(newPub)
+
+	// Operator runs `dicode relay trust-broker --yes`. The CLI path
+	// resolves to ReplaceBrokerPubkey.
+	if err := ReplaceBrokerPubkey(context.Background(), database, newPub); err != nil {
+		t.Fatalf("ReplaceBrokerPubkey (simulated trust-broker CLI): %v", err)
+	}
+
+	// Daemon 2 starts fresh. Its handshake should now see a matching pin
+	// and complete successfully.
+	_, cancel2 := startDaemonAndWait(t, wsURL, database, newPub, 5*time.Second)
+	defer cancel2()
+
+	stored, err := LoadBrokerPubkey(context.Background(), database)
+	if err != nil {
+		t.Fatalf("load pin: %v", err)
+	}
+	if stored != newPub {
+		t.Fatalf("post-trust-broker pin = %q, want %q", stored, newPub)
+	}
+}

--- a/pkg/relay/server.go
+++ b/pkg/relay/server.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/coder/websocket"
@@ -33,6 +34,13 @@ type Server struct {
 	log            *zap.Logger
 	host           string // e.g. "https://relay.example.com"
 	originPatterns []string
+
+	// brokerPubkey is the base64 SPKI DER the server advertises to connecting
+	// clients in the welcome message (for TOFU pinning). Zero-value empty
+	// string means "no pubkey advertised" — the Node dicode-relay always
+	// ships a key, but this Go server does not require one; a self-hosted
+	// Go relay opts in via SetBrokerPubkey.
+	brokerPubkey atomic.Pointer[string]
 
 	mu      sync.Mutex
 	clients map[string]*serverConn // uuid → conn
@@ -61,6 +69,21 @@ func NewServer(host string, log *zap.Logger, originPatterns ...string) *Server {
 // ServeHTTP implements http.Handler so the server can be embedded in tests.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.mux.ServeHTTP(w, r)
+}
+
+// SetBrokerPubkey updates the broker signing public key advertised in welcome
+// messages. Safe to call at any time; the new value applies to subsequent
+// welcomes only (already-established connections keep whatever they saw).
+//
+// Used for:
+//   - Self-hosted Go relays that want clients to pin their signing key
+//   - Tests that need to simulate broker key rotation between connects
+//
+// keyBase64 is expected to be a base64-encoded SPKI DER public key — the
+// same shape the Node dicode-relay advertises. An empty string clears
+// the advertised key (welcome.broker_pubkey will be omitted).
+func (s *Server) SetBrokerPubkey(keyBase64 string) {
+	s.brokerPubkey.Store(&keyBase64)
 }
 
 // serverConn represents one authenticated client connection.
@@ -107,7 +130,11 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 	}
 
 	welcomeURL := fmt.Sprintf("%s/u/%s/hooks/", s.host, sc.uuid)
-	welcomeData, _ := encodeMsg(welcomeMsg{Type: msgWelcome, URL: welcomeURL, Protocol: 2})
+	welcome := welcomeMsg{Type: msgWelcome, URL: welcomeURL, Protocol: 2}
+	if p := s.brokerPubkey.Load(); p != nil && *p != "" {
+		welcome.BrokerPubkey = *p
+	}
+	welcomeData, _ := encodeMsg(welcome)
 	if err := sc.write(ctx, welcomeData); err != nil {
 		return
 	}


### PR DESCRIPTION
## Summary

Closes #122. Four new tests lock down the daemon's TOFU state-machine around the broker signing pubkey; combined with the existing handshake + replay tests, every scenario on #122's acceptance list is now covered.

## Coverage vs #122 acceptance

| # | Scenario | Covered by |
|---|---|---|
| 1 | WSS handshake with ECDSA P-256 challenge-response | existing `TestHandshakeSuccess` / `TestHandshakeWrongKey` / `TestSignChallenge_*` |
| 2 | Broker pubkey pinned on first connect | **new** `TestTOFU_PinOnFirstConnect` |
| 3 | Reconnect preserves pin (no re-pinning) | **new** `TestTOFU_PinPreservedAcrossReconnects` |
| 4 | Mismatched key refused | **new** `TestTOFU_RefusesAfterBrokerKeyRotation` |
| 5 | `dicode relay trust-broker --yes` clears pin + re-pins | **new** `TestTOFU_TrustBrokerClearsPinAndRepins` |
| 6 | Timestamp / nonce replay protection | existing `TestHandshakeReplayedTimestamp` / `TestNonceReplay` |

## Design choices (worth flagging for review)

- **No hand-rolled stub broker.** The issue asks for one; I didn't build it. We already have a production-shaped `pkg/relay.Server` that speaks the wire protocol end-to-end, and adding a ~15-line `SetBrokerPubkey(keyBase64 string)` hook makes self-hosted Go relays TOFU-pinnable for free. Single source of truth for the protocol — a divergent stub would silently mask wire drift, which is exactly the class of bug #122's siblings #151/#152 already cost us.

- **Sequential-daemons pattern** for tests 4 and 5. The natural "rotate broker mid-connection and watch reconnect cycle" flow spends tens of seconds waiting for exponential backoff before the assertion can fire — the state-machine transition we actually care about is identical when you just cancel daemon1's context, rotate the broker, and start daemon2 against the same DB. The testcontainers suite in #163 covers "live reconnect under load" separately.

- **Mutation-verified.** Replacing `return BrokerPubkeyPinMismatch` with `return BrokerPubkeyPinMatch` in `CheckAndPinBrokerPubkey` makes `TestTOFU_RefusesAfterBrokerKeyRotation` fail (confirmed locally pre-commit).

## Files changed

- `pkg/relay/server.go` — add `brokerPubkey atomic.Pointer[string]` + `SetBrokerPubkey`. Welcome message includes the key if set (empty by default; real dicode-relay always ships one).
- `pkg/relay/reconnect_tofu_test.go` — new, four scenarios + small reusable helpers (`generateBrokerPubkeyB64`, `newTOFUTestDB`, `setupTOFURelay`, `startDaemonAndWait`, `waitForPubkey`).

## Test plan

- [x] `go test ./pkg/relay/... -count=1` — all tests pass (the full relay package, not just the new ones)
- [x] `go test ./pkg/relay/... -race -count=1` — race-detector clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean
- [x] Mutation test: breaking `CheckAndPinBrokerPubkey` catches via `TestTOFU_RefusesAfterBrokerKeyRotation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)