### PR TITLE
ci(e2e-relay): always run — drop path filter + add push-to-main trigger

### DIFF
--- a/.github/workflows/e2e-relay.yml
+++ b/.github/workflows/e2e-relay.yml
@@ -1,22 +1,20 @@
 name: E2E Relay
 
-# Runs the Go + testcontainers-go relay e2e suite (tests/e2e/relay) only on
-# PRs that touch the relay surface. The relay image tag is pinned in
-# tests/e2e/relay/testdata/Dockerfile.relay (tracked by Dependabot) — this
-# workflow defers to that file and does not duplicate the version.
+# Runs the Go + testcontainers-go relay e2e suite (tests/e2e/relay) on
+# every PR + every push to main. The path-filtered configuration from #138
+# was too conservative in practice: relay-affecting changes can land via
+# seemingly unrelated files (shared protocol types, IPC plumbing, Go module
+# bumps, Dockerfile changes that affect runtime behaviour, etc.), and the
+# 40s wall-clock cost is a cheap price for never wondering "did this PR
+# actually exercise the relay wire?". The relay image tag is pinned in
+# tests/e2e/relay/testdata/Dockerfile.relay (tracked by Dependabot) —
+# this workflow defers to that file and does not duplicate the version.
 
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'pkg/relay/**'
-      - 'pkg/ipc/**'
-      - 'pkg/runtime/deno/**'
-      - 'cmd/dicode/**'
-      - 'tasks/buildin/auth-start/**'
-      - 'tasks/buildin/auth-relay/**'
-      - 'tests/e2e/relay/**'
-      - '.github/workflows/e2e-relay.yml'
+  push:
+    branches: [main]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary

Run the relay e2e suite on **every** PR and push-to-main instead of only on paths-scoped PRs.

## Motivation

The path-filtered trigger list from #138 turned out to be too conservative. Relay-affecting bugs can land through files not in the allowlist — shared protocol types, IPC plumbing, Go module bumps, Dockerfile changes that shift runtime behaviour, and so on. Missing a run because \"this PR only touched pkg/config\" has the same class of cost that motivated #136/#137 in the first place: silent wire drift that only shows up when a user's \`dicode relay\` connection fails at 3am.

## Change

```diff
-on:
-  pull_request:
-    branches: [main]
-    paths:
-      - 'pkg/relay/**'
-      - ...
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
   workflow_dispatch:
```

- Added `push: { branches: [main] }` so post-merge state always gets the same gate (catches bugs introduced by non-obvious file interactions that only the merge commit surfaces).
- Dropped the `paths:` filter from `pull_request`.
- No change to `workflow_dispatch` or job steps.

## Cost

- Observed runtime on #168: **~40s** with a warm Docker cache (pre-pull step + build + 5 scenarios). First cold run against a new image tag is longer but Dependabot image bumps are rare enough to amortise.
- Adds ~40s to every PR's feedback loop. Cheap against the cost of an undetected regression.

## Test plan

- [ ] This PR itself will trigger the workflow (first change is the workflow file)
- [ ] Merge → push-to-main triggers it again (confirms the new push trigger fires)
- [ ] A subsequent docs-only PR should ALSO trigger it (previously wouldn't have)

🤖 Generated with [Claude Code](https://claude.com/claude-code)