### PR TITLE
feat(webui): POST /api/tasks/{id}/test REST endpoint

### DIFF
--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -554,18 +554,17 @@ type TaskTestResult struct {
 // handleTaskTest resolves the task from the registry, locates its sibling
 // test file, and invokes the appropriate runtime's test runner. Phase 1
 // supports the Deno runtime only; other runtimes return a clear error.
+//
+// Goes through tasktest.RunByID so the CLI control socket and the REST
+// endpoint (POST /api/tasks/{id}/test) share a single code path — the
+// "shared-helper invariant" tested in pkg/webui/server_task_test_test.go.
+// The CLI does not currently surface params or per-call timeouts, so both
+// are passed as zero/nil; the daemon's parent ctx still bounds the run.
 func (cs *ControlServer) handleTaskTest(ctx context.Context, req Request) (TaskTestResult, error) {
 	if req.TaskID == "" {
 		return TaskTestResult{}, errors.New("taskID required")
 	}
-	spec, ok := cs.reg.Get(req.TaskID)
-	if !ok {
-		return TaskTestResult{}, fmt.Errorf("task %q not found", req.TaskID)
-	}
-	// tasktest.Run returns both a partial Result and err on certain paths
-	// (e.g. unsupported runtime, deno-not-available). Convert the Result to
-	// the wire shape regardless so the CLI can surface the partial info.
-	res, err := tasktest.Run(ctx, spec)
+	res, _, err := tasktest.RunByID(ctx, cs.reg, req.TaskID, nil, 0)
 	wire := TaskTestResult{
 		TaskID:   res.TaskID,
 		Runtime:  res.Runtime,
@@ -579,6 +578,11 @@ func (cs *ControlServer) handleTaskTest(ctx context.Context, req Request) (TaskT
 		Error:    res.Error,
 	}
 	if err != nil {
+		// Preserve the legacy error wording for the "task not found" path
+		// so CLI users see the same message they did pre-refactor.
+		if errors.Is(err, tasktest.ErrTaskNotFound) {
+			return wire, fmt.Errorf("task %q not found", req.TaskID)
+		}
 		if wire.Error == "" {
 			wire.Error = err.Error()
 		}

--- a/pkg/task/params.go
+++ b/pkg/task/params.go
@@ -1,0 +1,166 @@
+package task
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// ParamError describes a single per-field problem encountered while validating
+// a params payload against a task's declared params schema. The Field name
+// matches the declared Param.Name; Message is suitable for surfacing to a
+// human or an HTTP API caller.
+type ParamError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+// ParamErrors is a multi-field aggregate. Implements error so callers can
+// return it from validation paths and still have errors.Is / errors.As
+// behave naturally; consumers that need per-field detail should type-assert.
+type ParamErrors []ParamError
+
+func (e ParamErrors) Error() string {
+	switch len(e) {
+	case 0:
+		return "params: no errors"
+	case 1:
+		return fmt.Sprintf("params: %s: %s", e[0].Field, e[0].Message)
+	default:
+		return fmt.Sprintf("params: %d field error(s): %s: %s (and %d more)",
+			len(e), e[0].Field, e[0].Message, len(e)-1)
+	}
+}
+
+// ValidateParams checks an inbound params map against the task's declared
+// Params schema. It returns a coerced map (string-typed values for the
+// runtime, since params are always serialised as strings on the wire to
+// the Deno/Python SDK) and a non-nil ParamErrors when one or more fields
+// fail validation.
+//
+// Unknown keys (i.e. keys present in input but not declared in spec.Params)
+// are reported as errors — the schema is intentionally closed so that typos
+// in a calling agent's payload surface immediately rather than being
+// silently dropped at runtime.
+//
+// Missing-but-required fields are flagged. Fields with a declared default
+// fall back to that default when absent.
+//
+// Type coercion rules:
+//   - "string" / "" — accepts JSON string, number, or boolean (stringified).
+//   - "number"       — accepts JSON number, or a string that parses as float64.
+//   - "boolean"      — accepts JSON boolean, or "true"/"false" strings (case-insensitive).
+//   - "cron"         — accepts a non-empty string; cron expression validity is
+//     not checked here (the trigger engine owns that).
+//
+// Other type names are accepted as-is — unknown types are not the validator's
+// job to police; they're already covered by the loader's spec validation.
+func ValidateParams(declared Params, input map[string]any) (map[string]string, ParamErrors) {
+	out := make(map[string]string, len(declared))
+	var errs ParamErrors
+
+	declaredByName := make(map[string]Param, len(declared))
+	for _, p := range declared {
+		declaredByName[p.Name] = p
+	}
+
+	// Catch unknown keys early so the caller sees the full picture in one shot.
+	for k := range input {
+		if _, ok := declaredByName[k]; !ok {
+			errs = append(errs, ParamError{Field: k, Message: "unknown parameter"})
+		}
+	}
+
+	for _, p := range declared {
+		raw, present := input[p.Name]
+		if !present {
+			if p.Default != "" {
+				out[p.Name] = p.Default
+				continue
+			}
+			if p.Required {
+				errs = append(errs, ParamError{Field: p.Name, Message: "required"})
+			}
+			continue
+		}
+		coerced, err := coerceParam(p.Type, raw)
+		if err != "" {
+			errs = append(errs, ParamError{Field: p.Name, Message: err})
+			continue
+		}
+		out[p.Name] = coerced
+	}
+
+	if len(errs) == 0 {
+		return out, nil
+	}
+	return out, errs
+}
+
+// coerceParam converts a single value to its string wire form, applying the
+// declared type's accept rules. Returns the coerced string and an empty
+// error message on success; an empty coerced string and a non-empty error
+// on rejection.
+func coerceParam(declaredType string, raw any) (string, string) {
+	switch declaredType {
+	case "string", "":
+		switch v := raw.(type) {
+		case string:
+			return v, ""
+		case bool:
+			return strconv.FormatBool(v), ""
+		case float64:
+			return strconv.FormatFloat(v, 'f', -1, 64), ""
+		case int:
+			return strconv.Itoa(v), ""
+		case int64:
+			return strconv.FormatInt(v, 10), ""
+		default:
+			return "", fmt.Sprintf("expected string, got %T", raw)
+		}
+	case "number":
+		switch v := raw.(type) {
+		case float64:
+			return strconv.FormatFloat(v, 'f', -1, 64), ""
+		case int:
+			return strconv.Itoa(v), ""
+		case int64:
+			return strconv.FormatInt(v, 10), ""
+		case string:
+			if _, err := strconv.ParseFloat(v, 64); err != nil {
+				return "", fmt.Sprintf("expected number, got %q", v)
+			}
+			return v, ""
+		default:
+			return "", fmt.Sprintf("expected number, got %T", raw)
+		}
+	case "boolean":
+		switch v := raw.(type) {
+		case bool:
+			return strconv.FormatBool(v), ""
+		case string:
+			b, err := strconv.ParseBool(v)
+			if err != nil {
+				return "", fmt.Sprintf("expected boolean, got %q", v)
+			}
+			return strconv.FormatBool(b), ""
+		default:
+			return "", fmt.Sprintf("expected boolean, got %T", raw)
+		}
+	case "cron":
+		s, ok := raw.(string)
+		if !ok {
+			return "", fmt.Sprintf("expected cron string, got %T", raw)
+		}
+		if s == "" {
+			return "", "cron expression must not be empty"
+		}
+		return s, ""
+	default:
+		// Unknown declared types fall back to a permissive string coercion;
+		// see ValidateParams godoc for rationale.
+		if s, ok := raw.(string); ok {
+			return s, ""
+		}
+		return fmt.Sprintf("%v", raw), ""
+	}
+}

--- a/pkg/task/params_test.go
+++ b/pkg/task/params_test.go
@@ -1,0 +1,150 @@
+package task
+
+import (
+	"testing"
+)
+
+func TestValidateParams_AcceptsCoercedTypes(t *testing.T) {
+	declared := Params{
+		{Name: "repo", Type: "string"},
+		{Name: "limit", Type: "number"},
+		{Name: "verbose", Type: "boolean"},
+		{Name: "cadence", Type: "cron"},
+	}
+	in := map[string]any{
+		"repo":    "deno/deno",
+		"limit":   float64(10), // JSON numbers decode to float64
+		"verbose": true,
+		"cadence": "0 9 * * *",
+	}
+	out, errs := ValidateParams(declared, in)
+	if errs != nil {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if out["repo"] != "deno/deno" {
+		t.Errorf("repo: got %q", out["repo"])
+	}
+	if out["limit"] != "10" {
+		t.Errorf("limit: got %q", out["limit"])
+	}
+	if out["verbose"] != "true" {
+		t.Errorf("verbose: got %q", out["verbose"])
+	}
+	if out["cadence"] != "0 9 * * *" {
+		t.Errorf("cadence: got %q", out["cadence"])
+	}
+}
+
+func TestValidateParams_FillsDefaults(t *testing.T) {
+	declared := Params{
+		{Name: "repo", Type: "string", Default: "deno/deno"},
+		{Name: "limit", Type: "number", Default: "5"},
+	}
+	out, errs := ValidateParams(declared, map[string]any{})
+	if errs != nil {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if out["repo"] != "deno/deno" || out["limit"] != "5" {
+		t.Errorf("defaults not applied: %v", out)
+	}
+}
+
+func TestValidateParams_RequiredMissing(t *testing.T) {
+	declared := Params{
+		{Name: "repo", Type: "string", Required: true},
+	}
+	_, errs := ValidateParams(declared, map[string]any{})
+	if len(errs) != 1 || errs[0].Field != "repo" || errs[0].Message != "required" {
+		t.Errorf("expected single 'required' error on repo, got %v", errs)
+	}
+}
+
+func TestValidateParams_RequiredWithDefaultIsSatisfied(t *testing.T) {
+	declared := Params{
+		{Name: "repo", Type: "string", Required: true, Default: "deno/deno"},
+	}
+	out, errs := ValidateParams(declared, map[string]any{})
+	if errs != nil {
+		t.Fatalf("default should satisfy required: %v", errs)
+	}
+	if out["repo"] != "deno/deno" {
+		t.Errorf("got %q", out["repo"])
+	}
+}
+
+func TestValidateParams_TypeMismatchNumber(t *testing.T) {
+	declared := Params{{Name: "limit", Type: "number"}}
+	_, errs := ValidateParams(declared, map[string]any{"limit": "not-a-number"})
+	if len(errs) != 1 || errs[0].Field != "limit" {
+		t.Errorf("expected type-mismatch on limit, got %v", errs)
+	}
+}
+
+func TestValidateParams_TypeMismatchBoolean(t *testing.T) {
+	declared := Params{{Name: "verbose", Type: "boolean"}}
+	_, errs := ValidateParams(declared, map[string]any{"verbose": "yes"})
+	if len(errs) != 1 || errs[0].Field != "verbose" {
+		t.Errorf("expected type-mismatch on verbose, got %v", errs)
+	}
+}
+
+func TestValidateParams_UnknownKeyRejected(t *testing.T) {
+	declared := Params{{Name: "repo", Type: "string"}}
+	_, errs := ValidateParams(declared, map[string]any{
+		"repo":  "deno/deno",
+		"extra": "surprise",
+	})
+	if len(errs) != 1 || errs[0].Field != "extra" || errs[0].Message != "unknown parameter" {
+		t.Errorf("expected unknown-param on 'extra', got %v", errs)
+	}
+}
+
+func TestValidateParams_AggregatesMultipleErrors(t *testing.T) {
+	declared := Params{
+		{Name: "repo", Type: "string", Required: true},
+		{Name: "limit", Type: "number"},
+	}
+	_, errs := ValidateParams(declared, map[string]any{
+		"limit": "not-a-number",
+		"junk":  1,
+	})
+	if len(errs) != 3 {
+		t.Errorf("expected 3 errors (required, type, unknown), got %d: %v", len(errs), errs)
+	}
+}
+
+func TestValidateParams_StringAcceptsNumericInput(t *testing.T) {
+	declared := Params{{Name: "label", Type: "string"}}
+	out, errs := ValidateParams(declared, map[string]any{"label": float64(42)})
+	if errs != nil {
+		t.Fatalf("string should accept stringifiable scalars: %v", errs)
+	}
+	if out["label"] != "42" {
+		t.Errorf("got %q", out["label"])
+	}
+}
+
+func TestValidateParams_CronEmptyRejected(t *testing.T) {
+	declared := Params{{Name: "schedule", Type: "cron"}}
+	_, errs := ValidateParams(declared, map[string]any{"schedule": ""})
+	if len(errs) != 1 {
+		t.Errorf("expected error for empty cron, got %v", errs)
+	}
+}
+
+func TestParamErrors_Error(t *testing.T) {
+	if (ParamErrors{}).Error() == "" {
+		t.Error("empty ParamErrors should still produce a message")
+	}
+	one := ParamErrors{{Field: "repo", Message: "required"}}
+	if one.Error() == "" {
+		t.Error("single-field ParamErrors should produce a message")
+	}
+	multi := ParamErrors{
+		{Field: "a", Message: "x"},
+		{Field: "b", Message: "y"},
+	}
+	if multi.Error() == "" {
+		t.Error("multi-field ParamErrors should produce a message")
+	}
+}

--- a/pkg/tasktest/runbyid.go
+++ b/pkg/tasktest/runbyid.go
@@ -1,0 +1,91 @@
+package tasktest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// SpecLookup is the registry-shaped interface RunByID needs. Defined locally
+// (rather than depending on pkg/registry) so tasktest stays free of the
+// registry's database+sync overhead and so callers in tests can stub it.
+type SpecLookup interface {
+	Get(id string) (*task.Spec, bool)
+}
+
+// ErrTaskNotFound is returned by RunByID when the task ID is unknown to the
+// supplied registry. Callers (HTTP handlers, MCP wrappers) map this to 404.
+var ErrTaskNotFound = errors.New("tasktest: task not found")
+
+// ErrTimeout signals that the configured timeout elapsed before the test
+// runner finished. Callers map this to 408 Request Timeout. The accompanying
+// Result still carries whatever output was captured before cancellation.
+var ErrTimeout = errors.New("tasktest: timeout exceeded")
+
+// ErrParamsInvalid wraps a per-field task.ParamErrors aggregate. Callers
+// (HTTP handlers) map this to 422 Unprocessable Entity and surface the
+// FieldErrors slice in the response body. errors.As(err, &task.ParamErrors{})
+// recovers the original aggregate.
+type ErrParamsInvalid struct {
+	FieldErrors task.ParamErrors
+}
+
+func (e *ErrParamsInvalid) Error() string {
+	return fmt.Sprintf("tasktest: %s", e.FieldErrors.Error())
+}
+
+func (e *ErrParamsInvalid) Unwrap() error { return e.FieldErrors }
+
+// RunByID is the shared entry point for the test harness used by the
+// REST endpoint (POST /api/tasks/{id}/test) and the CLI control-socket
+// (cli.task.test). It encapsulates:
+//
+//  1. Registry lookup → ErrTaskNotFound on miss.
+//  2. Params validation against the task's declared schema → *ErrParamsInvalid.
+//  3. Timeout enforcement via context.WithTimeout when timeout > 0.
+//  4. Delegation to Run.
+//  5. Mapping context.DeadlineExceeded → ErrTimeout while still returning
+//     the partial Result the runner captured before cancellation.
+//
+// timeout <= 0 means "use the parent context unchanged" — callers that want
+// the runner to inherit a server-wide deadline should pass 0 and bind their
+// own ctx upstream.
+//
+// The validated-and-coerced params are returned alongside the Result so
+// callers (or future SDK plumbing once tasktest.Run learns to forward them
+// to the runner) can inspect what was actually sent. Today the params are
+// validated but not yet forwarded to the Deno runner — see issue #208.
+func RunByID(ctx context.Context, reg SpecLookup, taskID string, params map[string]any, timeout time.Duration) (Result, map[string]string, error) {
+	if reg == nil {
+		return Result{}, nil, fmt.Errorf("tasktest: registry is nil")
+	}
+	spec, ok := reg.Get(taskID)
+	if !ok {
+		return Result{TaskID: taskID}, nil, ErrTaskNotFound
+	}
+
+	coerced, perrs := task.ValidateParams(spec.Params, params)
+	if perrs != nil {
+		return Result{TaskID: taskID}, nil, &ErrParamsInvalid{FieldErrors: perrs}
+	}
+
+	runCtx := ctx
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	res, err := Run(runCtx, spec)
+	// A deadline trip surfaces here either as runCtx.Err() (when Run returns
+	// nil because the runner cleaned up gracefully) or via the wrapped exec
+	// error. Normalise both paths to ErrTimeout so handlers don't have to
+	// special-case exec.ExitError vs context.DeadlineExceeded.
+	if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+		return res, coerced, ErrTimeout
+	}
+	return res, coerced, err
+}

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -1368,10 +1368,14 @@ func (s *Server) apiTestTask(w http.ResponseWriter, r *http.Request) {
 	// so we don't return 422 on the happy path. Cap the body so a misbehaving
 	// or malicious caller cannot stream gigabytes of JSON at the daemon
 	// (req.Params is unbounded by shape — only the byte count protects us).
+	// DisallowUnknownFields keeps the closed-schema posture symmetric with
+	// the params validator: top-level typos surface as 400 rather than being
+	// silently ignored.
 	var req testTaskRequest
 	if r.Body != nil {
 		r.Body = http.MaxBytesReader(w, r.Body, testTaskMaxBodyBytes)
 		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
 		if err := dec.Decode(&req); err != nil && err != io.EOF {
 			jsonErr(w, "invalid JSON body: "+err.Error(), http.StatusBadRequest)
 			return

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -8,6 +8,7 @@ import (
 	"embed"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"io"
@@ -451,7 +452,6 @@ func (s *Server) Handler() http.Handler {
 			r.Get("/tasks", s.apiListTasks)
 			r.Get("/tasks/{id}", s.apiGetTask)
 			r.Post("/tasks/{id}/run", s.apiRunTask)
-			r.Post("/tasks/{id}/test", s.apiTestTask)
 			r.Get("/tasks/{id}/runs", s.apiListRuns)
 			r.Get("/tasks/{id}/files/{filename}", s.apiGetFile)
 			r.Post("/tasks/{id}/files/{filename}", s.apiSaveFile)
@@ -521,6 +521,14 @@ func (s *Server) Handler() http.Handler {
 			http.Redirect(w, r, "/hooks/webui", http.StatusFound)
 		})
 	})
+
+	// Task test endpoint (#208) — API-key gated, mounted OUTSIDE the
+	// session-auth group so external automation (CI scripts, MCP clients)
+	// can drive the test harness with a Bearer token without first
+	// establishing a browser session. The requireAPIKey middleware is a
+	// no-op when server.auth is false, so the unauthenticated dev mode
+	// continues to work the same way as before.
+	r.With(s.requireAPIKey).Post("/api/tasks/{id}/test", s.apiTestTask)
 
 	return r
 }
@@ -1278,36 +1286,164 @@ func (s *Server) apiRunTask(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]string{"runId": runID})
 }
 
-// apiTestTask runs a task's sibling test file via tasktest.Run and returns the
-// structured result. Mirrors the cli.task.test IPC handler in pkg/ipc/control.go
-// so the buildin MCP task (and any other HTTP caller) can drive task tests
-// without going through the CLI control socket. Phase 1 supports the Deno
-// runtime only; other runtimes return a clear error in the result body.
+// testTaskRequest is the optional JSON body accepted by apiTestTask.
+//
+// Both fields are optional: an empty body, an empty {} object, or any
+// missing field is treated as "use the task's defaults". Params are
+// validated against the task.yaml `params` schema before the runner is
+// invoked — schema mismatches return 422 with per-field detail.
+type testTaskRequest struct {
+	Params   map[string]any `json:"params,omitempty"`
+	TimeoutS int            `json:"timeout_s,omitempty"`
+}
+
+// testTaskResponse is the wire shape returned on completion (200) regardless
+// of whether the task itself passed. Field names follow #208's spec —
+// snake_case here even though most other webui responses use camelCase,
+// because this endpoint is designed for external automation callers (MCP
+// clients, CI scripts) where snake_case is more idiomatic.
+//
+// Fields:
+//   - status:       "passed" | "failed" | "errored"
+//   - exit_code:    runner process exit code
+//   - stdout:       combined stdout+stderr from the runner (named stdout for
+//     compatibility with the issue spec; the runner intermixes streams).
+//   - stderr:       always "" today — Deno's `deno test` interleaves streams
+//     into a single buffer and we don't currently split them. Kept in the
+//     response shape so future runtime backends (Python, Docker) can supply it.
+//   - duration_ms:  wall-clock duration of the runner subprocess in ms
+//   - run_id:       opaque correlation ID for this test invocation; surface in
+//     logs / future audit trail. Not stored in the runs table because test
+//     invocations are intentionally separate from the production run log.
+type testTaskResponse struct {
+	Status     string `json:"status"`
+	ExitCode   int    `json:"exit_code"`
+	Stdout     string `json:"stdout"`
+	Stderr     string `json:"stderr"`
+	DurationMs int64  `json:"duration_ms"`
+	RunID      string `json:"run_id"`
+	// Diagnostic fields preserved from the underlying tasktest.Result so
+	// callers can inspect counts / file path without re-parsing stdout.
+	TestFile string `json:"test_file,omitempty"`
+	Passed   int    `json:"passed"`
+	Failed   int    `json:"failed"`
+	Skipped  int    `json:"skipped"`
+	Error    string `json:"error,omitempty"`
+}
+
+// apiTestTask runs a task's sibling test file via tasktest.RunByID and
+// returns a structured result. Closes #208.
+//
+// Authentication: requireAPIKey (Bearer); mirrors /mcp's auth posture so
+// the same API key works across both surfaces.
+//
+// Body (optional): {"params": {...}, "timeout_s": int}. params are validated
+// against the task's declared schema (422 on mismatch, with per-field detail).
+// timeout_s caps the runner subprocess lifetime; on expiry the handler
+// returns 408 with whatever output was captured before cancellation.
+//
+// Status codes:
+//   - 200 — runner completed (regardless of test pass/fail; see status field)
+//   - 401 — bad/missing API key (handled upstream by requireAPIKey)
+//   - 404 — task ID not registered
+//   - 408 — runner timed out
+//   - 422 — params payload failed schema validation
 func (s *Server) apiTestTask(w http.ResponseWriter, r *http.Request) {
 	id := taskIDParam(r)
-	spec, ok := s.registry.Get(id)
-	if !ok {
+
+	// Body is optional. An empty body is the common case for "just run the
+	// tests with defaults" — guard the decode against a zero-length stream
+	// so we don't return 422 on the happy path.
+	var req testTaskRequest
+	if r.Body != nil {
+		dec := json.NewDecoder(r.Body)
+		if err := dec.Decode(&req); err != nil && err != io.EOF {
+			jsonErr(w, "invalid JSON body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
+	timeout := time.Duration(req.TimeoutS) * time.Second
+	res, _, runErr := tasktest.RunByID(r.Context(), s.registry, id, req.Params, timeout)
+
+	// Map tasktest's typed errors to HTTP status codes per #208 acceptance.
+	switch {
+	case errors.Is(runErr, tasktest.ErrTaskNotFound):
 		jsonErr(w, fmt.Sprintf("task %q not found", id), http.StatusNotFound)
 		return
+	case errors.Is(runErr, tasktest.ErrTimeout):
+		// Surface the partial result alongside the 408 so callers see what
+		// the runner managed to capture before the deadline tripped. The
+		// status code is still authoritative ("did this complete?"); the
+		// body carries forensic detail.
+		body := buildTestTaskResponse(res, runErr, randomRunID())
+		body.Status = "timeout"
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusRequestTimeout)
+		_ = json.NewEncoder(w).Encode(body)
+		return
 	}
-	res, runErr := tasktest.Run(r.Context(), spec)
-	body := map[string]any{
-		"taskID":     res.TaskID,
-		"runtime":    res.Runtime,
-		"testFile":   res.TestFile,
-		"passed":     res.Passed,
-		"failed":     res.Failed,
-		"skipped":    res.Skipped,
-		"durationMs": res.Duration.Milliseconds(),
-		"exitCode":   res.ExitCode,
-		"output":     res.Output,
+	var paramsErr *tasktest.ErrParamsInvalid
+	if errors.As(runErr, &paramsErr) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error":  "invalid params",
+			"fields": paramsErr.FieldErrors,
+		})
+		return
 	}
-	if res.Error != "" {
-		body["error"] = res.Error
-	} else if runErr != nil {
-		body["error"] = runErr.Error()
+
+	// Successful completion — including failed tests. Per #208, 200 means
+	// "the runner completed and we have a verdict to return"; the verdict
+	// itself lives in the body's `status` field.
+	jsonOK(w, buildTestTaskResponse(res, runErr, randomRunID()))
+}
+
+// buildTestTaskResponse maps a tasktest.Result + runErr into the HTTP wire
+// shape. status is derived from exit code + parsed counts:
+//   - "errored" if Result.Error non-empty or runErr non-nil and not a clean
+//     non-zero exit (e.g. spawn failure, deno-not-installed)
+//   - "failed"  if exitCode != 0 OR Failed > 0
+//   - "passed"  otherwise
+func buildTestTaskResponse(res tasktest.Result, runErr error, runID string) testTaskResponse {
+	resp := testTaskResponse{
+		ExitCode:   res.ExitCode,
+		Stdout:     res.Output,
+		Stderr:     "", // see godoc on testTaskResponse.Stderr
+		DurationMs: res.Duration.Milliseconds(),
+		RunID:      runID,
+		TestFile:   res.TestFile,
+		Passed:     res.Passed,
+		Failed:     res.Failed,
+		Skipped:    res.Skipped,
+		Error:      res.Error,
 	}
-	jsonOK(w, body)
+	switch {
+	case res.Error != "" || (runErr != nil && res.ExitCode == 0):
+		resp.Status = "errored"
+		if resp.Error == "" && runErr != nil {
+			resp.Error = runErr.Error()
+		}
+	case res.ExitCode != 0 || res.Failed > 0:
+		resp.Status = "failed"
+	default:
+		resp.Status = "passed"
+	}
+	return resp
+}
+
+// randomRunID returns an opaque correlation ID for a test invocation. Not a
+// registry run ID — test invocations are deliberately kept off the runs
+// table so they don't pollute history dashboards.
+func randomRunID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		// Extremely unlikely (crypto/rand on Linux). Falling back to a
+		// timestamp-derived ID keeps the response shape valid.
+		return fmt.Sprintf("ts-%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b)
 }
 
 // handleMCP is the public /mcp endpoint. The actual JSON-RPC dispatch lives

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -1286,6 +1286,18 @@ func (s *Server) apiRunTask(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]string{"runId": runID})
 }
 
+// Hardening caps for apiTestTask. testTaskMaxBodyBytes bounds the request
+// payload so a misbehaving caller can't stream gigabytes of JSON; the cap is
+// well above any realistic params payload but small enough to fail fast.
+// testTaskMaxTimeout caps the runner subprocess lifetime so an authenticated
+// caller can't pin a Deno process indefinitely with a giant timeout_s value.
+//
+// testTaskMaxTimeout is a var (not a const) so the test suite can override
+// it to keep TimeoutCapClamps fast. Production code must never mutate it.
+const testTaskMaxBodyBytes = 64 * 1024
+
+var testTaskMaxTimeout = 5 * time.Minute
+
 // testTaskRequest is the optional JSON body accepted by apiTestTask.
 //
 // Both fields are optional: an empty body, an empty {} object, or any
@@ -1353,9 +1365,12 @@ func (s *Server) apiTestTask(w http.ResponseWriter, r *http.Request) {
 
 	// Body is optional. An empty body is the common case for "just run the
 	// tests with defaults" — guard the decode against a zero-length stream
-	// so we don't return 422 on the happy path.
+	// so we don't return 422 on the happy path. Cap the body so a misbehaving
+	// or malicious caller cannot stream gigabytes of JSON at the daemon
+	// (req.Params is unbounded by shape — only the byte count protects us).
 	var req testTaskRequest
 	if r.Body != nil {
+		r.Body = http.MaxBytesReader(w, r.Body, testTaskMaxBodyBytes)
 		dec := json.NewDecoder(r.Body)
 		if err := dec.Decode(&req); err != nil && err != io.EOF {
 			jsonErr(w, "invalid JSON body: "+err.Error(), http.StatusBadRequest)
@@ -1363,7 +1378,21 @@ func (s *Server) apiTestTask(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Clamp timeout_s to a safe upper bound. Without this an authenticated
+	// caller could pin a runner subprocess for arbitrarily long; the ceiling
+	// is generous (5 minutes) so legitimate slow test suites still fit.
+	// Negative values are silently treated as "use parent ctx" (timeout=0).
 	timeout := time.Duration(req.TimeoutS) * time.Second
+	if timeout > testTaskMaxTimeout {
+		timeout = testTaskMaxTimeout
+	}
+	if timeout < 0 {
+		timeout = 0
+	}
+	// TODO(#208 follow-up): wire `coerced` (the validated string-typed params)
+	// into tasktest.Run so the runner actually receives them. Today the
+	// validator gates the call but the params themselves never reach Deno
+	// — see the testTaskRequest godoc.
 	res, _, runErr := tasktest.RunByID(r.Context(), s.registry, id, req.Params, timeout)
 
 	// Map tasktest's typed errors to HTTP status codes per #208 acceptance.

--- a/pkg/webui/server_task_test_test.go
+++ b/pkg/webui/server_task_test_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/dicode/dicode/pkg/tasktest"
 )
 
-// registerTaskWithTest writes a task.yaml + task.ts + task.test.ts under a
-// temp dir and registers the resulting spec. The test file is whatever the
-// caller hands in so different scenarios can pass/fail/hang as needed.
+// registerTaskWithTest writes a task.ts + task.test.ts under a temp dir and
+// registers a directly-constructed task.Spec — the on-disk task.yaml is
+// intentionally NOT written because tasktest.Run discovers the test file via
+// spec.TaskDir and uses the in-memory spec for runtime/params; writing a
+// YAML that's never parsed would only invite drift between the two.
 //
 // The task carries a single optional string param "label" so the validator
 // path has something to chew on in the schema-mismatch test.
@@ -28,13 +30,6 @@ func registerTaskWithTest(t *testing.T, reg *registry.Registry, id, taskScript, 
 	td := filepath.Join(dir, id)
 	if err := os.MkdirAll(td, 0755); err != nil {
 		t.Fatalf("mkdir: %v", err)
-	}
-	yaml := "name: " + id + "\n" +
-		"trigger:\n  manual: true\n" +
-		"runtime: deno\n" +
-		"params:\n  label:\n    type: string\n    description: optional label\n"
-	if err := os.WriteFile(filepath.Join(td, "task.yaml"), []byte(yaml), 0644); err != nil {
-		t.Fatalf("write task.yaml: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(td, "task.ts"), []byte(taskScript), 0644); err != nil {
 		t.Fatalf("write task.ts: %v", err)
@@ -238,6 +233,111 @@ func TestAPI_TestTask_Timeout(t *testing.T) {
 	}
 	if resp.Status != "timeout" {
 		t.Errorf("status: got %q, want timeout", resp.Status)
+	}
+}
+
+// TestAPI_TestTask_ErroredStatus covers the buildTestTaskResponse "errored"
+// branch. Registers a task whose runtime is "docker" — tasktest.Run rejects
+// non-deno runtimes with *ErrUnsupportedRuntime today, which surfaces as a
+// non-nil runErr with res.ExitCode == 0 (no subprocess ran). The handler
+// must return 200 (per #208: 200 on completion regardless) with status set
+// to "errored" and the error message in the body.
+func TestAPI_TestTask_ErroredStatus(t *testing.T) {
+	srv, reg := newTestServer(t)
+	dir := t.TempDir()
+	td := filepath.Join(dir, "docker-task")
+	if err := os.MkdirAll(td, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Test file presence is required so we don't trip ErrNoTestFile first.
+	if err := os.WriteFile(filepath.Join(td, "task.test.ts"), []byte(passingTest), 0644); err != nil {
+		t.Fatal(err)
+	}
+	spec := &task.Spec{
+		ID:      "docker-task",
+		Name:    "docker-task",
+		Runtime: task.RuntimeDocker,
+		Trigger: task.TriggerConfig{Manual: true},
+		Timeout: 5 * time.Second,
+		TaskDir: td,
+	}
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/docker-task/test", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (errored is still 'completed'), got %d: %s", w.Code, w.Body.String())
+	}
+	var resp testTaskResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Status != "errored" {
+		t.Errorf("status: got %q, want errored", resp.Status)
+	}
+	if resp.Error == "" {
+		t.Error("error field must be populated on errored status")
+	}
+}
+
+// TestAPI_TestTask_TimeoutCapClamps verifies that an absurd timeout_s value
+// is silently clamped to testTaskMaxTimeout. We override the cap to 2 seconds
+// for the duration of the test so the assertion finishes fast — production
+// code must never mutate testTaskMaxTimeout, but the test harness may.
+//
+// The strategy: register a hanging task, send timeout_s = 86400 (24h), and
+// assert the request returns within a wall-clock bound that is well below
+// 24h but well above the lowered cap, so we know clamping (not the original
+// timeout_s) is what fired.
+func TestAPI_TestTask_TimeoutCapClamps(t *testing.T) {
+	original := testTaskMaxTimeout
+	testTaskMaxTimeout = 2 * time.Second
+	t.Cleanup(func() { testTaskMaxTimeout = original })
+
+	srv, reg := newTestServer(t)
+	registerTaskWithTest(t, reg, "clamp-task", "", hangingTest)
+
+	body := `{"timeout_s": 86400}` // 24h — must be clamped to 2s
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/clamp-task/test", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	start := time.Now()
+	srv.Handler().ServeHTTP(w, req)
+	elapsed := time.Since(start)
+
+	// Generous upper bound: 2s cap + Deno spawn + cleanup. Anything close
+	// to 24h would prove the cap was bypassed.
+	if elapsed > 30*time.Second {
+		t.Fatalf("timeout was not clamped: ran for %v (cap is %v)", elapsed, testTaskMaxTimeout)
+	}
+	if w.Code != http.StatusRequestTimeout {
+		t.Errorf("expected 408 after clamp fired, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestAPI_TestTask_OversizedBody verifies the MaxBytesReader cap rejects
+// payloads larger than testTaskMaxBodyBytes with a 4xx — the request must
+// not be allowed to drain arbitrary memory before json.Decode notices.
+func TestAPI_TestTask_OversizedBody(t *testing.T) {
+	srv, reg := newTestServer(t)
+	registerTaskWithTest(t, reg, "big-body-task", "", passingTest)
+
+	// Build a JSON payload larger than the 64KB cap. The shape is valid;
+	// the size is the only thing that should fail the decode.
+	huge := strings.Repeat("a", testTaskMaxBodyBytes+1024)
+	body := `{"params": {"label": "` + huge + `"}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/big-body-task/test", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest && w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 400 or 413, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/pkg/webui/server_task_test_test.go
+++ b/pkg/webui/server_task_test_test.go
@@ -320,6 +320,28 @@ func TestAPI_TestTask_TimeoutCapClamps(t *testing.T) {
 	}
 }
 
+// TestAPI_TestTask_UnknownTopLevelKeyRejected pins the
+// DisallowUnknownFields posture on the request decoder. A typo'd top-level
+// field (e.g. `timeout` instead of `timeout_s`) must surface as a 400 with
+// a descriptive error rather than being silently ignored.
+func TestAPI_TestTask_UnknownTopLevelKeyRejected(t *testing.T) {
+	srv, reg := newTestServer(t)
+	registerTaskWithTest(t, reg, "strict-decode-task", "", passingTest)
+
+	body := `{"timeout": 5, "params": {}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/strict-decode-task/test", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown top-level key, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "timeout") {
+		t.Errorf("expected error message to mention the offending key, got %s", w.Body.String())
+	}
+}
+
 // TestAPI_TestTask_OversizedBody verifies the MaxBytesReader cap rejects
 // payloads larger than testTaskMaxBodyBytes with a 4xx — the request must
 // not be allowed to drain arbitrary memory before json.Decode notices.

--- a/pkg/webui/server_task_test_test.go
+++ b/pkg/webui/server_task_test_test.go
@@ -1,0 +1,299 @@
+package webui
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+	"github.com/dicode/dicode/pkg/tasktest"
+)
+
+// registerTaskWithTest writes a task.yaml + task.ts + task.test.ts under a
+// temp dir and registers the resulting spec. The test file is whatever the
+// caller hands in so different scenarios can pass/fail/hang as needed.
+//
+// The task carries a single optional string param "label" so the validator
+// path has something to chew on in the schema-mismatch test.
+func registerTaskWithTest(t *testing.T, reg *registry.Registry, id, taskScript, testScript string) *task.Spec {
+	t.Helper()
+	dir := t.TempDir()
+	td := filepath.Join(dir, id)
+	if err := os.MkdirAll(td, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	yaml := "name: " + id + "\n" +
+		"trigger:\n  manual: true\n" +
+		"runtime: deno\n" +
+		"params:\n  label:\n    type: string\n    description: optional label\n"
+	if err := os.WriteFile(filepath.Join(td, "task.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatalf("write task.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(td, "task.ts"), []byte(taskScript), 0644); err != nil {
+		t.Fatalf("write task.ts: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(td, "task.test.ts"), []byte(testScript), 0644); err != nil {
+		t.Fatalf("write task.test.ts: %v", err)
+	}
+	spec := &task.Spec{
+		ID:      id,
+		Name:    id,
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Timeout: 5 * time.Second,
+		TaskDir: td,
+		Params: task.Params{
+			{Name: "label", Type: "string"},
+		},
+	}
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	return spec
+}
+
+// passingTest is the canonical Deno test fixture used by the success path.
+// Kept short so test runs stay snappy.
+const passingTest = `import { assertEquals } from "jsr:@std/assert@1";
+Deno.test("ok", () => { assertEquals(1, 1); });
+`
+
+// hangingTest spins forever so the timeout path can demonstrate cancellation.
+// Uses a chained setTimeout sleep loop rather than a single never-resolving
+// promise so Deno's "unresolved promise" detector doesn't short-circuit and
+// exit cleanly before the parent context cancels — that would defeat the
+// timeout assertion. Each tick stays inside a real timer so Deno keeps the
+// event loop alive past its self-check.
+const hangingTest = `Deno.test("hang", async () => {
+  while (true) {
+    await new Promise((r) => setTimeout(r, 100));
+  }
+});
+`
+
+// TestAPI_TestTask_Success verifies that a happy-path POST to the test
+// endpoint returns 200 with status="passed", a non-empty run_id, and the
+// expected counts parsed out of the runner's summary line.
+func TestAPI_TestTask_Success(t *testing.T) {
+	srv, reg := newTestServer(t)
+	registerTaskWithTest(t, reg, "ok-task", "", passingTest)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/ok-task/test", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp testTaskResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Status != "passed" {
+		t.Errorf("status: got %q, want passed (output: %s)", resp.Status, resp.Stdout)
+	}
+	if resp.RunID == "" {
+		t.Error("run_id must be non-empty")
+	}
+	if resp.Passed < 1 {
+		t.Errorf("passed: got %d, want >= 1", resp.Passed)
+	}
+}
+
+// TestAPI_TestTask_NotFound covers the 404 path: an unknown task ID must
+// return JSON {"error": ...} with HTTP 404, never 200.
+func TestAPI_TestTask_NotFound(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/nope/test", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestAPI_TestTask_MissingAPIKey covers the 401 path. requireAPIKey only
+// activates when cfg.Server.Auth is true, so we use newAuthServer.
+func TestAPI_TestTask_MissingAPIKey(t *testing.T) {
+	srv := newAuthServer(t, "hunter2")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/anything/test", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+	if got := w.Header().Get("WWW-Authenticate"); got == "" {
+		t.Errorf("WWW-Authenticate must be set on 401, got empty")
+	}
+}
+
+// TestAPI_TestTask_BadAPIKey verifies that a non-empty but unrecognized
+// Bearer token still results in 401 (not silent passthrough).
+func TestAPI_TestTask_BadAPIKey(t *testing.T) {
+	srv := newAuthServer(t, "hunter2")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/anything/test", nil)
+	req.Header.Set("Authorization", "Bearer dck_not-a-real-key")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+// TestAPI_TestTask_GoodAPIKey verifies the 401-then-200 path: an API key
+// freshly generated via apiKeys.generate authenticates the same request that
+// previously returned 401. We only assert that the request makes it past the
+// auth wall (not 401, not 403); the body itself can be 404 because the
+// in-memory registry is empty under newAuthServer.
+func TestAPI_TestTask_GoodAPIKey(t *testing.T) {
+	srv := newAuthServer(t, "hunter2")
+	raw, _, err := srv.apiKeys.generate(context.Background(), "test-fixture")
+	if err != nil {
+		t.Fatalf("generate api key: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/anything/test", nil)
+	req.Header.Set("Authorization", "Bearer "+raw)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code == http.StatusUnauthorized {
+		t.Fatalf("valid bearer rejected: %d body=%s", w.Code, w.Body.String())
+	}
+	// The fixture registry has no tasks, so 404 is the expected 'past the
+	// auth wall' signal here.
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 (no such task) past auth, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestAPI_TestTask_SchemaMismatch covers the 422 path. The fixture task
+// declares one optional param "label"; sending an unknown key should be
+// rejected with per-field detail in the response body.
+func TestAPI_TestTask_SchemaMismatch(t *testing.T) {
+	srv, reg := newTestServer(t)
+	registerTaskWithTest(t, reg, "schema-task", "", passingTest)
+
+	body := `{"params": {"unknown_key": "boom"}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/schema-task/test", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Error  string            `json:"error"`
+		Fields []task.ParamError `json:"fields"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Fields) != 1 || resp.Fields[0].Field != "unknown_key" {
+		t.Errorf("expected single field error on unknown_key, got %+v", resp.Fields)
+	}
+}
+
+// TestAPI_TestTask_Timeout covers the 408 path. The fixture's test file
+// hangs forever; the POST sets timeout_s=1 and we assert HTTP 408 with
+// status="timeout" in the body.
+func TestAPI_TestTask_Timeout(t *testing.T) {
+	srv, reg := newTestServer(t)
+	registerTaskWithTest(t, reg, "hang-task", "", hangingTest)
+
+	body := `{"timeout_s": 1}`
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/hang-task/test", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	start := time.Now()
+	srv.Handler().ServeHTTP(w, req)
+	elapsed := time.Since(start)
+
+	if w.Code != http.StatusRequestTimeout {
+		t.Fatalf("expected 408, got %d in %v: %s", w.Code, elapsed, w.Body.String())
+	}
+	// Generous upper bound: deno startup + 1s timeout + cleanup.
+	if elapsed > 30*time.Second {
+		t.Errorf("timeout took too long: %v", elapsed)
+	}
+	var resp testTaskResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Status != "timeout" {
+		t.Errorf("status: got %q, want timeout", resp.Status)
+	}
+}
+
+// TestAPI_TestTask_SharedHelperInvariant pins the refactor-fence: both the
+// REST handler (apiTestTask) and the CLI/IPC handler (handleTaskTest in
+// pkg/ipc/control.go) must route through tasktest.RunByID. We can't import
+// pkg/ipc here without a cycle, so we exercise RunByID directly with the
+// same registry+id and assert the structural Result equals what the REST
+// path produces.
+//
+// Concretely: take the underlying tasktest.Result from a direct RunByID
+// call and from a captured-from-handler buildTestTaskResponse. The Stdout,
+// Passed/Failed counts, ExitCode, and TestFile must agree (DurationMs and
+// RunID are intrinsically per-call so we don't compare those).
+func TestAPI_TestTask_SharedHelperInvariant(t *testing.T) {
+	srv, reg := newTestServer(t)
+	registerTaskWithTest(t, reg, "invariant-task", "", passingTest)
+
+	// 1) Direct RunByID call — what every other call-site (CLI, future
+	// SDK plumbing) goes through.
+	directRes, _, directErr := tasktest.RunByID(context.Background(), reg, "invariant-task", nil, 0)
+	if directErr != nil {
+		t.Fatalf("direct RunByID failed: %v", directErr)
+	}
+
+	// 2) Same task via the REST handler.
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/invariant-task/test", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("REST call: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var restResp testTaskResponse
+	if err := json.NewDecoder(w.Body).Decode(&restResp); err != nil {
+		t.Fatalf("decode REST resp: %v", err)
+	}
+
+	// Compare the load-bearing fields. The runner is deterministic for a
+	// passing fixture, so counts and exit codes must match exactly. Stdout
+	// strings carry timing info ("(1ms)"), so compare that the runner's
+	// summary line ("ok | 1 passed") appears in both — pinning structural
+	// equality without making the test flaky on timing jitter.
+	if restResp.Passed != directRes.Passed {
+		t.Errorf("passed mismatch: REST=%d direct=%d", restResp.Passed, directRes.Passed)
+	}
+	if restResp.Failed != directRes.Failed {
+		t.Errorf("failed mismatch: REST=%d direct=%d", restResp.Failed, directRes.Failed)
+	}
+	if restResp.ExitCode != directRes.ExitCode {
+		t.Errorf("exit_code mismatch: REST=%d direct=%d", restResp.ExitCode, directRes.ExitCode)
+	}
+	if restResp.TestFile != directRes.TestFile {
+		t.Errorf("test_file mismatch: REST=%q direct=%q", restResp.TestFile, directRes.TestFile)
+	}
+	if !strings.Contains(restResp.Stdout, "1 passed") || !strings.Contains(directRes.Output, "1 passed") {
+		t.Errorf("expected '1 passed' in both outputs; rest=%q direct=%q", restResp.Stdout, directRes.Output)
+	}
+}


### PR DESCRIPTION
Closes #208.
Part of #207.

## Summary
- New REST endpoint `POST /api/tasks/{id}/test` mounted behind `requireAPIKey` (mirrors `/mcp`'s auth posture). Lets external automation (CI scripts, MCP clients) drive the task test harness with a Bearer token, no browser session required.
- Extracted `tasktest.RunByID(ctx, reg, id, params, timeout)` as the single entry point. Both this handler and the existing CLI control-socket handler (`pkg/ipc/control.go handleTaskTest`) now route through it — pinned by a refactor-fence test.
- New `task.ValidateParams` walks the declared params schema (`string` / `number` / `boolean` / `cron`), enforces required-ness, and rejects unknown keys (closed schema). Surfaces as 422 with per-field detail.

## Endpoint contract

```bash
curl -X POST \
  -H "Authorization: Bearer $DICODE_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"params": {"label": "ci"}, "timeout_s": 30}' \
  http://localhost:8080/api/tasks/<id>/test
```

Response:
```json
{
  "status": "passed", "exit_code": 0,
  "stdout": "...", "stderr": "",
  "duration_ms": 142, "run_id": "<hex>",
  "test_file": "...", "passed": 1, "failed": 0, "skipped": 0
}
```

Status codes:
| Code | Path |
|---|---|
| 200 | Runner completed (verdict in `status`) |
| 401 | Missing / invalid Bearer key |
| 404 | Task ID unknown |
| 408 | `timeout_s` elapsed (status="timeout") |
| 422 | Params schema mismatch (response includes `fields[]`) |

## Test matrix (`pkg/webui/server_task_test_test.go`)
1. `TestAPI_TestTask_Success` — happy path, asserts 200 + status=passed + non-empty run_id + counts
2. `TestAPI_TestTask_NotFound` — unknown task → 404
3. `TestAPI_TestTask_MissingAPIKey` — auth on, no Bearer → 401 + WWW-Authenticate header
4. `TestAPI_TestTask_BadAPIKey` — auth on, garbage Bearer → 401
5. `TestAPI_TestTask_GoodAPIKey` — auth on, freshly minted key → past auth wall (404 because empty registry, but proves the auth flow works)
6. `TestAPI_TestTask_SchemaMismatch` — unknown param key → 422 with field-level error
7. `TestAPI_TestTask_Timeout` — hanging fixture + `timeout_s:1` → 408 with status=timeout
8. `TestAPI_TestTask_SharedHelperInvariant` — REST handler and direct `tasktest.RunByID` call produce structurally-equal results (Passed/Failed/ExitCode/TestFile)

Plus 11 unit tests for `task.ValidateParams` covering all coercion + error paths.

## Verification
- `go test ./pkg/webui/... ./pkg/tasktest/... ./pkg/ipc/... ./pkg/task/...` — green
- `make test` (full suite) — green
- `go vet ./...` and `gofmt -l .` — clean

## Docs PR
dicode-ayo/dicode-site#38 — adds a new H2 to `docs-src/concepts/sdk.md` with the curl example, auth model, request/response shape, and status code table.

## Caveats
- The investigation comment on the issue referenced `pkg/mcp/server.go:321 toolTestTask`; that file was removed in #201 (MCP became a buildin task). Today the only direct callers of `tasktest.Run` were `pkg/ipc/control.go` and a thin existing `apiTestTask` in `pkg/webui/server.go`. Both now route through `RunByID`.
- The endpoint sits OUTSIDE the session-auth `r.Group(requireAuth)` rather than inside it, because `requireAuth` would otherwise short-circuit Bearer-only callers with a session-401 before `requireAPIKey` ever runs. This matches what `/mcp` should do (and currently doesn't — separate problem).
- `params` are validated and coerced today but not yet forwarded to the Deno runner; that's a `tasktest.Run` plumbing change tracked separately. The validator return value is wired into the call site so flipping the switch is a one-line change.

## Test plan
- [ ] CI green on full Go test matrix
- [ ] Smoke test: `dicode daemon` + `curl -X POST /api/tasks/<id>/test` returns the documented shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)