### PR TITLE
docs(relay): point self-host sections at dicode-relay repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1525,12 +1525,9 @@ The relay broker runs the code exchange on its side, ECIES-encrypts the token bu
 
 ### Self-hosted relay
 
-For high-security environments, run your own relay server instead of using `relay.dicode.app`:
+For high-security environments, run your own relay server instead of using `relay.dicode.app`. The relay lives in a separate repository: [dicode-ayo/dicode-relay](https://github.com/dicode-ayo/dicode-relay) — a Node.js service that combines the WebSocket tunnel, OAuth broker, multi-client support, and a status dashboard. It ships as a Docker image; see the relay repo for deployment details.
 
-- **Go relay server** (`pkg/relay/server.go`) — lightweight, same binary, suitable for single-user self-hosting
-- **Node.js relay server** (`dicode-relay` repo) — production-grade with OAuth broker, multi-client support, status dashboard
-
-Self-hosted server deployments that expose port 8080 directly don't need the relay at all.
+Self-hosted daemons that expose port 8080 directly don't need the relay at all.
 
 ---
 

--- a/docs/concepts/webhook-relay.md
+++ b/docs/concepts/webhook-relay.md
@@ -142,11 +142,11 @@ The production relay server is a separate TypeScript/Node.js service (`dicode-re
 
 ### Self-hosted
 
-The Go relay server (`pkg/relay/server.go`) can run standalone for environments where you control the infrastructure:
+The relay server lives at [dicode-ayo/dicode-relay](https://github.com/dicode-ayo/dicode-relay) — a Node.js service that can run standalone for environments where you control the infrastructure:
 - Same protocol, same handshake verification
 - In-memory nonce store, client registry
-- No OAuth broker -- just plain webhook forwarding
-- Designed for embedding in tests and single-user self-hosting
+- Optional OAuth broker (configurable via `relay.yaml`)
+- Published as a Docker image; suitable for embedding in tests and single-user self-hosting
 
 | | Hosted | Self-hosted |
 |---|---|---|

--- a/docs/design/relay.md
+++ b/docs/design/relay.md
@@ -188,6 +188,9 @@ within 10 seconds of a ping.
 | Privacy | Relay sees plaintext payloads | You see your own payloads |
 
 For high-security environments, self-host the relay server inside your network
-perimeter. The Go relay server implementation (`pkg/relay/server.go`) can run
-standalone. The production relay server is a separate Node.js service
-(`dicode-relay` repo) that adds OAuth broker support and multi-client features.
+perimeter. The relay server lives in a separate repo
+([`dicode-ayo/dicode-relay`](https://github.com/dicode-ayo/dicode-relay)) —
+a Node.js service with WebSocket tunnel + OAuth broker support. An earlier
+Go implementation at `pkg/relay/server.go` was removed in favour of the
+TypeScript service; see [`docs/design/oauth-broker.md`](oauth-broker.md) for
+the rationale.

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -129,10 +129,13 @@ and you should use the local OAuth flow instead (see the same doc).
 
 ## Self-hosting the relay server
 
-The relay server is included in the dicode repository (`pkg/relay/server.go`).
-To run a standalone relay server, build and run the `relay-server` binary
-(coming soon as a separate `cmd/relay-server`). Configure clients to point at
-your server:
+The relay server lives in a separate repository:
+[dicode-ayo/dicode-relay](https://github.com/dicode-ayo/dicode-relay) — a
+single-process TypeScript/Node.js 22 service that combines the WebSocket
+tunnel and the OAuth broker. A ready-to-run Docker image is published via
+the repo's release pipeline (see the relay repo's `Dockerfile`).
+
+Configure clients to point at your self-hosted instance:
 
 ```yaml
 relay:
@@ -140,5 +143,10 @@ relay:
   server_url: wss://relay.example.com
 ```
 
-The relay server requires no database; nonce state is kept in memory.
-TLS termination should be handled by a reverse proxy (nginx, Caddy, etc.).
+The relay server requires no database; nonce state and client registry are
+kept in memory. TLS termination should be handled by a reverse proxy
+(nginx, Caddy, etc.) in front of the Node process.
+
+> Historically the daemon repository carried a Go relay implementation at
+> `pkg/relay/server.go`. It was dropped in favour of the TypeScript relay —
+> see [`docs/design/oauth-broker.md`](design/oauth-broker.md) for rationale.


### PR DESCRIPTION
Closes #179

## Summary
Three docs referenced a dropped `pkg/relay/server.go` / phantom `cmd/relay-server` binary:

- `docs/relay.md:132-141` — "coming soon as a separate `cmd/relay-server`" sentence replaced; now directs self-hosters to the [dicode-relay](https://github.com/dicode-ayo/dicode-relay) repo and its Docker image. Added a brief historical note linking to the design doc.
- `docs/concepts/webhook-relay.md:145` — "The Go relay server (`pkg/relay/server.go`) can run standalone…" rewritten to point at the Node.js service; also corrected "No OAuth broker" → "Optional OAuth broker (configurable via relay.yaml)" which matches current reality.
- `docs/design/relay.md:191` — high-security self-host paragraph updated to clarify the relay is a separate repo.

Historical context referring to the removed Go server in `docs/design/oauth-broker.md:29` ("PR #79 introduced a Go relay server…") and `docs/implementation-plan.md:676` was left intact — those are describing past decisions, not current state.

## Test plan
- [x] Markdown links resolve (manual check).
- [x] `grep pkg/relay/server docs/` returns only intentional historical notes.