### PR TITLE
refactor(relay,source/git): adopt cenkalti/backoff/v4 for resilience math

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/bep/debounce v1.2.1
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/coder/websocket v1.8.14
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.7.0
@@ -29,7 +30,6 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect

--- a/pkg/relay/backoff_test.go
+++ b/pkg/relay/backoff_test.go
@@ -1,0 +1,85 @@
+package relay
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNewReconnectBackoff_Defaults locks in the parameters fed to
+// cenkalti/backoff so we don't accidentally drift away from the original
+// hand-rolled math (1s initial, 60s cap, ±20% jitter, runs forever).
+func TestNewReconnectBackoff_Defaults(t *testing.T) {
+	bo := newReconnectBackoff()
+	if bo.InitialInterval != time.Second {
+		t.Errorf("InitialInterval = %v; want 1s", bo.InitialInterval)
+	}
+	if bo.MaxInterval != 60*time.Second {
+		t.Errorf("MaxInterval = %v; want 60s", bo.MaxInterval)
+	}
+	if bo.RandomizationFactor != 0.2 {
+		t.Errorf("RandomizationFactor = %v; want 0.2", bo.RandomizationFactor)
+	}
+	if bo.Multiplier != 2 {
+		t.Errorf("Multiplier = %v; want 2", bo.Multiplier)
+	}
+	// MaxElapsedTime == 0 is the cenkalti convention for "never stop".
+	// The relay reconnect loop is supervised by ctx, not an elapsed-time
+	// deadline; if this regresses to non-zero, NextBackOff() will start
+	// returning Stop and reconnects will silently break.
+	if bo.MaxElapsedTime != 0 {
+		t.Errorf("MaxElapsedTime = %v; want 0 (run forever)", bo.MaxElapsedTime)
+	}
+}
+
+// TestNewReconnectBackoff_NeverStops drives the backoff well past any
+// plausible elapsed-time budget and verifies NextBackOff() never returns
+// the sentinel Stop value. Defends against a future MaxElapsedTime tweak
+// silently breaking the reconnect loop.
+func TestNewReconnectBackoff_NeverStops(t *testing.T) {
+	bo := newReconnectBackoff()
+	for i := 0; i < 50; i++ {
+		if d := bo.NextBackOff(); d < 0 {
+			t.Fatalf("NextBackOff() returned Stop on iteration %d", i)
+		}
+	}
+}
+
+// TestNewReconnectBackoff_RespectsMaxInterval checks that the randomized
+// interval stays within the [1-r, 1+r]*MaxInterval band once it saturates.
+// This guards against a multiplier change accidentally letting the wait
+// drift well above 60s.
+func TestNewReconnectBackoff_RespectsMaxInterval(t *testing.T) {
+	bo := newReconnectBackoff()
+	// Drive the backoff until it saturates at MaxInterval (well past it).
+	for i := 0; i < 20; i++ {
+		bo.NextBackOff()
+	}
+	// Now sample a few more — they should all be within ±20% of 60s.
+	const lo = time.Duration(float64(60*time.Second) * 0.8)
+	const hi = time.Duration(float64(60*time.Second) * 1.2)
+	for i := 0; i < 10; i++ {
+		d := bo.NextBackOff()
+		if d < lo || d > hi {
+			t.Errorf("NextBackOff() = %v; want in [%v, %v] after saturation", d, lo, hi)
+		}
+	}
+}
+
+// TestNewReconnectBackoff_ResetRewindsToFloor verifies that calling
+// Reset() after the backoff has grown returns NextBackOff() to the 1s
+// initial-interval band. The relay Run loop relies on this to drop back
+// to a 1s reconnect after a stable connection finally drops.
+func TestNewReconnectBackoff_ResetRewindsToFloor(t *testing.T) {
+	bo := newReconnectBackoff()
+	// Saturate.
+	for i := 0; i < 20; i++ {
+		bo.NextBackOff()
+	}
+	bo.Reset()
+	d := bo.NextBackOff()
+	const lo = time.Duration(float64(time.Second) * 0.8)
+	const hi = time.Duration(float64(time.Second) * 1.2)
+	if d < lo || d > hi {
+		t.Errorf("NextBackOff() after Reset = %v; want in [%v, %v] (1s ±20%%)", d, lo, hi)
+	}
+}

--- a/pkg/relay/backoff_test.go
+++ b/pkg/relay/backoff_test.go
@@ -31,6 +31,21 @@ func TestNewReconnectBackoff_Defaults(t *testing.T) {
 	}
 }
 
+// TestNewReconnectBackoff_FirstCallReturnsInitialInterval pins the contract
+// that the very first NextBackOff() returns ~InitialInterval, not zero.
+// Old hand-rolled code started at `time.Second` before jitter; a future swap
+// to a backoff implementation that started at 0 would make the first
+// reconnect attempt fire instantly, hammering a flapping relay.
+func TestNewReconnectBackoff_FirstCallReturnsInitialInterval(t *testing.T) {
+	bo := newReconnectBackoff()
+	d := bo.NextBackOff()
+	const lo = time.Duration(float64(time.Second) * 0.8)
+	const hi = time.Duration(float64(time.Second) * 1.2)
+	if d < lo || d > hi {
+		t.Errorf("first NextBackOff() = %v; want in [%v, %v] (1s ±20%%)", d, lo, hi)
+	}
+}
+
 // TestNewReconnectBackoff_NeverStops drives the backoff well past any
 // plausible elapsed-time budget and verifies NextBackOff() never returns
 // the sentinel Stop value. Defends against a future MaxElapsedTime tweak

--- a/pkg/relay/client.go
+++ b/pkg/relay/client.go
@@ -146,25 +146,33 @@ func (c *Client) Run(ctx context.Context) error {
 
 	for {
 		connectedAt := time.Now()
-		if err := c.runOnce(ctx); err != nil {
+		runErr := c.runOnce(ctx)
+		if runErr != nil {
 			// Record the transport error BEFORE checking ctx so real
 			// failures racing with cancellation still land in Status().
-			c.markDisconnected(err)
+			c.markDisconnected(runErr)
 			if ctx.Err() != nil {
 				return nil
 			}
-			c.log.Warn("relay disconnected, reconnecting", zap.Error(err))
 		}
 
 		// Reset backoff if the connection was stable long enough.
 		// Reset() rewinds both the next interval AND the elapsed-time
 		// counter, so a long-lived connection that finally drops will
-		// retry from the 1s floor again.
+		// retry from the 1s floor again. Behaviorally equivalent to the
+		// hand-rolled `backoff = time.Second` reset; see
+		// TestNewReconnectBackoff_ResetRewindsToFloor for the contract.
 		if time.Since(connectedAt) >= stableConnectionThreshold {
 			bo.Reset()
 		}
 
 		wait := bo.NextBackOff()
+		if runErr != nil {
+			// Logged after NextBackOff() so the line carries the actual
+			// next-attempt delay — useful for diagnosing flapping in prod.
+			c.log.Warn("relay disconnected, reconnecting",
+				zap.Error(runErr), zap.Duration("backoff", wait))
+		}
 		t := time.NewTimer(wait)
 		select {
 		case <-ctx.Done():

--- a/pkg/relay/client.go
+++ b/pkg/relay/client.go
@@ -13,13 +13,12 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"math"
-	mathrand "math/rand/v2"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/coder/websocket"
 	"github.com/dicode/dicode/pkg/db"
 	relaypb "github.com/dicode/dicode/pkg/relay/pb"
@@ -118,11 +117,26 @@ func (c *Client) HookBaseURL() string {
 	return c.hookBaseURL
 }
 
+// newReconnectBackoff returns the exponential backoff used between relay
+// reconnect attempts. Configured to match the prior hand-rolled math:
+// 1s initial, 60s cap, ±20% jitter, no overall deadline.
+func newReconnectBackoff() *backoff.ExponentialBackOff {
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = time.Second
+	b.MaxInterval = 60 * time.Second
+	b.RandomizationFactor = 0.2
+	b.Multiplier = 2
+	// Run forever — the relay reconnect loop is supervised by ctx, not
+	// by an elapsed-time deadline. NextBackOff() must never return Stop.
+	b.MaxElapsedTime = 0
+	b.Reset()
+	return b
+}
+
 // Run connects to the relay server and maintains the connection until ctx is
 // cancelled. Reconnects with exponential backoff on disconnect.
 func (c *Client) Run(ctx context.Context) error {
-	backoff := time.Second
-	const maxBackoff = 60 * time.Second
+	bo := newReconnectBackoff()
 
 	// On any exit path (clean shutdown OR final error), flip the status
 	// pill to offline so the UI doesn't report a stale "connected"
@@ -139,32 +153,26 @@ func (c *Client) Run(ctx context.Context) error {
 			if ctx.Err() != nil {
 				return nil
 			}
-			c.log.Warn("relay disconnected, reconnecting", zap.Error(err), zap.Duration("backoff", backoff))
+			c.log.Warn("relay disconnected, reconnecting", zap.Error(err))
 		}
 
 		// Reset backoff if the connection was stable long enough.
+		// Reset() rewinds both the next interval AND the elapsed-time
+		// counter, so a long-lived connection that finally drops will
+		// retry from the 1s floor again.
 		if time.Since(connectedAt) >= stableConnectionThreshold {
-			backoff = time.Second
+			bo.Reset()
 		}
 
-		t := time.NewTimer(jitter(backoff))
+		wait := bo.NextBackOff()
+		t := time.NewTimer(wait)
 		select {
 		case <-ctx.Done():
 			t.Stop()
 			return nil
 		case <-t.C:
 		}
-
-		backoff = time.Duration(math.Min(float64(backoff*2), float64(maxBackoff)))
 	}
-}
-
-// jitter returns d ±20%.
-func jitter(d time.Duration) time.Duration {
-	f := float64(d)
-	delta := f * 0.2
-	offset := (mathrand.Float64()*2 - 1) * delta
-	return time.Duration(f + offset)
 }
 
 func (c *Client) runOnce(ctx context.Context) error {

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -109,6 +109,11 @@ func (g *GitSource) Start(ctx context.Context) (<-chan source.Event, error) {
 }
 
 // Sync triggers an immediate pull + rescan.
+//
+// May block up to cloneRetryMaxElapsed (~30s) on transient failures, since
+// the underlying clone-or-pull retries with exponential backoff. Callers on
+// interactive paths (UI buttons, request handlers) should pass a ctx with a
+// shorter deadline if they need to fail fast.
 func (g *GitSource) Sync(ctx context.Context) error {
 	if err := g.cloneOrPull(ctx); err != nil {
 		return err

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -6,6 +6,7 @@ package git
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/dicode/dicode/pkg/source"
 	"github.com/dicode/dicode/pkg/task"
 	gogit "github.com/go-git/go-git/v5"
@@ -24,7 +26,15 @@ import (
 	"go.uber.org/zap"
 )
 
-const defaultPoll = 30 * time.Second
+const (
+	defaultPoll = 30 * time.Second
+
+	// cloneRetryMaxElapsed caps total time spent on bounded retries inside
+	// cloneOrPull. Long enough to ride out a transient hiccup, short enough
+	// that the next poll tick happens roughly on schedule even if every
+	// attempt fails.
+	cloneRetryMaxElapsed = 30 * time.Second
+)
 
 // GitSource clones + polls a remote repository and emits task change events.
 type GitSource struct {
@@ -40,6 +50,11 @@ type GitSource struct {
 
 	mu       sync.Mutex
 	snapshot map[string]string // taskID → hash
+
+	// cloneOrPullOp, when non-nil, is invoked by cloneOrPull instead of
+	// the production tryCloneOrPull path. Tests use this to verify retry
+	// behaviour without standing up a real git server.
+	cloneOrPullOp cloneOrPullFn
 
 	log *zap.Logger
 }
@@ -122,7 +137,46 @@ func (g *GitSource) poll(ctx context.Context, ch chan<- source.Event) {
 	}
 }
 
+// cloneOrPullFn is the function signature cloneOrPull invokes for the actual
+// network call. Extracted to a field so tests can inject a mock and verify
+// retry behaviour without standing up a real git server.
+type cloneOrPullFn func(ctx context.Context) error
+
 func (g *GitSource) cloneOrPull(ctx context.Context) error {
+	op := g.cloneOrPullOp
+	if op == nil {
+		op = g.tryCloneOrPull
+	}
+
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 500 * time.Millisecond
+	bo.MaxInterval = 5 * time.Second
+	bo.RandomizationFactor = 0.2
+	bo.Multiplier = 2
+	bo.MaxElapsedTime = cloneRetryMaxElapsed
+	bo.Reset()
+
+	bctx := backoff.WithContext(bo, ctx)
+
+	return backoff.Retry(func() error {
+		err := op(ctx)
+		if err == nil {
+			return nil
+		}
+		// Don't burn cycles retrying broken config: auth failures and
+		// "repo not found" are operator errors, not transient ones.
+		// Wrap in backoff.Permanent so Retry surfaces them immediately.
+		if isPermanentGitError(err) {
+			return backoff.Permanent(err)
+		}
+		return err
+	}, bctx)
+}
+
+// tryCloneOrPull executes a single clone-or-pull attempt against the remote.
+// Returns nil on success or NoErrAlreadyUpToDate; any other error indicates
+// a failure the caller (cloneOrPull) may want to retry.
+func (g *GitSource) tryCloneOrPull(ctx context.Context) error {
 	auth := g.httpAuth()
 
 	// If the local dir already contains a repo, pull; otherwise clone.
@@ -168,6 +222,26 @@ func (g *GitSource) cloneOrPull(ctx context.Context) error {
 		return fmt.Errorf("clone: %w", err)
 	}
 	return nil
+}
+
+// isPermanentGitError reports whether err is a configuration-style failure
+// that retrying cannot fix. The poll loop will re-attempt on the next tick
+// regardless; classifying these as Permanent just avoids burning the
+// 30-second retry budget every poll interval.
+//
+// Conservatively scoped: only the unambiguous "your credentials/URL are
+// wrong" sentinels from go-git's transport layer. Everything else (network
+// timeout, 5xx, packfile decode error mid-clone, partial response, …) is
+// treated as transient.
+func isPermanentGitError(err error) bool {
+	switch {
+	case errors.Is(err, gogittransport.ErrAuthenticationRequired),
+		errors.Is(err, gogittransport.ErrAuthorizationFailed),
+		errors.Is(err, gogittransport.ErrInvalidAuthMethod),
+		errors.Is(err, gogittransport.ErrRepositoryNotFound):
+		return true
+	}
+	return false
 }
 
 // httpAuth returns HTTP basic-auth credentials if a token env var is set.

--- a/pkg/source/git/retry_test.go
+++ b/pkg/source/git/retry_test.go
@@ -133,6 +133,12 @@ func TestCloneOrPull_BoundedByMaxElapsed(t *testing.T) {
 	if elapsed > 2*cloneRetryMaxElapsed {
 		t.Errorf("retry took %v; expected <= %v", elapsed, 2*cloneRetryMaxElapsed)
 	}
+	// Lower bound is 2 attempts (not a higher number) because backoff jitter
+	// can push the first wait to ~750ms and the second to ~1.5s, leaving
+	// only ~3 attempts in the 30s budget at the worst end of the band.
+	// If InitialInterval is ever bumped meaningfully, this floor will need
+	// to drop — but never below 2, otherwise the test no longer proves
+	// retries happened at all.
 	if calls.Load() < 2 {
 		t.Errorf("expected at least 2 attempts; got %d", calls.Load())
 	}

--- a/pkg/source/git/retry_test.go
+++ b/pkg/source/git/retry_test.go
@@ -1,0 +1,199 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gogittransport "github.com/go-git/go-git/v5/plumbing/transport"
+	"go.uber.org/zap"
+)
+
+// Tests for the bounded retry wrapper around cloneOrPull.
+//
+// The production tryCloneOrPull path is exercised via the existing tests in
+// git_test.go (which use a real file:// remote). These tests focus on the
+// retry semantics: how many attempts are made, that auth-style failures
+// short-circuit, and that the operation doesn't burn the entire MaxElapsed
+// budget on a permanent error.
+//
+// Each test injects a mock cloneOrPullOp on a freshly-constructed GitSource
+// so the real go-git code path never runs.
+
+func newTestGitSource(t *testing.T, op cloneOrPullFn) *GitSource {
+	t.Helper()
+	gs, err := New(t.TempDir(), "https://example.invalid/repo.git", "main", time.Second, "", "", zap.NewNop())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	gs.cloneOrPullOp = op
+	return gs
+}
+
+// TestCloneOrPull_TransientErrorRetries verifies that a transient error
+// triggers at least one retry and eventually succeeds when the operation
+// recovers.
+func TestCloneOrPull_TransientErrorRetries(t *testing.T) {
+	var calls atomic.Int32
+	gs := newTestGitSource(t, func(ctx context.Context) error {
+		n := calls.Add(1)
+		if n < 3 {
+			return errors.New("connection reset by peer")
+		}
+		return nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := gs.cloneOrPull(ctx); err != nil {
+		t.Fatalf("cloneOrPull: %v", err)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Errorf("call count = %d; want 3 (2 retries before success)", got)
+	}
+}
+
+// TestCloneOrPull_AuthErrorIsPermanent verifies that an authentication
+// failure surfaces immediately without retrying. We deliberately avoid
+// retrying on auth errors so a misconfigured token doesn't burn the
+// 30-second retry budget on every poll tick — and so the operator gets a
+// fast, clear failure signal in the logs.
+func TestCloneOrPull_AuthErrorIsPermanent(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"AuthenticationRequired", gogittransport.ErrAuthenticationRequired},
+		{"AuthorizationFailed", gogittransport.ErrAuthorizationFailed},
+		{"InvalidAuthMethod", gogittransport.ErrInvalidAuthMethod},
+		{"RepositoryNotFound", gogittransport.ErrRepositoryNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int32
+			// Wrap the sentinel to mirror how the production code returns
+			// it (fmt.Errorf("clone: %w", err)) — isPermanentGitError must
+			// still recognise the error after wrapping.
+			wrapped := fmt.Errorf("clone: %w", tc.err)
+			gs := newTestGitSource(t, func(ctx context.Context) error {
+				calls.Add(1)
+				return wrapped
+			})
+
+			start := time.Now()
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			err := gs.cloneOrPull(ctx)
+			elapsed := time.Since(start)
+
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !errors.Is(err, tc.err) {
+				t.Errorf("err = %v; want errors.Is(%v) == true", err, tc.err)
+			}
+			if got := calls.Load(); got != 1 {
+				t.Errorf("call count = %d; want 1 (auth errors must not retry)", got)
+			}
+			// Should fail fast — well under the 30s MaxElapsedTime budget.
+			if elapsed > 5*time.Second {
+				t.Errorf("permanent error took %v to surface; want <5s", elapsed)
+			}
+		})
+	}
+}
+
+// TestCloneOrPull_BoundedByMaxElapsed verifies that a permanently failing
+// transient error eventually gives up — we don't loop forever, so a broken
+// upstream doesn't pin the poll goroutine in retry purgatory.
+func TestCloneOrPull_BoundedByMaxElapsed(t *testing.T) {
+	var calls atomic.Int32
+	gs := newTestGitSource(t, func(ctx context.Context) error {
+		calls.Add(1)
+		return errors.New("temporary failure in name resolution")
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*cloneRetryMaxElapsed)
+	defer cancel()
+
+	start := time.Now()
+	err := gs.cloneOrPull(ctx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error after retry budget exhausted")
+	}
+	// Allow some slack: backoff jitter + scheduler can push us slightly
+	// past MaxElapsedTime. Upper bound is 2x to catch a runaway loop.
+	if elapsed > 2*cloneRetryMaxElapsed {
+		t.Errorf("retry took %v; expected <= %v", elapsed, 2*cloneRetryMaxElapsed)
+	}
+	if calls.Load() < 2 {
+		t.Errorf("expected at least 2 attempts; got %d", calls.Load())
+	}
+}
+
+// TestCloneOrPull_ContextCancelStopsRetry verifies that cancelling ctx
+// during retry exits promptly rather than waiting for the next backoff
+// interval. Important for graceful shutdown — a daemon stop shouldn't
+// have to wait for a retry cycle to finish.
+func TestCloneOrPull_ContextCancelStopsRetry(t *testing.T) {
+	var calls atomic.Int32
+	gs := newTestGitSource(t, func(ctx context.Context) error {
+		calls.Add(1)
+		return errors.New("network unreachable")
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := gs.cloneOrPull(ctx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error when ctx cancelled mid-retry")
+	}
+	// Shouldn't take much longer than the ctx deadline; certainly nowhere
+	// near the 30s MaxElapsedTime.
+	if elapsed > 5*time.Second {
+		t.Errorf("ctx-cancelled retry took %v; expected ~ctx deadline", elapsed)
+	}
+}
+
+// TestIsPermanentGitError_PermanentSentinels exercises the classifier
+// directly — the Retry test above goes through the full backoff machinery
+// which is slower; this catches regressions in the sentinel list itself.
+func TestIsPermanentGitError_PermanentSentinels(t *testing.T) {
+	permanent := []error{
+		gogittransport.ErrAuthenticationRequired,
+		gogittransport.ErrAuthorizationFailed,
+		gogittransport.ErrInvalidAuthMethod,
+		gogittransport.ErrRepositoryNotFound,
+		fmt.Errorf("pull: %w", gogittransport.ErrAuthenticationRequired),
+		fmt.Errorf("clone: %w", gogittransport.ErrRepositoryNotFound),
+	}
+	for _, err := range permanent {
+		if !isPermanentGitError(err) {
+			t.Errorf("isPermanentGitError(%v) = false; want true", err)
+		}
+	}
+
+	transient := []error{
+		errors.New("connection refused"),
+		errors.New("i/o timeout"),
+		errors.New("EOF"),
+		fmt.Errorf("clone: %w", errors.New("503 service unavailable")),
+		nil,
+	}
+	for _, err := range transient {
+		if isPermanentGitError(err) {
+			t.Errorf("isPermanentGitError(%v) = true; want false", err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two related changes, bundled because both promote the same indirect dep — `cenkalti/backoff/v4` — to a direct one:

- **`pkg/relay/client.go`** — replace the hand-rolled exponential backoff in the WebSocket reconnect loop with `backoff.NewExponentialBackOff()`. Configured to match prior behavior (1s initial, 60s cap, ±20% jitter, `MaxElapsedTime=0` so it runs forever). The stable-connection reset path now calls `bo.Reset()` so a long-lived connection that finally drops returns to the 1s floor.
- **`pkg/source/git/git.go`** — wrap `cloneOrPull` with `backoff.Retry`. Bounded by `MaxElapsedTime=30s` (500ms→5s interval) so a transient network blip is cushioned without bubbling to the poll loop and waiting a full 30s poll interval before retrying. Auth-style failures (`ErrAuthenticationRequired`, `ErrAuthorizationFailed`, `ErrInvalidAuthMethod`, `ErrRepositoryNotFound`) are wrapped with `backoff.Permanent` so misconfigured tokens / wrong URLs surface immediately on the first poll instead of burning the retry budget.

The existing reconnect-loop subtleties are preserved — supervised goroutine lifecycle via ctx, the stable-connection threshold, the deferred `markDisconnected(nil)` for clean shutdowns, and the order of `markDisconnected(err)` before the ctx-cancellation check.

## Test plan

- [x] `go build ./...` — green
- [x] `go vet ./...` — green
- [x] `go test ./... -timeout 180s` — green (full suite, including the 35s `pkg/source/git` package which now exercises the retry budget)
- [x] New `pkg/relay/backoff_test.go` — pins the four exponential parameters, asserts `NextBackOff()` never returns `Stop`, that the saturated interval lives in `[1-r, 1+r]*MaxInterval`, and that `Reset()` rewinds to the 1s floor
- [x] New `pkg/source/git/retry_test.go` — mocks `cloneOrPullOp` and verifies: transient errors retry to success, the four auth-style sentinels short-circuit after one call, the retry budget is bounded by `cloneRetryMaxElapsed` (no infinite loop), `ctx` cancellation exits the retry loop promptly, and `isPermanentGitError` recognises wrapped sentinels via `errors.Is`

🤖 Generated with [Claude Code](https://claude.com/claude-code)