### PR TITLE
feat+test(secrets): redact secret values in task stdout/stderr logs (closes #126)

### DIFF
--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -61,6 +61,14 @@ type Server struct {
 	rotationActiveFn func() bool            // issue #144: reports whether a relay-identity rotation has started; nil means unchecked
 	log              *zap.Logger
 
+	// redactor strips secret values from inbound log messages before they
+	// hit the run log. Nil is safe (no redaction). Wired via SetRedactor
+	// after construction; runtimes that resolve env-sourced secrets should
+	// build a redactor from the resolved set and install it here so tasks
+	// calling `dicode.log` (the IPC log method, used by the Python SDK)
+	// get the same leak-protection as tasks printing to stdout/stderr.
+	redactor *secrets.Redactor
+
 	gateway *Gateway // optional; enables http.register for daemon tasks
 
 	ctx        context.Context
@@ -125,6 +133,12 @@ func New(
 // SetSecrets attaches the secrets manager so tasks with permissions.dicode.secrets_write
 // can call dicode.secrets_set() and dicode.secrets_delete().
 func (s *Server) SetSecrets(m secrets.Manager) { s.secrets = m }
+
+// SetRedactor installs a log-message redactor. Messages received via the
+// IPC "log" method are passed through r.RedactString before being
+// persisted to the run log, matching the protection stdout/stderr piping
+// already gets from runtime wrappers. Nil is safe (no redaction).
+func (s *Server) SetRedactor(r *secrets.Redactor) { s.redactor = r }
 
 // SetOAuthBroker wires the daemon's relay identity (used to sign /auth URLs
 // and decrypt token deliveries) plus the broker base URL and the
@@ -337,7 +351,10 @@ func (s *Server) handleConn(conn net.Conn) {
 			if level == "" {
 				level = "info"
 			}
-			s.bufferLog(level, req.Message)
+			// Redact env-injected secret values from the message before
+			// buffering. Nil redactor is pass-through — safe default for
+			// callers that haven't wired one (tests, legacy runtimes).
+			s.bufferLog(level, s.redactor.RedactString(req.Message))
 
 		case "kv.set":
 			if !hasCap(caps, CapKVWrite) {

--- a/pkg/ipc/server_test.go
+++ b/pkg/ipc/server_test.go
@@ -8,11 +8,13 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/dicode/dicode/pkg/db"
 	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/secrets"
 	"github.com/dicode/dicode/pkg/task"
 	"go.uber.org/zap"
 )
@@ -293,6 +295,74 @@ func TestServer_Input_Null(t *testing.T) {
 
 	if resp["result"] != nil {
 		t.Errorf("expected null input, got %v", resp["result"])
+	}
+}
+
+// TestServer_Log_RedactsSecretValue addresses dicode-core#126: the IPC
+// `log` method must strip env-injected secret values before persisting.
+// Without this, a task calling `log.info("token: " + value)` via the
+// Python SDK — which wires `dicode_sdk.py:155` straight onto the `log`
+// IPC method — would leak the value verbatim into the run-log table,
+// bypassing the stdout/stderr redactor the runtime wrappers install.
+func TestServer_Log_RedactsSecretValue(t *testing.T) {
+	const secretValue = "s3cr3t-p@ssw0rd-xyz"
+
+	e := newTestEnv(t)
+	runID := fmt.Sprintf("test-%d", time.Now().UnixNano())
+	srv := New(runID, "test-task", e.secret, e.reg, e.db, nil, nil, zap.NewNop(), nil, nil)
+	srv.SetRedactor(secrets.NewRedactor(map[string]string{"MY_TOKEN": secretValue}))
+
+	socketPath, token, err := srv.Start(context.Background())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(srv.Stop)
+	conn := dial(t, socketPath)
+	t.Cleanup(func() { conn.Close() })
+	doHandshake(t, conn, token)
+
+	sendMsg(t, conn, map[string]any{
+		"method":  "log",
+		"level":   "info",
+		"message": "secret leak attempt: " + secretValue + " trailing",
+	})
+	time.Sleep(20 * time.Millisecond)
+	srv.Stop()
+
+	logs, err := e.reg.GetRunLogs(context.Background(), srv.runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(logs) == 0 {
+		t.Fatal("expected log entry")
+	}
+	if strings.Contains(logs[0].Message, secretValue) {
+		t.Errorf("raw secret leaked through IPC log handler: %q", logs[0].Message)
+	}
+	wantMarker := "secret leak attempt: " + secrets.RedactionMarker + " trailing"
+	if logs[0].Message != wantMarker {
+		t.Errorf("unexpected redacted form: got %q, want %q", logs[0].Message, wantMarker)
+	}
+}
+
+// TestServer_Log_NilRedactorIsPassThrough pins the nil-safe contract —
+// a server with no redactor wired (existing callers, legacy tests) must
+// keep logging unmodified.
+func TestServer_Log_NilRedactorIsPassThrough(t *testing.T) {
+	e := newTestEnv(t)
+	conn, srv := e.start(t, nil, nil)
+
+	const msg = "token=abc123 (not a secret to this server)"
+	sendMsg(t, conn, map[string]any{"method": "log", "level": "info", "message": msg})
+	time.Sleep(20 * time.Millisecond)
+	srv.Stop()
+
+	logs, err := e.reg.GetRunLogs(context.Background(), srv.runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(logs) == 0 || logs[0].Message != msg {
+		t.Errorf("nil-redactor pass-through broken: logs=%+v", logs)
 	}
 }
 

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -234,6 +234,7 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	srv := ipc.New(runID, spec.ID, rt.secret, rt.registry, rt.db, mergedParams, opts.Input, rt.log, spec, rt.engine)
 	srv.SetGateway(rt.gateway)
 	srv.SetSecrets(rt.secretsManager)
+	srv.SetRedactor(redactor)
 	if rt.oauthIdentity != nil {
 		srv.SetOAuthBroker(rt.oauthIdentity, rt.oauthURL, rt.oauthPending, rt.brokerPubkeyFn, rt.supportsOAuthFn, rt.rotationActiveFn)
 	}

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -180,6 +180,13 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	// - entry.From   → read from host OS env (os.Getenv); inject as entry.Name
 	// - bare name    → allowlisted via --allow-env; script reads from host env at runtime
 	resolved := make(map[string]string, len(spec.Permissions.Env))
+	// Track values sourced from secrets only — these are the strings the
+	// log redactor will strip from task stdout/stderr before they reach
+	// the run log. Plain Value= entries and From= host-env values are
+	// excluded: they're not secrets by the spec's own definition, and
+	// over-redaction (wiping e.g. a common host env value from every
+	// log line) would destroy log readability for no security benefit.
+	resolvedSecrets := make(map[string]string)
 	for _, entry := range spec.Permissions.Env {
 		switch {
 		case entry.Value != "":
@@ -198,11 +205,13 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 				return result, nil
 			}
 			resolved[entry.Name] = val
+			resolvedSecrets[entry.Name] = val
 		case entry.From != "":
 			resolved[entry.Name] = os.Getenv(entry.From)
 			// bare name: --allow-env only, no injection
 		}
 	}
+	redactor := secrets.NewRedactor(resolvedSecrets)
 
 	taskPath := spec.ScriptPath()
 	if taskPath == "" {
@@ -339,14 +348,14 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		defer wg.Done()
 		scanner := bufio.NewScanner(stdout)
 		for scanner.Scan() {
-			_ = rt.registry.AppendLog(context.Background(), runID, "info", scanner.Text())
+			_ = rt.registry.AppendLog(context.Background(), runID, "info", redactor.RedactString(scanner.Text()))
 		}
 	}()
 	go func() {
 		defer wg.Done()
 		scanner := bufio.NewScanner(stderr)
 		for scanner.Scan() {
-			_ = rt.registry.AppendLog(context.Background(), runID, "error", scanner.Text())
+			_ = rt.registry.AppendLog(context.Background(), runID, "error", redactor.RedactString(scanner.Text()))
 		}
 	}()
 

--- a/pkg/runtime/deno/runtime_test.go
+++ b/pkg/runtime/deno/runtime_test.go
@@ -528,3 +528,114 @@ func (m mockSecretProvider) Name() string { return "mock" }
 func (m mockSecretProvider) Get(_ context.Context, key string) (string, error) {
 	return m[key], nil
 }
+
+// TestRuntime_LogRedaction_SecretValue addresses #126 item 3: a task that
+// writes a known secret value to stdout/stderr must have that value
+// redacted from the persisted run log. Catches regressions if the
+// stdout/stderr pipe wiring ever bypasses secrets.Redactor (e.g. adding
+// a second scanner that forgets to redact).
+func TestRuntime_LogRedaction_SecretValue(t *testing.T) {
+	const secretValue = "s3cr3t-p@ssw0rd-xyz"
+
+	e := newTestEnv(t)
+	e.rt.secrets = secrets.Chain{mockSecretProvider{"my_key": secretValue}}
+	spec := &task.Spec{
+		ID: "log-redact", Name: "log-redact", Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true}, Timeout: 30 * time.Second,
+		Permissions: task.Permissions{
+			Env: []task.EnvEntry{{Name: "MY_TOKEN", Secret: "my_key"}},
+		},
+	}
+	// Log the secret on both stdout (console.log) and stderr (console.error)
+	// so the redaction wiring on both pipes is exercised in one run.
+	r := e.runSpec(t, `
+		export default async function main() {
+			const v = Deno.env.get("MY_TOKEN");
+			console.log("stdout: " + v);
+			console.error("stderr: " + v);
+			return "ok";
+		}
+	`, spec)
+	if r.Error != nil {
+		t.Fatalf("error: %v", r.Error)
+	}
+
+	// The secret value MUST NOT appear in any log line.
+	for _, l := range r.Logs {
+		if strings.Contains(l.Message, secretValue) {
+			t.Errorf("log redaction failed — raw secret leaked on level %q: %q",
+				l.Level, l.Message)
+		}
+	}
+	// And the redaction marker MUST appear on both levels — guards against
+	// the "nothing was logged at all" failure mode looking like a pass.
+	var foundInfo, foundErr bool
+	for _, l := range r.Logs {
+		if strings.Contains(l.Message, secrets.RedactionMarker) {
+			switch l.Level {
+			case "info":
+				foundInfo = true
+			case "error":
+				foundErr = true
+			}
+		}
+	}
+	if !foundInfo {
+		t.Errorf("expected a redacted info-level log line, got: %+v", r.Logs)
+	}
+	if !foundErr {
+		t.Errorf("expected a redacted error-level log line, got: %+v", r.Logs)
+	}
+}
+
+// TestRuntime_LogRedaction_OnlyActualSecrets addresses an edge case of #126
+// item 3: plain-value env entries (entry.Value=...) and host-pass-through
+// entries (entry.From=...) are NOT secrets and must NOT be redacted. Otherwise
+// the redactor would wipe common env values from every task log.
+func TestRuntime_LogRedaction_OnlyActualSecrets(t *testing.T) {
+	const plainValue = "plain-config-value"
+	t.Setenv("DICODE_PLAIN_TEST_VAR", plainValue)
+
+	e := newTestEnv(t)
+	spec := &task.Spec{
+		ID: "log-redact-plain", Name: "log-redact-plain", Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true}, Timeout: 30 * time.Second,
+		Permissions: task.Permissions{
+			Env: []task.EnvEntry{
+				{Name: "PLAIN_INLINE", Value: plainValue},
+				{Name: "PLAIN_HOST", From: "DICODE_PLAIN_TEST_VAR"},
+			},
+		},
+	}
+	r := e.runSpec(t, `
+		export default async function main() {
+			console.log("inline: " + Deno.env.get("PLAIN_INLINE"));
+			console.log("host: "   + Deno.env.get("PLAIN_HOST"));
+			return "ok";
+		}
+	`, spec)
+	if r.Error != nil {
+		t.Fatalf("error: %v", r.Error)
+	}
+
+	var sawInline, sawHost bool
+	for _, l := range r.Logs {
+		if strings.Contains(l.Message, plainValue) {
+			switch {
+			case strings.HasPrefix(l.Message, "inline: "):
+				sawInline = true
+			case strings.HasPrefix(l.Message, "host: "):
+				sawHost = true
+			}
+		}
+		if strings.Contains(l.Message, secrets.RedactionMarker) {
+			t.Errorf("plain env value was incorrectly redacted: %q", l.Message)
+		}
+	}
+	if !sawInline {
+		t.Errorf("expected inline-value log to pass through unchanged, got: %+v", r.Logs)
+	}
+	if !sawHost {
+		t.Errorf("expected host-pass-through log to pass through unchanged, got: %+v", r.Logs)
+	}
+}

--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -164,6 +164,13 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	// - entry.From   → read from host OS env (os.Getenv); inject as entry.Name
 	// - bare name    → passthrough only, no injection needed
 	resolved := make(map[string]string, len(spec.Permissions.Env))
+	// Track secret-sourced env values so the run-log redactor catches them
+	// if a task writes them to stderr or via the IPC `log` method (which
+	// the Python SDK wraps as `log.info` / `log.error` / etc.). Symmetric
+	// to the deno runtime — plain Value= and host-env From= are NOT
+	// redacted because over-redaction would nuke common env values from
+	// every log line for no security benefit.
+	resolvedSecrets := make(map[string]string)
 	for _, entry := range spec.Permissions.Env {
 		switch {
 		case entry.Value != "":
@@ -181,10 +188,12 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 				return result, nil
 			}
 			resolved[entry.Name] = val
+			resolvedSecrets[entry.Name] = val
 		case entry.From != "":
 			resolved[entry.Name] = os.Getenv(entry.From)
 		}
 	}
+	redactor := secrets.NewRedactor(resolvedSecrets)
 
 	// Read the user's task.py.
 	scriptPath := spec.ScriptPath()
@@ -213,6 +222,7 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	srv := ipc.New(runID, spec.ID, e.secret, e.reg, e.db, mergedParams, opts.Input, e.log, spec, e.engine)
 	srv.SetGateway(e.gateway)
 	srv.SetSecrets(e.secretsManager)
+	srv.SetRedactor(redactor)
 	socketPath, token, err := srv.Start(execCtx)
 	if err != nil {
 		status = registry.StatusFailure
@@ -268,7 +278,7 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 		defer wg.Done()
 		scanner := bufio.NewScanner(stderr)
 		for scanner.Scan() {
-			_ = e.reg.AppendLog(context.Background(), runID, "warn", scanner.Text())
+			_ = e.reg.AppendLog(context.Background(), runID, "warn", redactor.RedactString(scanner.Text()))
 		}
 	}()
 

--- a/pkg/secrets/redactor.go
+++ b/pkg/secrets/redactor.go
@@ -1,0 +1,77 @@
+package secrets
+
+import (
+	"sort"
+	"strings"
+)
+
+// RedactionMarker is what replaces a matched secret value in any string
+// passed through a Redactor. Chosen to be obviously non-secret and to survive
+// naive substring checks for "leaked the actual value" in test assertions.
+const RedactionMarker = "<REDACTED>"
+
+// Redactor replaces known secret values in log lines with RedactionMarker.
+// The set of values is snapshot at construction and never refreshed — the
+// intended usage is one Redactor per task run, built from the secrets
+// resolved for that run's env permissions. Refreshing on every log line
+// would pull a database round-trip into the hot path of task stdout.
+//
+// The zero value is safe to use and redacts nothing. Methods are safe for
+// concurrent use (internally a *strings.Replacer, which is stateless).
+type Redactor struct {
+	// nil when there are no values to redact — the hot path bails early.
+	replacer *strings.Replacer
+}
+
+// NewRedactor returns a Redactor that replaces every distinct non-empty
+// value from `values` with RedactionMarker. Keys are ignored; only values
+// matter. Empty values are dropped (a 0-length "secret" would otherwise
+// match every position). Single-character values ARE accepted — if a
+// caller stored them as a secret we redact them, even if the log output
+// becomes unreadable; leaking the value is always worse than a noisy log.
+//
+// Duplicates are dropped so repeated secret registration doesn't produce
+// a duplicate-key argument to strings.NewReplacer (which would panic).
+func NewRedactor(values map[string]string) *Redactor {
+	if len(values) == 0 {
+		return &Redactor{}
+	}
+	seen := make(map[string]struct{}, len(values))
+	uniq := make([]string, 0, len(values))
+	for _, v := range values {
+		if v == "" {
+			continue
+		}
+		if _, dup := seen[v]; dup {
+			continue
+		}
+		seen[v] = struct{}{}
+		uniq = append(uniq, v)
+	}
+	if len(uniq) == 0 {
+		return &Redactor{}
+	}
+	// strings.Replacer matches pairs in argument order — whichever `old`
+	// appears first wins at a given position. Sort longest-first so a
+	// secret that contains another secret as a substring is replaced as
+	// a whole, not piecewise ("foobar" stays intact even if "foo" is
+	// also registered).
+	sort.SliceStable(uniq, func(i, j int) bool { return len(uniq[i]) > len(uniq[j]) })
+
+	pairs := make([]string, 0, len(uniq)*2)
+	for _, v := range uniq {
+		pairs = append(pairs, v, RedactionMarker)
+	}
+	return &Redactor{replacer: strings.NewReplacer(pairs...)}
+}
+
+// RedactString returns s with every occurrence of a known secret value
+// replaced by RedactionMarker. Safe on a nil receiver (returns s
+// unchanged), safe on the zero-value Redactor, and safe on concurrent
+// callers.
+func (r *Redactor) RedactString(s string) string {
+	if r == nil || r.replacer == nil || s == "" {
+		return s
+	}
+	return r.replacer.Replace(s)
+}

--- a/pkg/secrets/redactor_test.go
+++ b/pkg/secrets/redactor_test.go
@@ -1,0 +1,151 @@
+package secrets
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestRedactor_NilAndZeroValue(t *testing.T) {
+	t.Parallel()
+
+	// nil receiver must be safe and pass the string through.
+	var nilR *Redactor
+	if got := nilR.RedactString("hello"); got != "hello" {
+		t.Errorf("nil receiver RedactString(%q) = %q; want %q", "hello", got, "hello")
+	}
+
+	// Zero-value Redactor (no replacer) must be safe and pass-through.
+	var zero Redactor
+	if got := zero.RedactString("hello"); got != "hello" {
+		t.Errorf("zero Redactor RedactString(%q) = %q; want %q", "hello", got, "hello")
+	}
+}
+
+func TestRedactor_EmptyValueMap(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor(nil)
+	if got := r.RedactString("anything"); got != "anything" {
+		t.Errorf("NewRedactor(nil) redacts %q; want pass-through", got)
+	}
+	r = NewRedactor(map[string]string{})
+	if got := r.RedactString("anything"); got != "anything" {
+		t.Errorf("NewRedactor(empty) redacts %q; want pass-through", got)
+	}
+}
+
+func TestRedactor_SingleValue(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor(map[string]string{"MY_TOKEN": "s3cr3t"})
+	got := r.RedactString("got: s3cr3t (end)")
+	want := "got: " + RedactionMarker + " (end)"
+	if got != want {
+		t.Errorf("RedactString = %q; want %q", got, want)
+	}
+}
+
+func TestRedactor_MultipleOccurrencesSameValue(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor(map[string]string{"T": "pw"})
+	got := r.RedactString("pw and pw again: pw")
+	want := RedactionMarker + " and " + RedactionMarker + " again: " + RedactionMarker
+	if got != want {
+		t.Errorf("RedactString = %q; want %q", got, want)
+	}
+}
+
+func TestRedactor_OverlappingValuesLongestFirst(t *testing.T) {
+	t.Parallel()
+	// The short value "foo" is a substring of the long value "foobar".
+	// strings.Replacer's trie must prefer the long match at each position,
+	// otherwise "foobar" would be redacted as "<REDACTED>bar".
+	r := NewRedactor(map[string]string{"short": "foo", "long": "foobar"})
+	got := r.RedactString("see foobar please")
+	want := "see " + RedactionMarker + " please"
+	if got != want {
+		t.Errorf("overlap: RedactString = %q; want %q (longest match must win)", got, want)
+	}
+	// And bare "foo" alone still gets redacted.
+	got = r.RedactString("say foo then")
+	want = "say " + RedactionMarker + " then"
+	if got != want {
+		t.Errorf("short-match: RedactString = %q; want %q", got, want)
+	}
+}
+
+func TestRedactor_EmptyValueIsDropped(t *testing.T) {
+	t.Parallel()
+	// An empty-string secret would match every position if not dropped —
+	// this test pins the pathological case out.
+	r := NewRedactor(map[string]string{"EMPTY": "", "T": "token"})
+	got := r.RedactString("hello token world")
+	want := "hello " + RedactionMarker + " world"
+	if got != want {
+		t.Errorf("RedactString = %q; want %q", got, want)
+	}
+	// And a pure-empty-value redactor passes through.
+	r = NewRedactor(map[string]string{"ONLY_EMPTY": ""})
+	if got := r.RedactString("hello"); got != "hello" {
+		t.Errorf("all-empty redactor: RedactString(%q) = %q; want pass-through", "hello", got)
+	}
+}
+
+func TestRedactor_DuplicateValuesAreDeduped(t *testing.T) {
+	t.Parallel()
+	// Two keys resolving to the same value must not panic
+	// strings.NewReplacer (which disallows duplicate old-strings).
+	r := NewRedactor(map[string]string{"A": "same", "B": "same"})
+	got := r.RedactString("same stuff")
+	want := RedactionMarker + " stuff"
+	if got != want {
+		t.Errorf("RedactString = %q; want %q", got, want)
+	}
+}
+
+func TestRedactor_SingleCharValueAccepted(t *testing.T) {
+	t.Parallel()
+	// One-char secrets are accepted — if a caller stored one, leaking
+	// beats noisy output. Pinned explicitly so nobody adds a min-length
+	// filter without seeing the intent.
+	r := NewRedactor(map[string]string{"CH": "x"})
+	got := r.RedactString("axbx")
+	want := "a" + RedactionMarker + "b" + RedactionMarker
+	if got != want {
+		t.Errorf("RedactString = %q; want %q", got, want)
+	}
+}
+
+func TestRedactor_DoesNotRedactKeyNames(t *testing.T) {
+	t.Parallel()
+	// A secret registered under key MY_TOKEN must NOT redact the string
+	// "MY_TOKEN" in log output — only its value.
+	r := NewRedactor(map[string]string{"MY_TOKEN": "actual-secret"})
+	got := r.RedactString("env MY_TOKEN not set; used actual-secret instead")
+	if !strings.Contains(got, "MY_TOKEN") {
+		t.Errorf("RedactString redacted the key name, not just the value: %q", got)
+	}
+	if strings.Contains(got, "actual-secret") {
+		t.Errorf("RedactString failed to redact the value: %q", got)
+	}
+}
+
+func TestRedactor_ConcurrentRedactString(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor(map[string]string{"T": "token"})
+	var wg sync.WaitGroup
+	const goroutines = 16
+	const iters = 200
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				if got := r.RedactString("hello token"); got != "hello "+RedactionMarker {
+					t.Errorf("concurrent RedactString = %q", got)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/webui/secrets_api_test.go
+++ b/pkg/webui/secrets_api_test.go
@@ -247,6 +247,40 @@ func TestAPI_ListSecrets_AfterSetDoesNotIncludeValues(t *testing.T) {
 	}
 }
 
+// TestAPI_Metrics_NeverLeaksSecretValuesOrNames addresses #126 item 4:
+// no metrics/telemetry path may return a stored secret's key OR value.
+// The /api/metrics handler today is structurally incapable of leaking
+// (it reports heap/CPU/task-slot counters only), but this test pins
+// that invariant — any future field that accidentally plumbs a secret
+// through metric labels would fail here. Cheap guard against a class of
+// bugs that would otherwise require code review to catch every time.
+func TestAPI_Metrics_NeverLeaksSecretValuesOrNames(t *testing.T) {
+	srv, mgr := newSecretsTestServer(t)
+
+	// Plant a secret with both a distinctive key and a distinctive value
+	// so either one surfacing in the metrics response would trip the test.
+	const leakyKey = "METRICS_LEAK_GUARD_KEY"
+	const leakyVal = "METRICS_LEAK_GUARD_VALUE_shouldneverappear"
+	if err := mgr.Set(context.Background(), leakyKey, leakyVal); err != nil {
+		t.Fatalf("seed secret: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/metrics", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/metrics: status %d, body=%s", w.Code, w.Body.String())
+	}
+
+	body := w.Body.String()
+	if strings.Contains(body, leakyVal) {
+		t.Errorf("metrics response leaks secret VALUE: %s", body)
+	}
+	if strings.Contains(body, leakyKey) {
+		t.Errorf("metrics response leaks secret KEY: %s", body)
+	}
+}
+
 // sanity: ensure the Handler serves the secrets routes at all. Guards against
 // regressions where the group is mounted under a different path prefix.
 func TestAPI_SecretsRoute_Exists(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes the remaining gap in #126. Items 1 and 2 (GET/POST `/api/secrets` never leak values) were covered by #154; items 3 (log redaction) and 4 (metrics don't leak secrets) ship here.

## Item 3 — log redaction (new feature + tests)

### `pkg/secrets/redactor.go` (new, ~60 LOC)

New \`Redactor\` type backed by \`*strings.Replacer\`. Built once per task run from the resolved-secret value map, replaces every occurrence of any secret value in a string with the literal \`<REDACTED>\` marker.

Design points worth flagging:

- **Snapshot at construction, not live-pulled.** Refreshing on every log line would pull a DB round-trip into the stdout hot path.
- **Longest-first sort before building the Replacer.** Argument order determines precedence in \`strings.NewReplacer\`, so without the sort a secret that contains another secret as a substring would be partial-redacted (\"foobar\" → \`<REDACTED>bar\` if \"foo\" was registered first). Pinned by a dedicated test.
- **Empty values dropped, duplicates deduped.** A 0-length \"secret\" would match every position and nuke the whole log; duplicate \`old\` values would panic \`strings.NewReplacer\`. Pinned by tests.
- **Single-char values ACCEPTED.** Leaking always beats noisy logs — pinned explicitly so nobody adds a min-length filter thinking it's safer.
- **nil-safe, zero-value-safe, concurrency-safe.** Hammer test + explicit nil/zero tests cover it.

### `pkg/runtime/deno/runtime.go` — wire into stdout/stderr pipe

Two-line change at the existing line-scanner goroutines. A new \`resolvedSecrets\` map alongside the existing \`resolved\` map tracks ONLY the values sourced from \`entry.Secret\` — plain \`entry.Value\` config and \`entry.From\` host-env pass-through are NOT redacted. Over-redaction would wipe common env values from every task log with no security benefit.

### Integration tests

- **\`TestRuntime_LogRedaction_SecretValue\`**: task env-injects a known value, logs it on BOTH stdout and stderr, asserts the literal value never appears in any log line AND that \`<REDACTED>\` appears on both levels (so \"empty logs\" can't look like a pass). **Mutation-verified**: reverting the \`RedactString\` call in runtime.go makes this test fail with \"raw secret leaked on level info: stdout: s3cr3t-p@ssw0rd-xyz\".
- **\`TestRuntime_LogRedaction_OnlyActualSecrets\`**: pinned counter-example — plain \`entry.Value\` and \`entry.From\` host-env pass-through are NOT redacted. Catches a future mistake that over-broadens the redactor to include all resolved values.

## Item 4 — metrics don't leak secrets

### \`pkg/webui/secrets_api_test.go\` — guard test

\`TestAPI_Metrics_NeverLeaksSecretValuesOrNames\` seeds the in-memory secrets manager with a distinctive key+value pair, fetches \`/api/metrics\`, asserts neither appears in the response body. The current handler is structurally incapable of leaking (it's heap/CPU/task-count telemetry only), but this pins the invariant so a future \"last-run-by-user\" label that naively carries a secret gets caught at CI.

## Test plan

- [x] \`go test ./pkg/secrets/... -race\` — 10 new tests, all green
- [x] \`go test ./pkg/runtime/deno/... -race\` — 2 new integration tests, all green
- [x] \`go test ./pkg/webui/... -race\` — 1 new test, all green
- [x] Full \`go test ./... -race -count=1 -timeout 120s\` — every package passes
- [x] Mutation test on integration coverage — bypassing \`RedactString\` fails the test with a clear diagnostic

Closes #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)