### PR TITLE
fix(config): honor watch:false and mcp:false in YAML

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -175,8 +175,11 @@ type SourceConfig struct {
 	Auth         SourceAuth    `yaml:"auth,omitempty"`
 
 	// Local source fields
-	Path  string `yaml:"path,omitempty"`  // absolute path to taskset.yaml (local) or tasks dir (legacy)
-	Watch bool   `yaml:"watch,omitempty"` // enable fsnotify (default true for local)
+	Path string `yaml:"path,omitempty"` // absolute path to taskset.yaml (local) or tasks dir (legacy)
+	// Watch enables fsnotify on the local source. Nil means "unset — apply
+	// default"; an explicit `watch: false` in YAML preserves false so the
+	// user can opt out. Default (nil → true) is applied in applyDefaults.
+	Watch *bool `yaml:"watch,omitempty"`
 
 	// TaskSet fields (new model)
 	// Name is the root namespace segment for all tasks from this source.
@@ -207,7 +210,7 @@ type ServerConfig struct {
 	Auth           bool     `yaml:"auth"`                      // enable global auth wall (default: false)
 	AllowedOrigins []string `yaml:"allowed_origins,omitempty"` // CORS allowlist; empty = same-origin only
 	TrustProxy     bool     `yaml:"trust_proxy,omitempty"`     // trust X-Forwarded-For from upstream proxy
-	MCP            bool     `yaml:"mcp"`                       // expose MCP endpoint at /mcp (default: true)
+	MCP            *bool    `yaml:"mcp,omitempty"`             // expose MCP endpoint at /mcp; nil → default true, explicit false opts out
 	TLSCertFile    string   `yaml:"tls_cert,omitempty"`        // path to TLS certificate (PEM); enables HTTPS when set with tls_key
 	TLSKeyFile     string   `yaml:"tls_key,omitempty"`         // path to TLS private key (PEM)
 }
@@ -294,18 +297,24 @@ func applyDefaults(cfg *Config, configDir string) {
 			}
 		}
 		if s.Type == SourceTypeLocal {
-			// Watch defaults to true for local sources
-			if !s.Watch {
-				s.Watch = true
+			// Watch defaults to true for local sources. A pointer lets us
+			// distinguish "unset" (nil → apply default true) from "explicitly
+			// false" (user opted out) — the previous non-pointer form made
+			// `watch: false` a no-op.
+			if s.Watch == nil {
+				t := true
+				s.Watch = &t
 			}
 		}
 	}
 	if cfg.Server.Port == 0 {
 		cfg.Server.Port = 8080
 	}
-	// MCP defaults to enabled
-	if !cfg.Server.MCP {
-		cfg.Server.MCP = true
+	// MCP defaults to enabled. Pointer lets us distinguish unset (nil → true)
+	// from explicit false (opt-out).
+	if cfg.Server.MCP == nil {
+		t := true
+		cfg.Server.MCP = &t
 	}
 	// Default secret providers if none configured
 	if len(cfg.Secrets.Providers) == 0 {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -287,3 +287,64 @@ execution:
 		t.Errorf("Execution.MaxConcurrentTasks = %d, want 8", cfg.Execution.MaxConcurrentTasks)
 	}
 }
+
+// Regression for #177: `watch: false` and `mcp: false` in YAML must survive
+// applyDefaults. Previously both fields were `bool` with a default-flip
+// (`if !x { x = true }`) that made explicit false a no-op.
+func TestLoadWatchAndMCPRespectExplicitFalse(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+
+	content := `
+server:
+  port: 8080
+  mcp: false
+sources:
+  - type: local
+    path: ${CONFIGDIR}/tasks
+    watch: false
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Server.MCP == nil || *cfg.Server.MCP {
+		t.Errorf("Server.MCP = %v, want explicit false", cfg.Server.MCP)
+	}
+	if len(cfg.Sources) != 1 {
+		t.Fatalf("want 1 source, got %d", len(cfg.Sources))
+	}
+	if cfg.Sources[0].Watch == nil || *cfg.Sources[0].Watch {
+		t.Errorf("Sources[0].Watch = %v, want explicit false", cfg.Sources[0].Watch)
+	}
+}
+
+func TestLoadWatchAndMCPDefaultsToTrueWhenUnset(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+
+	content := `
+sources:
+  - type: local
+    path: ${CONFIGDIR}/tasks
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Server.MCP == nil || !*cfg.Server.MCP {
+		t.Errorf("Server.MCP = %v, want default true when unset", cfg.Server.MCP)
+	}
+	if len(cfg.Sources) != 1 {
+		t.Fatalf("want 1 source, got %d", len(cfg.Sources))
+	}
+	if cfg.Sources[0].Watch == nil || !*cfg.Sources[0].Watch {
+		t.Errorf("Sources[0].Watch = %v, want default true when unset", cfg.Sources[0].Watch)
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -469,7 +469,10 @@ func buildSources(cfg *config.Config, dataDir string, log *zap.Logger) ([]source
 		}
 		switch sc.Type {
 		case config.SourceTypeLocal:
-			s, err := local.New(sc.Path, sc.Path, log)
+			// Watch is a *bool pointer after #177; applyDefaults guarantees
+			// it's non-nil here, but treat nil as "watch enabled" defensively.
+			watchEnabled := sc.Watch == nil || *sc.Watch
+			s, err := local.New(sc.Path, sc.Path, watchEnabled, log)
 			if err != nil {
 				return nil, nil, fmt.Errorf("local source %q: %w", sc.Path, err)
 			}

--- a/pkg/source/local/local.go
+++ b/pkg/source/local/local.go
@@ -19,8 +19,9 @@ const debounce = 150 * time.Millisecond
 
 // LocalSource watches a local directory for task changes.
 type LocalSource struct {
-	id   string
-	path string // absolute path to the tasks directory
+	id           string
+	path         string // absolute path to the tasks directory
+	watchEnabled bool   // whether to run fsnotify; false = poll-only via explicit Sync()
 
 	mu       sync.Mutex
 	snapshot map[string]string // taskID → hash at last sync
@@ -28,17 +29,20 @@ type LocalSource struct {
 	log *zap.Logger
 }
 
-// New creates a LocalSource for the given directory.
-func New(id, path string, log *zap.Logger) (*LocalSource, error) {
+// New creates a LocalSource for the given directory. If watchEnabled is
+// false, Start performs the initial scan but does not set up fsnotify —
+// callers must drive updates explicitly via Sync().
+func New(id, path string, watchEnabled bool, log *zap.Logger) (*LocalSource, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return nil, err
 	}
 	return &LocalSource{
-		id:       id,
-		path:     abs,
-		snapshot: make(map[string]string),
-		log:      log,
+		id:           id,
+		path:         abs,
+		watchEnabled: watchEnabled,
+		snapshot:     make(map[string]string),
+		log:          log,
 	}, nil
 }
 
@@ -53,6 +57,17 @@ func (s *LocalSource) Start(ctx context.Context) (<-chan source.Event, error) {
 	if err := s.syncAndEmit(ctx, ch); err != nil {
 		close(ch)
 		return nil, err
+	}
+
+	// If watch is disabled, don't spin up fsnotify. Callers drive updates
+	// via Sync(). Channel stays open for the initial scan's events and is
+	// closed when ctx cancels.
+	if !s.watchEnabled {
+		go func() {
+			<-ctx.Done()
+			close(ch)
+		}()
+		return ch, nil
 	}
 
 	watcher, err := fsnotify.NewWatcher()

--- a/pkg/source/local/local_test.go
+++ b/pkg/source/local/local_test.go
@@ -29,7 +29,7 @@ func writeTask(t *testing.T, dir, name string) {
 
 func newTestSource(t *testing.T, dir string) *LocalSource {
 	t.Helper()
-	s, err := New("test", dir, zap.NewNop())
+	s, err := New("test", dir, true, zap.NewNop())
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}

--- a/pkg/source/local/local_test.go
+++ b/pkg/source/local/local_test.go
@@ -270,3 +270,42 @@ func TestLocalSource_SyncAndEmit_UnblocksOnCtxCancel(t *testing.T) {
 		t.Fatal("syncAndEmit did not return after ctx cancel")
 	}
 }
+
+// Regression for #177: with watchEnabled=false, Start must perform the
+// initial scan but must NOT set up fsnotify. Adding a new task after Start
+// should produce no events until something calls Sync() explicitly.
+func TestLocalSource_WatchDisabled_NoFsNotifyEvents(t *testing.T) {
+	dir := t.TempDir()
+	writeTask(t, dir, "initial")
+
+	s, err := New("test", dir, false, zap.NewNop())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, err := s.Start(ctx)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Initial scan is still expected to emit the existing task.
+	initial := collectEvents(ch, 100*time.Millisecond)
+	if len(initial) != 1 {
+		t.Fatalf("initial scan: want 1 event, got %d (%v)", len(initial), initial)
+	}
+
+	// Add a task AFTER Start. With fsnotify disabled, this must NOT trigger
+	// an event — only an explicit Sync() would pick it up.
+	writeTask(t, dir, "late")
+	evs := collectEvents(ch, 300*time.Millisecond)
+	if len(evs) != 0 {
+		t.Fatalf("watch=false should suppress fsnotify events, but got %d (%v)", len(evs), evs)
+	}
+
+	// Sanity: Sync() still works for callers driving updates manually.
+	if err := s.Sync(ctx); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+}

--- a/pkg/webui/auth_test.go
+++ b/pkg/webui/auth_test.go
@@ -28,12 +28,13 @@ func newAuthServer(t *testing.T, passphrase string) *Server {
 
 	reg := registry.New(d)
 	eng := trigger.New(reg, nil, zap.NewNop())
+	mcpOn := true
 	cfg := &config.Config{
 		Server: config.ServerConfig{
 			Port:   8080,
 			Auth:   true,
 			Secret: passphrase,
-			MCP:    true,
+			MCP:    &mcpOn,
 		},
 	}
 	srv, err := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())

--- a/pkg/webui/passphrase_test.go
+++ b/pkg/webui/passphrase_test.go
@@ -22,11 +22,12 @@ func newAuthServerNoDB(t *testing.T, passphrase string) *Server {
 	t.Helper()
 	reg := registry.New(nil)
 	eng := trigger.New(reg, nil, zap.NewNop())
+	mcpOn := true
 	cfg := &config.Config{Server: config.ServerConfig{
 		Port:   8080,
 		Auth:   true,
 		Secret: passphrase,
-		MCP:    true,
+		MCP:    &mcpOn,
 	}}
 	srv := &Server{
 		registry: reg,

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -451,7 +451,9 @@ func (s *Server) Handler() http.Handler {
 		})
 
 		// MCP endpoint — requires API key when auth is enabled.
-		if s.cfg == nil || s.cfg.Server.MCP {
+		// MCP is a *bool pointer; nil means "unset" (treated as default enabled
+		// when cfg is present — applyDefaults fills this in).
+		if s.cfg == nil || s.cfg.Server.MCP == nil || *s.cfg.Server.MCP {
 			mcpSrv := mcp.New(s.registry, s.sourceMgr)
 			r.With(s.requireAPIKey).Mount("/mcp", mcpSrv.Handler())
 		}
@@ -1437,7 +1439,8 @@ func (s *Server) apiAddSource(w http.ResponseWriter, r *http.Request) {
 			jsonErr(w, "path is required for local source", http.StatusBadRequest)
 			return
 		}
-		sc = config.SourceConfig{Type: config.SourceTypeLocal, Path: path, Watch: true}
+		watchTrue := true
+		sc = config.SourceConfig{Type: config.SourceTypeLocal, Path: path, Watch: &watchTrue}
 	case config.SourceTypeGit:
 		url := strings.TrimSpace(body.URL)
 		if url == "" {

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -1466,7 +1466,8 @@ func (s *Server) apiAddSource(w http.ResponseWriter, r *http.Request) {
 	if s.reconciler != nil {
 		switch sc.Type {
 		case config.SourceTypeLocal:
-			ls, err := local.New(sc.Path, sc.Path, s.log)
+			watchEnabled := sc.Watch == nil || *sc.Watch
+			ls, err := local.New(sc.Path, sc.Path, watchEnabled, s.log)
 			if err != nil {
 				jsonErr(w, "create local source: "+err.Error(), http.StatusInternalServerError)
 				return


### PR DESCRIPTION
Closes #177

## Summary
`pkg/config/config.go` previously had two broken-default patterns:

- `SourceConfig.Watch` (line 179) was `bool` with `if !s.Watch { s.Watch = true }` — any explicit `watch: false` got silently flipped to true.
- `ServerConfig.MCP` (line 213) had the identical bug — `mcp: false` was silently overridden.

Both fields are now `*bool`:
- `nil` means "unset in YAML" → default to true (preserves current default).
- `&false` means "user explicitly opted out" → preserved.
- `&true` is a no-op but still legal.

Updated call sites:
- `pkg/webui/server.go:451` (MCP consumer — nil-guarded).
- `pkg/webui/server.go:1440` (SourceConfig constructor now passes a `*bool`).
- `pkg/webui/auth_test.go:36` and `pkg/webui/passphrase_test.go:29` (test fixtures).

## Test plan
- [x] New unit tests in `pkg/config/config_test.go`:
  - `TestLoadWatchAndMCPRespectExplicitFalse` — asserts `watch: false` / `mcp: false` survive load.
  - `TestLoadWatchAndMCPDefaultsToTrueWhenUnset` — asserts defaults are still applied when fields are omitted.
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./pkg/config/... ./pkg/webui/...` green