### PR TITLE
feat(webui/auth): bcrypt passphrase + configurable cost + race-safe migration (#209)

### DIFF
--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -44,6 +44,60 @@ The effective passphrase is resolved in this order on every auth check:
 3. ""                    — bootstrap state (see auto-generation below)
 ```
 
+### Passphrase storage — bcrypt hashing
+
+The DB-backed passphrase (source #2 above) is stored as a **bcrypt hash**, not
+plaintext. The work factor defaults to 12 (~300ms per hash on 2024 server
+hardware) and is tunable via:
+
+```yaml
+server:
+  bcrypt_cost: 12          # default; valid range 4–14
+```
+
+Lower the cost on resource-constrained devices (e.g. `bcrypt_cost: 10` on a Pi
+Zero) where ~300ms per login is too slow; raise it on beefy boxes that can
+afford >1s logins. Values outside 4–14 are rejected at config-load time —
+bcrypt accepts up to 31, but anything above ~14 is multi-second and offers
+no practical security gain for a single-user passphrase while risking
+operator self-lockout from a typo'd config.
+
+**bcrypt 72-byte caveat**: bcrypt silently truncates passwords longer than
+72 bytes. To prevent operators from believing their 100-character passphrase
+is fully protecting them, `POST /api/auth/passphrase` rejects inputs longer
+than 72 bytes with `400 Bad Request`. UTF-8 length is byte-counted — a few
+emoji can blow this fast.
+
+**Lazy migration from legacy plaintext**: deployments that pre-date this
+change have a plaintext value in `kv["auth.passphrase"]`. The shape is
+detected by `looksLikeBcryptHash` (`$2a$`, `$2b$`, `$2y$`, `$2$` prefixes);
+anything else is treated as legacy plaintext. On the next **successful**
+login the value is rehashed and overwritten — no operator action required,
+no passphrase reset, no downtime.
+
+Migration semantics:
+
+- Failed login attempts never trigger a rehash (the legacy plaintext is the
+  authoritative source until a real success).
+- Rehash failures are logged at WARN and swallowed — the operator's already-
+  authenticated session is not denied because of a transient DB issue. The
+  next successful login will retry.
+- Concurrent successful logins on the same legacy plaintext are collapsed by
+  a `singleflight.Group` so exactly one bcrypt computation + DB write
+  happens per migration event, no matter how many goroutines race in.
+- The in-process cache (`Server.cachedPassphrase`) is warmed with the new
+  hash so subsequent verifications skip both the legacy branch and the DB
+  read.
+
+**Fail-closed on DB read errors**: a transient DB outage (or context
+deadline, or anything else that makes the `kv` query error) causes
+`passphraseSource()` to return `passphraseSourceUnknown` rather than
+`passphraseSourceNone`. This is load-bearing: the bootstrap fast-path in
+`apiSecretsUnlock` accepts any password when no passphrase is set yet, so
+silently returning "none" on an error would let any login through during
+an outage. The login and passphrase-change endpoints both translate
+`passphraseSourceUnknown` → `503 Service Unavailable`.
+
 **Auto-generation on first boot**: if `server.auth: true` and no passphrase is set (neither YAML nor DB), dicode generates a cryptographically random 43-character passphrase (32 random bytes, base64url) and prints it to stdout once:
 
 ```text
@@ -477,6 +531,7 @@ All security-relevant fields in `ServerConfig`:
 | `allowed_origins` | []string | `[]` | CORS allowlist — empty = same-origin only |
 | `trust_proxy` | bool | `false` | Trust `X-Forwarded-For` (set when behind a reverse proxy) |
 | `mcp` | bool | `true` | Expose MCP endpoint at `/mcp` |
+| `bcrypt_cost` | int | `12` | bcrypt work factor for the stored passphrase hash; valid range 4–14 |
 
 ---
 
@@ -496,7 +551,11 @@ All security-relevant fields in `ServerConfig`:
 | Session tokens are random | `crypto/rand`, 32 bytes, never passphrase-derived |
 | Device tokens stored as hash | SHA-256 in SQLite, raw value only in cookie |
 | API keys stored as hash | SHA-256 in SQLite, raw value returned once |
-| Password comparison is constant-time | `crypto/subtle.ConstantTimeCompare` |
+| Stored passphrase is hashed | bcrypt at cost 12 (configurable 4–14), embedded cost lets verification keep working across cost changes |
+| Lazy migration from legacy plaintext | On next successful login; race-free via `singleflight.Group` so concurrent logins yield one bcrypt + one write |
+| 72-byte bcrypt limit enforced | API rejects passphrases > 72 bytes with `400` rather than silently truncating |
+| Fail-closed on DB read errors | `passphraseSourceUnknown` → `503` from login + change endpoints; bootstrap fast-path never reached on transient outage |
+| Password comparison is constant-time | `crypto/subtle.ConstantTimeCompare` (YAML), `bcrypt.CompareHashAndPassword` (DB hashes) |
 | Webhook signatures are constant-time | `hmac.Equal` |
 | CSRF protection | `SameSite=Strict` on all cookies |
 | Clickjacking protection | `X-Frame-Options: SAMEORIGIN` |
@@ -506,4 +565,4 @@ All security-relevant fields in `ServerConfig`:
 | Brute force protection | 5 attempts/IP, then 15-min lockout |
 | Replay attack protection | 5-minute timestamp window on signed webhooks |
 | CORS misconfiguration guard | Origins validated with `url.Parse()` at startup |
-| Passphrase rotation requires current | `crypto/subtle.ConstantTimeCompare` on `current` field |
+| Passphrase rotation requires current | bcrypt verify on `current` field |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -213,6 +213,13 @@ type ServerConfig struct {
 	MCP            *bool    `yaml:"mcp,omitempty"`             // expose MCP endpoint at /mcp; nil → default true, explicit false opts out
 	TLSCertFile    string   `yaml:"tls_cert,omitempty"`        // path to TLS certificate (PEM); enables HTTPS when set with tls_key
 	TLSKeyFile     string   `yaml:"tls_key,omitempty"`         // path to TLS private key (PEM)
+	// BcryptCost is the work factor used when hashing the stored auth
+	// passphrase. Valid range 4–14. 0 means "unset" → defaults to 12 in
+	// applyDefaults. Higher = slower login but stronger against offline attacks
+	// if the SQLite DB ever leaks; lower can be useful on very small devices
+	// (e.g. Raspberry Pi Zero) where the default ~300ms login is too slow.
+	// Values outside 4–14 are rejected by validate.
+	BcryptCost int `yaml:"bcrypt_cost,omitempty"`
 }
 
 // Load reads and parses the config file at path, then applies defaults.
@@ -316,6 +323,14 @@ func applyDefaults(cfg *Config, configDir string) {
 		t := true
 		cfg.Server.MCP = &t
 	}
+	// BcryptCost defaults to 12 — ~300ms per hash on a 2024 server CPU.
+	// Operators can override via server.bcrypt_cost in dicode.yaml; validate()
+	// enforces the 4–14 range. We keep the unset → default mapping in
+	// applyDefaults rather than at the call site so every consumer sees the
+	// resolved value.
+	if cfg.Server.BcryptCost == 0 {
+		cfg.Server.BcryptCost = 12
+	}
 	// Default secret providers if none configured
 	if len(cfg.Secrets.Providers) == 0 {
 		cfg.Secrets.Providers = []SecretProviderConfig{
@@ -372,6 +387,14 @@ func (cfg *Config) validate() error {
 		if u.Host == "" {
 			return fmt.Errorf("relay.broker_url: missing host in %q", cfg.Relay.BrokerURL)
 		}
+	}
+	// bcrypt cost: x/crypto/bcrypt's MinCost = 4, MaxCost = 31, but anything
+	// above ~14 is multi-second per login on commodity hardware and serves no
+	// practical purpose for a single-user passphrase. Cap at 14 to prevent
+	// operators from accidentally locking themselves out (or causing a
+	// mid-attempt timeout) by setting 20 "to be safe".
+	if cfg.Server.BcryptCost != 0 && (cfg.Server.BcryptCost < 4 || cfg.Server.BcryptCost > 14) {
+		return fmt.Errorf("server.bcrypt_cost: must be between 4 and 14, got %d", cfg.Server.BcryptCost)
 	}
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -348,3 +348,76 @@ sources:
 		t.Errorf("Sources[0].Watch = %v, want default true when unset", cfg.Sources[0].Watch)
 	}
 }
+
+// ── server.bcrypt_cost (#209) ─────────────────────────────────────────────────
+
+// Default cost (12) when omitted. The webui passphrase store reads this value
+// directly, so an absent YAML entry must produce a usable default rather than
+// silently falling back to bcrypt's package-default of 10.
+func TestLoad_BcryptCost_DefaultIs12WhenUnset(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+	content := `
+sources:
+  - type: local
+    path: ${CONFIGDIR}/tasks
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Server.BcryptCost != 12 {
+		t.Errorf("Server.BcryptCost = %d, want default 12", cfg.Server.BcryptCost)
+	}
+}
+
+func TestLoad_BcryptCost_AcceptsValidOverride(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+	content := `
+sources:
+  - type: local
+    path: ${CONFIGDIR}/tasks
+server:
+  bcrypt_cost: 10
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Server.BcryptCost != 10 {
+		t.Errorf("Server.BcryptCost = %d, want 10 (operator override)", cfg.Server.BcryptCost)
+	}
+}
+
+// Out-of-range values must be rejected at Load time so the operator finds out
+// at startup rather than discovering at first login that bcrypt is rejecting
+// the cost. We cap at 14 to prevent pathological values like 20 (~minutes
+// per login) that would functionally lock a user out.
+func TestLoad_BcryptCost_RejectsOutOfRange(t *testing.T) {
+	for _, bad := range []int{1, 2, 3, 15, 20, 31} {
+		t.Run(fmt.Sprintf("cost=%d", bad), func(t *testing.T) {
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "dicode.yaml")
+			content := fmt.Sprintf(`
+sources:
+  - type: local
+    path: ${CONFIGDIR}/tasks
+server:
+  bcrypt_cost: %d
+`, bad)
+			if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Load(cfgPath); err == nil {
+				t.Errorf("Load(bcrypt_cost=%d): expected error, got nil", bad)
+			}
+		})
+	}
+}

--- a/pkg/webui/passphrase.go
+++ b/pkg/webui/passphrase.go
@@ -8,24 +8,41 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/dicode/dicode/pkg/db"
 	"go.uber.org/zap"
+	"golang.org/x/crypto/bcrypt"
 )
 
-const passphraseKVKey = "auth.passphrase"
+const (
+	passphraseKVKey = "auth.passphrase"
+
+	// bcryptCost is the work factor used when hashing a stored passphrase.
+	// bcrypt.DefaultCost is 10 (~80ms on a 2024 server CPU). 12 raises that
+	// to ~300ms — still tolerable for an interactive login on the rate-limited
+	// /api/auth/login endpoint and gives meaningful headroom against offline
+	// attacks if the SQLite DB ever leaks.
+	bcryptCost = 12
+)
 
 // passphraseStore persists the server auth passphrase in the SQLite kv table.
 // It is the authoritative source when server.auth is enabled; the YAML
 // server.secret field is a fallback override for scripted/headless setups.
+//
+// The stored value is normally a bcrypt hash (prefix "$2a$"/"$2b$"/"$2y$").
+// Older deployments may have a plaintext value left over from before the
+// bcrypt migration; verifyPassphrase handles both shapes and rehashes
+// plaintext entries on the next successful login.
 type passphraseStore struct {
 	db db.DB
 }
 
 func newPassphraseStore(d db.DB) *passphraseStore { return &passphraseStore{db: d} }
 
-// Get returns the stored passphrase, or "" if none is set.
+// get returns the raw stored value (hash or legacy plaintext), or "" if none
+// is set. Callers must not assume the returned string is plaintext.
 func (p *passphraseStore) get(ctx context.Context) (string, error) {
 	var val string
 	found := false
@@ -48,17 +65,29 @@ func (p *passphraseStore) get(ctx context.Context) (string, error) {
 	return val, nil
 }
 
-// Set stores a new passphrase, replacing any existing value.
-func (p *passphraseStore) set(ctx context.Context, passphrase string) error {
+// set stores a raw value (hash or, only via legacy migration paths, plaintext)
+// replacing any existing value.
+func (p *passphraseStore) set(ctx context.Context, value string) error {
 	return p.db.Exec(ctx,
 		`INSERT INTO kv (key, value) VALUES (?, ?)
 		 ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-		passphraseKVKey, passphrase,
+		passphraseKVKey, value,
 	)
 }
 
-// generateRandom produces a cryptographically random passphrase (32 bytes,
-// base64url-encoded — 43 printable characters, no padding).
+// setHashed hashes the given plaintext passphrase with bcrypt and stores the
+// result. This is the only call sites should use when persisting a
+// passphrase from the UI or from auto-generation.
+func (p *passphraseStore) setHashed(ctx context.Context, plaintext string) error {
+	hash, err := bcrypt.GenerateFromPassword([]byte(plaintext), bcryptCost)
+	if err != nil {
+		return fmt.Errorf("hash passphrase: %w", err)
+	}
+	return p.set(ctx, string(hash))
+}
+
+// generateRandomPassphrase produces a cryptographically random passphrase
+// (32 bytes, base64url-encoded — 43 printable characters, no padding).
 func generateRandomPassphrase() (string, error) {
 	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {
@@ -67,19 +96,76 @@ func generateRandomPassphrase() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
-// resolvePassphrase returns the effective passphrase for the server:
-//  1. YAML override (server.secret) — explicit operator config, highest priority
-//  2. DB-stored passphrase — set via UI or auto-generated on first boot
-//  3. "" — auth is configured but no passphrase exists yet (bootstrap state)
+// looksLikeBcryptHash reports whether v has one of the bcrypt prefixes
+// ($2a$/$2b$/$2y$). Used to distinguish hashed from legacy-plaintext values
+// during the lazy migration window.
+func looksLikeBcryptHash(v string) bool {
+	return strings.HasPrefix(v, "$2a$") || strings.HasPrefix(v, "$2b$") || strings.HasPrefix(v, "$2y$")
+}
+
+// verifyPassphrase checks a candidate passphrase against the configured
+// authentication source and returns true if it matches. It is the only
+// function that should be used to authenticate a user-supplied passphrase.
 //
-// The DB result is cached in memory and only re-read from SQLite on a cache
-// miss. The cache is warmed at startup (ensurePassphrase) and invalidated
-// whenever apiChangePassphrase succeeds.
-func (s *Server) resolvePassphrase(ctx context.Context) string {
-	// YAML override takes precedence so headless/scripted setups keep working.
-	if s.cfg.Server.Secret != "" {
-		return s.cfg.Server.Secret
+// Resolution order matches resolvePassphrase:
+//  1. YAML override (server.secret) — constant-time compare against the
+//     plaintext from the config file. We deliberately do not hash YAML
+//     overrides: rotating one already requires editing dicode.yaml, and a
+//     plaintext-comparable value is what operators expect for headless and
+//     scripted setups.
+//  2. DB-stored value:
+//     - bcrypt hash → bcrypt.CompareHashAndPassword (constant time internally)
+//     - legacy plaintext → constant-time compare; on match, opportunistically
+//     re-hash and persist so the next login uses bcrypt. Existing
+//     deployments therefore migrate transparently on the next successful
+//     login without forcing a passphrase reset.
+//  3. No passphrase configured anywhere → false.
+//
+// On any internal error (DB read, rehash failure) the function logs and
+// returns false; this fails closed.
+func (s *Server) verifyPassphrase(ctx context.Context, candidate string) bool {
+	if candidate == "" {
+		return false
 	}
+
+	// YAML override takes precedence. Compare in constant time.
+	if s.cfg.Server.Secret != "" {
+		return subtle.ConstantTimeCompare([]byte(candidate), []byte(s.cfg.Server.Secret)) == 1
+	}
+
+	stored := s.cachedDBValue(ctx)
+	if stored == "" {
+		return false
+	}
+
+	if looksLikeBcryptHash(stored) {
+		return bcrypt.CompareHashAndPassword([]byte(stored), []byte(candidate)) == nil
+	}
+
+	// Legacy plaintext path — constant-time compare, then rehash on success.
+	if subtle.ConstantTimeCompare([]byte(candidate), []byte(stored)) != 1 {
+		return false
+	}
+	if s.passphraseStore != nil {
+		if err := s.passphraseStore.setHashed(ctx, candidate); err != nil {
+			s.log.Warn("lazy bcrypt migration: failed to rehash legacy passphrase; will retry on next login",
+				zap.Error(err))
+		} else {
+			// Refresh the cache to the new hash so subsequent logins skip the
+			// legacy branch immediately.
+			s.cachedPassphraseMu.Lock()
+			s.cachedPassphrase = ""
+			s.cachedPassphraseMu.Unlock()
+			s.log.Info("auth passphrase migrated from legacy plaintext to bcrypt hash")
+		}
+	}
+	return true
+}
+
+// cachedDBValue returns the DB-stored passphrase value (hash or legacy
+// plaintext), reading from cache if warm and falling back to the DB. Callers
+// must not assume plaintext.
+func (s *Server) cachedDBValue(ctx context.Context) string {
 	if s.passphraseStore == nil {
 		return ""
 	}
@@ -102,9 +188,34 @@ func (s *Server) resolvePassphrase(ctx context.Context) string {
 	return val
 }
 
+// resolvePassphraseSource describes where the active passphrase comes from.
+// It exists so apiGetPassphraseStatus can answer "is one configured?" without
+// returning the value itself or accidentally implying plaintext access.
+type resolvePassphraseSource string
+
+const (
+	passphraseSourceNone resolvePassphraseSource = "none"
+	passphraseSourceYAML resolvePassphraseSource = "yaml"
+	passphraseSourceDB   resolvePassphraseSource = "db"
+)
+
+// passphraseSource reports where the effective passphrase lives. It does not
+// return the value because, post-bcrypt, the DB no longer contains plaintext.
+func (s *Server) passphraseSource(ctx context.Context) resolvePassphraseSource {
+	if s.cfg.Server.Secret != "" {
+		return passphraseSourceYAML
+	}
+	if s.cachedDBValue(ctx) != "" {
+		return passphraseSourceDB
+	}
+	return passphraseSourceNone
+}
+
 // ensurePassphrase is called at startup when server.auth is true. If no
 // passphrase is stored and no YAML override exists, it auto-generates one,
-// persists it, and prints it to stdout so the operator can record it.
+// stores its bcrypt hash, and prints the *plaintext* to stdout so the
+// operator can record it. The plaintext only ever lives in this stack
+// frame and the operator's terminal scrollback.
 func (s *Server) ensurePassphrase(ctx context.Context) error {
 	if !s.cfg.Server.Auth {
 		return nil // auth disabled — nothing to do
@@ -120,47 +231,49 @@ func (s *Server) ensurePassphrase(ctx context.Context) error {
 		return fmt.Errorf("read stored passphrase: %w", err)
 	}
 	if existing != "" {
-		return nil // already set
+		// Warm the cache with whatever shape is on disk (hash or legacy
+		// plaintext) so the first verifyPassphrase call avoids a DB hit.
+		s.cachedPassphraseMu.Lock()
+		s.cachedPassphrase = existing
+		s.cachedPassphraseMu.Unlock()
+		return nil
 	}
 
 	// First boot with auth enabled and no passphrase — generate one.
-	pass, err := generateRandomPassphrase()
+	plaintext, err := generateRandomPassphrase()
 	if err != nil {
 		return err
 	}
-	if err := s.passphraseStore.set(ctx, pass); err != nil {
+	if err := s.passphraseStore.setHashed(ctx, plaintext); err != nil {
 		return fmt.Errorf("store passphrase: %w", err)
 	}
-	s.cachedPassphraseMu.Lock()
-	s.cachedPassphrase = pass
-	s.cachedPassphraseMu.Unlock()
+	// Cache the hash so the next login validates against it directly.
+	hash, err := s.passphraseStore.get(ctx)
+	if err == nil && hash != "" {
+		s.cachedPassphraseMu.Lock()
+		s.cachedPassphrase = hash
+		s.cachedPassphraseMu.Unlock()
+	}
 
-	// Print clearly to stdout — this is the operator's only chance to see it.
+	// Print the plaintext clearly to stdout — this is the operator's only
+	// chance to see it. After this function returns, the plaintext is gone.
 	fmt.Println("╔══════════════════════════════════════════════════════════════╗")
 	fmt.Println("║  dicode — auth passphrase generated                         ║")
 	fmt.Println("║                                                              ║")
-	fmt.Printf("║  %s  ║\n", pass)
+	fmt.Printf("║  %s  ║\n", plaintext)
 	fmt.Println("║                                                              ║")
 	fmt.Println("║  Save this somewhere safe. You can change it any time at    ║")
 	fmt.Println("║  /security in the web UI (requires a valid session).        ║")
 	fmt.Println("╚══════════════════════════════════════════════════════════════╝")
 
-	s.log.Info("auth passphrase auto-generated and stored in database")
+	s.log.Info("auth passphrase auto-generated and stored as bcrypt hash")
 	return nil
 }
 
 // apiGetPassphraseStatus returns whether a passphrase is currently set and
 // where it comes from (yaml override, db, or none). Never returns the value.
 func (s *Server) apiGetPassphraseStatus(w http.ResponseWriter, r *http.Request) {
-	source := "none"
-	if s.cfg.Server.Secret != "" {
-		source = "yaml"
-	} else if s.passphraseStore != nil {
-		if val, _ := s.passphraseStore.get(r.Context()); val != "" {
-			source = "db"
-		}
-	}
-	jsonOK(w, map[string]string{"source": source})
+	jsonOK(w, map[string]string{"source": string(s.passphraseSource(r.Context()))})
 }
 
 // apiChangePassphrase allows changing the stored passphrase via the UI.
@@ -198,21 +311,22 @@ func (s *Server) apiChangePassphrase(w http.ResponseWriter, r *http.Request) {
 	// Require the current passphrase to prevent a stolen session from rotating
 	// the credential without knowing the existing secret. Skip only when no
 	// passphrase is set yet (bootstrap: first-time setup from a valid session).
-	existing := s.resolvePassphrase(r.Context())
-	if existing != "" && subtle.ConstantTimeCompare([]byte(body.Current), []byte(existing)) != 1 {
-		jsonErr(w, "current passphrase is incorrect", http.StatusUnauthorized)
-		return
+	if s.cachedDBValue(r.Context()) != "" {
+		if !s.verifyPassphrase(r.Context(), body.Current) {
+			jsonErr(w, "current passphrase is incorrect", http.StatusUnauthorized)
+			return
+		}
 	}
 
-	if err := s.passphraseStore.set(r.Context(), body.Passphrase); err != nil {
+	if err := s.passphraseStore.setHashed(r.Context(), body.Passphrase); err != nil {
 		s.log.Error("failed to store passphrase", zap.Error(err))
 		jsonErr(w, "failed to store passphrase", http.StatusInternalServerError)
 		return
 	}
 
-	// Update the in-memory cache so subsequent auth checks see the new value immediately.
+	// Invalidate the cache so the next verifyPassphrase reloads the new hash.
 	s.cachedPassphraseMu.Lock()
-	s.cachedPassphrase = body.Passphrase
+	s.cachedPassphrase = ""
 	s.cachedPassphraseMu.Unlock()
 
 	// Invalidate all current sessions — everyone must re-login with the new passphrase.

--- a/pkg/webui/passphrase.go
+++ b/pkg/webui/passphrase.go
@@ -76,14 +76,18 @@ func (p *passphraseStore) set(ctx context.Context, value string) error {
 }
 
 // setHashed hashes the given plaintext passphrase with bcrypt and stores the
-// result. This is the only call sites should use when persisting a
+// result, returning the hash so callers can warm in-process caches without a
+// second DB read. This is the only call sites should use when persisting a
 // passphrase from the UI or from auto-generation.
-func (p *passphraseStore) setHashed(ctx context.Context, plaintext string) error {
+func (p *passphraseStore) setHashed(ctx context.Context, plaintext string) (string, error) {
 	hash, err := bcrypt.GenerateFromPassword([]byte(plaintext), bcryptCost)
 	if err != nil {
-		return fmt.Errorf("hash passphrase: %w", err)
+		return "", fmt.Errorf("hash passphrase: %w", err)
 	}
-	return p.set(ctx, string(hash))
+	if err := p.set(ctx, string(hash)); err != nil {
+		return "", err
+	}
+	return string(hash), nil
 }
 
 // generateRandomPassphrase produces a cryptographically random passphrase
@@ -96,11 +100,17 @@ func generateRandomPassphrase() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
-// looksLikeBcryptHash reports whether v has one of the bcrypt prefixes
-// ($2a$/$2b$/$2y$). Used to distinguish hashed from legacy-plaintext values
-// during the lazy migration window.
+// looksLikeBcryptHash reports whether v has a bcrypt-style prefix. Used to
+// distinguish hashed from legacy-plaintext values during the lazy migration
+// window. Covers $2a$ (most common), $2b$, $2y$ (PHP variant), and the
+// pre-2002 $2$ Blowfish prefix; bcrypt.CompareHashAndPassword accepts all
+// of them, so misclassifying any as legacy plaintext would force a needless
+// rehash and lock us out for one login on a strict comparator.
 func looksLikeBcryptHash(v string) bool {
-	return strings.HasPrefix(v, "$2a$") || strings.HasPrefix(v, "$2b$") || strings.HasPrefix(v, "$2y$")
+	return strings.HasPrefix(v, "$2a$") ||
+		strings.HasPrefix(v, "$2b$") ||
+		strings.HasPrefix(v, "$2y$") ||
+		strings.HasPrefix(v, "$2$")
 }
 
 // verifyPassphrase checks a candidate passphrase against the configured
@@ -133,7 +143,11 @@ func (s *Server) verifyPassphrase(ctx context.Context, candidate string) bool {
 		return subtle.ConstantTimeCompare([]byte(candidate), []byte(s.cfg.Server.Secret)) == 1
 	}
 
-	stored := s.cachedDBValue(ctx)
+	stored, err := s.cachedDBValue(ctx)
+	if err != nil {
+		s.log.Error("verifyPassphrase: db read failed; failing closed", zap.Error(err))
+		return false
+	}
 	if stored == "" {
 		return false
 	}
@@ -147,14 +161,14 @@ func (s *Server) verifyPassphrase(ctx context.Context, candidate string) bool {
 		return false
 	}
 	if s.passphraseStore != nil {
-		if err := s.passphraseStore.setHashed(ctx, candidate); err != nil {
+		if hash, err := s.passphraseStore.setHashed(ctx, candidate); err != nil {
 			s.log.Warn("lazy bcrypt migration: failed to rehash legacy passphrase; will retry on next login",
 				zap.Error(err))
 		} else {
-			// Refresh the cache to the new hash so subsequent logins skip the
-			// legacy branch immediately.
+			// Warm the cache with the new hash so subsequent logins skip the
+			// legacy branch immediately, without a second DB round-trip.
 			s.cachedPassphraseMu.Lock()
-			s.cachedPassphrase = ""
+			s.cachedPassphrase = hash
 			s.cachedPassphraseMu.Unlock()
 			s.log.Info("auth passphrase migrated from legacy plaintext to bcrypt hash")
 		}
@@ -163,29 +177,33 @@ func (s *Server) verifyPassphrase(ctx context.Context, candidate string) bool {
 }
 
 // cachedDBValue returns the DB-stored passphrase value (hash or legacy
-// plaintext), reading from cache if warm and falling back to the DB. Callers
-// must not assume plaintext.
-func (s *Server) cachedDBValue(ctx context.Context) string {
+// plaintext), reading from cache if warm and falling back to the DB.
+//
+// Returns ("", nil) when no passphrase is configured (or the store is nil).
+// Returns ("", err) when the DB read fails — callers MUST distinguish this
+// from "" to avoid fail-open behavior. A swallowed DB error here previously
+// allowed apiSecretsUnlock to bypass authentication during a transient DB
+// outage; that bug was fixed alongside the bcrypt migration.
+func (s *Server) cachedDBValue(ctx context.Context) (string, error) {
 	if s.passphraseStore == nil {
-		return ""
+		return "", nil
 	}
 	s.cachedPassphraseMu.RLock()
 	cached := s.cachedPassphrase
 	s.cachedPassphraseMu.RUnlock()
 	if cached != "" {
-		return cached
+		return cached, nil
 	}
 	val, err := s.passphraseStore.get(ctx)
 	if err != nil {
-		s.log.Error("failed to read passphrase from DB", zap.Error(err))
-		return ""
+		return "", fmt.Errorf("read passphrase from db: %w", err)
 	}
 	if val != "" {
 		s.cachedPassphraseMu.Lock()
 		s.cachedPassphrase = val
 		s.cachedPassphraseMu.Unlock()
 	}
-	return val
+	return val, nil
 }
 
 // resolvePassphraseSource describes where the active passphrase comes from.
@@ -197,15 +215,31 @@ const (
 	passphraseSourceNone resolvePassphraseSource = "none"
 	passphraseSourceYAML resolvePassphraseSource = "yaml"
 	passphraseSourceDB   resolvePassphraseSource = "db"
+	// passphraseSourceUnknown is returned only when the underlying DB read
+	// failed; callers must treat it as "passphrase configured but
+	// unavailable" so login/secrets-change endpoints fail closed under a
+	// transient outage. Distinct from "none" specifically to prevent the
+	// bootstrap fast-path (which intentionally accepts any password when
+	// no passphrase has been set yet) from being entered on an error.
+	passphraseSourceUnknown resolvePassphraseSource = "unknown"
 )
 
 // passphraseSource reports where the effective passphrase lives. It does not
 // return the value because, post-bcrypt, the DB no longer contains plaintext.
+//
+// Returns passphraseSourceUnknown if the DB read fails — never silently
+// returns passphraseSourceNone on a transient error, which would let
+// apiSecretsUnlock skip the verify check and accept any password.
 func (s *Server) passphraseSource(ctx context.Context) resolvePassphraseSource {
 	if s.cfg.Server.Secret != "" {
 		return passphraseSourceYAML
 	}
-	if s.cachedDBValue(ctx) != "" {
+	val, err := s.cachedDBValue(ctx)
+	if err != nil {
+		s.log.Error("passphraseSource: db read failed; treating as unknown (fail-closed)", zap.Error(err))
+		return passphraseSourceUnknown
+	}
+	if val != "" {
 		return passphraseSourceDB
 	}
 	return passphraseSourceNone
@@ -244,16 +278,14 @@ func (s *Server) ensurePassphrase(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := s.passphraseStore.setHashed(ctx, plaintext); err != nil {
+	hash, err := s.passphraseStore.setHashed(ctx, plaintext)
+	if err != nil {
 		return fmt.Errorf("store passphrase: %w", err)
 	}
 	// Cache the hash so the next login validates against it directly.
-	hash, err := s.passphraseStore.get(ctx)
-	if err == nil && hash != "" {
-		s.cachedPassphraseMu.Lock()
-		s.cachedPassphrase = hash
-		s.cachedPassphraseMu.Unlock()
-	}
+	s.cachedPassphraseMu.Lock()
+	s.cachedPassphrase = hash
+	s.cachedPassphraseMu.Unlock()
 
 	// Print the plaintext clearly to stdout — this is the operator's only
 	// chance to see it. After this function returns, the plaintext is gone.
@@ -307,26 +339,45 @@ func (s *Server) apiChangePassphrase(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, "passphrase must be at least 16 characters", http.StatusBadRequest)
 		return
 	}
+	// bcrypt silently truncates inputs longer than 72 bytes — reject with a
+	// clear error rather than letting the user think the extra characters
+	// are protecting them. (UTF-8: len() is byte length, so a few emoji can
+	// blow this fast.)
+	if len(body.Passphrase) > 72 {
+		jsonErr(w, "passphrase must be at most 72 bytes (bcrypt limit)", http.StatusBadRequest)
+		return
+	}
 
 	// Require the current passphrase to prevent a stolen session from rotating
 	// the credential without knowing the existing secret. Skip only when no
 	// passphrase is set yet (bootstrap: first-time setup from a valid session).
-	if s.cachedDBValue(r.Context()) != "" {
+	// On DB error treat as "configured" — refusing to identify the bootstrap
+	// case fails closed and matches apiSecretsUnlock's behavior.
+	stored, err := s.cachedDBValue(r.Context())
+	if err != nil {
+		s.log.Error("apiChangePassphrase: db read failed; failing closed", zap.Error(err))
+		jsonErr(w, "service temporarily unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	if stored != "" {
 		if !s.verifyPassphrase(r.Context(), body.Current) {
 			jsonErr(w, "current passphrase is incorrect", http.StatusUnauthorized)
 			return
 		}
 	}
 
-	if err := s.passphraseStore.setHashed(r.Context(), body.Passphrase); err != nil {
+	hash, err := s.passphraseStore.setHashed(r.Context(), body.Passphrase)
+	if err != nil {
 		s.log.Error("failed to store passphrase", zap.Error(err))
 		jsonErr(w, "failed to store passphrase", http.StatusInternalServerError)
 		return
 	}
 
-	// Invalidate the cache so the next verifyPassphrase reloads the new hash.
+	// Warm the cache with the new hash directly — saves a DB read on the
+	// next verifyPassphrase and keeps observable state consistent with the
+	// just-completed write.
 	s.cachedPassphraseMu.Lock()
-	s.cachedPassphrase = ""
+	s.cachedPassphrase = hash
 	s.cachedPassphraseMu.Unlock()
 
 	// Invalidate all current sessions — everyone must re-login with the new passphrase.

--- a/pkg/webui/passphrase.go
+++ b/pkg/webui/passphrase.go
@@ -19,12 +19,13 @@ import (
 const (
 	passphraseKVKey = "auth.passphrase"
 
-	// bcryptCost is the work factor used when hashing a stored passphrase.
-	// bcrypt.DefaultCost is 10 (~80ms on a 2024 server CPU). 12 raises that
-	// to ~300ms — still tolerable for an interactive login on the rate-limited
-	// /api/auth/login endpoint and gives meaningful headroom against offline
-	// attacks if the SQLite DB ever leaks.
-	bcryptCost = 12
+	// defaultBcryptCost is the work factor used when no operator override is
+	// supplied via server.bcrypt_cost. bcrypt.DefaultCost is 10 (~80ms on a
+	// 2024 server CPU). 12 raises that to ~300ms — still tolerable for an
+	// interactive login on the rate-limited /api/auth/login endpoint and
+	// gives meaningful headroom against offline attacks if the SQLite DB
+	// ever leaks. Operators can tune via server.bcrypt_cost (range 4–14).
+	defaultBcryptCost = 12
 )
 
 // passphraseStore persists the server auth passphrase in the SQLite kv table.
@@ -75,12 +76,20 @@ func (p *passphraseStore) set(ctx context.Context, value string) error {
 	)
 }
 
-// setHashed hashes the given plaintext passphrase with bcrypt and stores the
-// result, returning the hash so callers can warm in-process caches without a
-// second DB read. This is the only call sites should use when persisting a
-// passphrase from the UI or from auto-generation.
-func (p *passphraseStore) setHashed(ctx context.Context, plaintext string) (string, error) {
-	hash, err := bcrypt.GenerateFromPassword([]byte(plaintext), bcryptCost)
+// setHashed hashes the given plaintext passphrase with bcrypt at the given
+// cost factor and stores the result, returning the hash so callers can warm
+// in-process caches without a second DB read. This is the only call sites
+// should use when persisting a passphrase from the UI or from auto-generation.
+//
+// cost must be in bcrypt's accepted range (MinCost=4 .. MaxCost=31). When
+// cost <= 0, defaultBcryptCost is used so test helpers and a hypothetical
+// zero-config caller can't accidentally drop work factor to bcrypt's
+// silent-fallback DefaultCost (10).
+func (p *passphraseStore) setHashed(ctx context.Context, plaintext string, cost int) (string, error) {
+	if cost <= 0 {
+		cost = defaultBcryptCost
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(plaintext), cost)
 	if err != nil {
 		return "", fmt.Errorf("hash passphrase: %w", err)
 	}
@@ -161,7 +170,7 @@ func (s *Server) verifyPassphrase(ctx context.Context, candidate string) bool {
 		return false
 	}
 	if s.passphraseStore != nil {
-		if hash, err := s.passphraseStore.setHashed(ctx, candidate); err != nil {
+		if hash, err := s.passphraseStore.setHashed(ctx, candidate, s.cfg.Server.BcryptCost); err != nil {
 			s.log.Warn("lazy bcrypt migration: failed to rehash legacy passphrase; will retry on next login",
 				zap.Error(err))
 		} else {
@@ -278,7 +287,7 @@ func (s *Server) ensurePassphrase(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	hash, err := s.passphraseStore.setHashed(ctx, plaintext)
+	hash, err := s.passphraseStore.setHashed(ctx, plaintext, s.cfg.Server.BcryptCost)
 	if err != nil {
 		return fmt.Errorf("store passphrase: %w", err)
 	}
@@ -366,7 +375,7 @@ func (s *Server) apiChangePassphrase(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	hash, err := s.passphraseStore.setHashed(r.Context(), body.Passphrase)
+	hash, err := s.passphraseStore.setHashed(r.Context(), body.Passphrase, s.cfg.Server.BcryptCost)
 	if err != nil {
 		s.log.Error("failed to store passphrase", zap.Error(err))
 		jsonErr(w, "failed to store passphrase", http.StatusInternalServerError)

--- a/pkg/webui/passphrase.go
+++ b/pkg/webui/passphrase.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dicode/dicode/pkg/db"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -122,6 +123,23 @@ func looksLikeBcryptHash(v string) bool {
 		strings.HasPrefix(v, "$2$")
 }
 
+// passphraseMigrator collapses concurrent legacy-plaintext → bcrypt migration
+// attempts into a single bcrypt computation + DB write. Without it, two valid
+// logins racing on the same plaintext would each compute a fresh ~300ms hash
+// and INSERT…ON CONFLICT each other, doubling CPU and producing two audit-log
+// "migrated" entries when one is correct. With it, the second caller blocks
+// briefly on the first's hash result and shares it.
+//
+// singleflight.Group is safe for concurrent use and zero-value ready, so the
+// embedding into Server needs no initialisation. We always key on the kvKey
+// constant (there's only one passphrase per server) — using the candidate
+// plaintext as the key would leak information into the global key space and
+// gain nothing since concurrent attempts on different plaintexts can't both
+// be valid.
+type passphraseMigrator struct {
+	g singleflight.Group
+}
+
 // verifyPassphrase checks a candidate passphrase against the configured
 // authentication source and returns true if it matches. It is the only
 // function that should be used to authenticate a user-supplied passphrase.
@@ -170,19 +188,72 @@ func (s *Server) verifyPassphrase(ctx context.Context, candidate string) bool {
 		return false
 	}
 	if s.passphraseStore != nil {
-		if hash, err := s.passphraseStore.setHashed(ctx, candidate, s.cfg.Server.BcryptCost); err != nil {
-			s.log.Warn("lazy bcrypt migration: failed to rehash legacy passphrase; will retry on next login",
-				zap.Error(err))
-		} else {
-			// Warm the cache with the new hash so subsequent logins skip the
-			// legacy branch immediately, without a second DB round-trip.
-			s.cachedPassphraseMu.Lock()
-			s.cachedPassphrase = hash
-			s.cachedPassphraseMu.Unlock()
-			s.log.Info("auth passphrase migrated from legacy plaintext to bcrypt hash")
-		}
+		s.migrateLegacyPlaintext(ctx, candidate)
 	}
 	return true
+}
+
+// migrateLegacyPlaintext rehashes a verified legacy-plaintext passphrase to
+// bcrypt and warms the cache. It is safe under concurrent successful logins
+// on the same plaintext: singleflight collapses the bcrypt + DB write to a
+// single execution and the duplicate callers receive the same hash without
+// re-computing or re-writing.
+//
+// Any error is logged at WARN and swallowed — the caller has already verified
+// the passphrase, so failing the migration must NOT fail the login. The next
+// successful login will retry; in the meantime the legacy plaintext stays
+// readable and verifiable.
+//
+// Caller must hold no locks: the singleflight callback re-acquires
+// cachedPassphraseMu for the cache warm-up.
+func (s *Server) migrateLegacyPlaintext(ctx context.Context, plaintext string) {
+	// Re-check cache inside the singleflight key path: if a concurrent
+	// migrator already wrote the bcrypt hash, the cache will reflect it and
+	// we can skip the rehash entirely. This isn't strictly necessary for
+	// correctness (singleflight already collapses concurrent calls) but it
+	// prevents an unnecessary bcrypt CPU burn for late arrivals that come
+	// in just after the in-flight migration completes.
+	s.cachedPassphraseMu.RLock()
+	cached := s.cachedPassphrase
+	s.cachedPassphraseMu.RUnlock()
+	if looksLikeBcryptHash(cached) {
+		return
+	}
+
+	// singleflight key is the constant kvKey — there's only one passphrase
+	// per server, so all concurrent migrations on this server must share a
+	// single in-flight execution.
+	_, err, _ := s.migrateGroup.g.Do(passphraseKVKey, func() (any, error) {
+		// Inside the singleflight: re-check one more time so the SECOND of
+		// two truly concurrent callers (both passed the outer cache check
+		// before either entered Do) doesn't redo the work the FIRST one is
+		// finishing — this is the case singleflight.Do already guarantees
+		// once both are inside Do, but the re-check tightens the window for
+		// callers that arrive while the first's write has propagated to the
+		// cache via warm-up but the singleflight key has just been released.
+		s.cachedPassphraseMu.RLock()
+		cached := s.cachedPassphrase
+		s.cachedPassphraseMu.RUnlock()
+		if looksLikeBcryptHash(cached) {
+			return cached, nil
+		}
+
+		hash, err := s.passphraseStore.setHashed(ctx, plaintext, s.cfg.Server.BcryptCost)
+		if err != nil {
+			return "", err
+		}
+		// Warm the cache with the new hash so subsequent logins skip the
+		// legacy branch immediately, without a second DB round-trip.
+		s.cachedPassphraseMu.Lock()
+		s.cachedPassphrase = hash
+		s.cachedPassphraseMu.Unlock()
+		s.log.Info("auth passphrase migrated from legacy plaintext to bcrypt hash")
+		return hash, nil
+	})
+	if err != nil {
+		s.log.Warn("lazy bcrypt migration: failed to rehash legacy passphrase; will retry on next login",
+			zap.Error(err))
+	}
 }
 
 // cachedDBValue returns the DB-stored passphrase value (hash or legacy

--- a/pkg/webui/passphrase_test.go
+++ b/pkg/webui/passphrase_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/dicode/dicode/pkg/config"
@@ -714,6 +716,108 @@ func TestApiChangePassphrase_DBErrorRejects(t *testing.T) {
 
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503 on DB outage, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// ── concurrent lazy migration (#209) ─────────────────────────────────────────
+//
+// Two simultaneous successful logins on a legacy plaintext passphrase must
+// produce exactly one bcrypt computation and one DB write. Without the
+// singleflight-backed migrator a race could land two writes (idempotent on
+// the row, but doubling bcrypt CPU and emitting two "migrated" audit-log
+// entries when one is correct).
+
+// countingDB wraps a real DB and tallies how many times the passphrase row
+// was written. We only care about Exec calls that include the passphraseKVKey
+// — there are other kv writes in the broader test setup (and we don't want
+// to count the initial seed write the test itself does).
+type countingDB struct {
+	db.DB
+	mu        sync.Mutex
+	writes    int
+	countOnly string // only count Exec calls whose args include this string
+}
+
+func (c *countingDB) Exec(ctx context.Context, query string, args ...any) error {
+	if c.countOnly != "" {
+		for _, a := range args {
+			if s, ok := a.(string); ok && s == c.countOnly {
+				c.mu.Lock()
+				c.writes++
+				c.mu.Unlock()
+				break
+			}
+		}
+	}
+	return c.DB.Exec(ctx, query, args...)
+}
+
+func (c *countingDB) writeCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.writes
+}
+
+func TestVerifyPassphrase_ConcurrentLegacyMigration_SingleWrite(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	reg := registry.New(d)
+	eng := trigger.New(reg, nil, zap.NewNop())
+	cfg := &config.Config{Server: config.ServerConfig{Auth: true, BcryptCost: bcrypt.MinCost}}
+	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
+
+	// Seed the legacy plaintext value via the underlying DB directly so the
+	// counting wrapper doesn't see this write.
+	if err := srv.passphraseStore.set(context.Background(), "legacy-plain-pass-pp"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now swap the store's DB for a counting wrapper. The migrator's writes
+	// (via setHashed → Exec INSERT…ON CONFLICT) will be counted.
+	cdb := &countingDB{DB: d, countOnly: passphraseKVKey}
+	srv.passphraseStore = newPassphraseStore(cdb)
+
+	// Race N goroutines on the same valid legacy plaintext.
+	const N = 16
+	var (
+		wg     sync.WaitGroup
+		ready  sync.WaitGroup
+		start  = make(chan struct{})
+		oks    int32
+	)
+	wg.Add(N)
+	ready.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			ready.Done()
+			<-start // line everyone up at the same instant
+			if srv.verifyPassphrase(context.Background(), "legacy-plain-pass-pp") {
+				atomic.AddInt32(&oks, 1)
+			}
+		}()
+	}
+	ready.Wait()
+	close(start)
+	wg.Wait()
+
+	if oks != N {
+		t.Fatalf("all %d concurrent verifications should succeed, got %d", N, oks)
+	}
+
+	// The whole point of the singleflight migrator: at most ONE bcrypt+write
+	// for N concurrent valid logins. We allow 1 here. Allowing 0 would be
+	// wrong — exactly one goroutine must have done the migration. >1 means
+	// the race is unfixed.
+	if got := cdb.writeCount(); got != 1 {
+		t.Errorf("expected exactly 1 migration write under N=%d concurrent legacy logins, got %d", N, got)
+	}
+
+	// And the post-race state must be a bcrypt hash, not the legacy plaintext.
+	stored, _ := srv.passphraseStore.get(context.Background())
+	if !looksLikeBcryptHash(stored) {
+		t.Errorf("expected DB to be migrated to bcrypt, got %q", stored)
 	}
 }
 

--- a/pkg/webui/passphrase_test.go
+++ b/pkg/webui/passphrase_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/dicode/dicode/pkg/config"
@@ -14,6 +15,7 @@ import (
 	"github.com/dicode/dicode/pkg/registry"
 	"github.com/dicode/dicode/pkg/trigger"
 	"go.uber.org/zap"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // newAuthServerNoDB builds a server with auth enabled but no DB — simulates
@@ -59,20 +61,44 @@ func TestPassphraseStore_GetEmpty(t *testing.T) {
 	}
 }
 
-func TestPassphraseStore_SetAndGet(t *testing.T) {
+func TestPassphraseStore_SetAndGet_RawValue(t *testing.T) {
 	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
 	defer d.Close()
 
 	ps := newPassphraseStore(d)
-	if err := ps.set(context.Background(), "my-secret-pass"); err != nil {
+	if err := ps.set(context.Background(), "raw-value"); err != nil {
 		t.Fatalf("set: %v", err)
 	}
 	val, err := ps.get(context.Background())
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
-	if val != "my-secret-pass" {
-		t.Errorf("expected %q, got %q", "my-secret-pass", val)
+	if val != "raw-value" {
+		t.Errorf("expected %q, got %q", "raw-value", val)
+	}
+}
+
+func TestPassphraseStore_SetHashed_StoresBcryptHash(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	ps := newPassphraseStore(d)
+	if err := ps.setHashed(context.Background(), "my-secret-pass"); err != nil {
+		t.Fatalf("setHashed: %v", err)
+	}
+	val, err := ps.get(context.Background())
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !looksLikeBcryptHash(val) {
+		t.Fatalf("stored value should be a bcrypt hash, got %q", val)
+	}
+	// Plaintext must not appear anywhere in the stored value.
+	if strings.Contains(val, "my-secret-pass") {
+		t.Errorf("plaintext leaked into stored value: %q", val)
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(val), []byte("my-secret-pass")); err != nil {
+		t.Errorf("bcrypt compare against stored hash failed: %v", err)
 	}
 }
 
@@ -81,36 +107,65 @@ func TestPassphraseStore_Overwrite(t *testing.T) {
 	defer d.Close()
 
 	ps := newPassphraseStore(d)
-	_ = ps.set(context.Background(), "first")
-	_ = ps.set(context.Background(), "second")
+	_ = ps.setHashed(context.Background(), "first-pass-1234")
+	_ = ps.setHashed(context.Background(), "second-pass-5678")
 
 	val, _ := ps.get(context.Background())
-	if val != "second" {
-		t.Errorf("expected %q after overwrite, got %q", "second", val)
+	if !looksLikeBcryptHash(val) {
+		t.Fatalf("expected bcrypt hash, got %q", val)
+	}
+	// Verify the *second* passphrase wins.
+	if err := bcrypt.CompareHashAndPassword([]byte(val), []byte("second-pass-5678")); err != nil {
+		t.Errorf("expected second hash to verify, got: %v", err)
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(val), []byte("first-pass-1234")); err == nil {
+		t.Error("first passphrase should not verify against the overwritten hash")
 	}
 }
 
-// ── resolvePassphrase priority ────────────────────────────────────────────────
+func TestLooksLikeBcryptHash(t *testing.T) {
+	cases := map[string]bool{
+		"$2a$12$abcdef":       true,
+		"$2b$10$abcdef":       true,
+		"$2y$12$abcdef":       true,
+		"":                    false,
+		"plaintext-pass":      false,
+		"$2x$12$weirdvariant": false,
+		"prefix$2a$12$x":      false,
+	}
+	for in, want := range cases {
+		if got := looksLikeBcryptHash(in); got != want {
+			t.Errorf("looksLikeBcryptHash(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
 
-func TestResolvePassphrase_YAMLOverrideTakesPrecedence(t *testing.T) {
+// ── verifyPassphrase / passphraseSource priority ─────────────────────────────
+
+func TestVerifyPassphrase_YAMLOverrideTakesPrecedence(t *testing.T) {
 	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
 	defer d.Close()
-
-	ps := newPassphraseStore(d)
-	_ = ps.set(context.Background(), "db-passphrase")
 
 	reg := registry.New(d)
 	eng := trigger.New(reg, nil, zap.NewNop())
 	cfg := &config.Config{Server: config.ServerConfig{Auth: true, Secret: "yaml-passphrase"}}
 	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
 
-	got := srv.resolvePassphrase(context.Background())
-	if got != "yaml-passphrase" {
-		t.Errorf("YAML override should take precedence, got %q", got)
+	// Even if the DB has a (different) bcrypt hash, the YAML override wins.
+	_ = srv.passphraseStore.setHashed(context.Background(), "db-passphrase")
+
+	if !srv.verifyPassphrase(context.Background(), "yaml-passphrase") {
+		t.Error("YAML passphrase should verify when set in config.Server.Secret")
+	}
+	if srv.verifyPassphrase(context.Background(), "db-passphrase") {
+		t.Error("DB passphrase should not verify while YAML override is active")
+	}
+	if got := srv.passphraseSource(context.Background()); got != passphraseSourceYAML {
+		t.Errorf("source = %q, want %q", got, passphraseSourceYAML)
 	}
 }
 
-func TestResolvePassphrase_DBUsedWhenNoYAML(t *testing.T) {
+func TestVerifyPassphrase_DBHashUsedWhenNoYAML(t *testing.T) {
 	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
 	defer d.Close()
 
@@ -119,15 +174,20 @@ func TestResolvePassphrase_DBUsedWhenNoYAML(t *testing.T) {
 	cfg := &config.Config{Server: config.ServerConfig{Auth: true, Secret: ""}}
 	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
 
-	_ = srv.passphraseStore.set(context.Background(), "stored-pass")
+	_ = srv.passphraseStore.setHashed(context.Background(), "stored-pass")
 
-	got := srv.resolvePassphrase(context.Background())
-	if got != "stored-pass" {
-		t.Errorf("expected DB passphrase, got %q", got)
+	if !srv.verifyPassphrase(context.Background(), "stored-pass") {
+		t.Error("verifyPassphrase should accept the correct DB-hashed passphrase")
+	}
+	if srv.verifyPassphrase(context.Background(), "wrong-pass") {
+		t.Error("verifyPassphrase should reject a wrong passphrase")
+	}
+	if got := srv.passphraseSource(context.Background()); got != passphraseSourceDB {
+		t.Errorf("source = %q, want %q", got, passphraseSourceDB)
 	}
 }
 
-func TestResolvePassphrase_EmptyWhenNeitherSet(t *testing.T) {
+func TestVerifyPassphrase_EmptyWhenNeitherSet(t *testing.T) {
 	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
 	defer d.Close()
 
@@ -136,15 +196,95 @@ func TestResolvePassphrase_EmptyWhenNeitherSet(t *testing.T) {
 	cfg := &config.Config{Server: config.ServerConfig{Auth: true}}
 	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
 
-	got := srv.resolvePassphrase(context.Background())
-	if got != "" {
-		t.Errorf("expected empty passphrase, got %q", got)
+	if srv.verifyPassphrase(context.Background(), "anything") {
+		t.Error("verifyPassphrase should reject any candidate when nothing is configured")
+	}
+	if got := srv.passphraseSource(context.Background()); got != passphraseSourceNone {
+		t.Errorf("source = %q, want %q", got, passphraseSourceNone)
+	}
+}
+
+func TestVerifyPassphrase_RejectsEmptyCandidate(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	reg := registry.New(d)
+	eng := trigger.New(reg, nil, zap.NewNop())
+	cfg := &config.Config{Server: config.ServerConfig{Auth: true, Secret: "yaml"}}
+	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
+
+	if srv.verifyPassphrase(context.Background(), "") {
+		t.Error("empty candidate must never verify")
+	}
+}
+
+// ── lazy migration: legacy plaintext → bcrypt on next successful login ───────
+
+func TestVerifyPassphrase_LazyMigrationFromLegacyPlaintext(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	reg := registry.New(d)
+	eng := trigger.New(reg, nil, zap.NewNop())
+	cfg := &config.Config{Server: config.ServerConfig{Auth: true}}
+	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
+
+	// Simulate an existing pre-bcrypt deployment: plaintext value in DB.
+	if err := srv.passphraseStore.set(context.Background(), "legacy-plaintext-pass"); err != nil {
+		t.Fatalf("set legacy: %v", err)
+	}
+
+	// First successful login: must verify AND rehash.
+	if !srv.verifyPassphrase(context.Background(), "legacy-plaintext-pass") {
+		t.Fatal("legacy plaintext passphrase should verify")
+	}
+
+	// DB now contains a bcrypt hash, not plaintext.
+	stored, err := srv.passphraseStore.get(context.Background())
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !looksLikeBcryptHash(stored) {
+		t.Fatalf("expected DB to be rehashed to bcrypt, still got %q", stored)
+	}
+	if strings.Contains(stored, "legacy-plaintext-pass") {
+		t.Errorf("plaintext leaked into rehashed value: %q", stored)
+	}
+
+	// Subsequent verification must keep working against the new hash.
+	if !srv.verifyPassphrase(context.Background(), "legacy-plaintext-pass") {
+		t.Error("post-migration verify should still accept the same plaintext")
+	}
+	if srv.verifyPassphrase(context.Background(), "wrong") {
+		t.Error("post-migration verify should reject wrong passphrase")
+	}
+}
+
+func TestVerifyPassphrase_LegacyMismatchDoesNotMigrate(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	reg := registry.New(d)
+	eng := trigger.New(reg, nil, zap.NewNop())
+	cfg := &config.Config{Server: config.ServerConfig{Auth: true}}
+	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
+
+	_ = srv.passphraseStore.set(context.Background(), "legacy-plaintext-pass")
+
+	if srv.verifyPassphrase(context.Background(), "wrong-attempt") {
+		t.Fatal("wrong passphrase should not verify against legacy plaintext")
+	}
+
+	// DB must still be the plaintext — no rehash on a failed attempt.
+	stored, _ := srv.passphraseStore.get(context.Background())
+	if stored != "legacy-plaintext-pass" {
+		t.Errorf("legacy plaintext should be untouched on failed attempt, got %q", stored)
 	}
 }
 
 // ── ensurePassphrase auto-generation ─────────────────────────────────────────
 
-func TestEnsurePassphrase_GeneratesWhenMissing(t *testing.T) {
+func TestEnsurePassphrase_GeneratesAndStoresHash(t *testing.T) {
 	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
 	defer d.Close()
 
@@ -159,10 +299,11 @@ func TestEnsurePassphrase_GeneratesWhenMissing(t *testing.T) {
 
 	stored, _ := srv.passphraseStore.get(context.Background())
 	if stored == "" {
-		t.Error("expected passphrase to be auto-generated and stored")
+		t.Fatal("expected passphrase to be auto-generated and stored")
 	}
-	if len(stored) < 20 {
-		t.Errorf("auto-generated passphrase too short: %q", stored)
+	// Must be a bcrypt hash, not raw base64 plaintext.
+	if !looksLikeBcryptHash(stored) {
+		t.Errorf("auto-generated passphrase must be stored as bcrypt hash, got %q", stored)
 	}
 }
 
@@ -175,14 +316,38 @@ func TestEnsurePassphrase_DoesNotOverwriteExisting(t *testing.T) {
 	cfg := &config.Config{Server: config.ServerConfig{Auth: true}}
 	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
 
-	_ = srv.passphraseStore.set(context.Background(), "already-set")
+	_ = srv.passphraseStore.setHashed(context.Background(), "already-set-1234")
+	before, _ := srv.passphraseStore.get(context.Background())
+
 	if err := srv.ensurePassphrase(context.Background()); err != nil {
 		t.Fatalf("ensurePassphrase: %v", err)
 	}
 
-	stored, _ := srv.passphraseStore.get(context.Background())
-	if stored != "already-set" {
-		t.Errorf("existing passphrase should not be overwritten, got %q", stored)
+	after, _ := srv.passphraseStore.get(context.Background())
+	if after != before {
+		t.Errorf("existing passphrase hash should not be overwritten\n before: %q\n after:  %q", before, after)
+	}
+}
+
+func TestEnsurePassphrase_DoesNotOverwriteLegacyPlaintext(t *testing.T) {
+	// If the DB already holds a legacy plaintext value, ensurePassphrase
+	// must leave it alone — the migration happens lazily on the next login.
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	reg := registry.New(d)
+	eng := trigger.New(reg, nil, zap.NewNop())
+	cfg := &config.Config{Server: config.ServerConfig{Auth: true}}
+	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
+
+	_ = srv.passphraseStore.set(context.Background(), "legacy-plaintext-pass")
+
+	if err := srv.ensurePassphrase(context.Background()); err != nil {
+		t.Fatalf("ensurePassphrase: %v", err)
+	}
+	after, _ := srv.passphraseStore.get(context.Background())
+	if after != "legacy-plaintext-pass" {
+		t.Errorf("legacy plaintext should be left intact for lazy migration, got %q", after)
 	}
 }
 
@@ -228,11 +393,11 @@ func TestEnsurePassphrase_NoopWhenYAMLOverridePresent(t *testing.T) {
 
 func TestPassphraseAPI_StatusEndpoint(t *testing.T) {
 	srv := newAuthServer(t, "") // auth enabled, no YAML secret
-	// Manually set a DB passphrase
-	_ = srv.passphraseStore.set(context.Background(), "test-pass")
+	// Manually set a DB passphrase via the hashed path.
+	_ = srv.passphraseStore.setHashed(context.Background(), "test-pass-1234")
 
 	h := srv.Handler()
-	cookie := login(t, h, "test-pass", false)
+	cookie := login(t, h, "test-pass-1234", false)
 	if cookie == nil {
 		t.Fatal("login failed")
 	}
@@ -254,7 +419,7 @@ func TestPassphraseAPI_StatusEndpoint(t *testing.T) {
 
 func TestPassphraseAPI_ChangePassphrase(t *testing.T) {
 	srv := newAuthServer(t, "")
-	_ = srv.passphraseStore.set(context.Background(), "old-passphrase-here")
+	_ = srv.passphraseStore.setHashed(context.Background(), "old-passphrase-here")
 
 	h := srv.Handler()
 	cookie := login(t, h, "old-passphrase-here", false)
@@ -274,6 +439,12 @@ func TestPassphraseAPI_ChangePassphrase(t *testing.T) {
 		t.Fatalf("expected 200 on passphrase change, got %d: %s", w.Code, w.Body)
 	}
 
+	// New value must be stored as a bcrypt hash, not plaintext.
+	stored, _ := srv.passphraseStore.get(context.Background())
+	if !looksLikeBcryptHash(stored) {
+		t.Errorf("expected new passphrase to be stored as bcrypt hash, got %q", stored)
+	}
+
 	// Old passphrase must be rejected.
 	oldCookie := login(t, h, "old-passphrase-here", false)
 	if oldCookie != nil {
@@ -287,9 +458,41 @@ func TestPassphraseAPI_ChangePassphrase(t *testing.T) {
 	}
 }
 
+func TestPassphraseAPI_ChangeFromLegacyPlaintext(t *testing.T) {
+	// An operator on a pre-bcrypt deployment can rotate via the API; the
+	// "current" they supply is plaintext, which must verify against the
+	// legacy plaintext DB value, and the new value must land as a bcrypt hash.
+	srv := newAuthServer(t, "")
+	_ = srv.passphraseStore.set(context.Background(), "legacy-plain-1234")
+
+	h := srv.Handler()
+	cookie := login(t, h, "legacy-plain-1234", false)
+	if cookie == nil {
+		t.Fatal("legacy login should still work pre-rotation")
+	}
+
+	body, _ := json.Marshal(map[string]string{"current": "legacy-plain-1234", "passphrase": "rotated-passphrase-99"})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/passphrase", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 on rotation from legacy plaintext, got %d: %s", w.Code, w.Body)
+	}
+
+	stored, _ := srv.passphraseStore.get(context.Background())
+	if !looksLikeBcryptHash(stored) {
+		t.Errorf("rotated value should be a bcrypt hash, got %q", stored)
+	}
+	if login(t, h, "rotated-passphrase-99", false) == nil {
+		t.Error("rotated passphrase should authenticate")
+	}
+}
+
 func TestPassphraseAPI_ChangeRequiresSession(t *testing.T) {
 	srv := newAuthServer(t, "")
-	_ = srv.passphraseStore.set(context.Background(), "existing-pass-1234")
+	_ = srv.passphraseStore.setHashed(context.Background(), "existing-pass-1234")
 	h := srv.Handler()
 
 	body, _ := json.Marshal(map[string]string{"current": "existing-pass-1234", "passphrase": "new-pass-should-fail"})
@@ -306,7 +509,7 @@ func TestPassphraseAPI_ChangeRequiresSession(t *testing.T) {
 
 func TestPassphraseAPI_ChangeTooShortRejected(t *testing.T) {
 	srv := newAuthServer(t, "")
-	_ = srv.passphraseStore.set(context.Background(), "existing-long-pass-1234")
+	_ = srv.passphraseStore.setHashed(context.Background(), "existing-long-pass-1234")
 	h := srv.Handler()
 
 	cookie := login(t, h, "existing-long-pass-1234", false)
@@ -328,7 +531,7 @@ func TestPassphraseAPI_ChangeTooShortRejected(t *testing.T) {
 
 func TestPassphraseAPI_WrongCurrentRejected(t *testing.T) {
 	srv := newAuthServer(t, "")
-	_ = srv.passphraseStore.set(context.Background(), "correct-current-pass-123")
+	_ = srv.passphraseStore.setHashed(context.Background(), "correct-current-pass-123")
 	h := srv.Handler()
 
 	cookie := login(t, h, "correct-current-pass-123", false)

--- a/pkg/webui/passphrase_test.go
+++ b/pkg/webui/passphrase_test.go
@@ -781,10 +781,10 @@ func TestVerifyPassphrase_ConcurrentLegacyMigration_SingleWrite(t *testing.T) {
 	// Race N goroutines on the same valid legacy plaintext.
 	const N = 16
 	var (
-		wg     sync.WaitGroup
-		ready  sync.WaitGroup
-		start  = make(chan struct{})
-		oks    int32
+		wg    sync.WaitGroup
+		ready sync.WaitGroup
+		start = make(chan struct{})
+		oks   int32
 	)
 	wg.Add(N)
 	ready.Add(N)

--- a/pkg/webui/passphrase_test.go
+++ b/pkg/webui/passphrase_test.go
@@ -83,8 +83,12 @@ func TestPassphraseStore_SetHashed_StoresBcryptHash(t *testing.T) {
 	defer d.Close()
 
 	ps := newPassphraseStore(d)
-	if err := ps.setHashed(context.Background(), "my-secret-pass"); err != nil {
+	hash, err := ps.setHashed(context.Background(), "my-secret-pass")
+	if err != nil {
 		t.Fatalf("setHashed: %v", err)
+	}
+	if !looksLikeBcryptHash(hash) {
+		t.Fatalf("setHashed must return the bcrypt hash; got %q", hash)
 	}
 	val, err := ps.get(context.Background())
 	if err != nil {
@@ -107,8 +111,8 @@ func TestPassphraseStore_Overwrite(t *testing.T) {
 	defer d.Close()
 
 	ps := newPassphraseStore(d)
-	_ = ps.setHashed(context.Background(), "first-pass-1234")
-	_ = ps.setHashed(context.Background(), "second-pass-5678")
+	_, _ = ps.setHashed(context.Background(), "first-pass-1234")
+	_, _ = ps.setHashed(context.Background(), "second-pass-5678")
 
 	val, _ := ps.get(context.Background())
 	if !looksLikeBcryptHash(val) {
@@ -125,9 +129,15 @@ func TestPassphraseStore_Overwrite(t *testing.T) {
 
 func TestLooksLikeBcryptHash(t *testing.T) {
 	cases := map[string]bool{
-		"$2a$12$abcdef":       true,
-		"$2b$10$abcdef":       true,
-		"$2y$12$abcdef":       true,
+		// Modern variants — $2a$ is what golang.org/x/crypto/bcrypt emits.
+		"$2a$12$abcdef": true,
+		"$2b$10$abcdef": true,
+		"$2y$12$abcdef": true,
+		// Pre-2002 OpenBSD variant. Vanishingly rare in the wild, but
+		// bcrypt.CompareHashAndPassword accepts it; misclassifying it as
+		// legacy plaintext would force a needless rehash and lock out the
+		// account for one login on a stricter comparator.
+		"$2$10$abcdef":        true,
 		"":                    false,
 		"plaintext-pass":      false,
 		"$2x$12$weirdvariant": false,
@@ -152,7 +162,7 @@ func TestVerifyPassphrase_YAMLOverrideTakesPrecedence(t *testing.T) {
 	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
 
 	// Even if the DB has a (different) bcrypt hash, the YAML override wins.
-	_ = srv.passphraseStore.setHashed(context.Background(), "db-passphrase")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "db-passphrase")
 
 	if !srv.verifyPassphrase(context.Background(), "yaml-passphrase") {
 		t.Error("YAML passphrase should verify when set in config.Server.Secret")
@@ -174,7 +184,7 @@ func TestVerifyPassphrase_DBHashUsedWhenNoYAML(t *testing.T) {
 	cfg := &config.Config{Server: config.ServerConfig{Auth: true, Secret: ""}}
 	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
 
-	_ = srv.passphraseStore.setHashed(context.Background(), "stored-pass")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "stored-pass")
 
 	if !srv.verifyPassphrase(context.Background(), "stored-pass") {
 		t.Error("verifyPassphrase should accept the correct DB-hashed passphrase")
@@ -316,7 +326,7 @@ func TestEnsurePassphrase_DoesNotOverwriteExisting(t *testing.T) {
 	cfg := &config.Config{Server: config.ServerConfig{Auth: true}}
 	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
 
-	_ = srv.passphraseStore.setHashed(context.Background(), "already-set-1234")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "already-set-1234")
 	before, _ := srv.passphraseStore.get(context.Background())
 
 	if err := srv.ensurePassphrase(context.Background()); err != nil {
@@ -394,7 +404,7 @@ func TestEnsurePassphrase_NoopWhenYAMLOverridePresent(t *testing.T) {
 func TestPassphraseAPI_StatusEndpoint(t *testing.T) {
 	srv := newAuthServer(t, "") // auth enabled, no YAML secret
 	// Manually set a DB passphrase via the hashed path.
-	_ = srv.passphraseStore.setHashed(context.Background(), "test-pass-1234")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "test-pass-1234")
 
 	h := srv.Handler()
 	cookie := login(t, h, "test-pass-1234", false)
@@ -419,7 +429,7 @@ func TestPassphraseAPI_StatusEndpoint(t *testing.T) {
 
 func TestPassphraseAPI_ChangePassphrase(t *testing.T) {
 	srv := newAuthServer(t, "")
-	_ = srv.passphraseStore.setHashed(context.Background(), "old-passphrase-here")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "old-passphrase-here")
 
 	h := srv.Handler()
 	cookie := login(t, h, "old-passphrase-here", false)
@@ -492,7 +502,7 @@ func TestPassphraseAPI_ChangeFromLegacyPlaintext(t *testing.T) {
 
 func TestPassphraseAPI_ChangeRequiresSession(t *testing.T) {
 	srv := newAuthServer(t, "")
-	_ = srv.passphraseStore.setHashed(context.Background(), "existing-pass-1234")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "existing-pass-1234")
 	h := srv.Handler()
 
 	body, _ := json.Marshal(map[string]string{"current": "existing-pass-1234", "passphrase": "new-pass-should-fail"})
@@ -509,7 +519,7 @@ func TestPassphraseAPI_ChangeRequiresSession(t *testing.T) {
 
 func TestPassphraseAPI_ChangeTooShortRejected(t *testing.T) {
 	srv := newAuthServer(t, "")
-	_ = srv.passphraseStore.setHashed(context.Background(), "existing-long-pass-1234")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "existing-long-pass-1234")
 	h := srv.Handler()
 
 	cookie := login(t, h, "existing-long-pass-1234", false)
@@ -531,7 +541,7 @@ func TestPassphraseAPI_ChangeTooShortRejected(t *testing.T) {
 
 func TestPassphraseAPI_WrongCurrentRejected(t *testing.T) {
 	srv := newAuthServer(t, "")
-	_ = srv.passphraseStore.setHashed(context.Background(), "correct-current-pass-123")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "correct-current-pass-123")
 	h := srv.Handler()
 
 	cookie := login(t, h, "correct-current-pass-123", false)
@@ -596,5 +606,142 @@ func TestGenerateRandomPassphrase_Unique(t *testing.T) {
 	b, _ := generateRandomPassphrase()
 	if a == b {
 		t.Error("two generated passphrases should not be equal")
+	}
+}
+
+// ── DB-error fail-closed paths ────────────────────────────────────────────────
+//
+// failingDB wraps a real DB but rejects every Query — used to drive the
+// "passphrase row read failed transiently" branch on the verify, source, and
+// change paths. We don't pass nil for a missing method because passphraseStore
+// only ever calls Query / Exec.
+type failingDB struct {
+	db.DB
+	queryErr error
+	execErr  error
+}
+
+func (f *failingDB) Query(_ context.Context, _ string, _ []any, _ func(db.Scanner) error) error {
+	return f.queryErr
+}
+
+func (f *failingDB) Exec(_ context.Context, _ string, _ ...any) error {
+	return f.execErr
+}
+
+// invalidateCache clears the in-process passphrase cache so the next read goes
+// through to the (failing) DB.
+func invalidateCache(s *Server) {
+	s.cachedPassphraseMu.Lock()
+	s.cachedPassphrase = ""
+	s.cachedPassphraseMu.Unlock()
+}
+
+func TestVerifyPassphrase_DBErrorFailsClosed(t *testing.T) {
+	srv := newAuthServer(t, "")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "stored-pass-1234")
+
+	srv.passphraseStore = newPassphraseStore(&failingDB{queryErr: context.DeadlineExceeded})
+	invalidateCache(srv)
+
+	if srv.verifyPassphrase(context.Background(), "stored-pass-1234") {
+		t.Fatal("verifyPassphrase must fail closed when the DB read errors")
+	}
+}
+
+func TestPassphraseSource_DBErrorReturnsUnknown(t *testing.T) {
+	srv := newAuthServer(t, "")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "stored-pass-1234")
+
+	srv.passphraseStore = newPassphraseStore(&failingDB{queryErr: context.DeadlineExceeded})
+	invalidateCache(srv)
+
+	if got := srv.passphraseSource(context.Background()); got != passphraseSourceUnknown {
+		t.Errorf("passphraseSource on db error = %q; want %q", got, passphraseSourceUnknown)
+	}
+}
+
+// TestApiSecretsUnlock_DBErrorRejects exercises the regression that originally
+// motivated this whole patch: a transient DB outage previously made
+// `passphraseSource` return `none`, and `apiSecretsUnlock`'s bootstrap
+// fast-path then accepted ANY password. Now it must reject with 503.
+func TestApiSecretsUnlock_DBErrorRejects(t *testing.T) {
+	srv := newAuthServer(t, "")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "stored-pass-1234")
+
+	srv.passphraseStore = newPassphraseStore(&failingDB{queryErr: context.DeadlineExceeded})
+	invalidateCache(srv)
+
+	h := srv.Handler()
+	body, _ := json.Marshal(map[string]any{"password": "anything-at-all"})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 on DB outage, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	for _, c := range w.Result().Cookies() {
+		if c.Name == sessionCookie && c.Value != "" {
+			t.Errorf("must not issue a session cookie under db outage; got %q", c.Value)
+		}
+	}
+}
+
+func TestApiChangePassphrase_DBErrorRejects(t *testing.T) {
+	srv := newAuthServer(t, "")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "old-pass-here-123")
+
+	h := srv.Handler()
+	cookie := login(t, h, "old-pass-here-123", false)
+	if cookie == nil {
+		t.Fatal("pre-outage login should succeed")
+	}
+
+	srv.passphraseStore = newPassphraseStore(&failingDB{queryErr: context.DeadlineExceeded})
+	invalidateCache(srv)
+
+	body, _ := json.Marshal(map[string]string{
+		"current":    "old-pass-here-123",
+		"passphrase": "new-pass-here-1234567",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/passphrase", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 on DB outage, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// ── bcrypt input length cap ──────────────────────────────────────────────────
+
+func TestPassphraseAPI_ChangeRejectsLongerThanBcryptLimit(t *testing.T) {
+	srv := newAuthServer(t, "")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "current-pass-1234567")
+
+	h := srv.Handler()
+	cookie := login(t, h, "current-pass-1234567", false)
+	if cookie == nil {
+		t.Fatal("login failed")
+	}
+
+	// 73 bytes — one over bcrypt's silent-truncation threshold.
+	tooLong := strings.Repeat("a", 73)
+	body, _ := json.Marshal(map[string]string{
+		"current":    "current-pass-1234567",
+		"passphrase": tooLong,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/passphrase", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("73-byte passphrase should be rejected with 400, got %d (body: %s)", w.Code, w.Body.String())
 	}
 }

--- a/pkg/webui/passphrase_test.go
+++ b/pkg/webui/passphrase_test.go
@@ -83,7 +83,7 @@ func TestPassphraseStore_SetHashed_StoresBcryptHash(t *testing.T) {
 	defer d.Close()
 
 	ps := newPassphraseStore(d)
-	hash, err := ps.setHashed(context.Background(), "my-secret-pass")
+	hash, err := ps.setHashed(context.Background(), "my-secret-pass", bcrypt.MinCost)
 	if err != nil {
 		t.Fatalf("setHashed: %v", err)
 	}
@@ -111,8 +111,8 @@ func TestPassphraseStore_Overwrite(t *testing.T) {
 	defer d.Close()
 
 	ps := newPassphraseStore(d)
-	_, _ = ps.setHashed(context.Background(), "first-pass-1234")
-	_, _ = ps.setHashed(context.Background(), "second-pass-5678")
+	_, _ = ps.setHashed(context.Background(), "first-pass-1234", bcrypt.MinCost)
+	_, _ = ps.setHashed(context.Background(), "second-pass-5678", bcrypt.MinCost)
 
 	val, _ := ps.get(context.Background())
 	if !looksLikeBcryptHash(val) {
@@ -162,7 +162,7 @@ func TestVerifyPassphrase_YAMLOverrideTakesPrecedence(t *testing.T) {
 	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
 
 	// Even if the DB has a (different) bcrypt hash, the YAML override wins.
-	_, _ = srv.passphraseStore.setHashed(context.Background(), "db-passphrase")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "db-passphrase", bcrypt.MinCost)
 
 	if !srv.verifyPassphrase(context.Background(), "yaml-passphrase") {
 		t.Error("YAML passphrase should verify when set in config.Server.Secret")
@@ -184,7 +184,7 @@ func TestVerifyPassphrase_DBHashUsedWhenNoYAML(t *testing.T) {
 	cfg := &config.Config{Server: config.ServerConfig{Auth: true, Secret: ""}}
 	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
 
-	_, _ = srv.passphraseStore.setHashed(context.Background(), "stored-pass")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "stored-pass", bcrypt.MinCost)
 
 	if !srv.verifyPassphrase(context.Background(), "stored-pass") {
 		t.Error("verifyPassphrase should accept the correct DB-hashed passphrase")
@@ -326,7 +326,7 @@ func TestEnsurePassphrase_DoesNotOverwriteExisting(t *testing.T) {
 	cfg := &config.Config{Server: config.ServerConfig{Auth: true}}
 	srv, _ := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
 
-	_, _ = srv.passphraseStore.setHashed(context.Background(), "already-set-1234")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "already-set-1234", bcrypt.MinCost)
 	before, _ := srv.passphraseStore.get(context.Background())
 
 	if err := srv.ensurePassphrase(context.Background()); err != nil {
@@ -404,7 +404,7 @@ func TestEnsurePassphrase_NoopWhenYAMLOverridePresent(t *testing.T) {
 func TestPassphraseAPI_StatusEndpoint(t *testing.T) {
 	srv := newAuthServer(t, "") // auth enabled, no YAML secret
 	// Manually set a DB passphrase via the hashed path.
-	_, _ = srv.passphraseStore.setHashed(context.Background(), "test-pass-1234")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "test-pass-1234", bcrypt.MinCost)
 
 	h := srv.Handler()
 	cookie := login(t, h, "test-pass-1234", false)
@@ -429,7 +429,7 @@ func TestPassphraseAPI_StatusEndpoint(t *testing.T) {
 
 func TestPassphraseAPI_ChangePassphrase(t *testing.T) {
 	srv := newAuthServer(t, "")
-	_, _ = srv.passphraseStore.setHashed(context.Background(), "old-passphrase-here")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "old-passphrase-here", bcrypt.MinCost)
 
 	h := srv.Handler()
 	cookie := login(t, h, "old-passphrase-here", false)
@@ -502,7 +502,7 @@ func TestPassphraseAPI_ChangeFromLegacyPlaintext(t *testing.T) {
 
 func TestPassphraseAPI_ChangeRequiresSession(t *testing.T) {
 	srv := newAuthServer(t, "")
-	_, _ = srv.passphraseStore.setHashed(context.Background(), "existing-pass-1234")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "existing-pass-1234", bcrypt.MinCost)
 	h := srv.Handler()
 
 	body, _ := json.Marshal(map[string]string{"current": "existing-pass-1234", "passphrase": "new-pass-should-fail"})
@@ -519,7 +519,7 @@ func TestPassphraseAPI_ChangeRequiresSession(t *testing.T) {
 
 func TestPassphraseAPI_ChangeTooShortRejected(t *testing.T) {
 	srv := newAuthServer(t, "")
-	_, _ = srv.passphraseStore.setHashed(context.Background(), "existing-long-pass-1234")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "existing-long-pass-1234", bcrypt.MinCost)
 	h := srv.Handler()
 
 	cookie := login(t, h, "existing-long-pass-1234", false)
@@ -541,7 +541,7 @@ func TestPassphraseAPI_ChangeTooShortRejected(t *testing.T) {
 
 func TestPassphraseAPI_WrongCurrentRejected(t *testing.T) {
 	srv := newAuthServer(t, "")
-	_, _ = srv.passphraseStore.setHashed(context.Background(), "correct-current-pass-123")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "correct-current-pass-123", bcrypt.MinCost)
 	h := srv.Handler()
 
 	cookie := login(t, h, "correct-current-pass-123", false)
@@ -639,7 +639,7 @@ func invalidateCache(s *Server) {
 
 func TestVerifyPassphrase_DBErrorFailsClosed(t *testing.T) {
 	srv := newAuthServer(t, "")
-	_, _ = srv.passphraseStore.setHashed(context.Background(), "stored-pass-1234")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "stored-pass-1234", bcrypt.MinCost)
 
 	srv.passphraseStore = newPassphraseStore(&failingDB{queryErr: context.DeadlineExceeded})
 	invalidateCache(srv)
@@ -651,7 +651,7 @@ func TestVerifyPassphrase_DBErrorFailsClosed(t *testing.T) {
 
 func TestPassphraseSource_DBErrorReturnsUnknown(t *testing.T) {
 	srv := newAuthServer(t, "")
-	_, _ = srv.passphraseStore.setHashed(context.Background(), "stored-pass-1234")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "stored-pass-1234", bcrypt.MinCost)
 
 	srv.passphraseStore = newPassphraseStore(&failingDB{queryErr: context.DeadlineExceeded})
 	invalidateCache(srv)
@@ -667,7 +667,7 @@ func TestPassphraseSource_DBErrorReturnsUnknown(t *testing.T) {
 // fast-path then accepted ANY password. Now it must reject with 503.
 func TestApiSecretsUnlock_DBErrorRejects(t *testing.T) {
 	srv := newAuthServer(t, "")
-	_, _ = srv.passphraseStore.setHashed(context.Background(), "stored-pass-1234")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "stored-pass-1234", bcrypt.MinCost)
 
 	srv.passphraseStore = newPassphraseStore(&failingDB{queryErr: context.DeadlineExceeded})
 	invalidateCache(srv)
@@ -691,7 +691,7 @@ func TestApiSecretsUnlock_DBErrorRejects(t *testing.T) {
 
 func TestApiChangePassphrase_DBErrorRejects(t *testing.T) {
 	srv := newAuthServer(t, "")
-	_, _ = srv.passphraseStore.setHashed(context.Background(), "old-pass-here-123")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "old-pass-here-123", bcrypt.MinCost)
 
 	h := srv.Handler()
 	cookie := login(t, h, "old-pass-here-123", false)
@@ -717,11 +717,74 @@ func TestApiChangePassphrase_DBErrorRejects(t *testing.T) {
 	}
 }
 
+// ── configurable bcrypt cost (#209) ──────────────────────────────────────────
+
+// The server.bcrypt_cost YAML knob must reach GenerateFromPassword at every
+// hashing site (apiChangePassphrase, ensurePassphrase, lazy migration). We
+// inspect the resulting hash via bcrypt.Cost — it returns the cost embedded
+// in the hash header — to assert the wire-up rather than mocking.
+func TestApiChangePassphrase_HonorsConfiguredBcryptCost(t *testing.T) {
+	srv := newAuthServer(t, "")
+	srv.cfg.Server.BcryptCost = 5 // intentionally non-default; still > MinCost
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "old-pass-here-123", bcrypt.MinCost)
+
+	h := srv.Handler()
+	cookie := login(t, h, "old-pass-here-123", false)
+	if cookie == nil {
+		t.Fatal("login failed")
+	}
+
+	body, _ := json.Marshal(map[string]string{
+		"current":    "old-pass-here-123",
+		"passphrase": "new-strong-passphrase-123",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/passphrase", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	stored, _ := srv.passphraseStore.get(context.Background())
+	cost, err := bcrypt.Cost([]byte(stored))
+	if err != nil {
+		t.Fatalf("bcrypt.Cost: %v", err)
+	}
+	if cost != 5 {
+		t.Errorf("stored hash cost = %d, want 5 (configured)", cost)
+	}
+}
+
+// setHashed must treat cost <= 0 as "use the package default" — protects
+// against test helpers and hand-built Config structs that skip applyDefaults.
+// Without this we'd silently pass 0 to bcrypt, which falls back to its own
+// DefaultCost (10) — close to what we want, but we prefer the documented
+// constant we control.
+func TestSetHashed_ZeroCostFallsBackToDefault(t *testing.T) {
+	d, _ := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	defer d.Close()
+
+	ps := newPassphraseStore(d)
+	hash, err := ps.setHashed(context.Background(), "pp-default-cost", 0)
+	if err != nil {
+		t.Fatalf("setHashed: %v", err)
+	}
+	cost, err := bcrypt.Cost([]byte(hash))
+	if err != nil {
+		t.Fatalf("bcrypt.Cost: %v", err)
+	}
+	if cost != defaultBcryptCost {
+		t.Errorf("hash cost = %d, want %d (defaultBcryptCost)", cost, defaultBcryptCost)
+	}
+}
+
 // ── bcrypt input length cap ──────────────────────────────────────────────────
 
 func TestPassphraseAPI_ChangeRejectsLongerThanBcryptLimit(t *testing.T) {
 	srv := newAuthServer(t, "")
-	_, _ = srv.passphraseStore.setHashed(context.Background(), "current-pass-1234567")
+	_, _ = srv.passphraseStore.setHashed(context.Background(), "current-pass-1234567", bcrypt.MinCost)
 
 	h := srv.Handler()
 	cookie := login(t, h, "current-pass-1234567", false)

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -920,7 +920,17 @@ func (s *Server) apiSecretsUnlock(w http.ResponseWriter, r *http.Request) {
 	// Auth is enabled but no passphrase has been configured yet (bootstrap
 	// state) — accept any password, mirroring the previous behaviour. The
 	// /security UI will force one to be set as soon as the operator logs in.
-	if s.passphraseSource(r.Context()) != passphraseSourceNone {
+	//
+	// passphraseSourceUnknown means the DB read failed; we deliberately do
+	// NOT treat that as bootstrap (which would accept any password). Reject
+	// the login with 503 so the operator can investigate the outage rather
+	// than silently letting anyone in.
+	src := s.passphraseSource(r.Context())
+	if src == passphraseSourceUnknown {
+		s.loginError(w, r, "service temporarily unavailable", http.StatusServiceUnavailable, safeNext)
+		return
+	}
+	if src != passphraseSourceNone {
 		if !s.verifyPassphrase(r.Context(), password) {
 			s.loginError(w, r, "incorrect password", http.StatusUnauthorized, safeNext)
 			return

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -164,9 +164,10 @@ type Server struct {
 	sessions           *sessionStore
 	dbSessions         *dbSessionStore  // persistent sessions / trusted devices
 	apiKeys            *apiKeyStore     // MCP / programmatic API keys
-	passphraseStore    *passphraseStore // auth passphrase persisted in DB
-	cachedPassphrase   string           // in-memory cache of stored DB value (bcrypt hash, or legacy plaintext during migration); invalidated on change
-	cachedPassphraseMu sync.RWMutex
+	passphraseStore    *passphraseStore   // auth passphrase persisted in DB
+	cachedPassphrase   string             // in-memory cache of stored DB value (bcrypt hash, or legacy plaintext during migration); invalidated on change
+	cachedPassphraseMu sync.RWMutex       // guards cachedPassphrase
+	migrateGroup       passphraseMigrator // collapses concurrent legacy-passphrase migrations to one bcrypt+write
 	limiter            *unlockLimiter
 	logs               *LogBroadcaster
 	ws                 *WSHub

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -4,7 +4,6 @@ package webui
 import (
 	"context"
 	"crypto/rand"
-	"crypto/subtle"
 	"embed"
 	"encoding/hex"
 	"encoding/json"
@@ -166,7 +165,7 @@ type Server struct {
 	dbSessions         *dbSessionStore  // persistent sessions / trusted devices
 	apiKeys            *apiKeyStore     // MCP / programmatic API keys
 	passphraseStore    *passphraseStore // auth passphrase persisted in DB
-	cachedPassphrase   string           // in-memory cache of resolved passphrase; invalidated on change
+	cachedPassphrase   string           // in-memory cache of stored DB value (bcrypt hash, or legacy plaintext during migration); invalidated on change
 	cachedPassphraseMu sync.RWMutex
 	limiter            *unlockLimiter
 	logs               *LogBroadcaster
@@ -918,10 +917,14 @@ func (s *Server) apiSecretsUnlock(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	expected := s.resolvePassphrase(r.Context())
-	if expected != "" && subtle.ConstantTimeCompare([]byte(password), []byte(expected)) != 1 {
-		s.loginError(w, r, "incorrect password", http.StatusUnauthorized, safeNext)
-		return
+	// Auth is enabled but no passphrase has been configured yet (bootstrap
+	// state) — accept any password, mirroring the previous behaviour. The
+	// /security UI will force one to be set as soon as the operator logs in.
+	if s.passphraseSource(r.Context()) != passphraseSourceNone {
+		if !s.verifyPassphrase(r.Context(), password) {
+			s.loginError(w, r, "incorrect password", http.StatusUnauthorized, safeNext)
+			return
+		}
 	}
 
 	token := s.sessions.issue()

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -162,8 +162,8 @@ type Server struct {
 	relayClient        *relay.Client
 	managedRuntimes    []pkgruntime.ManagedRuntime
 	sessions           *sessionStore
-	dbSessions         *dbSessionStore  // persistent sessions / trusted devices
-	apiKeys            *apiKeyStore     // MCP / programmatic API keys
+	dbSessions         *dbSessionStore    // persistent sessions / trusted devices
+	apiKeys            *apiKeyStore       // MCP / programmatic API keys
 	passphraseStore    *passphraseStore   // auth passphrase persisted in DB
 	cachedPassphrase   string             // in-memory cache of stored DB value (bcrypt hash, or legacy plaintext during migration); invalidated on change
 	cachedPassphraseMu sync.RWMutex       // guards cachedPassphrase


### PR DESCRIPTION
Closes #209.
Part of #207.
Supersedes #204.

## Summary

Lands the bcrypt passphrase + lazy migration work scoped in #209. Built on top of the two well-reviewed commits from #204 (which addressed the prior `/review` + `/security-review` HIGH/MEDIUM/LOW findings around fail-open auth on DB error, bcrypt 72-byte truncation, and the `$2$` prefix), and adds the three #209 acceptance items #204 didn't cover:

1. **Configurable `server.bcrypt_cost`** (default 12, range 4–14) — operators on tiny devices can lower; beefy boxes can raise. Validation runs at config-load time so a typo'd `bcrypt_cost: 20` fails fast rather than at first login.

2. **Race-safe concurrent migration** via `singleflight.Group` — two simultaneous successful logins on a legacy plaintext now produce exactly one bcrypt computation + one DB write (was N writes under contention, doubling CPU and emitting duplicate "migrated" log lines per real event).

3. **`docs/concepts/security.md` bcrypt section** covering the hashing scheme, the lazy-migration contract, the `bcrypt_cost` knob, the 72-byte caveat, the singleflight semantics, and the fail-closed behaviour on DB read errors. Configuration Reference and Security Properties Summary tables updated to match.

## Commits

```
247bf58 feat(webui/auth): bcrypt-hash stored passphrase with lazy migration  [from #204]
e860636 review: fix fail-open auth path on transient DB errors                [from #204]
83ddecf feat(config/webui): expose server.bcrypt_cost knob (4–14, default 12)
0ae75a0 fix(webui/auth): collapse concurrent legacy-passphrase migrations
c7c1024 test(webui/auth): assert single migration write under concurrent legacy logins
8c202bb docs(security): document bcrypt passphrase storage and lazy migration
cdaf115 chore(webui): apply gofmt to passphrase changes
```

The first two are unchanged cherry-picks from #204 — keeping them as separate commits preserves attribution and makes it easy to spot the new work atop the previously-reviewed baseline.

## Test matrix

| Area | Tests |
| --- | --- |
| `passphraseStore` round-trip | `TestPassphraseStore_GetEmpty`, `_SetAndGet_RawValue`, `_SetHashed_StoresBcryptHash`, `_Overwrite` |
| Bcrypt prefix detection | `TestLooksLikeBcryptHash` (5 modern + legacy variants, 4 negatives) |
| Verify priority | `TestVerifyPassphrase_YAMLOverrideTakesPrecedence`, `_DBHashUsedWhenNoYAML`, `_EmptyWhenNeitherSet`, `_RejectsEmptyCandidate` |
| Lazy migration | `TestVerifyPassphrase_LazyMigrationFromLegacyPlaintext`, `_LegacyMismatchDoesNotMigrate` |
| **Concurrent migration (NEW)** | `TestVerifyPassphrase_ConcurrentLegacyMigration_SingleWrite` — 16 goroutines barrier-released onto same valid legacy plaintext; asserts all 16 succeed AND exactly 1 DB write occurs. Stable under `-race -count=3`. |
| ensurePassphrase | `TestEnsurePassphrase_GeneratesAndStoresHash`, `_DoesNotOverwriteExisting`, `_DoesNotOverwriteLegacyPlaintext`, `_NoopWhenAuthDisabled`, `_NoopWhenYAMLOverridePresent` |
| HTTP API | `TestPassphraseAPI_StatusEndpoint`, `_ChangePassphrase`, `_ChangeFromLegacyPlaintext`, `_ChangeRequiresSession`, `_ChangeTooShortRejected`, `_WrongCurrentRejected`, `_YAMLOverrideBlocksAPIChange`, `_ChangeRejectsLongerThanBcryptLimit` |
| **Configurable cost (NEW)** | `TestApiChangePassphrase_HonorsConfiguredBcryptCost` (asserts `bcrypt.Cost` of stored hash matches configured value end-to-end), `TestSetHashed_ZeroCostFallsBackToDefault` |
| Fail-closed on DB error | `TestVerifyPassphrase_DBErrorFailsClosed`, `TestPassphraseSource_DBErrorReturnsUnknown`, `TestApiSecretsUnlock_DBErrorRejects`, `TestApiChangePassphrase_DBErrorRejects` |
| **Config validation (NEW)** | `TestLoad_BcryptCost_DefaultIs12WhenUnset`, `_AcceptsValidOverride`, `_RejectsOutOfRange` (6 sub-tests: 1, 2, 3, 15, 20, 31) |

Verification:

- `go test ./pkg/webui/...` — green (2.3s)
- `go test ./pkg/config/...` — green
- `make test` — full suite green
- `go vet ./...` — clean
- `gofmt -l .` — clean
- `go test -race -count=3` over the touched test set — stable

## Security summary

This PR is security-sensitive — the call-out for the security-review pass:

- **Race fix is the headline change.** Without singleflight, the prior implementation could compute two bcrypt hashes and execute two `INSERT…ON CONFLICT` writes on a contested legacy login. The writes were idempotent (no row corruption) but provided a CPU amplification vector against the configured bcrypt cost: an attacker who discovered the legacy plaintext could replay the login from N clients to consume N×cost CPU. Now collapsed to exactly one execution per migration event.

- **Cost knob is bounded and validated.** Range 4–14, rejected at config load. The lower bound (4 = `bcrypt.MinCost`) prevents an operator from setting cost=1 thinking it's "more secure"; the upper bound (14) prevents lock-out from cost=20 (~minutes per login on commodity hardware). `setHashed` defaults `cost <= 0` to `defaultBcryptCost` (12) so a hand-built Config struct that skips `applyDefaults` doesn't silently fall back to bcrypt's package DefaultCost (10).

- **Migration error handling is unchanged from #204.** Rehash failures are WARN-logged and swallowed — failing the rehash must NOT fail the operator's already-validated login. The legacy plaintext stays readable until the next successful login retries.

- **Cache warm-up race**: the migrator re-checks the cache both *before* entering `singleflight.Do` and *inside* the Do callback. The outer check is an optimisation (skip the singleflight ceremony entirely if a sibling already warmed); the inner check tightens the window for callers that arrive between cache-warm completion and singleflight key release.

- **No changes to the YAML-secret path or the constant-time comparator** — those were already correct in #204 and verified by the existing `TestVerifyPassphrase_YAMLOverrideTakesPrecedence` and `TestPassphraseAPI_YAMLOverrideBlocksAPIChange`.

## Test plan

- [x] `go test ./pkg/webui/...` green
- [x] `go test ./pkg/config/...` green
- [x] `make test` (full suite) green
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go test -race -count=3` over passphrase tests stable
- [ ] `/review` subagent satisfied (post-create)
- [ ] `/security-review` subagent satisfied — race fix + cost knob + DB error paths (post-create)

🤖 Generated with [Claude Code](https://claude.com/claude-code)