### PR TITLE
fix(taskset): full clone instead of shallow (closes #175)

### DIFF
--- a/pkg/taskset/git.go
+++ b/pkg/taskset/git.go
@@ -43,11 +43,14 @@ func cloneOrPull(ctx context.Context, dir, url, branch, tokenEnv string) error {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("mkdir: %w", err)
 	}
+	// Full clone (no Depth). A shallow clone costs bandwidth once but
+	// fails PullContext with "object not found" the first time the remote
+	// advances past the shallow tip — go-git can't compute a merge base
+	// when the parent commits aren't in the local object DB. See #175.
 	opts := &gogit.CloneOptions{
 		URL:           url,
 		ReferenceName: plumbing.NewBranchReferenceName(branch),
 		SingleBranch:  true,
-		Depth:         1,
 	}
 	if auth != nil {
 		opts.Auth = auth

--- a/pkg/taskset/git_test.go
+++ b/pkg/taskset/git_test.go
@@ -1,0 +1,147 @@
+package taskset
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	gogitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// seededBareRepo is a bare repo on disk plus a scratch worktree used to
+// push commits, mirroring the pattern in pkg/source/git/git_test.go.
+type seededBareRepo struct {
+	bareDir string
+	url     string
+	wt      *gogit.Repository
+	wtPath  string
+	branch  string
+}
+
+func newSeededBareRepo(t *testing.T) *seededBareRepo {
+	t.Helper()
+
+	bareDir := filepath.Join(t.TempDir(), "bare.git")
+	if _, err := gogit.PlainInitWithOptions(bareDir, &gogit.PlainInitOptions{
+		Bare:        true,
+		InitOptions: gogit.InitOptions{DefaultBranch: plumbing.NewBranchReferenceName("main")},
+	}); err != nil {
+		t.Fatalf("init bare: %v", err)
+	}
+
+	wtPath := filepath.Join(t.TempDir(), "seed-wt")
+	wt, err := gogit.PlainInitWithOptions(wtPath, &gogit.PlainInitOptions{
+		InitOptions: gogit.InitOptions{DefaultBranch: plumbing.NewBranchReferenceName("main")},
+	})
+	if err != nil {
+		t.Fatalf("init wt: %v", err)
+	}
+	if _, err := wt.CreateRemote(&gogitconfig.RemoteConfig{
+		Name: "origin",
+		URLs: []string{bareDir},
+	}); err != nil {
+		t.Fatalf("create remote: %v", err)
+	}
+
+	return &seededBareRepo{
+		bareDir: bareDir,
+		url:     "file://" + bareDir,
+		wt:      wt,
+		wtPath:  wtPath,
+		branch:  "main",
+	}
+}
+
+func (r *seededBareRepo) commit(t *testing.T, filename, body, msg string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(r.wtPath, filename), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	tree, err := r.wt.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	if _, err := tree.Add(filename); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if _, err := tree.Commit(msg, &gogit.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@t", When: time.Now()},
+	}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if err := r.wt.Push(&gogit.PushOptions{RemoteName: "origin"}); err != nil && err != gogit.NoErrAlreadyUpToDate {
+		t.Fatalf("push: %v", err)
+	}
+}
+
+// countCommits walks HEAD and returns how many commits are reachable.
+// A shallow clone (Depth:1) reports 1 regardless of upstream history.
+func countCommits(t *testing.T, dir string) int {
+	t.Helper()
+	repo, err := gogit.PlainOpen(dir)
+	if err != nil {
+		t.Fatalf("open clone: %v", err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+	iter, err := repo.Log(&gogit.LogOptions{From: head.Hash()})
+	if err != nil {
+		t.Fatalf("log: %v", err)
+	}
+	n := 0
+	_ = iter.ForEach(func(*object.Commit) error { n++; return nil })
+	return n
+}
+
+// TestCloneOrPull_FetchesFullHistory guards against the #175 regression:
+// a shallow (Depth:1) clone silently stalls on `object not found` when
+// the remote advances past the shallow tip. A full clone has the
+// ancestry it needs to fast-forward cleanly. If this test sees only 1
+// commit the clone has reverted to shallow.
+func TestCloneOrPull_FetchesFullHistory(t *testing.T) {
+	bare := newSeededBareRepo(t)
+	bare.commit(t, "a", "one", "commit 1")
+	bare.commit(t, "b", "two", "commit 2")
+	bare.commit(t, "c", "three", "commit 3")
+
+	clone := filepath.Join(t.TempDir(), "clone")
+	if err := cloneOrPull(context.Background(), clone, bare.url, "main", ""); err != nil {
+		t.Fatalf("cloneOrPull: %v", err)
+	}
+
+	if got := countCommits(t, clone); got < 3 {
+		t.Errorf("clone has %d commits; want >=3 (shallow clone would report 1)", got)
+	}
+}
+
+// TestCloneOrPull_PullAfterRemoteAdvance ensures the second call — the
+// pull path — succeeds against a remote that has received new commits
+// since the initial clone. Under the old Depth:1 scheme this was the
+// exact path that produced "pull: object not found" in production.
+func TestCloneOrPull_PullAfterRemoteAdvance(t *testing.T) {
+	bare := newSeededBareRepo(t)
+	bare.commit(t, "a", "one", "commit 1")
+
+	clone := filepath.Join(t.TempDir(), "clone")
+	if err := cloneOrPull(context.Background(), clone, bare.url, "main", ""); err != nil {
+		t.Fatalf("initial cloneOrPull: %v", err)
+	}
+
+	bare.commit(t, "b", "two", "commit 2")
+	bare.commit(t, "c", "three", "commit 3")
+
+	if err := cloneOrPull(context.Background(), clone, bare.url, "main", ""); err != nil {
+		t.Fatalf("pull after remote advance: %v", err)
+	}
+
+	if got := countCommits(t, clone); got < 3 {
+		t.Errorf("after pull, clone has %d commits; want >=3", got)
+	}
+}


### PR DESCRIPTION
## Summary

Drops \`Depth: 1\` from the taskset git clone options in [\`pkg/taskset/git.go\`](pkg/taskset/git.go). Closes #175.

The shallow clone was silently stalling every user's tasksets whenever the remote got a new commit. go-git's \`PullContext\` needs the parent commits in the local object DB to compute a merge base; on a depth-1 clone it doesn't have them, so the pull fails with \`pull: object not found\` and the source serves stale state until daemon restart.

## Reproduction

1. Fresh \`dicode daemon\` with onboarding defaults (three git sources at \`github.com/dicode-ayo/dicode-core\`).
2. Any new commit lands on \`main\`.
3. Next pull ticker tick (30s default): \`WARN taskset source: pull failed\` spam, source frozen on the initial snapshot.

Observed live during #170 onboarding testing.

## Why not "re-clone on error" (Option 1 from #175)?

Simpler fix and the bandwidth delta is negligible for GitOps task repos (dicode-core is a few MB of history). Full clones never hit this failure mode, no fallback logic needed, no corner cases left to debug.

## Tests

New \`pkg/taskset/git_test.go\` with two live-git regression tests, using the same bare-repo fixture pattern as \`pkg/source/git/git_test.go\`:

- \`TestCloneOrPull_FetchesFullHistory\` — clone a repo with 3 commits, assert the local clone has all 3. A regression back to \`Depth: 1\` would report 1 and fail.
- \`TestCloneOrPull_PullAfterRemoteAdvance\` — clone at commit 1, push two more commits upstream, pull again, assert it succeeds and catches up. Exercises the exact failure path from #175.

## Test plan

- [x] \`go test ./pkg/taskset/... -timeout 60s\` — passes (including the two new tests)
- [x] \`go test ./... -timeout 120s\` — full suite green
- [x] \`go vet ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)