### PR TITLE
fix(source): block-with-ctx instead of dropping events on full channel

### DIFF
--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -85,7 +85,7 @@ func (g *GitSource) Start(ctx context.Context) (<-chan source.Event, error) {
 	}
 
 	ch := make(chan source.Event, 32)
-	if err := g.syncAndEmit(ch); err != nil {
+	if err := g.syncAndEmit(ctx, ch); err != nil {
 		g.log.Warn("git source: initial scan failed", zap.String("url", g.url), zap.Error(err))
 	}
 
@@ -115,7 +115,7 @@ func (g *GitSource) poll(ctx context.Context, ch chan<- source.Event) {
 				g.log.Warn("git source: pull failed", zap.String("url", g.url), zap.Error(err))
 				continue
 			}
-			if err := g.syncAndEmit(ch); err != nil {
+			if err := g.syncAndEmit(ctx, ch); err != nil {
 				g.log.Warn("git source: scan failed", zap.String("url", g.url), zap.Error(err))
 			}
 		}
@@ -182,7 +182,14 @@ func (g *GitSource) httpAuth() *http.BasicAuth {
 	return &http.BasicAuth{Username: "git", Password: token}
 }
 
-func (g *GitSource) syncAndEmit(ch chan<- source.Event) error {
+// syncAndEmit computes a diff against the previous snapshot and sends events.
+//
+// Events are sent with a blocking select guarded by ctx.Done: under
+// back-pressure the poller parks until the consumer drains or shutdown
+// begins. A non-blocking send would silently drop events — because diff()
+// has already advanced the snapshot, a dropped event is permanent
+// (no next poll would re-emit it). See #178.
+func (g *GitSource) syncAndEmit(ctx context.Context, ch chan<- source.Event) error {
 	events, err := g.diff()
 	if err != nil {
 		return err
@@ -190,8 +197,8 @@ func (g *GitSource) syncAndEmit(ch chan<- source.Event) error {
 	for _, ev := range events {
 		select {
 		case ch <- ev:
-		default:
-			g.log.Warn("git source: event channel full, dropping", zap.String("task", ev.TaskID))
+		case <-ctx.Done():
+			return nil
 		}
 	}
 	return nil

--- a/pkg/source/local/local.go
+++ b/pkg/source/local/local.go
@@ -50,7 +50,7 @@ func (s *LocalSource) Start(ctx context.Context) (<-chan source.Event, error) {
 	ch := make(chan source.Event, 32)
 
 	// Initial scan — emit Added for every task already on disk.
-	if err := s.syncAndEmit(ch); err != nil {
+	if err := s.syncAndEmit(ctx, ch); err != nil {
 		close(ch)
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (s *LocalSource) watch(ctx context.Context, watcher *fsnotify.Watcher, ch c
 
 	fire := func() {
 		timerC = nil
-		if err := s.syncAndEmit(ch); err != nil {
+		if err := s.syncAndEmit(ctx, ch); err != nil {
 			s.log.Warn("local source sync error", zap.String("path", s.path), zap.Error(err))
 		}
 	}
@@ -145,7 +145,13 @@ func (s *LocalSource) watch(ctx context.Context, watcher *fsnotify.Watcher, ch c
 }
 
 // syncAndEmit computes a diff against the previous snapshot and sends events.
-func (s *LocalSource) syncAndEmit(ch chan<- source.Event) error {
+//
+// Events are sent with a blocking select guarded by ctx.Done: under
+// back-pressure the watcher parks until the consumer drains or shutdown
+// begins. A non-blocking send would silently drop events — because diff()
+// has already advanced the snapshot, a dropped event is permanent
+// (no next poll would re-emit it). See #178.
+func (s *LocalSource) syncAndEmit(ctx context.Context, ch chan<- source.Event) error {
 	events, err := s.diff()
 	if err != nil {
 		return err
@@ -153,9 +159,8 @@ func (s *LocalSource) syncAndEmit(ch chan<- source.Event) error {
 	for _, ev := range events {
 		select {
 		case ch <- ev:
-		default:
-			s.log.Warn("local source event channel full, dropping event",
-				zap.String("task", ev.TaskID))
+		case <-ctx.Done():
+			return nil
 		}
 	}
 	return nil

--- a/pkg/source/local/local_test.go
+++ b/pkg/source/local/local_test.go
@@ -201,3 +201,72 @@ func TestLocalSource_EmptyDir(t *testing.T) {
 		t.Fatalf("expected no events for empty dir, got %v", evs)
 	}
 }
+
+// Regression for #178: syncAndEmit must block (not silently drop) when the
+// event channel is full. Before the fix, a full channel caused events to be
+// dropped permanently because diff() had already advanced the snapshot.
+func TestLocalSource_SyncAndEmit_BlocksOnFullChannel(t *testing.T) {
+	dir := t.TempDir()
+	writeTask(t, dir, "alpha")
+	s := newTestSource(t, dir)
+
+	// Zero-capacity channel — any send blocks until drained.
+	ch := make(chan source.Event)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- s.syncAndEmit(ctx, ch)
+	}()
+
+	// syncAndEmit should be blocked on the send.
+	select {
+	case err := <-done:
+		t.Fatalf("syncAndEmit returned before any receive (err=%v); event would have been dropped pre-#178", err)
+	case <-time.After(50 * time.Millisecond):
+		// Expected: blocked.
+	}
+
+	// Drain one event; syncAndEmit should now return cleanly.
+	select {
+	case <-ch:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("no event available on channel")
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("syncAndEmit: %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("syncAndEmit did not return after drain")
+	}
+}
+
+func TestLocalSource_SyncAndEmit_UnblocksOnCtxCancel(t *testing.T) {
+	dir := t.TempDir()
+	writeTask(t, dir, "alpha")
+	s := newTestSource(t, dir)
+
+	ch := make(chan source.Event)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- s.syncAndEmit(ctx, ch)
+	}()
+
+	// Let the goroutine park on the send.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("syncAndEmit on ctx-cancel: %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("syncAndEmit did not return after ctx cancel")
+	}
+}


### PR DESCRIPTION
Closes #178

## Summary
Both `LocalSource.syncAndEmit` and `GitSource.syncAndEmit` used a non-blocking select that silently dropped events:

```go
select {
case ch <- ev:
default:
    log.Warn("dropping event")
}
```

Combined with the snapshot-swap in `diff()` (which already marked the task as "seen"), a dropped event was **permanent** — the next poll produced no event because the snapshot matched. A task added on disk could never register.

Fix: take `ctx context.Context` and use a blocking select guarded by ctx-cancel:

```go
select {
case ch <- ev:
case <-ctx.Done():
    return nil
}
```

Under backpressure the watcher parks until the reconciler drains. Under shutdown it exits cleanly.

## Risk review
The reconciler (`pkg/registry/reconciler.go`) always drains the merged channel in its main loop; the forwarder goroutine at line 108 blindly writes to `rc.merged` which is buffered at 64. No deadlock path exists under normal operation. If the reconciler's main loop has exited but sources are still firing, ctx-cancel now unblocks them instead of hanging.

## Test plan
- [x] New tests in `pkg/source/local/local_test.go`:
  - `TestLocalSource_SyncAndEmit_BlocksOnFullChannel` — verifies the send blocks instead of dropping
  - `TestLocalSource_SyncAndEmit_UnblocksOnCtxCancel` — verifies ctx-cancel unblocks
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./pkg/source/... ./pkg/registry/...` green (local 4.3s, git 5.2s, registry 0.5s)