### PR TITLE
chore(alpha): hygiene — security disclosure, ctx-aware forwarder, skill doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ That's it. The task appears in your dashboard within seconds.
 
 ---
 
+> [!WARNING]
+> **Alpha software — not yet human security-reviewed.**
+>
+> dicode (and the companion [dicode-relay](https://github.com/dicode-ayo/dicode-relay)) was written by AI. The crypto-adjacent code paths — ECDSA P-256 handshake, ECIES (ECDH + AES-256-GCM + HKDF-SHA256) token delivery, TOFU broker pubkey pinning, ECDSA-signed delivery envelopes, OAuth broker flow — have **not** undergone human security review yet. Current tests pass and the design looks sensible, but "sensible on paper, reviewed only by the AI co-author" is not the bar to assume for software handling OAuth tokens and tunneling inbound HTTP on your behalf.
+>
+> What this means for v0.1.0 alpha users:
+> - Use it with **throwaway OAuth apps** in development only.
+> - **Do not** connect a production daemon to `relay.dicode.app` with long-lived secrets.
+> - **Expect breaking protocol changes** as the crypto surface is audited.
+>
+> Tracked in epic [#189](https://github.com/dicode-ayo/dicode-core/issues/189). Pre-GA hardening migrations in [#192](https://github.com/dicode-ayo/dicode-core/issues/192).
+
+---
+
 ## What it is
 
 `dicode` is a single Go binary that:

--- a/pkg/registry/reconciler.go
+++ b/pkg/registry/reconciler.go
@@ -107,7 +107,16 @@ func (rc *Reconciler) startSource(src source.Source) error {
 
 	go func() {
 		for ev := range ch {
-			rc.merged <- ev
+			// Without the ctx select, a slow main loop plus a closed merged
+			// reader during shutdown would block this goroutine forever
+			// holding source events. ctx is the parent context, not the
+			// per-source srcCtx, so this drains naturally on full reconciler
+			// shutdown rather than per-source cancellation.
+			select {
+			case rc.merged <- ev:
+			case <-ctx.Done():
+				return
+			}
 		}
 	}()
 	return nil

--- a/tasks/skills/dicode-task-dev.md
+++ b/tasks/skills/dicode-task-dev.md
@@ -21,13 +21,13 @@ Follow this order every time — no exceptions:
    - `<task-id>/task.ts`   — task logic (TypeScript for `runtime: deno`; use `task.py` for `runtime: python`)
    - `<task-id>/task.test.ts` — unit tests (required, no exceptions)
 6. `validate_task("<task-id>")` — fix ALL errors before proceeding
-7. `test_task("<task-id>")` — ALL tests must pass before proceeding
+7. Run the task's tests — ALL tests must pass before proceeding. From the CLI: `dicode task test <task-id>` (or `make test-tasks` for the full sweep). From the HTTP API: `POST /api/tasks/{id}/test`. Deno runtime only today; Python + Docker parity tracked in [#159](https://github.com/dicode-ayo/dicode-core/issues/159).
 8. `dry_run_task("<task-id>")` — verify HTTP calls and secret resolution
 9. `commit_task("<task-id>", "<source-id>")` — only when 6–8 are clean
 
 ## Hard rules
 
-- **Never commit** if `validate_task` or `test_task` return any errors
+- **Never commit** if `validate_task` returns any errors or task tests fail
 - **Always write `task.test.ts`** — a task without tests will not be committed
 - `task.ts` **must return a JSON-serializable value** — required for chain triggers
 - **Never hardcode secrets** — use `env.get("VAR")` in the script; declare the var in `permissions.env`


### PR DESCRIPTION
## Summary

Three small post-release hygiene items lined up by the v0.1.0 alpha triage sweep. All low-risk, all worth landing before any external alpha announcement.

- **#188** — Add a "not yet human security-reviewed" warning callout to the README, with explicit guidance for v0.1.0 alpha users (throwaway OAuth apps, no production secrets, expect protocol churn).
- **#186** — Wrap the reconciler source-event forwarder send in a \`ctx\` select. A slow main loop plus a closed \`merged\` reader during shutdown could otherwise block this goroutine forever.
- **#161** — Drop the bare \`test_task("...")\` reference in the dicode-task-dev skill (the MCP tool now returns a hint, not a result) in favour of \`dicode task test <id>\` / \`make test-tasks\` / \`POST /api/tasks/{id}/test\`, with a forward link to the Python+Docker parity follow-up #159.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./pkg/registry/...\` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)