### PR TITLE
feat(webui): zap-based HTTP request logger (closes #23)

### DIFF
--- a/docs/superpowers/specs/2026-04-22-http-request-log-levels-design.md
+++ b/docs/superpowers/specs/2026-04-22-http-request-log-levels-design.md
@@ -67,20 +67,15 @@ func (e *zapLogEntry) Panic(v interface{}, stack []byte) {
 
 ### Wire-up in `pkg/webui/server.go`
 
-Replace line 322:
-
-```go
-r.Use(middleware.Logger)
-```
-
-with:
+Replace the bare `r.Use(middleware.Logger)` with:
 
 ```go
 r.Use(middleware.RequestID)
 r.Use(middleware.RequestLogger(&zapLogFormatter{log: s.log}))
+r.Use(middleware.Recoverer)
 ```
 
-`RequestID` must precede `RequestLogger` so `GetReqID` resolves inside `NewLogEntry`. Both sit *after* `middleware.Recoverer` — the recoverer calls our `Panic` via the formatter.
+**Ordering is load-bearing.** `RequestID` must precede `RequestLogger` so `GetReqID` resolves inside `NewLogEntry`. `RequestLogger` must precede `Recoverer` because chi's `Recoverer` reads the `LogEntry` from the request context (populated by `RequestLogger`) to route panics through our `Panic` method — reverse the order and panics fall through to chi's `PrintPrettyStack` on stderr, bypassing zap entirely.
 
 ### Level semantics
 
@@ -94,7 +89,7 @@ r.Use(middleware.RequestLogger(&zapLogFormatter{log: s.log}))
 ### What stays unchanged
 
 - Existing `s.log.Info/Warn/Error` call sites inside handlers (login flow, config save, etc.) — untouched.
-- `middleware.Recoverer` ordering — remains first; our logger entry's `Panic` gets called by it.
+- `middleware.Recoverer` still catches panics and writes 500; only its position in the stack changes (inner to `RequestLogger`).
 - `securityHeaders` and the rest of the chain — unchanged.
 
 ## Testing

--- a/pkg/webui/log_middleware.go
+++ b/pkg/webui/log_middleware.go
@@ -1,0 +1,59 @@
+package webui
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5/middleware"
+	"go.uber.org/zap"
+)
+
+// zapLogFormatter routes chi's per-request log entries through a zap.Logger.
+// Level by status: 2xx/3xx → Debug, 4xx → Warn, 5xx → Error. Panics from
+// middleware.Recoverer are logged at Error with the stack.
+type zapLogFormatter struct{ log *zap.Logger }
+
+func (f *zapLogFormatter) NewLogEntry(r *http.Request) middleware.LogEntry {
+	return &zapLogEntry{
+		log:    f.log,
+		method: r.Method,
+		path:   r.URL.Path,
+		remote: r.RemoteAddr,
+		reqID:  middleware.GetReqID(r.Context()),
+	}
+}
+
+type zapLogEntry struct {
+	log                         *zap.Logger
+	method, path, remote, reqID string
+}
+
+func (e *zapLogEntry) Write(status, bytes int, _ http.Header, elapsed time.Duration, _ interface{}) {
+	fields := []zap.Field{
+		zap.String("method", e.method),
+		zap.String("path", e.path),
+		zap.Int("status", status),
+		zap.Int("bytes", bytes),
+		zap.Duration("dur", elapsed),
+		zap.String("remote", e.remote),
+		zap.String("req_id", e.reqID),
+	}
+	switch {
+	case status >= 500:
+		e.log.Error("http", fields...)
+	case status >= 400:
+		e.log.Warn("http", fields...)
+	default:
+		e.log.Debug("http", fields...)
+	}
+}
+
+func (e *zapLogEntry) Panic(v interface{}, stack []byte) {
+	e.log.Error("http panic",
+		zap.String("method", e.method),
+		zap.String("path", e.path),
+		zap.String("req_id", e.reqID),
+		zap.Any("panic", v),
+		zap.ByteString("stack", stack),
+	)
+}

--- a/pkg/webui/log_middleware_test.go
+++ b/pkg/webui/log_middleware_test.go
@@ -1,0 +1,149 @@
+package webui
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// newObservedLogger returns a zap.Logger that records every entry at
+// DebugLevel-or-higher into an observer.ObservedLogs for assertion.
+func newObservedLogger() (*zap.Logger, *observer.ObservedLogs) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	return zap.New(core), logs
+}
+
+// runRequest wraps an http.HandlerFunc in chi + RequestID + our middleware,
+// fires one request, and returns the captured log entries.
+func runRequest(t *testing.T, log *zap.Logger, handler http.HandlerFunc, req *http.Request) *httptest.ResponseRecorder {
+	t.Helper()
+	r := chi.NewRouter()
+	r.Use(middleware.RequestID)
+	r.Use(middleware.RequestLogger(&zapLogFormatter{log: log}))
+	r.Handle("/*", handler)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestRequestLogger_2xx_Debug(t *testing.T) {
+	log, logs := newObservedLogger()
+	runRequest(t, log, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}, httptest.NewRequest(http.MethodGet, "/ok", nil))
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("want 1 log entry, got %d", len(entries))
+	}
+	if entries[0].Level != zapcore.DebugLevel {
+		t.Errorf("level = %s; want Debug", entries[0].Level)
+	}
+	fields := entries[0].ContextMap()
+	if got, ok := fields["status"].(int64); !ok || got != 200 {
+		t.Errorf("status field = %v; want 200", fields["status"])
+	}
+	if fields["method"] != "GET" {
+		t.Errorf("method field = %v; want GET", fields["method"])
+	}
+	if fields["path"] != "/ok" {
+		t.Errorf("path field = %v; want /ok", fields["path"])
+	}
+}
+
+func TestRequestLogger_4xx_Warn(t *testing.T) {
+	log, logs := newObservedLogger()
+	runRequest(t, log, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}, httptest.NewRequest(http.MethodGet, "/missing", nil))
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("want 1 log entry, got %d", len(entries))
+	}
+	if entries[0].Level != zapcore.WarnLevel {
+		t.Errorf("level = %s; want Warn", entries[0].Level)
+	}
+	if got, ok := entries[0].ContextMap()["status"].(int64); !ok || got != 404 {
+		t.Errorf("status = %v; want 404", entries[0].ContextMap()["status"])
+	}
+}
+
+func TestRequestLogger_5xx_Error(t *testing.T) {
+	log, logs := newObservedLogger()
+	runRequest(t, log, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}, httptest.NewRequest(http.MethodGet, "/boom", nil))
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("want 1 log entry, got %d", len(entries))
+	}
+	if entries[0].Level != zapcore.ErrorLevel {
+		t.Errorf("level = %s; want Error", entries[0].Level)
+	}
+	if got, ok := entries[0].ContextMap()["status"].(int64); !ok || got != 500 {
+		t.Errorf("status = %v; want 500", entries[0].ContextMap()["status"])
+	}
+}
+
+func TestRequestLogger_ReqID_Propagates(t *testing.T) {
+	log, logs := newObservedLogger()
+	rec := runRequest(t, log, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}, httptest.NewRequest(http.MethodGet, "/id", nil))
+
+	entries := logs.All()
+	if len(entries) != 1 {
+		t.Fatalf("want 1 log entry, got %d", len(entries))
+	}
+	got, ok := entries[0].ContextMap()["req_id"].(string)
+	if !ok || got == "" {
+		t.Fatalf("req_id field missing or empty: %v", entries[0].ContextMap()["req_id"])
+	}
+	if header := rec.Header().Get("X-Request-Id"); header != "" && header != got {
+		t.Errorf("req_id field %q does not match X-Request-Id header %q", got, header)
+	}
+}
+
+func TestRequestLogger_Panic_Logged(t *testing.T) {
+	log, logs := newObservedLogger()
+
+	// RequestLogger must be OUTER to Recoverer: chi's Recoverer reads the
+	// LogEntry from the request context, which RequestLogger populates.
+	r := chi.NewRouter()
+	r.Use(middleware.RequestID)
+	r.Use(middleware.RequestLogger(&zapLogFormatter{log: log}))
+	r.Use(middleware.Recoverer)
+	r.Handle("/*", http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic("boom")
+	}))
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/panic", nil))
+
+	var panicEntry *observer.LoggedEntry
+	for i := range logs.All() {
+		e := logs.All()[i]
+		if e.Message == "http panic" {
+			panicEntry = &e
+			break
+		}
+	}
+	if panicEntry == nil {
+		t.Fatalf("no 'http panic' entry in logs: %+v", logs.All())
+	}
+	if panicEntry.Level != zapcore.ErrorLevel {
+		t.Errorf("level = %s; want Error", panicEntry.Level)
+	}
+	if panicEntry.ContextMap()["panic"] == nil {
+		t.Error("missing 'panic' field")
+	}
+}

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -318,8 +318,12 @@ func New(port int, r *registry.Registry, eng *trigger.Engine, cfg *config.Config
 func (s *Server) Handler() http.Handler {
 	r := chi.NewRouter()
 	r.Use(useEncodedPath)
+	// RequestLogger must wrap Recoverer: chi's Recoverer reads the LogEntry
+	// from the request context that RequestLogger installs, and routes panics
+	// to its Panic method. Reversing the order silently drops panic logging.
+	r.Use(middleware.RequestID)
+	r.Use(middleware.RequestLogger(&zapLogFormatter{log: s.log}))
 	r.Use(middleware.Recoverer)
-	r.Use(middleware.Logger)
 	r.Use(securityHeaders)
 
 	// Auth endpoints — always public (login flow must be reachable without session).


### PR DESCRIPTION
## Summary

- Replaces chi's `middleware.Logger` with a zap-backed `LogFormatter` that routes by status: 2xx/3xx→`Debug`, 4xx→`Warn`, 5xx→`Error`, panic→`Error`.
- Every line carries a `req_id` from `middleware.RequestID` so debug-level request logs are actually correlatable.
- Default log level stays `info` so request noise is silenced; flip to `debug` to see it.

Closes #23.

## Spec

[`docs/superpowers/specs/2026-04-22-http-request-log-levels-design.md`](https://github.com/dicode-ayo/dicode-core/blob/feat/23-http-request-log-levels/docs/superpowers/specs/2026-04-22-http-request-log-levels-design.md) — updated during implementation to fix a middleware-ordering bug: `RequestLogger` must *wrap* `Recoverer`, not sit under it, or chi's `Recoverer` can't find the `LogEntry` on the context and panics fall through to `PrintPrettyStack` on stderr instead of zap.

## Files

- `pkg/webui/log_middleware.go` (new, ~60 LoC) — `zapLogFormatter` + `zapLogEntry` implementing `chi.LogFormatter`
- `pkg/webui/log_middleware_test.go` (new) — 5 scenarios via `zaptest/observer`
- `pkg/webui/server.go` — swap the three lines at 320-322 (Recoverer-then-Logger → RequestID, RequestLogger, Recoverer)
- `docs/superpowers/specs/2026-04-22-http-request-log-levels-design.md` — correct the ordering rationale

## Test plan

- [x] `go test ./pkg/webui/...` — all passing (existing + 5 new)
- [x] `go test ./... -timeout 120s` — full suite green
- [x] `go vet ./...` clean
- [x] Manual: `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)