### PR TITLE
refactor(ipc): authenticate CLI control channel via SO_PEERCRED

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.50.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/sys v0.43.0
 	golang.org/x/term v0.42.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.49.1
@@ -91,7 +92,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -105,22 +105,10 @@ func NewControlServer(
 		return nil, fmt.Errorf("control: issue token: %w", err)
 	}
 	cs.token = tok
-	if err := writeTokenFile(tokenPath, tok); err != nil {
+	if err := writeCLITokenFile(tokenPath, tok); err != nil {
 		return nil, fmt.Errorf("control: write token file: %w", err)
 	}
 	return cs, nil
-}
-
-// writeTokenFile writes the token to path atomically (tmp + rename, mode 0600).
-func writeTokenFile(path, token string) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-		return err
-	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, []byte(token), 0600); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
 }
 
 // Start begins accepting connections. It removes any stale socket file first.
@@ -171,12 +159,23 @@ func (cs *ControlServer) handleConn(ctx context.Context, conn net.Conn) {
 	if err := readMsg(conn, &hs); err != nil {
 		return
 	}
-	claims, err := VerifyToken(cs.secret, hs.Token)
-	if err != nil || claims.Identity != "cli" {
-		_ = writeMsg(conn, handshakeErr{Error: "invalid token"})
-		return
+
+	// On Linux, SO_PEERCRED on a 0600 socket is strictly more secure than a
+	// token file on disk — the kernel fills ucred at connect() time, so the
+	// check is race-safe, and there is no credential to steal via filesystem
+	// access. When the peer UID matches the daemon UID, grant full CLI caps
+	// without requiring a token. Non-Linux (peerCredSupported == false) and
+	// same-host UID-mismatch cases fall through to token verification.
+	caps := cliCaps()
+	if match, _ := peerUIDMatches(conn); !match {
+		claims, err := VerifyToken(cs.secret, hs.Token)
+		if err != nil || claims.Identity != "cli" {
+			_ = writeMsg(conn, handshakeErr{Error: "invalid token"})
+			return
+		}
+		caps = claims.Caps
 	}
-	_ = writeMsg(conn, handshakeResp{Proto: 1, Caps: claims.Caps})
+	_ = writeMsg(conn, handshakeResp{Proto: 1, Caps: caps})
 	_ = conn.SetDeadline(time.Time{})
 
 	// Derive a per-connection context so that when the client disconnects,

--- a/pkg/ipc/control_client.go
+++ b/pkg/ipc/control_client.go
@@ -3,7 +3,6 @@ package ipc
 import (
 	"fmt"
 	"net"
-	"os"
 	"time"
 )
 
@@ -16,10 +15,12 @@ type ControlClient struct {
 	caps []string
 }
 
-// Dial connects to the daemon control socket at socketPath and authenticates
-// using the token stored in tokenPath. Returns a ready-to-use ControlClient.
+// Dial connects to the daemon control socket at socketPath and authenticates.
+// On Linux, authentication happens via SO_PEERCRED (UID match) — tokenPath is
+// ignored and may not exist on disk. On other platforms, the token is read
+// from tokenPath and sent in the handshake.
 func Dial(socketPath, tokenPath string) (*ControlClient, error) {
-	tok, err := os.ReadFile(tokenPath)
+	tok, err := readCLITokenFile(tokenPath)
 	if err != nil {
 		return nil, fmt.Errorf("read token file %s: %w", tokenPath, err)
 	}
@@ -30,7 +31,7 @@ func Dial(socketPath, tokenPath string) (*ControlClient, error) {
 	}
 
 	c := &ControlClient{conn: conn}
-	if err := c.handshake(string(tok)); err != nil {
+	if err := c.handshake(tok); err != nil {
 		conn.Close()
 		return nil, err
 	}

--- a/pkg/ipc/control_peercred_test.go
+++ b/pkg/ipc/control_peercred_test.go
@@ -1,0 +1,81 @@
+//go:build linux
+
+package ipc
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// TestControlServerPeerCred proves the core security property: on Linux, the
+// CLI can authenticate to the daemon control socket with NO TOKEN FILE on disk.
+// SO_PEERCRED alone gates access. This test exists to prevent a silent
+// regression in which the daemon begins writing the token again (re-introducing
+// the on-disk attack surface).
+func TestControlServerPeerCred(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "ctrl.sock")
+	tokenPath := filepath.Join(dir, "ctrl.token")
+
+	cs, err := NewControlServer(socketPath, tokenPath, nil, &mockEngine{}, nil, MetricsProvider{}, "test", zap.NewNop(), nil, "")
+	if err != nil {
+		t.Fatalf("NewControlServer: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = cs.Start(ctx) }()
+
+	// Wait for socket.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(socketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("socket never appeared")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Core assertion: the token file must NOT exist on disk on Linux.
+	if _, err := os.Stat(tokenPath); !os.IsNotExist(err) {
+		t.Fatalf("token file unexpectedly present at %s (err=%v) — SO_PEERCRED should make it unnecessary", tokenPath, err)
+	}
+
+	// Dial and perform a handshake with an EMPTY token. The server must
+	// accept via SO_PEERCRED (same process UID) and return proto=1 + caps.
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	if err := writeMsg(conn, handshakeReq{Token: ""}); err != nil {
+		t.Fatalf("handshake send: %v", err)
+	}
+	var hs struct {
+		Proto int      `json:"proto"`
+		Caps  []string `json:"caps"`
+		Error string   `json:"error"`
+	}
+	_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+	if err := readMsg(conn, &hs); err != nil {
+		t.Fatalf("handshake recv: %v", err)
+	}
+	if hs.Error != "" {
+		t.Fatalf("server rejected same-uid peer: %s", hs.Error)
+	}
+	if hs.Proto != 1 {
+		t.Fatalf("proto=%d, want 1", hs.Proto)
+	}
+	if len(hs.Caps) == 0 {
+		t.Fatalf("server returned no caps; expected cliCaps() set")
+	}
+}

--- a/pkg/ipc/control_test.go
+++ b/pkg/ipc/control_test.go
@@ -55,7 +55,7 @@ func controlTestEnv(t *testing.T, mp MetricsProvider) (net.Conn, func()) {
 	}
 
 	// Read the token the server wrote.
-	tok, err := os.ReadFile(tokenPath)
+	tok, err := readCLITokenFile(tokenPath)
 	if err != nil {
 		cancel()
 		t.Fatalf("read token: %v", err)
@@ -132,7 +132,7 @@ func TestControl_Handshake_EmitsEmptyTaskAndRunIDFields(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 
-	tok, err := os.ReadFile(tokenPath)
+	tok, err := readCLITokenFile(tokenPath)
 	if err != nil {
 		t.Fatalf("read token: %v", err)
 	}
@@ -309,7 +309,7 @@ func TestControl_AI_FiresConfiguredTask_AndReturnsReply(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 
-	tok, err := os.ReadFile(tokenPath)
+	tok, err := readCLITokenFile(tokenPath)
 	if err != nil {
 		t.Fatalf("read token: %v", err)
 	}
@@ -405,7 +405,7 @@ func TestControl_AI_NumericSessionID(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 
-	tok, _ := os.ReadFile(tokenPath)
+	tok, _ := readCLITokenFile(tokenPath)
 	conn, err := net.Dial("unix", socketPath)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
@@ -468,7 +468,7 @@ func TestControl_AI_NoDefault_NoOverride_ReturnsError(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 
-	tok, _ := os.ReadFile(tokenPath)
+	tok, _ := readCLITokenFile(tokenPath)
 	conn, err := net.Dial("unix", socketPath)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
@@ -545,7 +545,7 @@ func TestControl_RelayRotate_InvokesRotator(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 
-	tok, err := os.ReadFile(tokenPath)
+	tok, err := readCLITokenFile(tokenPath)
 	if err != nil {
 		t.Fatalf("token: %v", err)
 	}
@@ -630,7 +630,7 @@ func TestControl_RelayRotate_RotatorError_SurfacesVerbatim(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 
-	tok, err := os.ReadFile(tokenPath)
+	tok, err := readCLITokenFile(tokenPath)
 	if err != nil {
 		t.Fatalf("token: %v", err)
 	}

--- a/pkg/ipc/peercred_linux.go
+++ b/pkg/ipc/peercred_linux.go
@@ -1,0 +1,51 @@
+//go:build linux
+
+package ipc
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// peerCredSupported reports whether this platform authenticates CLI control
+// connections via SO_PEERCRED UID match. When true, the token-file path is
+// not written or read for the CLI control channel.
+const peerCredSupported = true
+
+// peerUIDMatches reports whether the peer on conn has the same UID as the
+// current process. The Linux kernel fills ucred at connect() time, so this
+// is race-safe — there is no TOCTOU window between accept and the check.
+// Returns (false, nil) for non-AF_UNIX conns.
+func peerUIDMatches(conn net.Conn) (bool, error) {
+	uc, ok := conn.(*net.UnixConn)
+	if !ok {
+		return false, nil
+	}
+	raw, err := uc.SyscallConn()
+	if err != nil {
+		return false, fmt.Errorf("raw conn: %w", err)
+	}
+	var ucred *unix.Ucred
+	var sockErr error
+	ctlErr := raw.Control(func(fd uintptr) {
+		ucred, sockErr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
+	})
+	if ctlErr != nil {
+		return false, fmt.Errorf("control fd: %w", ctlErr)
+	}
+	if sockErr != nil {
+		return false, fmt.Errorf("SO_PEERCRED: %w", sockErr)
+	}
+	return int(ucred.Uid) == os.Getuid(), nil
+}
+
+// writeCLITokenFile is a no-op on Linux — the CLI authenticates via
+// SO_PEERCRED, so there is no token file to leave on disk.
+func writeCLITokenFile(_, _ string) error { return nil }
+
+// readCLITokenFile returns the empty string on Linux. Dial passes "" to the
+// server, which accepts it when peerUIDMatches succeeds.
+func readCLITokenFile(_ string) (string, error) { return "", nil }

--- a/pkg/ipc/peercred_other.go
+++ b/pkg/ipc/peercred_other.go
@@ -1,0 +1,38 @@
+//go:build !linux
+
+package ipc
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+)
+
+const peerCredSupported = false
+
+// peerUIDMatches always returns false on non-Linux platforms; callers fall
+// back to token-file authentication.
+func peerUIDMatches(_ net.Conn) (bool, error) { return false, nil }
+
+// writeCLITokenFile writes the CLI token to path atomically (tmp + rename,
+// mode 0600). Only used on non-Linux platforms — on Linux the CLI control
+// channel authenticates via SO_PEERCRED and no token file is written.
+func writeCLITokenFile(path, token string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(token), 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// readCLITokenFile reads the token from disk on non-Linux platforms.
+func readCLITokenFile(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}


### PR DESCRIPTION
## Summary

Replace token-file auth on the CLI→daemon control socket with `SO_PEERCRED`. The control socket is already `chmod 0600`; kernel-enforced UID match at `connect()` time is strictly more secure than a pre-shared token file on disk. Closes item (12) in #195.

- **Linux**: `peerCredSupported = true`; token file is never written. CLI authenticates via `unix.GetsockoptUcred` on accept. Handshake wire protocol unchanged (empty token is sent; server accepts on UID match).
- **Darwin/BSD**: existing token-file path preserved via `peercred_other.go`. No behavior change for cross-platform builds.
- **Task-shim `Server` (subprocess boundary) is unchanged** — subprocess tokens still use HMAC capability tokens because UID match is meaningless across that boundary.

Net LOC approximately break-even. The value is deleting an on-disk attack surface for the control channel, not line-count reduction.

## Test plan

- [x] `make test` green (88 existing `pkg/ipc` tests + new `control_peercred_test.go` pass)
- [x] `make test-race` green
- [x] `make lint` clean (`go fmt` + `go vet`)
- [x] `make build` produces a binary with the same libc linkage as `main`
- [x] New test pins the core security property: socket must still authenticate after the token file is absent from disk on Linux
- [ ] Manual verification: delete `~/.dicode/run/daemon.token` between daemon restart and `dicode status` — still succeeds on Linux

## Risk

Low. Task-shim auth path is untouched. Non-Linux platforms keep the existing token-file flow unchanged behind a build tag. If the peer-cred check ever returns false (e.g. a non-AF_UNIX listener), the server falls through to token verification — there is no bypass path that weakens non-Linux auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)