### PR TITLE
refactor(webui): adopt gorilla/csrf for login CSRF protection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,8 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/gorilla/csrf v1.7.3 // indirect
+	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,10 @@ github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17k
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/csrf v1.7.3 h1:BHWt6FTLZAb2HtWT5KDBf6qgpZzvtbp9QWDRKZMXJC0=
+github.com/gorilla/csrf v1.7.3/go.mod h1:F1Fj3KG23WYHE6gozCmBAezKookxbIvUJT+121wTuLk=
+github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kXD8ePA=
+github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=

--- a/pkg/webui/browser_sim_test.go
+++ b/pkg/webui/browser_sim_test.go
@@ -1,0 +1,147 @@
+package webui_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/config"
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/ipc"
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/trigger"
+	"github.com/dicode/dicode/pkg/webui"
+	"go.uber.org/zap"
+)
+
+// TestLogin_FormPost_BrowserOriginHeader pins two properties at once:
+//
+//  1. A same-origin form POST with a valid Origin header is accepted by the
+//     gorilla/csrf middleware (regression test for the playwright failure
+//     where Chrome sent Origin: null under Referrer-Policy: no-referrer, which
+//     gorilla rejected as "origin invalid").
+//
+//  2. The login page's Referrer-Policy is not `no-referrer` — that header
+//     causes Chrome to strip the Origin header from form POSTs, breaking the
+//     real-browser login flow. `strict-origin-when-cross-origin` (or any
+//     same-origin-preserving policy) is required.
+func TestLogin_FormPost_BrowserOriginHeader(t *testing.T) {
+	h := newBrowserTestHandler(t, "hunter2")
+
+	getReq := httptest.NewRequestWithContext(context.Background(), "GET", "http://localhost:8765/login", nil)
+	getReq.Host = "localhost:8765"
+	getW := httptest.NewRecorder()
+	h.ServeHTTP(getW, getReq)
+	if getW.Code != 200 {
+		t.Fatalf("GET /login: expected 200, got %d", getW.Code)
+	}
+
+	// Regression guard: Referrer-Policy must NOT be `no-referrer` (Chrome sends
+	// Origin: null on form POSTs under that policy, which gorilla/csrf rejects).
+	if rp := getW.Header().Get("Referrer-Policy"); rp == "no-referrer" {
+		t.Fatalf("Referrer-Policy must not be no-referrer (strips Origin header on POST, breaks CSRF sameOrigin check); got %q", rp)
+	}
+
+	var csrfCookieVal string
+	for _, c := range getW.Result().Cookies() {
+		if c.Name == "dicode_csrf" {
+			csrfCookieVal = c.Value
+		}
+	}
+	if csrfCookieVal == "" {
+		t.Fatal("no dicode_csrf cookie on /login GET")
+	}
+
+	body := getW.Body.String()
+	const marker = `name="_csrf" value="`
+	i := strings.Index(body, marker)
+	if i < 0 {
+		t.Fatal("no _csrf field in rendered login form")
+	}
+	rest := body[i+len(marker):]
+	end := strings.Index(rest, `"`)
+	token := rest[:end]
+
+	form := url.Values{}
+	form.Set("password", "hunter2")
+	form.Set("next", "/hooks/webui")
+	form.Set("_csrf", token)
+
+	postReq := httptest.NewRequestWithContext(context.Background(), "POST", "http://localhost:8765/api/auth/login", strings.NewReader(form.Encode()))
+	postReq.Host = "localhost:8765"
+	postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	postReq.Header.Set("Origin", "http://localhost:8765")
+	postReq.Header.Set("Referer", "http://localhost:8765/login")
+	postReq.AddCookie(&http.Cookie{Name: "dicode_csrf", Value: csrfCookieVal})
+
+	postW := httptest.NewRecorder()
+	h.ServeHTTP(postW, postReq)
+	if postW.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d: %s", postW.Code, postW.Body.String())
+	}
+}
+
+// TestLogin_FormPost_OriginNull verifies that Origin: null is rejected. This
+// is the correct security posture — if the browser is sending an anonymised
+// Origin, the same-origin property cannot be established and the request
+// should be refused rather than accepted.
+func TestLogin_FormPost_OriginNull(t *testing.T) {
+	h := newBrowserTestHandler(t, "hunter2")
+
+	getReq := httptest.NewRequestWithContext(context.Background(), "GET", "http://localhost:8765/login", nil)
+	getReq.Host = "localhost:8765"
+	getW := httptest.NewRecorder()
+	h.ServeHTTP(getW, getReq)
+
+	var csrfCookieVal string
+	for _, c := range getW.Result().Cookies() {
+		if c.Name == "dicode_csrf" {
+			csrfCookieVal = c.Value
+		}
+	}
+	body := getW.Body.String()
+	const marker = `name="_csrf" value="`
+	i := strings.Index(body, marker)
+	rest := body[i+len(marker):]
+	end := strings.Index(rest, `"`)
+	token := rest[:end]
+
+	form := url.Values{}
+	form.Set("password", "hunter2")
+	form.Set("_csrf", token)
+
+	postReq := httptest.NewRequestWithContext(context.Background(), "POST", "http://localhost:8765/api/auth/login", strings.NewReader(form.Encode()))
+	postReq.Host = "localhost:8765"
+	postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	postReq.Header.Set("Origin", "null")
+	postReq.AddCookie(&http.Cookie{Name: "dicode_csrf", Value: csrfCookieVal})
+
+	postW := httptest.NewRecorder()
+	h.ServeHTTP(postW, postReq)
+	if postW.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for Origin: null, got %d", postW.Code)
+	}
+}
+
+func newBrowserTestHandler(t *testing.T, passphrase string) http.Handler {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{Port: 8765, Auth: true, Secret: passphrase},
+	}
+	reg := registry.New(d)
+	eng := trigger.New(reg, nil, zap.NewNop())
+	srv, err := webui.New(8765, reg, eng, cfg, "", nil, nil, nil, "", webui.NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return srv.Handler()
+}

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -991,8 +991,10 @@ func isFormRequest(r *http.Request) bool {
 
 // setLoginPageHeaders applies defence-in-depth headers on any response that
 // renders the login form. Clickjacking prevention (XFO + frame-ancestors),
-// no-referrer to keep the `next` path from leaking to upstream origins, and
-// a CSP that allows only same-origin subresources plus inline styles.
+// a referrer policy that keeps the `next` path from leaking cross-origin
+// but preserves the Origin header on same-origin POSTs (gorilla/csrf rejects
+// Origin: null, which Chrome sends when the policy is `no-referrer`), and a
+// CSP that allows only same-origin subresources plus inline styles.
 func setLoginPageHeaders(w http.ResponseWriter) {
 	h := w.Header()
 	h.Set("Content-Type", "text/html; charset=utf-8")
@@ -1000,7 +1002,7 @@ func setLoginPageHeaders(w http.ResponseWriter) {
 	h.Set("Content-Security-Policy",
 		"default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'none'; "+
 			"img-src 'self' data:; frame-ancestors 'none'; base-uri 'none'; form-action 'self'")
-	h.Set("Referrer-Policy", "no-referrer")
+	h.Set("Referrer-Policy", "strict-origin-when-cross-origin")
 }
 
 func (s *Server) loginTitle(next string) string {

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/dicode/dicode/pkg/trigger"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/gorilla/csrf"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 )
@@ -173,6 +174,12 @@ type Server struct {
 	log                *zap.Logger
 	port               int
 	srv                *http.Server
+
+	// csrfKey is a per-daemon random 32-byte HMAC key for gorilla/csrf. It is
+	// regenerated on every daemon restart — any open browser tab that was
+	// mid-login must reload /login to get a fresh token. Not persisted so a
+	// stolen key cannot outlast a restart.
+	csrfKey []byte
 }
 
 // SetRelayClient stores a reference to the relay client so the API can expose
@@ -197,6 +204,11 @@ func New(port int, r *registry.Registry, eng *trigger.Engine, cfg *config.Config
 	go ss.purgeLoop()
 
 	wsHub := NewWSHub(log)
+
+	csrfKey := make([]byte, 32)
+	if _, err := rand.Read(csrfKey); err != nil {
+		return nil, fmt.Errorf("webui: generate csrf key: %w", err)
+	}
 
 	var dbs *dbSessionStore
 	var aks *apiKeyStore
@@ -226,6 +238,7 @@ func New(port int, r *registry.Registry, eng *trigger.Engine, cfg *config.Config
 		log:             log,
 		port:            port,
 		gateway:         gateway,
+		csrfKey:         csrfKey,
 	}
 
 	// Wire run started hook → broadcast run:started
@@ -327,9 +340,50 @@ func (s *Server) Handler() http.Handler {
 	r.Use(securityHeaders)
 
 	// Auth endpoints — always public (login flow must be reachable without session).
-	r.Post("/api/auth/login", s.apiSecretsUnlock)
+	//
+	// CSRF protection via gorilla/csrf is scoped to the login-form flow only.
+	// GET /login sets/refreshes the masked token cookie; the form POST is
+	// validated by the middleware automatically. The JSON variant of
+	// /api/auth/login is exempted in csrfGuard below because it follows a
+	// different threat model (same-origin fetch with credentials; no cookie
+	// to forge in a cross-origin form).
+	tlsConfigured := s.cfg.Server.TLSCertFile != ""
+	csrfProtect := csrf.Protect(
+		s.csrfKey,
+		csrf.CookieName("dicode_csrf"),
+		csrf.FieldName("_csrf"),
+		csrf.Path("/"),
+		csrf.Secure(tlsConfigured),
+		csrf.SameSite(csrf.SameSiteStrictMode),
+		csrf.MaxAge(3600),
+	)
+	csrfGuard := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			// JSON POSTs to /api/auth/login bypass CSRF validation — see
+			// comment above. All other methods + content types go through.
+			if req.URL.Path == "/api/auth/login" && req.Method == http.MethodPost && !isFormRequest(req) {
+				next.ServeHTTP(w, req)
+				return
+			}
+			// gorilla/csrf defaults to treating the request as HTTPS and
+			// enforces Origin/Referer checks. dicode's daemon is typically
+			// HTTP over localhost (TLS only when TLSCertFile is configured),
+			// so mark the request plaintext when TLS is not configured —
+			// otherwise every local form submission is rejected with
+			// "referer not supplied". Under TLS, the strict-referer check
+			// stays on to defend against HTTP-downgrade MITM.
+			if !tlsConfigured {
+				req = csrf.PlaintextHTTPRequest(req)
+			}
+			csrfProtect(next).ServeHTTP(w, req)
+		})
+	}
+	r.Group(func(lr chi.Router) {
+		lr.Use(csrfGuard)
+		lr.Post("/api/auth/login", s.apiSecretsUnlock)
+		lr.Get("/login", s.handleLoginPage)
+	})
 	r.Post("/api/auth/refresh", s.apiAuthRefresh)
-	r.Get("/login", s.handleLoginPage)
 
 	// Webhook passthrough — auth via per-task HMAC secret or optional session cookie.
 	// When a task sets trigger.auth: true, a valid dicode session is required for
@@ -829,12 +883,10 @@ func (s *Server) apiSecretsUnlock(w http.ResponseWriter, r *http.Request) {
 			s.loginError(w, r, "invalid form", http.StatusBadRequest, "")
 			return
 		}
-		if !validateCSRF(r) {
-			s.log.Warn("login form rejected: csrf token missing or mismatch",
-				zap.String("ip", ip))
-			s.loginError(w, r, "session expired — please reload the login page", http.StatusForbidden, "")
-			return
-		}
+		// CSRF: gorilla/csrf middleware has already validated the token on
+		// POST (see csrfGuard in Handler()) — the request would have been
+		// rejected with 403 before reaching here if the token was missing or
+		// mismatched.
 		password = r.PostFormValue("password")
 		trust = r.PostFormValue("trust") != ""
 		nextPath = r.PostFormValue("next")
@@ -899,13 +951,10 @@ func (s *Server) loginError(w http.ResponseWriter, r *http.Request, msg string, 
 		jsonErr(w, msg, code)
 		return
 	}
-	csrf, err := s.issueCSRFToken(w)
-	if err != nil {
-		s.log.Error("login error render: failed to issue csrf token", zap.Error(err))
-		jsonErr(w, msg, code)
-		return
-	}
-	body, err := renderLoginPage(s.loginTitle(safeNext), safeNext, csrf, msg)
+	// gorilla/csrf middleware has already placed a fresh masked token on the
+	// response cookie; csrf.TemplateField(r) returns the same value to embed in the
+	// retry form.
+	body, err := renderLoginPage(s.loginTitle(safeNext), safeNext, csrf.TemplateField(r), msg)
 	if err != nil {
 		s.log.Error("login error render: template execute", zap.Error(err))
 		jsonErr(w, msg, code)
@@ -922,13 +971,7 @@ func (s *Server) handleLoginPage(w http.ResponseWriter, r *http.Request) {
 		s.log.Warn("rejecting unsafe next on login page", zap.String("next", next))
 		next = ""
 	}
-	csrf, err := s.issueCSRFToken(w)
-	if err != nil {
-		s.log.Error("login page: failed to issue csrf token", zap.Error(err))
-		http.Error(w, "internal error", http.StatusInternalServerError)
-		return
-	}
-	body, err := renderLoginPage(s.loginTitle(next), next, csrf, "")
+	body, err := renderLoginPage(s.loginTitle(next), next, csrf.TemplateField(r), "")
 	if err != nil {
 		s.log.Error("login page: template execute", zap.Error(err))
 		http.Error(w, "internal error", http.StatusInternalServerError)
@@ -958,50 +1001,6 @@ func setLoginPageHeaders(w http.ResponseWriter) {
 		"default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'none'; "+
 			"img-src 'self' data:; frame-ancestors 'none'; base-uri 'none'; form-action 'self'")
 	h.Set("Referrer-Policy", "no-referrer")
-}
-
-const csrfCookie = "dicode_csrf"
-
-// issueCSRFToken generates a fresh CSRF token, sets it as a same-site cookie,
-// and returns the raw value for embedding in a form's hidden _csrf field.
-// The double-submit pattern: the cookie travels only on same-origin requests
-// (SameSite=Strict), so a cross-site POST cannot include the cookie — and
-// without it validateCSRF rejects the request.
-//
-// The Secure attribute is set whenever TLS is configured (cfg.Server.TLSCert
-// non-empty). Set it unconditionally and plain-HTTP localhost loses the
-// cookie entirely, breaking the login flow; skip it and HTTPS deployments
-// are vulnerable to cookie leak over any downgrade. Conditional on TLS
-// config is the pragmatic middle ground.
-func (s *Server) issueCSRFToken(w http.ResponseWriter) (string, error) {
-	token, err := randomToken()
-	if err != nil {
-		return "", err
-	}
-	http.SetCookie(w, &http.Cookie{
-		Name:     csrfCookie,
-		Value:    token,
-		Path:     "/",
-		HttpOnly: true,
-		Secure:   s.cfg.Server.TLSCertFile != "",
-		SameSite: http.SameSiteStrictMode,
-	})
-	return token, nil
-}
-
-// validateCSRF enforces the double-submit cookie on a form POST. The cookie
-// value (set by a prior /login GET) must match the form's _csrf field.
-// Call only after r.ParseForm() has run. Constant-time compare.
-func validateCSRF(r *http.Request) bool {
-	c, err := r.Cookie(csrfCookie)
-	if err != nil || c.Value == "" {
-		return false
-	}
-	got := r.PostFormValue("_csrf")
-	if got == "" {
-		return false
-	}
-	return subtle.ConstantTimeCompare([]byte(c.Value), []byte(got)) == 1
 }
 
 func (s *Server) loginTitle(next string) string {
@@ -1062,7 +1061,7 @@ var loginPageTpl = template.Must(template.New("login").Parse(`<!doctype html>
 <label>Password<input type="password" name="password" autocomplete="current-password" autofocus required></label>
 <label class="dc-check"><input type="checkbox" name="trust" value="1">Trust this browser</label>
 <input type="hidden" name="next" value="{{.Next}}">
-<input type="hidden" name="_csrf" value="{{.CSRF}}">
+{{.CSRFField}}
 <button type="submit">Sign in</button>
 </form>
 </main>
@@ -1070,19 +1069,23 @@ var loginPageTpl = template.Must(template.New("login").Parse(`<!doctype html>
 </html>`))
 
 type loginPageData struct {
-	Title string
-	Next  string
-	CSRF  string
-	Err   string
+	Title     string
+	Next      string
+	CSRFField template.HTML // rendered <input> tag from csrf.TemplateField
+	Err       string
 }
 
 // renderLoginPage produces the login form HTML with contextual auto-escaping
-// via html/template. Returns nil + error only on template execution failure,
-// which indicates a bug in the template itself (not a user-input issue).
-func renderLoginPage(title, next, csrf, errMsg string) ([]byte, error) {
+// via html/template. The CSRF field is a template.HTML value produced by
+// csrf.TemplateField(r) — it carries its own escape-safe `<input>` tag so
+// html/template doesn't re-escape the base64 token's `+` characters as
+// numeric references, which would corrupt the form value in simple
+// string-based extractors (real browsers HTML-decode attribute values,
+// but not all clients do).
+func renderLoginPage(title, next string, csrfField template.HTML, errMsg string) ([]byte, error) {
 	var b strings.Builder
 	if err := loginPageTpl.Execute(&b, loginPageData{
-		Title: title, Next: next, CSRF: csrf, Err: errMsg,
+		Title: title, Next: next, CSRFField: csrfField, Err: errMsg,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -847,8 +847,12 @@ func TestLoginPage_SetsSecurityHeaders(t *testing.T) {
 	if !strings.Contains(csp, "script-src 'none'") {
 		t.Errorf("CSP must set script-src 'none' on login page, got %q", csp)
 	}
-	if got := w.Header().Get("Referrer-Policy"); got != "no-referrer" {
-		t.Errorf("Referrer-Policy: want no-referrer, got %q", got)
+	// Referrer-Policy must preserve the Origin header on same-origin POSTs —
+	// `no-referrer` makes Chrome send Origin: null, which gorilla/csrf then
+	// rejects as "origin invalid". `strict-origin-when-cross-origin` keeps
+	// the anti-leak property cross-origin while letting the login form work.
+	if got := w.Header().Get("Referrer-Policy"); got != "strict-origin-when-cross-origin" {
+		t.Errorf("Referrer-Policy: want strict-origin-when-cross-origin, got %q", got)
 	}
 }
 

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -545,6 +545,10 @@ func TestLoginPage_Served_WhenPathIsPublic(t *testing.T) {
 	}
 }
 
+// csrfCookie is the cookie name set by gorilla/csrf middleware. Kept here
+// (not in server.go) as a test helper so tests can assert on a stable name.
+const csrfCookie = "dicode_csrf"
+
 // prepareLoginPost performs a GET /login to obtain a CSRF cookie and token,
 // then builds a POST request carrying both. Returned request has the cookie
 // attached and the form body includes the matching _csrf field.


### PR DESCRIPTION
## Summary

Replace hand-rolled double-submit CSRF helpers with \`gorilla/csrf\`. Closes item (6) in #195.

- Middleware scoped via a chi group to \`/login\` (GET) + \`/api/auth/login\` (POST). JSON variant of the login POST is exempted (different threat model).
- When TLS is not configured, requests are wrapped with \`csrf.PlaintextHTTPRequest\` to skip gorilla's HTTPS-only Origin/Referer enforcement — dicode's daemon is typically HTTP on localhost.
- Template uses \`csrf.TemplateField\` instead of embedding the raw token in \`value=\"{{.CSRF}}\"\` — avoids \`html/template\`'s attribute escaper rewriting \`+\` (present in base64 tokens) as \`&#43;\`.

## Scope note — item (4) parked

On closer inspection, the \`alexedwards/scs\` swap proposed for item (4) is more tangled than the audit estimated: the in-memory \`sessionStore\` has 7 call sites across \`apikeys.go\` / \`auth.go\` / \`passphrase.go\` / \`sessions_db.go\`, and SCS's ctx-based session identity doesn't cleanly map to the \"revoke this specific cookie value\" flow used by the trusted-device revocation UI. The current 48-LOC in-memory store is already minimal and correct. Filing a follow-up note on #195.

## Test plan

- [x] \`make test\` green (96 pkg/webui tests incl. CSRF-protected form flows)
- [x] \`make test-race\` green
- [x] \`make lint\` clean

Net diff +13 LOC (the new middleware and scoping wrapper add slightly more LOC than the old helpers, but the value is: timing-safe comparison, HMAC-signed masked tokens, Origin/Referer validation under TLS — all from a battle-tested library).

🤖 Generated with [Claude Code](https://claude.com/claude-code)