### PR TITLE
docs(spec): on-failure AI auto-fix loop design (#228)

### DIFF
--- a/docs/superpowers/specs/2026-04-28-on-failure-auto-fix-loop-design.md
+++ b/docs/superpowers/specs/2026-04-28-on-failure-auto-fix-loop-design.md
@@ -3,6 +3,7 @@
 **Status:** draft, awaiting review
 **Owner:** TBD
 **Epic:** [#207 — landing-page promises](https://github.com/dicode-ayo/dicode-core/issues/207)
+**Tracking issue:** [#228](https://github.com/dicode-ayo/dicode-core/issues/228)
 
 ## 1. Why
 
@@ -10,9 +11,9 @@ The dicode landing page advertises a continuous AI loop — *create, validate, d
 
 - An `on_failure_chain` mechanism fires a target task on failure, but the chained task only sees the failed run's `output`. It cannot see the original input that triggered the failure, the source code that produced the failure, or the run logs.
 - Run inputs are not persisted (the `runs` table has no `input` column). A failed webhook payload is gone after the run ends, so no agent can replay it once a fix is proposed.
-- `commit_task` and dev-mode workflow tools exist for *humans* iterating in the WebUI dev panel, but they are not wired to a chain trigger and there is no headless agent loop that replicates the dev workflow on a failure.
+- The dicode SDK exposes `list_tasks` / `run_task` / `kv` / `log` / `output` to tasks but lacks calls for testing a task, toggling dev mode on a source, or committing changes back to a source. These exist as Go-internal APIs and REST endpoints today; an internal agent task cannot reach them.
 
-This spec closes those gaps with the smallest set of additions, reusing existing primitives (dev mode, MCP dev tools, `buildin/dicodai`, the `temp-cleanup` cron pattern, the `from: task:` extensibility shape used for secret providers).
+This spec closes those gaps with the smallest set of additions, reusing existing primitives (dev mode, `buildin/dicodai`, the `temp-cleanup` cron pattern, the buildin TaskSet `overrides:` mechanism that defines `dicodai` itself).
 
 ## 2. Scope
 
@@ -20,16 +21,18 @@ In scope:
 
 1. Persisted, encrypted run inputs with parameterizable retention and pluggable storage.
 2. Replay primitive that re-fires a failed run with its persisted input.
-3. Dev mode extension that lets the engine clone-and-checkout a worktree on a named branch, so an agent can iterate in isolation without touching the production source.
+3. Dev mode extension that lets the engine clone-and-checkout a worktree on a named branch.
 4. Chain trigger that can pass parameters to the chained task.
-5. A buildin `auto-fix` task (preset of `buildin/dicodai`) that consumes the failure context, iterates fix → validate → push, and either merges to main (autonomous) or opens a PR (review).
-6. Loop guardrails: per-failure iteration cap, token budget, cooldown, concurrency cap, depth limit, failure-storm circuit breaker.
+5. SDK additions exposing what auto-fix needs over the unix-socket IPC: `tasks.test`, `sources.set_dev_mode`, `git.commit_push`, plus the run-input plumbing (replay, get_input, list_expired, delete_input, pin/unpin).
+6. A buildin `auto-fix` taskset entry (override of `buildin/dicodai`) that consumes the failure context, iterates fix → validate → push, and either merges to main (autonomous) or opens a PR (review).
+7. Loop guardrails: per-failure iteration cap, per-iteration timeout, LLM token budget, cooldown, concurrency cap, depth limit, failure-storm circuit breaker, autonomous-mode opt-in protections.
 
 Out of scope (deferred):
 
+- **Extending the buildin MCP task with `write_task_file` / `validate_task` / `commit_task` / `dry_run_task` / `read_task_file`** to close the gap with the documented `dicode-task-dev` skill. Useful for *external* agents (Claude Code, Cursor) but unnecessary for auto-fix because auto-fix is an internal task with direct SDK access. Tracked separately under epic #207.
+- Auto-revert on monitoring signals from a *successful* deploy (the LP "When AI is wrong" copy). v1 covers the on-failure path only; revert-on-regression is a follow-up.
 - Multi-task fixes (agent edits a dependency task, not the failing task itself). v1 limits the agent to writing inside the failed task's directory.
 - Forge integrations beyond GitHub. The PR step is implemented as a buildin `git-pr` task using the `gh` CLI; users replace it with their own task to support GitLab/Gitea/Forgejo.
-- Auto-revert on monitoring signals from a *successful* deploy (the LP "When AI is wrong" copy). v1 covers the on-failure path only; revert is a follow-up.
 
 ## 3. Architecture
 
@@ -44,80 +47,164 @@ Out of scope (deferred):
          ▼                               ▼
 ┌─────────────────┐            ┌────────────────────┐
 │ run-input store │            │ buildin/auto-fix    │
-│  (AES-GCM core, │            │ (dicodai preset)   │
+│  (ChaCha20-Poly,│            │ (dicodai override)  │
 │   storage task) │            │                    │
-└────────┬────────┘            │  uses MCP tools:   │
-         ▲                     │   switch_dev_mode  │
-         │ replay              │   write_task_file  │
-         │                     │   validate_task    │
-         │                     │   test_task        │
-         │                     │   dry_run_task     │
-         │                     │   replay_run       │
-         │                     │   commit_task      │
-         │                     │  uses task tools:  │
-         │                     │   buildin/git-pr   │
+└────────┬────────┘            │  uses dicode SDK:   │
+         ▲                     │   runs.replay       │
+         │ replay              │   runs.get_input    │
+         │                     │   tasks.test        │
+         │                     │   sources.set_dev_mode│
+         │                     │   git.commit_push    │
+         │                     │  uses Deno fs:       │
+         │                     │   readTextFile       │
+         │                     │   writeTextFile      │
+         │                     │  uses task tools:    │
+         │                     │   buildin/git-pr     │
          │                     └────────────────────┘
          │
-┌────────┴────────┐
-│ run-inputs-     │  cron     ┌────────────────────┐
-│ cleanup task    │──────────▶│ storage task        │
-│ (buildin)       │  delete   │  put | get | delete │
-└─────────────────┘            └────────────────────┘
+┌────────┴────────┐  cron     ┌────────────────────┐
+│ run-inputs-     │──────────▶│ storage task        │
+│ cleanup task    │  delete   │  put | get | delete │
+│ (buildin)       │            └────────────────────┘
+└─────────────────┘
+
+┌────────────────────┐
+│ dev-worktrees-     │  cron, mirrors temp-cleanup
+│ cleanup task       │  removes orphan worktrees
+│ (buildin)          │  whose runID is no longer
+└────────────────────┘  pinned in `runs`
 ```
 
 ### 3.2 Existing primitives reused (not in scope to change)
 
-- `pkg/taskset.SetDevMode(enabled, opts)` — dev-ref substitution + immediate registry re-sync. Used today for human dev workflow.
-- `buildin/dicodai` — `ai-agent` preset preloaded with `dicode-task-dev` + `dicode-basics` skills.
-- MCP tools `validate_task`, `test_task`, `dry_run_task`, `commit_task`, `write_task_file`, `switch_dev_mode` — the agent's existing dev surface.
-- `pkg/secrets` AES master key — reused (via HKDF sub-key) for run-input encryption.
-- `temp-cleanup` cron pattern — replicated for run-input retention.
-- "Delegate I/O to a swappable task" pattern — same shape as the secret-provider design (§ runner-internal). Here it is exposed as a config field (`defaults.run_inputs.storage_task`, `params.pr_task`) pointing at any task that satisfies the contract, not as a `from: task:` env-injection prefix.
+- **`pkg/taskset.SetDevMode(enabled, opts)`** — dev-ref substitution + immediate registry re-sync. Used today for human dev workflow ([source.go:121-147](../../pkg/taskset/source.go#L121-L147)).
+- **`buildin/dicodai`** — a TaskSet `overrides:` entry defined in [`tasks/buildin/taskset.yaml:32-`](../../tasks/buildin/taskset.yaml#L32) that overrides `ai-agent` with the `dicode-task-dev` + `dicode-basics` skills preloaded.
+- **`pkg/secrets/local.go`** ChaCha20-Poly1305 + Argon2id — reused (with a per-purpose Argon2id salt) for run-input encryption. See § 4.1.
+- **`pkg/tasktest.Run`** — runs `task.test.{ts,js}` via `pkg/tasktest`. Wrapped by a new `dicode.tasks.test` SDK call.
+- **`pkg/source/git`** + go-git — used for clone/worktree/commit/push. Wrapped by a new `dicode.git.commit_push` SDK call. Honours dicode's "no git binary" constraint ([CLAUDE.md key constraints](../../CLAUDE.md)).
+- **`temp-cleanup` cron pattern** — replicated for both run-input retention and dev-worktree orphan cleanup.
+- **"Delegate I/O to a swappable task" pattern** — same shape as the secret-provider design (separately tracked). Here it is exposed as a config field (`defaults.run_inputs.storage_task`, `params.pr_task`) pointing at any task that satisfies the contract.
+
+### 3.3 What MCP is — and is not — used for here
+
+The buildin MCP task ([`tasks/buildin/mcp/task.ts`](../../tasks/buildin/mcp/task.ts)) is a JSON-RPC wrapper exposed to *external* MCP clients (Claude Code, Cursor). It currently exposes 6 tools, three of which are hints redirecting the client to the REST API (`list_sources`, `switch_dev_mode`, `test_task`).
+
+The auto-fix task is an *internal* dicode task running in the same Deno sandbox the MCP task does, with the same SDK surface available over the unix-socket IPC. It does **not** route through MCP. It calls the dicode SDK directly. The MCP-tool extensions documented in the `dicode-task-dev` skill (`write_task_file`, `validate_task`, `commit_task`, `dry_run_task`, `read_task_file`) are useful *for external agents*, are tracked as a separate child of epic #207, and are not a prerequisite for auto-fix.
 
 ## 4. Detailed design
 
 ### 4.1 Persisted run inputs
 
-**Schema delta on `runs` table** ([pkg/db/sqlite.go:69-76](../../pkg/db/sqlite.go#L69-L76)):
+#### 4.1.1 Schema delta on `runs` table
+
+[pkg/db/sqlite.go:69-76](../../pkg/db/sqlite.go#L69-L76):
 
 ```sql
 ALTER TABLE runs ADD COLUMN input_storage_key TEXT;        -- handle returned by storage task
-ALTER TABLE runs ADD COLUMN input_size INTEGER;            -- ciphertext size, for diagnostics + GC
-ALTER TABLE runs ADD COLUMN input_stored_at INTEGER;       -- unix seconds
-ALTER TABLE runs ADD COLUMN input_pinned INTEGER NOT NULL DEFAULT 0; -- 1 = in-flight auto-fix references this; do not GC
+ALTER TABLE runs ADD COLUMN input_size INTEGER;            -- ciphertext size
+ALTER TABLE runs ADD COLUMN input_stored_at INTEGER;       -- unix seconds, for retention
+ALTER TABLE runs ADD COLUMN input_pinned INTEGER NOT NULL DEFAULT 0; -- non-zero = referenced by in-flight auto-fix
+ALTER TABLE runs ADD COLUMN input_redacted_fields TEXT;    -- JSON array of dotted paths that were redacted
 ```
 
-No plaintext column. The storage task holds the only copy of the encrypted blob.
+This is the **first** use of `ALTER TABLE` in the dicode schema (today's migrations are all `CREATE TABLE IF NOT EXISTS` at init time). Implementation must:
 
-**Encryption.** AES-256-GCM. Key derived from `pkg/secrets` master key via HKDF with context string `"dicode/run-inputs/v1"`. Per-row 12-byte random nonce. On-disk blob layout:
+1. Use `ALTER TABLE … ADD COLUMN IF NOT EXISTS` (modernc/sqlite supports this in current versions; verify and fall back to `PRAGMA table_info` introspection if not).
+2. Run after the existing `CREATE TABLE IF NOT EXISTS` block in `migrate()`.
+3. Be idempotent so a downgrade-then-upgrade cycle works.
+
+This is documented as the introduction of dicode's first migration step. A real migration framework can wait until the second migration arrives.
+
+#### 4.1.2 Encryption
+
+**Cipher: XChaCha20-Poly1305** (matches `pkg/secrets/local.go` for consistency; we derive a separate key, not a separate cipher).
+
+**Key derivation:** Argon2id from the same master key the secrets store uses, but with a **purpose-specific salt** (`"dicode/run-inputs/v1"`) and the same Argon2id parameters as `pkg/secrets`. This means a leak of the secrets-store derived key does not reveal the run-inputs derived key (different salts → different outputs from Argon2id), and vice versa.
+
+**Nonce:** 24-byte random per row (XChaCha20-Poly1305 nonce size).
+
+**AEAD additional data:** `runID || ":" || input_stored_at_string`. Binds the ciphertext to its row identity — a copy-paste of the blob into a different row's storage key fails decryption.
+
+**On-disk blob layout** (handed to the storage task as base64):
 
 ```
-[12B nonce][N bytes ciphertext][16B GCM tag]
+[24B nonce][N bytes ciphertext][16B Poly1305 tag]
 ```
 
-**Write path.** When a run starts, the engine collects the structured input it would normally pass to the runtime:
+**Master key rotation** is out of scope here. When `pkg/secrets` adds rotation, the same mechanism extends naturally (re-derive both keys from the new master).
+
+#### 4.1.3 Redaction policy
+
+The engine assembles a structured `PersistedInput`:
 
 ```go
 type PersistedInput struct {
-    Source  string                 `json:"source"`  // webhook | cron | manual | chain | daemon
-    Headers map[string]string      `json:"headers,omitempty"` // webhook only, post-redaction
-    Body    json.RawMessage        `json:"body,omitempty"`    // webhook only, post-redaction
-    Query   map[string]string      `json:"query,omitempty"`   // webhook only
-    Params  map[string]any         `json:"params,omitempty"`  // manual / SDK / chain
+    Source      string                 `json:"source"`        // webhook | cron | manual | chain | daemon | replay
+    Method      string                 `json:"method,omitempty"`        // webhook only
+    Path        string                 `json:"path,omitempty"`          // webhook only
+    Headers     map[string]string      `json:"headers,omitempty"`       // webhook only, post-redaction
+    Query       map[string]string      `json:"query,omitempty"`         // webhook only, post-redaction
+    Body        json.RawMessage        `json:"body,omitempty"`          // webhook only, see body policy below
+    BodyKind    string                 `json:"body_kind,omitempty"`     // "json" | "form" | "binary" | "text" | "omitted"
+    BodyHash    string                 `json:"body_hash,omitempty"`     // sha256 hex; present when body is omitted/binary
+    Params      map[string]any         `json:"params,omitempty"`        // post-redaction (recursive)
+    RedactedFields []string            `json:"redacted_fields,omitempty"` // dotted paths that were redacted
 }
 ```
 
-Before encryption the engine walks the JSON and zeroes out values for keys matching a built-in deny-list (case-insensitive substring match):
+**Redaction is name-based, applied recursively to map keys.** A built-in deny-list (Go constant in `pkg/registry/inputs.go`) of case-insensitive matches:
 
 ```
 authorization, cookie, set-cookie,
-x-*-signature*, x-*-token*, x-*-key*, x-api-key,
-password, passphrase, api_key, apikey, token, secret
+x-hub-signature, x-hub-signature-256,
+x-dicode-signature, x-dicode-timestamp,
+x-slack-signature, x-line-signature,
+password, passphrase, api_key, apikey, api-key,
+secret, token, bearer
 ```
 
-The deny-list is a Go constant in `pkg/registry/inputs.go`. Users who need stricter redaction set `persist_inputs: false` per-task to disable persistence entirely. Users who need looser redaction must accept the deny-list as is — there is no allow-override in v1, on the grounds that an "allow this header that looks like a secret" knob is a footgun.
+Match rule: a field's name is redacted if it equals (case-insensitive) any item in the deny-list, or if it contains the substring `"signature"`, `"token"`, `"secret"`, `"password"`, or `"key"` after lowercasing. Substring matching catches `MY_SLACK_TOKEN` and `gh-secret-X`; over-redaction (e.g. a legitimate field named `tokens_per_minute`) is the safe failure mode.
 
-**Storage task contract** (3 ops, no `list`):
+**Per-bucket redaction:**
+
+- **Headers:** lowercase the header name, apply the match rule. Redacted values are replaced with `"<redacted>"`. Header names recorded in `RedactedFields` as `headers.<name>`.
+- **Query:** same rule. `RedactedFields` entries as `query.<name>`.
+- **Params:** recursive walk over `map[string]any` and nested maps; lists are walked positionally. `RedactedFields` entries as dotted paths (`params.user.token`, `params.items[3].secret`).
+- **Body:**
+  - `application/json` → walk like Params, store post-redaction as JSON.
+  - `application/x-www-form-urlencoded` → parse, treat as `map[string][]string`, walk, re-encode.
+  - `multipart/form-data` → store metadata (field names, file presence, sizes) but not values; `BodyKind = "omitted"`, `BodyHash` set.
+  - Any other content type (binary, plain text, XML, …) → `BodyKind = "binary"` or `"text"`, `BodyHash` set, body itself omitted unless `persist_inputs.body_full_textual: true` per-task. This is conservative-by-default.
+
+**Per-task / global controls:**
+
+```yaml
+# dicode.yaml
+defaults:
+  run_inputs:
+    enabled: true             # default true; set false to disable persistence globally
+    retention: 30d            # global default
+    storage_task: local-storage
+    body_full_textual: false  # default false; allow plain-text/XML body persistence
+
+# task.yaml — per-task overrides
+run_inputs:
+  enabled: false              # opt this task out
+  retention: 7d
+  body_full_textual: true     # this task's bodies are non-sensitive (e.g. internal cron heartbeats)
+```
+
+**Auto-fix-specific opt-out:** distinct from `run_inputs.enabled`, a task can persist input but withhold it from the auto-fix agent's prompt:
+
+```yaml
+# task.yaml
+auto_fix:
+  include_input: false  # input is persisted (replay still works for humans), but auto-fix sees only logs+output
+```
+
+#### 4.1.4 Storage task contract
+
+3 ops, no `list` (core tracks `runID → storage_key` in the `runs` table):
 
 ```yaml
 # tasks/buildin/local-storage/task.yaml — default backend
@@ -125,13 +212,15 @@ apiVersion: dicode/v1
 kind: Task
 name: "Local Storage (run inputs)"
 runtime: deno
+trigger:
+  manual: true              # only invoked by core via run_task
 params:
   op:    { type: string, required: true }   # put | get | delete
-  key:   { type: string, required: true }   # opaque, format chosen by core
+  key:   { type: string, required: true }
   value: { type: string, default: "" }      # base64(blob); put only
 permissions:
   fs:
-    - path: "${DICODE_DATA_DIR}/run-inputs"
+    - path: "${DATADIR}/run-inputs"
       permission: rw
 timeout: 30s
 notify:
@@ -139,40 +228,35 @@ notify:
   on_failure: true
 ```
 
-Returns `{ ok: true, value?: "<base64>" }` on success, `{ ok: false, error: "..." }` on failure. Core is responsible for retry on transient failure; storage task itself is stateless across calls.
+Returns `{ ok: true, value?: "<base64>" }` on success, `{ ok: false, error: "..." }` on failure. Core retries transient failures (network, S3 throttling); storage task itself is stateless.
 
-**Configuration:**
+Note: `${DATADIR}` is a new template var introduced as part of this work — exposes the daemon's data directory (the same one used by `pkg/db` for SQLite, by `pkg/source/git` for clones, etc.). Added to [pkg/task/template.go](../../pkg/task/template.go) alongside `TASK_DIR` / `HOME` / `TASK_SET_DIR`.
 
-```yaml
-# dicode.yaml
-defaults:
-  run_inputs:
-    enabled: true            # default: true; set false to disable persistence globally
-    retention: 30d           # global default; per-task override via task.yaml run_inputs.retention
-    storage_task: local-storage   # any task ID implementing the contract
-```
+#### 4.1.5 Read path
 
-Per-task override:
-
-```yaml
-# task.yaml
-run_inputs:
-  enabled: false             # opt this task out (e.g. tasks handling Stripe webhooks)
-  retention: 7d              # tighter retention than global
-```
-
-**Read path** (used by `replay_run` and the auto-fix agent's prompt builder):
+Used by `dicode.runs.replay`, the auto-fix driver's prompt builder (`dicode.runs.get_input`, internal-only), and the cleanup task.
 
 1. Look up `input_storage_key` for `runID` in `runs` table.
 2. Call configured storage task with `op: get, key: <stored_key>`.
-3. Base64-decode, split nonce/ciphertext/tag, AES-GCM decrypt.
-4. Return as structured `PersistedInput`.
+3. Base64-decode, split nonce/ciphertext/tag, XChaCha20-Poly1305 decrypt with AEAD-AD `runID || ":" || input_stored_at`.
+4. Return as structured `PersistedInput`. The decrypted struct includes `RedactedFields` so callers can surface the list.
 
-If the input has been GC'd or never stored, return a typed `ErrInputUnavailable`. Callers (the auto-fix agent and `replay_run`) must handle this gracefully — typically by aborting the loop with a clear message rather than retrying.
+If the input has been GC'd or never stored, return a typed `ErrInputUnavailable`. Callers must handle this gracefully — typically by aborting the loop with a clear message.
+
+#### 4.1.6 Pinning + crash-recovery
+
+`runs.input_pinned` is set when the auto-fix driver starts (it pins the failed run's input); cleared when the driver exits (success or failure). The driver MUST `defer cleanup()` to ensure unpinning on panic / context-cancel.
+
+If the engine crashes mid-fix, stale pins survive in the database. **Engine startup**:
+
+1. Mark all runs with `input_pinned = 1` whose `parent_run_id` IS NULL or whose triggering auto-fix run is no longer in `running` status as pinned-but-orphaned.
+2. Sweep: clear the pin so the next retention cycle can collect them.
+
+This is a single SQL update at startup, not a separate task.
 
 ### 4.2 Retention via cleanup task
 
-A new buildin, modeled exactly on [`buildin/temp-cleanup`](../../tasks/buildin/temp-cleanup/task.yaml):
+A new buildin, modeled on [`buildin/temp-cleanup`](../../tasks/buildin/temp-cleanup/task.yaml):
 
 ```yaml
 # tasks/buildin/run-inputs-cleanup/task.yaml
@@ -181,7 +265,7 @@ kind: Task
 name: "Run-input retention sweep"
 runtime: deno
 trigger:
-  cron: "17 * * * *"   # hourly, off the hour
+  cron: "17 * * * *"   # hourly
 permissions:
   dicode:
     runs_list_expired: true      # new SDK call
@@ -192,14 +276,44 @@ notify:
   on_failure: true
 ```
 
-Logic: `dicode.runs.list_expired({exclude_pinned: true})` returns runIDs whose `input_stored_at + retention < now`. For each, call `dicode.runs.delete_input(runID)` — core looks up the storage key, calls the configured storage task's `delete` op, clears the row's input columns. Pinned rows (referenced by an in-flight auto-fix run) are skipped; the auto-fix run is responsible for unpinning when it terminates.
+Logic: `dicode.runs.list_expired({ exclude_pinned: true })` returns runIDs whose `input_stored_at + retention < now`. For each, call `dicode.runs.delete_input(runID)` — core looks up the storage key, calls the configured storage task's `delete` op, clears the row's input columns. Pinned rows are skipped.
+
+A second cleanup buildin handles dev-mode worktrees (analogous and independent):
+
+```yaml
+# tasks/buildin/dev-worktrees-cleanup/task.yaml
+apiVersion: dicode/v1
+kind: Task
+name: "Dev-worktree orphan sweep"
+runtime: deno
+trigger:
+  cron: "*/15 * * * *"
+permissions:
+  fs:
+    - path: "${DATADIR}/dev-worktrees"
+      permission: rw
+  run: ["git"]   # only `git worktree prune/remove`; documented narrow purpose
+  dicode:
+    list_runs: true
+timeout: 60s
+notify:
+  on_failure: true
+```
+
+Logic: list directory entries under `${DATADIR}/dev-worktrees/<source>/<runID>`, cross-check against running auto-fix runs (`dicode.list_runs({ status: "running", task_id_prefix: "auto-fix" })`); any worktree dir whose `<runID>` is not in the running set is removed via `git worktree remove --force` + branch retained on disk.
+
+(`run: ["git"]` here is a deliberate narrow exception — only the cleanup task uses git binary, and only for worktree pruning. The auto-fix task itself uses `dicode.git.commit_push`, which goes through go-git in core. See § 4.6.4 for rationale.)
 
 ### 4.3 Replay primitive
 
-**SDK / MCP tool:**
+**SDK / REST:**
 
 ```ts
-replay_run(runID: string, task_name?: string): { run_id: string }
+// dicode SDK (internal use by tasks)
+dicode.runs.replay(runID: string, taskName?: string): Promise<{ run_id: string }>
+
+// REST mirror
+POST /api/runs/:id/replay  with { "task_name"?: "..." }
 ```
 
 Behavior:
@@ -207,12 +321,16 @@ Behavior:
 1. Resolve original run; require non-empty `input_storage_key`.
 2. Decrypt input via the read path.
 3. Resolve target task: `task_name` if provided, else original run's task.
-4. Fire as a *new* run with `parent_run_id = original.id`, `triggerSource = "replay"`. The new run's input is itself persisted (same retention rules) so a replay-of-a-replay works.
-5. Return the new run ID synchronously; the run executes asynchronously.
+4. Fire as a *new* run with `parent_run_id = original.id`, `triggerSource = "replay"`. The new run's input is itself persisted (same retention rules) — recursive replay works.
+5. **Replay-triggered runs do NOT fire `on_failure_chain` if they fail.** This prevents the agent's validation step from re-triggering itself. The engine checks `triggerSource == "replay"` in `FireChain` and skips chain firing.
+6. **Cooldown does NOT apply to replay.** The cooldown is on chain-firing, not on running the task. Replay is human/agent-initiated; if a user asks for a replay, they get one.
+7. Return the new run ID synchronously; the run executes asynchronously.
 
-`task_name` is the only knob and is optional. The branch is *not* a parameter — the live source's resolution (with or without dev mode) decides what code runs. This is intentional: replay always runs *the currently resolved version of the task*, which is exactly what the auto-fix loop wants (it has dev mode pointing at the fix worktree).
+`task_name` is optional and is the only knob. Branch is not a parameter — the live source's resolution decides what code runs (with or without dev mode).
 
-REST mirror: `POST /api/runs/:id/replay` with `{ "task_name": "..." }`.
+**Replay-fidelity limitation (documented, not solved in v1):** the input was redacted at store-time. Authorization headers, signatures, etc. are gone. A replay is therefore an *internal* invocation by the agent, not a faithful re-impersonation of the original sender. If the failing task's logic depends on the redacted fields (e.g., HMAC-validates the body), replay will not exercise that codepath — and worse, may *succeed* for the wrong reason. The auto-fix prompt explicitly surfaces `redacted_fields` so the agent can reason about the gap. Operators with sensitive auth flows should set `auto_fix.include_input: false` and let the agent work from logs+output only.
+
+MCP exposure: a `replay_run` MCP tool may be added later to the buildin MCP task for external agents. Out of scope here.
 
 ### 4.4 Dev mode with branch parameter
 
@@ -233,25 +351,40 @@ type DevModeOpts struct {
 Engine behavior when `enabled=true, Branch != ""`:
 
 1. Resolve the source's git URL (must be a git source; error if local-only).
-2. Compute worktree path: `<data_dir>/dev-worktrees/<source>/<branch>`.
-3. If worktree doesn't exist: `git worktree add <path> <branch>`. If branch doesn't exist on remote, create it from `Base` (default = the source's tracked branch).
+2. Compute worktree path: `${DATADIR}/dev-worktrees/<sourceName>/<branch-sanitized>/`.
+3. If worktree doesn't exist: use go-git to add a worktree on `<branch>`. If branch doesn't exist locally: create from `Base` (default = the source's tracked branch); if it doesn't exist remotely either, that's fine — push will create it.
 4. Set `s.devRootPath = <path>/<root entry yaml>`, `s.resolver.SetDevMode(true)`, trigger immediate sync.
 
 Engine behavior when `enabled=false` *and* the source was previously in worktree-mode:
 
 1. Disable dev-ref substitution (existing behavior).
-2. Run `git worktree prune` and `git worktree remove --force <path>` on the worktree dir.
-3. The branch ref itself is *retained* (commits made by the agent live on disk and on remote after push).
+2. Use go-git to remove the worktree.
+3. The branch ref itself is *retained* (commits made by the agent live on disk and are pushed to remote on the way out).
 
-Concurrency: at most one dev-mode-with-branch session per source at a time. A second `SetDevMode(enabled=true, Branch=...)` on a source that's already in worktree-mode returns `ErrDevModeBusy`. The auto-fix engine serialises via the per-task `max_concurrent` guard (§ 4.6).
+Concurrency: at most one dev-mode-with-branch session per source at a time. A second `SetDevMode(enabled=true, Branch=...)` on a source that's already in worktree-mode returns `ErrDevModeBusy`. Auto-fix engine serialises via the per-task `max_concurrent` guard (§ 4.7).
 
-REST mirror: `PATCH /sources/{name}/dev` body extended:
+Crash safety: see the `dev-worktrees-cleanup` buildin in § 4.2.
+
+**SDK exposure** (new):
+
+```ts
+dicode.sources.set_dev_mode(name: string, opts: {
+    enabled: boolean,
+    local_path?: string,
+    branch?: string,
+    base?: string,
+}): Promise<{ ok: true }>
+```
+
+Wraps the existing `SourceManager.SetDevMode` Go call, exposed via IPC. Authorisation: a task needs `permissions.dicode.sources_set_dev_mode: true` to call it (new permission flag).
+
+REST mirror: existing `PATCH /api/sources/{name}/dev` body extended:
 
 ```json
 { "enabled": true, "branch": "fix/abc-123", "base": "main" }
 ```
 
-MCP tool `switch_dev_mode` arguments extended likewise.
+MCP: existing `switch_dev_mode` tool's argument schema extends to accept `branch` + `base`.
 
 ### 4.5 Chain trigger with parameter passing
 
@@ -262,7 +395,7 @@ defaults:
   on_failure_chain:
     task: auto-fix
     params:
-      mode: review
+      mode: review            # review | autonomous (autonomous REJECTED here, see below)
       max_iterations: 5
 ```
 
@@ -278,6 +411,12 @@ on_failure_chain:
     mode: autonomous   # this task is non-critical, fix and ship without review
 ```
 
+**Config-load validation** (hard errors, not warnings):
+
+1. Reserved-key collision: if `params` contains any of `taskID`, `runID`, `status`, `output`, `_chain_depth`, **fail config load**. These keys are populated by the engine and cannot be user-overridden.
+2. **`mode: autonomous` at `defaults.on_failure_chain.params` is rejected** with a config-load error directing the user to opt in per-task. Rationale: a `defaults`-level `autonomous` silently applies to every new task added later, which is exactly the surprise the LP "guardrails built in" copy promises against. Per-task `on_failure_chain.params.mode: autonomous` is the only valid path.
+3. **Branch protection prerequisite** for autonomous mode: documented (not enforced) requirement that the source's tracked branch be branch-protected on the forge — the agent shouldn't be the only review for direct-to-main pushes. Doc'd in `dicode-task-dev.md` and the auto-fix README.
+
 Chain payload merge in [pkg/trigger/engine.go:670-677](../../pkg/trigger/engine.go#L670-L677):
 
 ```go
@@ -286,117 +425,150 @@ input := map[string]any{
     "runID":  runID,
     "status": runStatus,
     "output": output,
+    "_chain_depth": parentChainDepth + 1,
 }
 for k, v := range chain.Params {
-    if _, exists := input[k]; !exists {  // never overwrite the four reserved keys
-        input[k] = v
-    }
+    input[k] = v   // engine reserved keys are guaranteed by config-load validation
+                   // not to appear in chain.Params, so no collision possible at runtime
 }
 ```
-
-Reserved keys (`taskID`, `runID`, `status`, `output`) are not overridable by user params. A param named the same is silently ignored — and a validation step at config-load time emits a warning.
 
 The auto-fix task reads its `mode` (and other guardrails) from `params` like any normal task.
 
-Note on user composition: this lets users define **two `task.yaml` entries** that wrap `auto-fix` with different param defaults — same pattern as `tasks/examples/ai-agent-{openai,ollama,groq}`. Their `dicode.yaml` then references whichever wrapper they want as the chain target. The buildin ships the canonical `auto-fix` task; user-authored `auto-fix-strict`, `auto-fix-conservative`, etc. are taskset-level overrides.
+User composition: this lets users define **two `task.yaml` entries** that wrap `auto-fix` with different param defaults — same pattern as `tasks/examples/ai-agent-{openai,ollama,groq}`. Their `dicode.yaml` then references whichever wrapper they want.
 
 ### 4.6 Auto-fix task
 
-**File:** `tasks/buildin/auto-fix/task.yaml`. Preset of `buildin/dicodai`. Trigger is `chain` (no webhook).
+**Defined as a TaskSet override entry** in [`tasks/buildin/taskset.yaml`](../../tasks/buildin/taskset.yaml), mirroring the existing `dicodai` entry's shape (`ref:` → `./ai-agent/task.yaml`, with `overrides:` setting flat `params: key: value` defaults plus per-section overrides for `trigger`, `env`, `net`, `permissions`):
 
 ```yaml
-apiVersion: dicode/v1
-kind: Task
-name: "Auto-fix on failure"
-description: |
-  Diagnoses a failed task run, edits source on a worktree, validates via
-  task tests + replay, and either merges to main (autonomous) or opens a
-  PR (review). Wired by setting on_failure_chain to this task ID.
-extends: dicodai
-trigger:
-  chain:
-    on: failure                 # accepts taskID/runID/status/output + merged params
-params:
-  mode:
-    type: string
-    default: "review"           # review | autonomous
-  max_iterations:
-    type: number
-    default: 5
-  max_tokens:
-    type: number
-    default: 50000              # passed to the underlying ai-agent's response_max_tokens × budget
-  branch_prefix:
-    type: string
-    default: "fix/"
-  pr_task:
-    type: string
-    default: "git-pr"           # buildin task implementing the PR contract; replace for non-GitHub forges
-  base_branch:
-    type: string
-    default: ""                 # empty = source's tracked branch
-permissions:
-  dicode:
-    list_tasks: true
-    get_runs: true
-    runs_get_input: true
-    runs_replay: true
-    sources_set_dev_mode: true
-    tasks:
-      - "validate_task"
-      - "test_task"
-      - "dry_run_task"
-      - "commit_task"
-      - "write_task_file"
-      - "${param.pr_task}"      # the PR task is callable as a tool
-timeout: 1800s                  # 30 min hard cap
-notify:
-  on_success: true              # operator wants to know when an auto-fix lands
-  on_failure: true
+# tasks/buildin/taskset.yaml — additional entry (sketch — exact override syntax
+# follows the live dicodai entry; see lines 37-77 of taskset.yaml today)
+auto-fix:
+  ref:
+    path: ./ai-agent/task.yaml
+  overrides:
+    name: "Auto-fix on failure"
+    description: |
+      Diagnoses a failed task run, edits source on a worktree, validates via
+      task tests + replay, and either merges to main (autonomous) or opens a
+      PR (review). Fired by setting `on_failure_chain: auto-fix`.
+    trigger:
+      manual: true              # fired by on_failure_chain dispatcher, not user
+    params:
+      # Override ai-agent's existing params with auto-fix defaults:
+      skills: "dicode-task-dev,dicode-basics,dicode-auto-fix"
+      prompt: "(set from chain input by the auto-fix skill prompt)"
+      system_prompt: "(replaced by the dicode-auto-fix skill at load time)"
+      max_tool_iterations: 30   # higher than ai-agent's 10 — fix loops chatter more
+    timeout: 1800s
+    notify:
+      on_success: true
+      on_failure: true
+    # NEW SDK permission flags added in child issue (2):
+    permissions_dicode:
+      runs_replay: true
+      runs_get_input: true
+      runs_pin_input: true
+      runs_unpin_input: true
+      sources_set_dev_mode: true
+      tasks_test: true
+      git_commit_push: true
+      list_tasks: true
+      get_runs: true
+      tasks:
+        - git-pr                  # static literal; users override to point elsewhere
+    permissions_fs:
+      - path: "${DATADIR}/dev-worktrees"
+        permission: rw
 ```
 
-The task's `task.ts` is a small driver that:
+(Exact override merging semantics follow the existing `Resolver` in [pkg/taskset/resolver.go](../../pkg/taskset/resolver.go); implementation must verify whether overrides extend `permissions.dicode.{tasks,*flags}` and `permissions.fs` correctly, and add the merge if not. This is a small clarification, not a redesign.)
 
-1. Reads chain payload: `{ taskID, runID, status, output, mode, ... }`.
-2. Pins the failed run's input (`dicode.runs.pin_input(runID)`).
-3. Generates fix branch name: autonomous mode → `base_branch || sourceTrackedBranch`; review mode → `${branch_prefix}${runID}`.
-4. Calls `switch_dev_mode(source=<failed task's source>, enabled=true, branch=<fixBranch>, base=<base>)`.
-5. Builds the agent prompt:
-   - Failure context: task ID, run ID, status, exit code, last 200 log lines, persisted input (from `runs_get_input` — internal SDK only, not exposed as MCP tool).
-   - Source context: failing task's `task.yaml` and source files (read by the agent via `read_task_file` if it exists, else inlined into prompt).
-   - Instructions: follow the `dicode-task-dev` workflow, validate via `task.test.*` + `replay_run(runID)`, commit when both green.
-6. Invokes the underlying `dicodai` agent loop (this is the existing `ai-agent` machinery — no new code).
-7. Loop terminator conditions:
-   - **Success:** validate + test + dry_run + replay all green. Agent calls `commit_task`. Driver pushes worktree. If `mode == "review"`, driver invokes `pr_task` with branch + body. Driver disables dev mode.
-   - **Iteration cap:** `max_iterations` reached without success. Driver leaves the worktree branch on disk, opens a PR titled `[auto-fix WIP] runID=...` with a "needs human" body, disables dev mode.
-   - **Token budget:** same as iteration cap.
-   - **Hard error:** infrastructure error (decrypt fail, push fail, dev-mode error). Driver disables dev mode (cleanup), unpins input, exits with failure — which itself triggers `on_failure` notification but **not** another chain (chain depth check, § 4.7).
-8. Unpins the failed run's input on exit (success or failure).
+**Auto-fix-specific config** (`mode`, `max_iterations`, `max_iteration_seconds`, `max_tokens`, `branch_prefix`, `pr_task`, `base_branch`) does NOT live in `params:` declarations — it arrives via the **chain trigger params merge** described in § 4.5. The engine fires `auto-fix` with an input map of `{ taskID, runID, status, output, _chain_depth, mode, max_iterations, ... }`. The `dicode-auto-fix` skill prompt instructs the agent to read these from the input map.
+
+This avoids redeclaring schema in an override (which the current TaskSet override mechanism doesn't natively support — overrides set values for existing params, not new param shapes).
+
+The agent loop is implemented as a new buildin skill (`dicode-auto-fix`, a markdown file under `tasks/skills/`) loaded into the `ai-agent` system prompt via the override's `skills` param. The skill prescribes the workflow:
+
+1. Read failure context: `taskID`, `runID`, `status`, `output`, plus persisted input via `dicode.runs.get_input(runID)` (returns `{ input, redacted_fields }`). If `auto_fix.include_input: false` on the failing task, the agent gets only logs+output and is told the input is intentionally withheld.
+2. `dicode.runs.pin_input(runID)` — keep the input alive for the duration of the loop.
+3. `defer dicode.runs.unpin_input(runID)` semantics — the task's wrapper sets up cleanup that runs on success, failure, or timeout.
+4. Generate fix branch name (review: `${branch_prefix}${runID}`; autonomous: `base_branch || sourceTrackedBranch`).
+5. `dicode.sources.set_dev_mode(<source>, { enabled: true, branch: <fixBranch>, base: <base> })`.
+6. Iterate (capped at `max_iterations`, each iteration capped at `max_iteration_seconds`):
+   - Read failing task's source files via `Deno.readTextFile` from the worktree path.
+   - Edit via `Deno.writeTextFile` to the same worktree path. (Permissions: `fs.rw: ${DATADIR}/dev-worktrees`.) The agent's edit scope is enforced by the path it writes to — cross-task edits are explicitly out of scope and the loop's prompt forbids them.
+   - Validate by inline YAML/schema parse.
+   - Test via `dicode.tasks.test(<failingTaskID>)` (runs `task.test.{ts,js}` if present; if absent, the agent is instructed to write one as part of the fix).
+   - Replay via `dicode.runs.replay(<failedRunID>)`. Wait for the new run to finish; check status.
+   - If both green → exit loop.
+7. On success: `dicode.git.commit_push(<source>, <message>, branch=<fixBranch>)`. Engine validates the branch matches the `branch_prefix` allow-list (or is the source's tracked branch in autonomous mode), refuses force-push.
+8. If `mode == "review"`: invoke the PR task via `dicode.run_task(params.pr_task, { source_id, branch: fixBranch, base: base, title, body })`.
+9. `dicode.sources.set_dev_mode(<source>, { enabled: false })` — engine removes the worktree; branch retained.
+10. Unpin the failed run's input.
+
+Loop terminator conditions:
+
+- **Success:** as above.
+- **Iteration cap:** push the partial work to `${branch_prefix}wip-${runID}`, open a "needs human" PR, exit. (Review mode only; autonomous mode aborts without pushing partials to main.)
+- **Token budget:** same as iteration cap.
+- **Hard error:** infrastructure error (decrypt fail, push fail, dev-mode error). Driver disables dev mode, unpins, exits with failure.
+- **Timeout (1800s):** runtime kills the task; `defer` cleanup runs (unpins, attempts to disable dev mode).
+
+#### 4.6.1 Why no shell-out to `git`
+
+dicode's "no git binary" key constraint ([CLAUDE.md](../../CLAUDE.md)) says the daemon uses go-git for all git operations. The auto-fix task respects this by routing commit/push through a new `dicode.git.commit_push` SDK call that the Go core implements via go-git.
+
+The single deliberate exception is the `dev-worktrees-cleanup` task (§ 4.2), which uses `git worktree prune` because go-git's worktree support is more limited and cleanup is a sysadmin operation rather than user-facing. This is documented at the task and limited to that one task's permissions.
+
+#### 4.6.2 git_commit_push contract
+
+```ts
+dicode.git.commit_push(sourceID: string, opts: {
+    message: string,
+    branch?: string,        // default: source's currently-active dev mode branch (if any)
+    files?: string[],       // default: all tracked changes in the worktree
+    allow_main: boolean,    // default false; must be true for autonomous mode
+}): Promise<{ commit: string, pushed: boolean }>
+```
+
+Engine enforces:
+
+- The branch must match `${branch_prefix}*` patterns (read from per-task config) OR equal the source's tracked branch when `allow_main=true`.
+- Never `--force`. A diverged branch causes the call to error out; the driver's recovery is to abandon the loop with a structured error.
+- Push uses the source's existing auth (env-injected forge token, same as reconciler pulls).
 
 ### 4.7 Loop guardrails (engine-level)
 
 | Guard | Default | Where enforced | Override |
 |---|---|---|---|
-| Max fix iterations per run | `5` | auto-fix task driver | `params.max_iterations` |
-| LLM token budget per run | `50_000` | auto-fix task driver | `params.max_tokens` |
+| Max fix iterations per run | `5` | auto-fix driver | `params.max_iterations` |
+| Per-iteration timeout | `300s` | auto-fix driver | `params.max_iteration_seconds` |
+| LLM token budget per run | `50_000` | auto-fix driver | `params.max_tokens` |
 | Cooldown after auto-fix runs (per failing task) | `10m` | trigger engine | `defaults.on_failure_chain.cooldown`; per-task override |
 | Concurrent auto-fixes per failing task | `1` | trigger engine | `defaults.on_failure_chain.max_concurrent` |
 | Concurrent auto-fixes globally | `3` | trigger engine | `defaults.on_failure_chain.max_concurrent_global` |
-| Chain depth | max `2` | trigger engine — input carries `_chain_depth`, increments on each chain fire, refuse to fire if ≥ limit | `defaults.on_failure_chain.max_depth` |
-| Failure storm circuit breaker | trip if > `10` chain fires within `1m`; suppress for `30m`; emit notification | trigger engine | `defaults.on_failure_chain.storm.{rate, suppress}` |
+| Chain depth | max `2` | trigger engine; reserved key `_chain_depth` | `defaults.on_failure_chain.max_depth` |
+| Failure storm circuit breaker | trip if > `10` chain fires within `1m`; suppress for `30m`; emit notification | trigger engine, **scope = per-source** (failures in one user's source don't suppress another's) | `defaults.on_failure_chain.storm.{rate, suppress, scope}` |
+| Replay → `on_failure_chain` | suppressed (`triggerSource == "replay"` skips FireChain) | trigger engine | not configurable in v1 |
+| Cooldown → replay | not enforced (replay is human/agent-initiated) | trigger engine | not configurable in v1 |
+| Push refspec scoping | `${branch_prefix}*` allowlist + tracked branch when `allow_main=true` | git_commit_push | per-task `branch_prefix` |
 
-Cooldown semantics: if task X fails at T0 and auto-fix fires, a second failure of X at T0+5m does **not** fire auto-fix. The notification still fires per the existing `on_failure` flag. The cooldown's purpose is to prevent fix-loops where the auto-fix push triggers the same task and it fails again instantly.
+Cooldown semantics: if task X fails at T0 and auto-fix fires, a second failure of X at T0+5m does **not** fire auto-fix. The on-failure notification still fires per the existing `on_failure` flag.
 
-The chain-depth check is recorded on the chained run's persisted input (alongside the user params), so a chain of `A → auto-fix → A → auto-fix` is detected by the second auto-fix invocation, which sees `_chain_depth = 2` and refuses. Reserved key `_chain_depth` (underscore prefix) avoids user-param collision.
+Config-load warnings sink: zap log at WARN level + a `webui_warnings` table row (new, single-purpose) so the WebUI can surface "your config has X issues" on startup. Schema for that table is out of scope — TODO is filed; the warning content is logged for now.
 
-### 4.8 Git-PR task (review mode only)
+### 4.8 git-pr task (review mode)
 
 ```yaml
 # tasks/buildin/git-pr/task.yaml — reference implementation
 apiVersion: dicode/v1
 kind: Task
-name: "Open Pull Request"
+name: "Open Pull Request (GitHub)"
 runtime: deno
+trigger:
+  manual: true
 params:
   source_id: { type: string, required: true }
   branch:    { type: string, required: true }
@@ -404,70 +576,93 @@ params:
   title:     { type: string, required: true }
   body:      { type: string, default: "" }
 permissions:
-  run: ["gh"]                   # shells to gh CLI
+  run: ["gh"]
   env:
-    - GH_TOKEN
+    - name: GH_TOKEN
+      from: GH_TOKEN_AUTOFIX     # documented: provision a fine-grained PAT scoped
+                                  # to {contents:write, pull_requests:write} on the
+                                  # specific repo; do NOT reuse an admin token.
   fs:
-    - path: "${DICODE_DATA_DIR}/dev-worktrees"
-      permission: r              # read worktree path to resolve cwd
+    - path: "${DATADIR}/dev-worktrees"
+      permission: r
 timeout: 60s
 ```
 
 Returns `{ ok: true, url: "..." }` or `{ ok: false, error: "..." }`. Replaceable by users with their own task targeting GitLab/Gitea/Forgejo/Bitbucket.
 
+**Security note on `permissions.run: [gh]`:** the dicode `run` permission is binary-name-scoped, not subcommand-scoped. With `gh` allowed, the task can in principle invoke `gh repo delete`, `gh auth login`, `gh secret set`, etc. The defenses are layered:
+
+1. `GH_TOKEN_AUTOFIX` should be a fine-grained PAT — even if the agent prompts `gh repo delete`, the PAT lacks the scope.
+2. The agent's prompt does not include `gh` as a tool; only the `git-pr` task does. The agent invokes `git-pr` via `dicode.run_task("git-pr", ...)` — it cannot reach into git-pr's runtime.
+3. Documented in onboarding as a prerequisite: "auto-fix requires a scoped PAT, not your default `gh` auth".
+
+A future hardening (out of scope here): wrap `gh` invocation in a vendored shim that whitelists subcommands. Tracked under epic #207.
+
 ## 5. Data flow walkthrough — review mode
 
 A webhook task `process-payment` fails with a 500 from a downstream API.
 
-1. **t=0:** webhook arrives. Engine: persist input → AES-GCM blob → call `local-storage` task `op=put, key=run-inputs/<runID>` → store key + size + timestamp on the new run row.
+1. **t=0:** webhook arrives. Engine: build `PersistedInput` (with redaction applied to headers/query/body) → encrypt with XChaCha20-Poly1305 → call `local-storage` task `op=put, key=run-inputs/<runID>` → store `input_storage_key + size + stored_at + redacted_fields` on the new run row.
 2. **t=0+1s:** task runs, fails. `FireChain` checks `defaults.on_failure_chain` — set to `{ task: auto-fix, params: { mode: review } }`.
 3. Engine fires `auto-fix` with input `{ taskID: "process-payment", runID: "<id>", status: "failure", output: <500 body>, mode: "review", _chain_depth: 1 }`.
-4. **t=0+2s:** `auto-fix` driver pins input, picks branch `fix/<runID>`, calls `switch_dev_mode("user-tasks", enabled=true, branch="fix/<runID>", base="main")`.
-5. Engine: `git worktree add /var/lib/dicode/dev-worktrees/user-tasks/fix-<runID> fix/<runID>` (created from main since branch didn't exist), resolver swaps source root, registry reloads tasks from worktree.
-6. **t=0+5s:** driver builds prompt with failure context, hands off to `dicodai`. Agent reads logs, sees "500 from upstream", proposes adding a retry-with-backoff. Calls `write_task_file(process-payment/task.ts, ...)` which writes to the worktree.
-7. Agent calls `validate_task("process-payment")` — passes.
-8. Agent calls `test_task("process-payment")` — sees no test; writes `task.test.ts` with a regression test for the 500 case using a mocked fetch; reruns — passes.
-9. Agent calls `replay_run("<id>")` — engine decrypts the original webhook body, fires a new run on the worktree code, this time with retry — passes.
-10. Agent calls `commit_task("process-payment", "user-tasks")` — engine commits the `process-payment/` directory on the worktree branch and pushes `origin/fix/<runID>`.
-11. Driver invokes `pr_task` (`buildin/git-pr`) with `branch=fix/<runID>, base=main, title="auto-fix: process-payment retry on 5xx", body=<failure summary + change rationale>`. `gh pr create` returns URL.
-12. Driver calls `switch_dev_mode("user-tasks", enabled=false)`. Engine removes worktree, source resumes pulling main.
-13. Driver unpins the failed run's input, returns `{ ok: true, pr_url: "..." }`.
-14. Operator gets notification "auto-fix opened PR <url> for process-payment runID=...". Reviews and merges. Reconciler picks up the change on the next poll.
+4. **t=0+2s:** `auto-fix` driver pins input via `dicode.runs.pin_input("<id>")`, picks branch `fix/<runID>`, calls `dicode.sources.set_dev_mode("user-tasks", { enabled: true, branch: "fix/<runID>", base: "main" })`.
+5. Engine: go-git `Worktree.Checkout` on `${DATADIR}/dev-worktrees/user-tasks/fix-<runID>/` (created from main since branch didn't exist), resolver swaps source root, registry reloads tasks from worktree.
+6. **t=0+5s:** driver builds prompt with failure context (`{ logs, output, input, redacted_fields: ["headers.authorization", "headers.x-stripe-signature"] }`) plus reads task source via `Deno.readTextFile`. Hands off to the underlying `ai-agent` runtime. Agent reads logs, sees "500 from upstream", proposes adding a retry-with-backoff. Calls `Deno.writeTextFile` to the worktree's `process-payment/task.ts`.
+7. Agent calls `dicode.tasks.test("process-payment")` — sees no test; writes `task.test.ts` with a regression test for the 500 case using a mocked fetch; reruns — passes.
+8. Agent calls `dicode.runs.replay("<id>")` — engine decrypts the original webhook body (sans Stripe signature), fires a new run on the worktree code with retry. The replay run does NOT fire `on_failure_chain` (we suppressed it for `triggerSource == "replay"`). Replay run passes (no auth check exercised because of redaction; agent was warned via `redacted_fields`).
+9. Agent calls `dicode.git.commit_push("user-tasks", { message: "auto-fix: process-payment retry on 5xx", branch: "fix/<runID>" })`. Engine validates `fix/<runID>` matches `${branch_prefix}*`, runs go-git `Add` + `Commit` + `Push` (no `--force`).
+10. Driver invokes the PR task via `dicode.run_task("git-pr", { source_id, branch: "fix/<runID>", base: "main", title, body })`. `gh pr create` returns URL.
+11. Driver calls `dicode.sources.set_dev_mode("user-tasks", { enabled: false })`. Engine removes worktree, source resumes pulling main.
+12. Driver unpins via `dicode.runs.unpin_input("<id>")`, returns `{ ok: true, pr_url: "..." }`.
+13. Operator gets notification "auto-fix opened PR <url> for process-payment runID=...". Reviews, sees the PR mentions "redacted_fields contained Stripe signature — please verify the retry logic doesn't bypass signature validation" in the auto-generated body. Reviews carefully and merges. Reconciler picks up the change on the next poll.
 
 ## 6. Decomposition into child issues
 
-Filed under epic [#207](https://github.com/dicode-ayo/dicode-core/issues/207):
+Filed under epic [#207](https://github.com/dicode-ayo/dicode-core/issues/207); tracked from [#228](https://github.com/dicode-ayo/dicode-core/issues/228):
 
-1. **Run-input persistence + storage task contract** — schema, encryption, deny-list redaction, `local-storage` buildin, retention sweep buildin. SDK additions: `runs.list_expired`, `runs.delete_input`, `runs.pin_input`, `runs.unpin_input`, `runs.get_input` (internal).
-2. **Replay primitive** — `replay_run(runID, task_name?)` IPC + REST + MCP. Depends on (1).
-3. **Dev mode with branch + chain params** — extend `SetDevMode` to support `Branch` + worktree lifecycle; extend `on_failure_chain` to accept structured `{ task, params }` form. Independent of (1) and (2).
-4. **Auto-fix buildin + git-pr buildin + guardrails** — the agent driver, the PR helper, the engine-side guardrails (cooldown, concurrency, chain depth, storm circuit breaker). Depends on (1), (2), (3).
+1. **Run-input persistence + storage task contract + retention sweep** — schema delta with first-`ALTER TABLE` migration step, XChaCha20-Poly1305 + Argon2id (purpose-specific salt), redaction policy with explicit per-bucket rules, `local-storage` buildin, `run-inputs-cleanup` buildin, the new `${DATADIR}` template var, startup-time stale-pin sweep. SDK additions: `runs.list_expired`, `runs.delete_input`, `runs.pin_input`, `runs.unpin_input`, `runs.get_input` (internal-only).
 
-Each child issue is independently mergeable: (1) ships persistence with no consumers; (2) ships replay usable from the WebUI; (3) ships dev-mode-on-a-branch usable by humans; (4) finally wires the loop. Recommend shipping in this order so v0.2.0 can include (1)+(2)+(3) and the auto-fix loop arrives in v0.3.0 once each foundation block is hardened.
+2. **Auto-fix SDK surface** — `dicode.runs.replay`, `dicode.tasks.test`, `dicode.sources.set_dev_mode` (with branch+base support), `dicode.git.commit_push` (go-git, refspec scoping, no `--force`). REST mirrors. Permissions for each (`runs_replay`, `tasks_test`, `sources_set_dev_mode`, `git_commit_push`). Depends on (1) for replay's input read.
+
+3. **Dev mode `branch` lifecycle + `on_failure_chain` parameter passing** — `SetDevMode` opts struct with `Branch`/`Base`, go-git worktree create/remove, dev-worktrees-cleanup buildin, `on_failure_chain` structured form with reserved-key + autonomous-at-defaults config-load errors. Independent of (1) and (2) — usable by humans without auto-fix.
+
+4. **Auto-fix taskset override + git-pr buildin + engine guardrails + auto-fix skill** — add `auto-fix` to `tasks/buildin/taskset.yaml` as a `dicodai` override, `git-pr` reference impl, the engine-side guardrails (cooldown, concurrency, chain depth, storm circuit breaker, replay→chain suppression, push refspec scoping), the `dicode-auto-fix` skill markdown. Depends on (1), (2), (3).
+
+Each child issue is independently mergeable: (1) ships persistence with no consumers; (2) ships replay+SDK surfaces usable from any task and from REST; (3) ships dev-mode-on-a-branch usable by humans; (4) finally wires the loop.
+
+Recommend shipping in this order so v0.2.0 can include (1)+(2)+(3) — replay-from-WebUI is itself a useful debugging tool — and the auto-fix loop arrives in v0.3.0 once each foundation block is hardened.
 
 ## 7. Open questions / explicitly deferred
 
 - **Auto-revert on monitoring signals from a successful deploy.** The LP "When AI is wrong" copy implies that a *successful* deploy that subsequently breaks production is also auto-fixed. v1 covers the on-failure path only; revert-on-regression is a follow-up under the same epic.
-- **Multi-task fixes.** v1 restricts the agent to writing inside the failed task's directory. A failure rooted in a *dependency* task is detectable by the agent (it can read other tasks' source) but the fix would have to be outside its write scope. v1 punts this with a clear error from `write_task_file` if the path escapes the failing task's dir.
-- **Forge auth UX.** `git-pr` ships with `GH_TOKEN` env. A first-launch onboarding step that prompts for the GH token (similar to the OpenAI key prompt) is desirable but out of scope here.
-- **WebUI surfacing.** The fix worktree's branch and the in-flight auto-fix's progress should appear in the WebUI runs view. Concrete UI design is deferred to a follow-up site/webui PR.
+- **Multi-task fixes.** v1 restricts the agent to writing inside the failed task's directory. A failure rooted in a *dependency* task is detectable by the agent (it can read other tasks' source) but the fix would have to be outside its write scope. v1 punts this with a clear error from the prompt and the worktree's path-scoped permissions.
+- **Forge auth UX.** `git-pr` ships with `GH_TOKEN_AUTOFIX` env. A first-launch onboarding step that prompts for a fine-grained PAT (similar to the OpenAI key prompt) is desirable but out of scope here.
+- **WebUI surfacing.** The fix worktree's branch and the in-flight auto-fix's progress should appear in the WebUI runs view. Concrete UI design is deferred.
 - **Cost telemetry.** Token spend per auto-fix should be aggregated and surfaced. Deferred — first ship the loop, then add accounting.
+- **Subcommand-scoped `gh` shim.** Wrapping `gh` invocation to whitelist `pr create` / `pr view` / `pr list` only. Hardening, not v1.
+- **MCP-tool extensions** (`write_task_file`, `validate_task`, `commit_task`, `dry_run_task`, `read_task_file`) for external agents. Tracked separately under epic #207.
+- **Migration framework.** This spec's `ALTER TABLE` is dicode's first schema migration. A real migration framework (versioned, ordered, tested) can wait until the second migration arrives.
 
 ## 8. Security considerations
 
-- Run-input encryption uses an HKDF sub-key, so a leak of the run-input key does not compromise the secrets table's key (and vice versa).
-- Header redaction is deny-list only. A user storing webhook bodies that themselves carry credentials in non-standard fields (e.g. JSON `{"my_secret": ...}`) gets no redaction — the deny-list scans key names, not value entropy. Documented as a limitation; users with sensitive payloads set `persist_inputs: false`.
-- The agent runs with `dicode.list_tasks` and access to a curated tool list. It cannot escalate to filesystem or network access beyond what its underlying `dicodai` task already has. The fix worktree is sandboxed by the runtime's existing permission model.
-- Autonomous mode pushes directly to the source's tracked branch. Users opting in (`mode: autonomous`) accept that an LLM can land code on main without human review. The default in the buildin's `task.yaml` is `review`, so the only path to autonomous is explicit user opt-in via `params.mode`.
-- The `git-pr` task uses `permissions.run: [gh]`, which is a deliberate widening of the runtime's default deny-all `run` policy. Documented in the task description.
+- Run-input encryption uses an Argon2id sub-key with a purpose-specific salt, so a leak of one derived key does not compromise the other.
+- AEAD additional data binds each ciphertext to its `runID + stored_at`. Splicing across rows fails decryption.
+- Header/query/body redaction is name-based deny-list with substring matching on `signature`, `token`, `secret`, `password`, `key`. Over-redaction is the safe failure mode. Users with sensitive non-standard field names set `auto_fix.include_input: false` per task.
+- Multipart and binary bodies are stored as `BodyKind + BodyHash`, not contents.
+- The agent runs with a curated SDK permission set (`runs_replay`, `tasks_test`, `git_commit_push`, etc.). It cannot escalate to filesystem or network access beyond what the override declares. Worktree path-scoping prevents cross-task edits.
+- **Autonomous mode requires per-task opt-in.** A `defaults.on_failure_chain.params.mode: autonomous` is a config-load error. Users must explicitly opt each task in by setting `on_failure_chain.params.mode: autonomous` in that task's `task.yaml`. Documented in onboarding: pair with branch protection on the source's tracked branch — the agent should never be the only review for direct-to-main pushes.
+- `git-pr` uses `permissions.run: [gh]`. Rationale + threat model documented in § 4.8. Recommend a fine-grained PAT.
+- `dev-worktrees-cleanup` uses `permissions.run: [git]` for `git worktree prune` only. Documented narrow exception to the "no git binary" constraint, isolated to one task.
+- Replay-fidelity: a replay validates against post-redaction input, not the original sender's request. The agent prompt explicitly surfaces `redacted_fields`. PRs include a "redacted fields were [...]" line in their body so reviewers can sanity-check the agent's reasoning.
+- Stale pin recovery on engine startup prevents indefinite `input_pinned = 1` lingering from a crashed driver.
 
 ## 9. Landing-page mapping
 
 | LP claim | Spec section |
 |---|---|
 | "API down → AI diagnoses → auto-fix deployed" | § 5 (full walkthrough) |
-| "Every step is a git commit you can review" | § 4.6 step 7 (commit_task push), § 4.8 (PR step) |
-| "Require review before deploy, or run fully autonomous" | § 4.6 `params.mode` |
+| "Every step is a git commit you can review" | § 4.6 step 7, § 4.8 |
+| "Require review before deploy, or run fully autonomous" | § 4.6 `params.mode`; § 4.5 autonomous-at-defaults guard; § 8 prerequisites |
 | "Auto-revert on failure" | Deferred — § 7 |
-| "When AI is wrong → the monitor catches it → git revert is one command away" | § 4.6 step 7c (iteration cap → WIP PR with "needs human" body); revert deferred § 7 |
+| "When AI is wrong → the monitor catches it → git revert is one command away" | Partial — § 4.6 iteration-cap WIP-PR fallback; revert deferred § 7 |
 | "Continuous loop — create, validate, deploy, monitor, **fix**" | This spec covers the *fix* arc; the rest already exist. |

--- a/docs/superpowers/specs/2026-04-28-on-failure-auto-fix-loop-design.md
+++ b/docs/superpowers/specs/2026-04-28-on-failure-auto-fix-loop-design.md
@@ -1,0 +1,473 @@
+# On-failure auto-fix loop — design
+
+**Status:** draft, awaiting review
+**Owner:** TBD
+**Epic:** [#207 — landing-page promises](https://github.com/dicode-ayo/dicode-core/issues/207)
+
+## 1. Why
+
+The dicode landing page advertises a continuous AI loop — *create, validate, deploy, monitor, **fix*** — with the headline scenario *"API down → AI diagnoses → auto-fix deployed"* and the guardrail dial *"Require review before deploy, or run fully autonomous."* Today none of the fix-side machinery exists end-to-end:
+
+- An `on_failure_chain` mechanism fires a target task on failure, but the chained task only sees the failed run's `output`. It cannot see the original input that triggered the failure, the source code that produced the failure, or the run logs.
+- Run inputs are not persisted (the `runs` table has no `input` column). A failed webhook payload is gone after the run ends, so no agent can replay it once a fix is proposed.
+- `commit_task` and dev-mode workflow tools exist for *humans* iterating in the WebUI dev panel, but they are not wired to a chain trigger and there is no headless agent loop that replicates the dev workflow on a failure.
+
+This spec closes those gaps with the smallest set of additions, reusing existing primitives (dev mode, MCP dev tools, `buildin/dicodai`, the `temp-cleanup` cron pattern, the `from: task:` extensibility shape used for secret providers).
+
+## 2. Scope
+
+In scope:
+
+1. Persisted, encrypted run inputs with parameterizable retention and pluggable storage.
+2. Replay primitive that re-fires a failed run with its persisted input.
+3. Dev mode extension that lets the engine clone-and-checkout a worktree on a named branch, so an agent can iterate in isolation without touching the production source.
+4. Chain trigger that can pass parameters to the chained task.
+5. A buildin `auto-fix` task (preset of `buildin/dicodai`) that consumes the failure context, iterates fix → validate → push, and either merges to main (autonomous) or opens a PR (review).
+6. Loop guardrails: per-failure iteration cap, token budget, cooldown, concurrency cap, depth limit, failure-storm circuit breaker.
+
+Out of scope (deferred):
+
+- Multi-task fixes (agent edits a dependency task, not the failing task itself). v1 limits the agent to writing inside the failed task's directory.
+- Forge integrations beyond GitHub. The PR step is implemented as a buildin `git-pr` task using the `gh` CLI; users replace it with their own task to support GitLab/Gitea/Forgejo.
+- Auto-revert on monitoring signals from a *successful* deploy (the LP "When AI is wrong" copy). v1 covers the on-failure path only; revert is a follow-up.
+
+## 3. Architecture
+
+### 3.1 Component map
+
+```
+┌─────────────────┐  failure   ┌────────────────────┐
+│  trigger engine │──────────▶│ on_failure_chain    │
+│  (pkg/trigger)  │            │ (params merge)     │
+└────────┬────────┘            └─────────┬──────────┘
+         │ persist input                 │ fires
+         ▼                               ▼
+┌─────────────────┐            ┌────────────────────┐
+│ run-input store │            │ buildin/auto-fix    │
+│  (AES-GCM core, │            │ (dicodai preset)   │
+│   storage task) │            │                    │
+└────────┬────────┘            │  uses MCP tools:   │
+         ▲                     │   switch_dev_mode  │
+         │ replay              │   write_task_file  │
+         │                     │   validate_task    │
+         │                     │   test_task        │
+         │                     │   dry_run_task     │
+         │                     │   replay_run       │
+         │                     │   commit_task      │
+         │                     │  uses task tools:  │
+         │                     │   buildin/git-pr   │
+         │                     └────────────────────┘
+         │
+┌────────┴────────┐
+│ run-inputs-     │  cron     ┌────────────────────┐
+│ cleanup task    │──────────▶│ storage task        │
+│ (buildin)       │  delete   │  put | get | delete │
+└─────────────────┘            └────────────────────┘
+```
+
+### 3.2 Existing primitives reused (not in scope to change)
+
+- `pkg/taskset.SetDevMode(enabled, opts)` — dev-ref substitution + immediate registry re-sync. Used today for human dev workflow.
+- `buildin/dicodai` — `ai-agent` preset preloaded with `dicode-task-dev` + `dicode-basics` skills.
+- MCP tools `validate_task`, `test_task`, `dry_run_task`, `commit_task`, `write_task_file`, `switch_dev_mode` — the agent's existing dev surface.
+- `pkg/secrets` AES master key — reused (via HKDF sub-key) for run-input encryption.
+- `temp-cleanup` cron pattern — replicated for run-input retention.
+- "Delegate I/O to a swappable task" pattern — same shape as the secret-provider design (§ runner-internal). Here it is exposed as a config field (`defaults.run_inputs.storage_task`, `params.pr_task`) pointing at any task that satisfies the contract, not as a `from: task:` env-injection prefix.
+
+## 4. Detailed design
+
+### 4.1 Persisted run inputs
+
+**Schema delta on `runs` table** ([pkg/db/sqlite.go:69-76](../../pkg/db/sqlite.go#L69-L76)):
+
+```sql
+ALTER TABLE runs ADD COLUMN input_storage_key TEXT;        -- handle returned by storage task
+ALTER TABLE runs ADD COLUMN input_size INTEGER;            -- ciphertext size, for diagnostics + GC
+ALTER TABLE runs ADD COLUMN input_stored_at INTEGER;       -- unix seconds
+ALTER TABLE runs ADD COLUMN input_pinned INTEGER NOT NULL DEFAULT 0; -- 1 = in-flight auto-fix references this; do not GC
+```
+
+No plaintext column. The storage task holds the only copy of the encrypted blob.
+
+**Encryption.** AES-256-GCM. Key derived from `pkg/secrets` master key via HKDF with context string `"dicode/run-inputs/v1"`. Per-row 12-byte random nonce. On-disk blob layout:
+
+```
+[12B nonce][N bytes ciphertext][16B GCM tag]
+```
+
+**Write path.** When a run starts, the engine collects the structured input it would normally pass to the runtime:
+
+```go
+type PersistedInput struct {
+    Source  string                 `json:"source"`  // webhook | cron | manual | chain | daemon
+    Headers map[string]string      `json:"headers,omitempty"` // webhook only, post-redaction
+    Body    json.RawMessage        `json:"body,omitempty"`    // webhook only, post-redaction
+    Query   map[string]string      `json:"query,omitempty"`   // webhook only
+    Params  map[string]any         `json:"params,omitempty"`  // manual / SDK / chain
+}
+```
+
+Before encryption the engine walks the JSON and zeroes out values for keys matching a built-in deny-list (case-insensitive substring match):
+
+```
+authorization, cookie, set-cookie,
+x-*-signature*, x-*-token*, x-*-key*, x-api-key,
+password, passphrase, api_key, apikey, token, secret
+```
+
+The deny-list is a Go constant in `pkg/registry/inputs.go`. Users who need stricter redaction set `persist_inputs: false` per-task to disable persistence entirely. Users who need looser redaction must accept the deny-list as is — there is no allow-override in v1, on the grounds that an "allow this header that looks like a secret" knob is a footgun.
+
+**Storage task contract** (3 ops, no `list`):
+
+```yaml
+# tasks/buildin/local-storage/task.yaml — default backend
+apiVersion: dicode/v1
+kind: Task
+name: "Local Storage (run inputs)"
+runtime: deno
+params:
+  op:    { type: string, required: true }   # put | get | delete
+  key:   { type: string, required: true }   # opaque, format chosen by core
+  value: { type: string, default: "" }      # base64(blob); put only
+permissions:
+  fs:
+    - path: "${DICODE_DATA_DIR}/run-inputs"
+      permission: rw
+timeout: 30s
+notify:
+  on_success: false
+  on_failure: true
+```
+
+Returns `{ ok: true, value?: "<base64>" }` on success, `{ ok: false, error: "..." }` on failure. Core is responsible for retry on transient failure; storage task itself is stateless across calls.
+
+**Configuration:**
+
+```yaml
+# dicode.yaml
+defaults:
+  run_inputs:
+    enabled: true            # default: true; set false to disable persistence globally
+    retention: 30d           # global default; per-task override via task.yaml run_inputs.retention
+    storage_task: local-storage   # any task ID implementing the contract
+```
+
+Per-task override:
+
+```yaml
+# task.yaml
+run_inputs:
+  enabled: false             # opt this task out (e.g. tasks handling Stripe webhooks)
+  retention: 7d              # tighter retention than global
+```
+
+**Read path** (used by `replay_run` and the auto-fix agent's prompt builder):
+
+1. Look up `input_storage_key` for `runID` in `runs` table.
+2. Call configured storage task with `op: get, key: <stored_key>`.
+3. Base64-decode, split nonce/ciphertext/tag, AES-GCM decrypt.
+4. Return as structured `PersistedInput`.
+
+If the input has been GC'd or never stored, return a typed `ErrInputUnavailable`. Callers (the auto-fix agent and `replay_run`) must handle this gracefully — typically by aborting the loop with a clear message rather than retrying.
+
+### 4.2 Retention via cleanup task
+
+A new buildin, modeled exactly on [`buildin/temp-cleanup`](../../tasks/buildin/temp-cleanup/task.yaml):
+
+```yaml
+# tasks/buildin/run-inputs-cleanup/task.yaml
+apiVersion: dicode/v1
+kind: Task
+name: "Run-input retention sweep"
+runtime: deno
+trigger:
+  cron: "17 * * * *"   # hourly, off the hour
+permissions:
+  dicode:
+    runs_list_expired: true      # new SDK call
+    runs_delete_input: true      # new SDK call
+timeout: 120s
+notify:
+  on_success: false
+  on_failure: true
+```
+
+Logic: `dicode.runs.list_expired({exclude_pinned: true})` returns runIDs whose `input_stored_at + retention < now`. For each, call `dicode.runs.delete_input(runID)` — core looks up the storage key, calls the configured storage task's `delete` op, clears the row's input columns. Pinned rows (referenced by an in-flight auto-fix run) are skipped; the auto-fix run is responsible for unpinning when it terminates.
+
+### 4.3 Replay primitive
+
+**SDK / MCP tool:**
+
+```ts
+replay_run(runID: string, task_name?: string): { run_id: string }
+```
+
+Behavior:
+
+1. Resolve original run; require non-empty `input_storage_key`.
+2. Decrypt input via the read path.
+3. Resolve target task: `task_name` if provided, else original run's task.
+4. Fire as a *new* run with `parent_run_id = original.id`, `triggerSource = "replay"`. The new run's input is itself persisted (same retention rules) so a replay-of-a-replay works.
+5. Return the new run ID synchronously; the run executes asynchronously.
+
+`task_name` is the only knob and is optional. The branch is *not* a parameter — the live source's resolution (with or without dev mode) decides what code runs. This is intentional: replay always runs *the currently resolved version of the task*, which is exactly what the auto-fix loop wants (it has dev mode pointing at the fix worktree).
+
+REST mirror: `POST /api/runs/:id/replay` with `{ "task_name": "..." }`.
+
+### 4.4 Dev mode with branch parameter
+
+Today: `Source.SetDevMode(ctx, enabled bool, localPath string)` ([pkg/taskset/source.go:124](../../pkg/taskset/source.go#L124)).
+
+Extended:
+
+```go
+func (s *Source) SetDevMode(ctx context.Context, enabled bool, opts DevModeOpts) error
+
+type DevModeOpts struct {
+    LocalPath string  // existing: point at user's local checkout
+    Branch    string  // new: engine clones a worktree on this branch
+    Base      string  // new: branch to fork from when Branch doesn't exist (default: source's tracked branch)
+}
+```
+
+Engine behavior when `enabled=true, Branch != ""`:
+
+1. Resolve the source's git URL (must be a git source; error if local-only).
+2. Compute worktree path: `<data_dir>/dev-worktrees/<source>/<branch>`.
+3. If worktree doesn't exist: `git worktree add <path> <branch>`. If branch doesn't exist on remote, create it from `Base` (default = the source's tracked branch).
+4. Set `s.devRootPath = <path>/<root entry yaml>`, `s.resolver.SetDevMode(true)`, trigger immediate sync.
+
+Engine behavior when `enabled=false` *and* the source was previously in worktree-mode:
+
+1. Disable dev-ref substitution (existing behavior).
+2. Run `git worktree prune` and `git worktree remove --force <path>` on the worktree dir.
+3. The branch ref itself is *retained* (commits made by the agent live on disk and on remote after push).
+
+Concurrency: at most one dev-mode-with-branch session per source at a time. A second `SetDevMode(enabled=true, Branch=...)` on a source that's already in worktree-mode returns `ErrDevModeBusy`. The auto-fix engine serialises via the per-task `max_concurrent` guard (§ 4.6).
+
+REST mirror: `PATCH /sources/{name}/dev` body extended:
+
+```json
+{ "enabled": true, "branch": "fix/abc-123", "base": "main" }
+```
+
+MCP tool `switch_dev_mode` arguments extended likewise.
+
+### 4.5 Chain trigger with parameter passing
+
+Today `defaults.on_failure_chain` is a string (task ID). Extended to accept a structured form:
+
+```yaml
+defaults:
+  on_failure_chain:
+    task: auto-fix
+    params:
+      mode: review
+      max_iterations: 5
+```
+
+Backwards-compatibility: bare string remains valid, equivalent to `{ task: <string>, params: {} }`.
+
+Same shape on per-task override:
+
+```yaml
+# task.yaml
+on_failure_chain:
+  task: auto-fix
+  params:
+    mode: autonomous   # this task is non-critical, fix and ship without review
+```
+
+Chain payload merge in [pkg/trigger/engine.go:670-677](../../pkg/trigger/engine.go#L670-L677):
+
+```go
+input := map[string]any{
+    "taskID": completedTaskID,
+    "runID":  runID,
+    "status": runStatus,
+    "output": output,
+}
+for k, v := range chain.Params {
+    if _, exists := input[k]; !exists {  // never overwrite the four reserved keys
+        input[k] = v
+    }
+}
+```
+
+Reserved keys (`taskID`, `runID`, `status`, `output`) are not overridable by user params. A param named the same is silently ignored — and a validation step at config-load time emits a warning.
+
+The auto-fix task reads its `mode` (and other guardrails) from `params` like any normal task.
+
+Note on user composition: this lets users define **two `task.yaml` entries** that wrap `auto-fix` with different param defaults — same pattern as `tasks/examples/ai-agent-{openai,ollama,groq}`. Their `dicode.yaml` then references whichever wrapper they want as the chain target. The buildin ships the canonical `auto-fix` task; user-authored `auto-fix-strict`, `auto-fix-conservative`, etc. are taskset-level overrides.
+
+### 4.6 Auto-fix task
+
+**File:** `tasks/buildin/auto-fix/task.yaml`. Preset of `buildin/dicodai`. Trigger is `chain` (no webhook).
+
+```yaml
+apiVersion: dicode/v1
+kind: Task
+name: "Auto-fix on failure"
+description: |
+  Diagnoses a failed task run, edits source on a worktree, validates via
+  task tests + replay, and either merges to main (autonomous) or opens a
+  PR (review). Wired by setting on_failure_chain to this task ID.
+extends: dicodai
+trigger:
+  chain:
+    on: failure                 # accepts taskID/runID/status/output + merged params
+params:
+  mode:
+    type: string
+    default: "review"           # review | autonomous
+  max_iterations:
+    type: number
+    default: 5
+  max_tokens:
+    type: number
+    default: 50000              # passed to the underlying ai-agent's response_max_tokens × budget
+  branch_prefix:
+    type: string
+    default: "fix/"
+  pr_task:
+    type: string
+    default: "git-pr"           # buildin task implementing the PR contract; replace for non-GitHub forges
+  base_branch:
+    type: string
+    default: ""                 # empty = source's tracked branch
+permissions:
+  dicode:
+    list_tasks: true
+    get_runs: true
+    runs_get_input: true
+    runs_replay: true
+    sources_set_dev_mode: true
+    tasks:
+      - "validate_task"
+      - "test_task"
+      - "dry_run_task"
+      - "commit_task"
+      - "write_task_file"
+      - "${param.pr_task}"      # the PR task is callable as a tool
+timeout: 1800s                  # 30 min hard cap
+notify:
+  on_success: true              # operator wants to know when an auto-fix lands
+  on_failure: true
+```
+
+The task's `task.ts` is a small driver that:
+
+1. Reads chain payload: `{ taskID, runID, status, output, mode, ... }`.
+2. Pins the failed run's input (`dicode.runs.pin_input(runID)`).
+3. Generates fix branch name: autonomous mode → `base_branch || sourceTrackedBranch`; review mode → `${branch_prefix}${runID}`.
+4. Calls `switch_dev_mode(source=<failed task's source>, enabled=true, branch=<fixBranch>, base=<base>)`.
+5. Builds the agent prompt:
+   - Failure context: task ID, run ID, status, exit code, last 200 log lines, persisted input (from `runs_get_input` — internal SDK only, not exposed as MCP tool).
+   - Source context: failing task's `task.yaml` and source files (read by the agent via `read_task_file` if it exists, else inlined into prompt).
+   - Instructions: follow the `dicode-task-dev` workflow, validate via `task.test.*` + `replay_run(runID)`, commit when both green.
+6. Invokes the underlying `dicodai` agent loop (this is the existing `ai-agent` machinery — no new code).
+7. Loop terminator conditions:
+   - **Success:** validate + test + dry_run + replay all green. Agent calls `commit_task`. Driver pushes worktree. If `mode == "review"`, driver invokes `pr_task` with branch + body. Driver disables dev mode.
+   - **Iteration cap:** `max_iterations` reached without success. Driver leaves the worktree branch on disk, opens a PR titled `[auto-fix WIP] runID=...` with a "needs human" body, disables dev mode.
+   - **Token budget:** same as iteration cap.
+   - **Hard error:** infrastructure error (decrypt fail, push fail, dev-mode error). Driver disables dev mode (cleanup), unpins input, exits with failure — which itself triggers `on_failure` notification but **not** another chain (chain depth check, § 4.7).
+8. Unpins the failed run's input on exit (success or failure).
+
+### 4.7 Loop guardrails (engine-level)
+
+| Guard | Default | Where enforced | Override |
+|---|---|---|---|
+| Max fix iterations per run | `5` | auto-fix task driver | `params.max_iterations` |
+| LLM token budget per run | `50_000` | auto-fix task driver | `params.max_tokens` |
+| Cooldown after auto-fix runs (per failing task) | `10m` | trigger engine | `defaults.on_failure_chain.cooldown`; per-task override |
+| Concurrent auto-fixes per failing task | `1` | trigger engine | `defaults.on_failure_chain.max_concurrent` |
+| Concurrent auto-fixes globally | `3` | trigger engine | `defaults.on_failure_chain.max_concurrent_global` |
+| Chain depth | max `2` | trigger engine — input carries `_chain_depth`, increments on each chain fire, refuse to fire if ≥ limit | `defaults.on_failure_chain.max_depth` |
+| Failure storm circuit breaker | trip if > `10` chain fires within `1m`; suppress for `30m`; emit notification | trigger engine | `defaults.on_failure_chain.storm.{rate, suppress}` |
+
+Cooldown semantics: if task X fails at T0 and auto-fix fires, a second failure of X at T0+5m does **not** fire auto-fix. The notification still fires per the existing `on_failure` flag. The cooldown's purpose is to prevent fix-loops where the auto-fix push triggers the same task and it fails again instantly.
+
+The chain-depth check is recorded on the chained run's persisted input (alongside the user params), so a chain of `A → auto-fix → A → auto-fix` is detected by the second auto-fix invocation, which sees `_chain_depth = 2` and refuses. Reserved key `_chain_depth` (underscore prefix) avoids user-param collision.
+
+### 4.8 Git-PR task (review mode only)
+
+```yaml
+# tasks/buildin/git-pr/task.yaml — reference implementation
+apiVersion: dicode/v1
+kind: Task
+name: "Open Pull Request"
+runtime: deno
+params:
+  source_id: { type: string, required: true }
+  branch:    { type: string, required: true }
+  base:      { type: string, default: "main" }
+  title:     { type: string, required: true }
+  body:      { type: string, default: "" }
+permissions:
+  run: ["gh"]                   # shells to gh CLI
+  env:
+    - GH_TOKEN
+  fs:
+    - path: "${DICODE_DATA_DIR}/dev-worktrees"
+      permission: r              # read worktree path to resolve cwd
+timeout: 60s
+```
+
+Returns `{ ok: true, url: "..." }` or `{ ok: false, error: "..." }`. Replaceable by users with their own task targeting GitLab/Gitea/Forgejo/Bitbucket.
+
+## 5. Data flow walkthrough — review mode
+
+A webhook task `process-payment` fails with a 500 from a downstream API.
+
+1. **t=0:** webhook arrives. Engine: persist input → AES-GCM blob → call `local-storage` task `op=put, key=run-inputs/<runID>` → store key + size + timestamp on the new run row.
+2. **t=0+1s:** task runs, fails. `FireChain` checks `defaults.on_failure_chain` — set to `{ task: auto-fix, params: { mode: review } }`.
+3. Engine fires `auto-fix` with input `{ taskID: "process-payment", runID: "<id>", status: "failure", output: <500 body>, mode: "review", _chain_depth: 1 }`.
+4. **t=0+2s:** `auto-fix` driver pins input, picks branch `fix/<runID>`, calls `switch_dev_mode("user-tasks", enabled=true, branch="fix/<runID>", base="main")`.
+5. Engine: `git worktree add /var/lib/dicode/dev-worktrees/user-tasks/fix-<runID> fix/<runID>` (created from main since branch didn't exist), resolver swaps source root, registry reloads tasks from worktree.
+6. **t=0+5s:** driver builds prompt with failure context, hands off to `dicodai`. Agent reads logs, sees "500 from upstream", proposes adding a retry-with-backoff. Calls `write_task_file(process-payment/task.ts, ...)` which writes to the worktree.
+7. Agent calls `validate_task("process-payment")` — passes.
+8. Agent calls `test_task("process-payment")` — sees no test; writes `task.test.ts` with a regression test for the 500 case using a mocked fetch; reruns — passes.
+9. Agent calls `replay_run("<id>")` — engine decrypts the original webhook body, fires a new run on the worktree code, this time with retry — passes.
+10. Agent calls `commit_task("process-payment", "user-tasks")` — engine commits the `process-payment/` directory on the worktree branch and pushes `origin/fix/<runID>`.
+11. Driver invokes `pr_task` (`buildin/git-pr`) with `branch=fix/<runID>, base=main, title="auto-fix: process-payment retry on 5xx", body=<failure summary + change rationale>`. `gh pr create` returns URL.
+12. Driver calls `switch_dev_mode("user-tasks", enabled=false)`. Engine removes worktree, source resumes pulling main.
+13. Driver unpins the failed run's input, returns `{ ok: true, pr_url: "..." }`.
+14. Operator gets notification "auto-fix opened PR <url> for process-payment runID=...". Reviews and merges. Reconciler picks up the change on the next poll.
+
+## 6. Decomposition into child issues
+
+Filed under epic [#207](https://github.com/dicode-ayo/dicode-core/issues/207):
+
+1. **Run-input persistence + storage task contract** — schema, encryption, deny-list redaction, `local-storage` buildin, retention sweep buildin. SDK additions: `runs.list_expired`, `runs.delete_input`, `runs.pin_input`, `runs.unpin_input`, `runs.get_input` (internal).
+2. **Replay primitive** — `replay_run(runID, task_name?)` IPC + REST + MCP. Depends on (1).
+3. **Dev mode with branch + chain params** — extend `SetDevMode` to support `Branch` + worktree lifecycle; extend `on_failure_chain` to accept structured `{ task, params }` form. Independent of (1) and (2).
+4. **Auto-fix buildin + git-pr buildin + guardrails** — the agent driver, the PR helper, the engine-side guardrails (cooldown, concurrency, chain depth, storm circuit breaker). Depends on (1), (2), (3).
+
+Each child issue is independently mergeable: (1) ships persistence with no consumers; (2) ships replay usable from the WebUI; (3) ships dev-mode-on-a-branch usable by humans; (4) finally wires the loop. Recommend shipping in this order so v0.2.0 can include (1)+(2)+(3) and the auto-fix loop arrives in v0.3.0 once each foundation block is hardened.
+
+## 7. Open questions / explicitly deferred
+
+- **Auto-revert on monitoring signals from a successful deploy.** The LP "When AI is wrong" copy implies that a *successful* deploy that subsequently breaks production is also auto-fixed. v1 covers the on-failure path only; revert-on-regression is a follow-up under the same epic.
+- **Multi-task fixes.** v1 restricts the agent to writing inside the failed task's directory. A failure rooted in a *dependency* task is detectable by the agent (it can read other tasks' source) but the fix would have to be outside its write scope. v1 punts this with a clear error from `write_task_file` if the path escapes the failing task's dir.
+- **Forge auth UX.** `git-pr` ships with `GH_TOKEN` env. A first-launch onboarding step that prompts for the GH token (similar to the OpenAI key prompt) is desirable but out of scope here.
+- **WebUI surfacing.** The fix worktree's branch and the in-flight auto-fix's progress should appear in the WebUI runs view. Concrete UI design is deferred to a follow-up site/webui PR.
+- **Cost telemetry.** Token spend per auto-fix should be aggregated and surfaced. Deferred — first ship the loop, then add accounting.
+
+## 8. Security considerations
+
+- Run-input encryption uses an HKDF sub-key, so a leak of the run-input key does not compromise the secrets table's key (and vice versa).
+- Header redaction is deny-list only. A user storing webhook bodies that themselves carry credentials in non-standard fields (e.g. JSON `{"my_secret": ...}`) gets no redaction — the deny-list scans key names, not value entropy. Documented as a limitation; users with sensitive payloads set `persist_inputs: false`.
+- The agent runs with `dicode.list_tasks` and access to a curated tool list. It cannot escalate to filesystem or network access beyond what its underlying `dicodai` task already has. The fix worktree is sandboxed by the runtime's existing permission model.
+- Autonomous mode pushes directly to the source's tracked branch. Users opting in (`mode: autonomous`) accept that an LLM can land code on main without human review. The default in the buildin's `task.yaml` is `review`, so the only path to autonomous is explicit user opt-in via `params.mode`.
+- The `git-pr` task uses `permissions.run: [gh]`, which is a deliberate widening of the runtime's default deny-all `run` policy. Documented in the task description.
+
+## 9. Landing-page mapping
+
+| LP claim | Spec section |
+|---|---|
+| "API down → AI diagnoses → auto-fix deployed" | § 5 (full walkthrough) |
+| "Every step is a git commit you can review" | § 4.6 step 7 (commit_task push), § 4.8 (PR step) |
+| "Require review before deploy, or run fully autonomous" | § 4.6 `params.mode` |
+| "Auto-revert on failure" | Deferred — § 7 |
+| "When AI is wrong → the monitor catches it → git revert is one command away" | § 4.6 step 7c (iteration cap → WIP PR with "needs human" body); revert deferred § 7 |
+| "Continuous loop — create, validate, deploy, monitor, **fix**" | This spec covers the *fix* arc; the rest already exist. |

--- a/docs/superpowers/specs/2026-04-28-on-failure-auto-fix-loop-design.md
+++ b/docs/superpowers/specs/2026-04-28-on-failure-auto-fix-loop-design.md
@@ -21,7 +21,7 @@ In scope:
 
 1. Persisted, encrypted run inputs with parameterizable retention and pluggable storage.
 2. Replay primitive that re-fires a failed run with its persisted input.
-3. Dev mode extension that lets the engine clone-and-checkout a worktree on a named branch.
+3. Dev mode extension that lets the engine clone the source on a named branch into a fresh per-fix directory.
 4. Chain trigger that can pass parameters to the chained task.
 5. SDK additions exposing what auto-fix needs over the unix-socket IPC: `tasks.test`, `sources.set_dev_mode`, `git.commit_push`, plus the run-input plumbing (replay, get_input, list_expired, delete_input, pin/unpin).
 6. A buildin `auto-fix` taskset entry (override of `buildin/dicodai`) that consumes the failure context, iterates fix → validate → push, and either merges to main (autonomous) or opens a PR (review).
@@ -69,10 +69,10 @@ Out of scope (deferred):
 └─────────────────┘
 
 ┌────────────────────┐
-│ dev-worktrees-     │  cron, mirrors temp-cleanup
-│ cleanup task       │  removes orphan worktrees
-│ (buildin)          │  whose runID is no longer
-└────────────────────┘  pinned in `runs`
+│ dev-clones-cleanup │  cron, mirrors temp-cleanup
+│ task (buildin)     │  rm -rf orphan clone dirs
+│                    │  whose runID is no longer
+└────────────────────┘  in the running set
 ```
 
 ### 3.2 Existing primitives reused (not in scope to change)
@@ -81,8 +81,8 @@ Out of scope (deferred):
 - **`buildin/dicodai`** — a TaskSet `overrides:` entry defined in [`tasks/buildin/taskset.yaml:32-`](../../tasks/buildin/taskset.yaml#L32) that overrides `ai-agent` with the `dicode-task-dev` + `dicode-basics` skills preloaded.
 - **`pkg/secrets/local.go`** ChaCha20-Poly1305 + Argon2id — reused (with a per-purpose Argon2id salt) for run-input encryption. See § 4.1.
 - **`pkg/tasktest.Run`** — runs `task.test.{ts,js}` via `pkg/tasktest`. Wrapped by a new `dicode.tasks.test` SDK call.
-- **`pkg/source/git`** + go-git — used for clone/worktree/commit/push. Wrapped by a new `dicode.git.commit_push` SDK call. Honours dicode's "no git binary" constraint ([CLAUDE.md key constraints](../../CLAUDE.md)).
-- **`temp-cleanup` cron pattern** — replicated for both run-input retention and dev-worktree orphan cleanup.
+- **`pkg/source/git`** + go-git — used for clone, commit, push. **Worktrees (`git worktree add`) are NOT used** — go-git v5.18 (`go.mod:13`) does not implement them. Each fix gets its own fresh clone instead (see § 4.4). Pure go-git, no `git` binary anywhere. Honours dicode's "no git binary" constraint ([CLAUDE.md key constraints](../../CLAUDE.md)).
+- **`temp-cleanup` cron pattern** — replicated for both run-input retention and dev-clone orphan cleanup.
 - **"Delegate I/O to a swappable task" pattern** — same shape as the secret-provider design (separately tracked). Here it is exposed as a config field (`defaults.run_inputs.storage_task`, `params.pr_task`) pointing at any task that satisfies the contract.
 
 ### 3.3 What MCP is — and is not — used for here
@@ -123,7 +123,9 @@ This is documented as the introduction of dicode's first migration step. A real 
 
 **Nonce:** 24-byte random per row (XChaCha20-Poly1305 nonce size).
 
-**AEAD additional data:** `runID || ":" || input_stored_at_string`. Binds the ciphertext to its row identity — a copy-paste of the blob into a different row's storage key fails decryption.
+**AEAD additional data (AAD):** fixed-width binary concat — `runID_uuid_bytes (16B) || input_stored_at (8B big-endian uint64)`. No string separator (avoids ambiguity if a runID ever contains `:`). Binds the ciphertext to its row identity — a copy-paste of the blob into a different row's storage key fails decryption.
+
+`input_stored_at` is **write-once**: the engine sets it on the initial `INSERT` of the row's input columns and never updates it post-store. If a re-store is somehow needed (e.g. backfill), the new ciphertext must be re-encrypted with the new AAD.
 
 **On-disk blob layout** (handed to the storage task as base64):
 
@@ -139,16 +141,25 @@ The engine assembles a structured `PersistedInput`:
 
 ```go
 type PersistedInput struct {
-    Source      string                 `json:"source"`        // webhook | cron | manual | chain | daemon | replay
+    Source      string                 `json:"source"`                  // webhook | cron | manual | chain | daemon | replay
     Method      string                 `json:"method,omitempty"`        // webhook only
     Path        string                 `json:"path,omitempty"`          // webhook only
-    Headers     map[string]string      `json:"headers,omitempty"`       // webhook only, post-redaction
-    Query       map[string]string      `json:"query,omitempty"`         // webhook only, post-redaction
+    Headers     map[string][]string    `json:"headers,omitempty"`       // webhook; multi-valued for HTTP fidelity; post-redaction
+    Query       map[string][]string    `json:"query,omitempty"`         // webhook; same shape; post-redaction
     Body        json.RawMessage        `json:"body,omitempty"`          // webhook only, see body policy below
-    BodyKind    string                 `json:"body_kind,omitempty"`     // "json" | "form" | "binary" | "text" | "omitted"
-    BodyHash    string                 `json:"body_hash,omitempty"`     // sha256 hex; present when body is omitted/binary
+    BodyKind    string                 `json:"body_kind,omitempty"`     // "json" | "form" | "multipart" | "binary" | "text" | "omitted"
+    BodyHash    string                 `json:"body_hash,omitempty"`     // sha256 hex; present when body is omitted/binary/multipart
+    BodyParts   []PartMeta             `json:"body_parts,omitempty"`    // multipart: per-part metadata (no values)
     Params      map[string]any         `json:"params,omitempty"`        // post-redaction (recursive)
     RedactedFields []string            `json:"redacted_fields,omitempty"` // dotted paths that were redacted
+}
+
+type PartMeta struct {
+    Name        string `json:"name"`                   // form-field name; redacted to "<redacted>" if name matches deny-list
+    Kind        string `json:"kind"`                   // "field" | "file"
+    Filename    string `json:"filename,omitempty"`     // file parts only; redacted via filename rules
+    ContentType string `json:"content_type,omitempty"`
+    Size        int64  `json:"size"`
 }
 ```
 
@@ -167,14 +178,16 @@ Match rule: a field's name is redacted if it equals (case-insensitive) any item 
 
 **Per-bucket redaction:**
 
-- **Headers:** lowercase the header name, apply the match rule. Redacted values are replaced with `"<redacted>"`. Header names recorded in `RedactedFields` as `headers.<name>`.
-- **Query:** same rule. `RedactedFields` entries as `query.<name>`.
+- **Headers** (`map[string][]string`): lowercase the header name, apply the match rule. *Every value* in the slice is replaced with `"<redacted>"` if the name matches (single-valued substitution preserves length information without leaking content). Header names recorded in `RedactedFields` as `headers.<name>`.
+- **Query** (`map[string][]string`): same rule. `RedactedFields` entries as `query.<name>`.
 - **Params:** recursive walk over `map[string]any` and nested maps; lists are walked positionally. `RedactedFields` entries as dotted paths (`params.user.token`, `params.items[3].secret`).
-- **Body:**
-  - `application/json` → walk like Params, store post-redaction as JSON.
-  - `application/x-www-form-urlencoded` → parse, treat as `map[string][]string`, walk, re-encode.
-  - `multipart/form-data` → store metadata (field names, file presence, sizes) but not values; `BodyKind = "omitted"`, `BodyHash` set.
-  - Any other content type (binary, plain text, XML, …) → `BodyKind = "binary"` or `"text"`, `BodyHash` set, body itself omitted unless `persist_inputs.body_full_textual: true` per-task. This is conservative-by-default.
+- **Body** (content-type-driven):
+  - `application/json` → walk like Params, store post-redaction as JSON. `BodyKind = "json"`.
+  - `application/x-www-form-urlencoded` → parse, treat as `map[string][]string`, walk, re-encode. `BodyKind = "form"`.
+  - `multipart/form-data` → walk parts; store `BodyParts[]` with name/kind/filename/content-type/size only; **values are not persisted**. `BodyKind = "multipart"`, `BodyHash` set on the raw body for forensic comparison if needed.
+  - Any other content type (binary, plain text, XML, …) → `BodyKind = "binary"` or `"text"`, `BodyHash` set, body itself omitted **by default**.
+
+**`body_full_textual: true` foot-gun warning:** setting this on a task makes the engine persist the verbatim text body (XML, plain-text, etc.) WITHOUT redaction — name-based redaction can't reach unstructured content. Tasks setting this option are explicitly accepting that the body may contain credentials. Documented in §8 and surfaced as a warning at config load (`auto_fix.body_full_textual: true` AND `run_inputs.enabled: true` triggers a startup WARN log: *"task X persists raw textual bodies — confirm this is intentional"*). Best practice: pair with `auto_fix.include_input: false` so the auto-fix agent's prompt doesn't see the raw body either.
 
 **Per-task / global controls:**
 
@@ -199,8 +212,11 @@ run_inputs:
 ```yaml
 # task.yaml
 auto_fix:
-  include_input: false  # input is persisted (replay still works for humans), but auto-fix sees only logs+output
+  include_input: false             # input is persisted (replay still works for humans), but auto-fix sees only logs+output
+  show_redacted_field_names: true  # default true; set false to also withhold the *names* of redacted fields
 ```
+
+The `show_redacted_field_names` knob handles the edge case where field names are themselves sensitive (e.g., a header named `X-CustomerId-Token-Foo` reveals the existence of a customer-specific token endpoint). Default is `true` because in most cases knowing what was redacted helps the agent reason about the failure without giving up secret values. Set to `false` for tasks where the field topology itself is private; the agent then sees a redaction *count* but not *names*.
 
 #### 4.1.4 Storage task contract
 
@@ -278,21 +294,20 @@ notify:
 
 Logic: `dicode.runs.list_expired({ exclude_pinned: true })` returns runIDs whose `input_stored_at + retention < now`. For each, call `dicode.runs.delete_input(runID)` — core looks up the storage key, calls the configured storage task's `delete` op, clears the row's input columns. Pinned rows are skipped.
 
-A second cleanup buildin handles dev-mode worktrees (analogous and independent):
+A second cleanup buildin handles dev-mode clones (analogous and independent):
 
 ```yaml
-# tasks/buildin/dev-worktrees-cleanup/task.yaml
+# tasks/buildin/dev-clones-cleanup/task.yaml
 apiVersion: dicode/v1
 kind: Task
-name: "Dev-worktree orphan sweep"
+name: "Dev-clone orphan sweep"
 runtime: deno
 trigger:
   cron: "*/15 * * * *"
 permissions:
   fs:
-    - path: "${DATADIR}/dev-worktrees"
+    - path: "${DATADIR}/dev-clones"
       permission: rw
-  run: ["git"]   # only `git worktree prune/remove`; documented narrow purpose
   dicode:
     list_runs: true
 timeout: 60s
@@ -300,9 +315,9 @@ notify:
   on_failure: true
 ```
 
-Logic: list directory entries under `${DATADIR}/dev-worktrees/<source>/<runID>`, cross-check against running auto-fix runs (`dicode.list_runs({ status: "running", task_id_prefix: "auto-fix" })`); any worktree dir whose `<runID>` is not in the running set is removed via `git worktree remove --force` + branch retained on disk.
+Logic: list directory entries under `${DATADIR}/dev-clones/<source>/<runID>`, cross-check against running auto-fix runs (`dicode.list_runs({ status: "running", task_id_prefix: "auto-fix" })`); any clone dir whose `<runID>` is not in the running set is removed via Deno's `Deno.remove(path, { recursive: true })`. **No `git` binary involved** — clones are plain directories from the daemon's perspective and `rm -rf` (via Deno fs APIs) is sufficient. The dicode "no git binary" constraint holds throughout.
 
-(`run: ["git"]` here is a deliberate narrow exception — only the cleanup task uses git binary, and only for worktree pruning. The auto-fix task itself uses `dicode.git.commit_push`, which goes through go-git in core. See § 4.6.4 for rationale.)
+The branches the cleanup task removes are *local-only* clone directories. Remote branches are not touched — the auto-fix flow already pushed them (or chose not to), and remote branch lifecycle is the user's responsibility (PR merge → delete branch, or manual cleanup).
 
 ### 4.3 Replay primitive
 
@@ -343,27 +358,31 @@ func (s *Source) SetDevMode(ctx context.Context, enabled bool, opts DevModeOpts)
 
 type DevModeOpts struct {
     LocalPath string  // existing: point at user's local checkout
-    Branch    string  // new: engine clones a worktree on this branch
+    Branch    string  // new: engine creates a fresh clone on this branch
     Base      string  // new: branch to fork from when Branch doesn't exist (default: source's tracked branch)
+    RunID     string  // new: tag the clone dir with the auto-fix run ID, used for cleanup
 }
 ```
+
+**Why a fresh clone, not a `git worktree`:** go-git v5 does not implement `git worktree add` (`Worktree.Add` stages files — it's the `git add` semantics). Per-fix fresh clones keep dicode pure-go-git with zero dependency on a `git` binary. Disk cost is acceptable: fix branches are short-lived and the dev-clones-cleanup task (§ 4.2) sweeps them.
 
 Engine behavior when `enabled=true, Branch != ""`:
 
 1. Resolve the source's git URL (must be a git source; error if local-only).
-2. Compute worktree path: `${DATADIR}/dev-worktrees/<sourceName>/<branch-sanitized>/`.
-3. If worktree doesn't exist: use go-git to add a worktree on `<branch>`. If branch doesn't exist locally: create from `Base` (default = the source's tracked branch); if it doesn't exist remotely either, that's fine — push will create it.
-4. Set `s.devRootPath = <path>/<root entry yaml>`, `s.resolver.SetDevMode(true)`, trigger immediate sync.
+2. **Validate the branch name** (see § 4.6.3): must satisfy `git check-ref-format`, must start with the configured `branch_prefix` literal (no glob/regex), must not contain `..`, leading `-`, control chars, or `~`/`^`/`:`/`?`/`*`/`[`/`\`. Reject invalid names with `ErrInvalidBranchName`.
+3. Compute clone path: `${DATADIR}/dev-clones/<sourceName>/<RunID>/`. The directory name is the run ID (UUID, sanitized by construction), NOT the branch name — so traversal-style branch names cannot escape the data dir even if validation is bypassed.
+4. `go-git Clone` the repo into the path with `CheckoutBranch: <Branch>`. If the branch doesn't exist remotely, clone the source's tracked branch and create `<Branch>` locally from `Base` (default = source's tracked branch). Push will create the remote branch on the way out.
+5. Set `s.devRootPath = <clonePath>/<root entry yaml>`, `s.resolver.SetDevMode(true)`, trigger immediate sync.
 
-Engine behavior when `enabled=false` *and* the source was previously in worktree-mode:
+Engine behavior when `enabled=false` *and* the source was previously in clone-mode:
 
 1. Disable dev-ref substitution (existing behavior).
-2. Use go-git to remove the worktree.
-3. The branch ref itself is *retained* (commits made by the agent live on disk and are pushed to remote on the way out).
+2. `Deno.remove(clonePath, { recursive: true })` (or Go-side `os.RemoveAll`).
+3. The branch ref on the *remote* is retained if it was pushed; this is what makes review-mode PRs work.
 
-Concurrency: at most one dev-mode-with-branch session per source at a time. A second `SetDevMode(enabled=true, Branch=...)` on a source that's already in worktree-mode returns `ErrDevModeBusy`. Auto-fix engine serialises via the per-task `max_concurrent` guard (§ 4.7).
+Concurrency: at most one dev-mode-with-branch session per source at a time. A second `SetDevMode(enabled=true, Branch=...)` on a source that's already in clone-mode returns `ErrDevModeBusy`. Auto-fix engine serialises via the per-task `max_concurrent` guard (§ 4.7).
 
-Crash safety: see the `dev-worktrees-cleanup` buildin in § 4.2.
+Crash safety: see the `dev-clones-cleanup` buildin in § 4.2.
 
 **SDK exposure** (new):
 
@@ -400,6 +419,14 @@ defaults:
 ```
 
 Backwards-compatibility: bare string remains valid, equivalent to `{ task: <string>, params: {} }`.
+
+**Merge semantics:** per-task `on_failure_chain` **fully replaces** `defaults.on_failure_chain` (no deep-merge). If a task wants the global default with one tweak, it must restate the full block. This is the same shape every other override in dicode uses (e.g., `notify`) and avoids the surprise where a per-task `params: { mode: autonomous }` silently inherits an unrelated default's `params: { max_iterations: 10 }`.
+
+**Validation order at config-load:**
+
+1. Parse the config.
+2. For every task, if `on_failure_chain` is set, validate its `params` against the reserved-key list and the autonomous-at-defaults rule. Validation errors here fail the entire config load (the daemon refuses to start) — same severity as a syntax error.
+3. Resolve the chain target: the named task must exist after the resolver completes, OR the config-load reports a structured error. Today the resolver runs after config parsing; this introduces a second config-validation pass once tasks are resolved.
 
 Same shape on per-task override:
 
@@ -450,9 +477,9 @@ auto-fix:
   overrides:
     name: "Auto-fix on failure"
     description: |
-      Diagnoses a failed task run, edits source on a worktree, validates via
-      task tests + replay, and either merges to main (autonomous) or opens a
-      PR (review). Fired by setting `on_failure_chain: auto-fix`.
+      Diagnoses a failed task run, edits source in a per-fix clone, validates
+      via task tests + replay, and either merges to main (autonomous) or
+      opens a PR (review). Fired by setting `on_failure_chain: auto-fix`.
     trigger:
       manual: true              # fired by on_failure_chain dispatcher, not user
     params:
@@ -479,11 +506,17 @@ auto-fix:
       tasks:
         - git-pr                  # static literal; users override to point elsewhere
     permissions_fs:
-      - path: "${DATADIR}/dev-worktrees"
+      - path: "${DATADIR}/dev-clones"
         permission: rw
 ```
 
-(Exact override merging semantics follow the existing `Resolver` in [pkg/taskset/resolver.go](../../pkg/taskset/resolver.go); implementation must verify whether overrides extend `permissions.dicode.{tasks,*flags}` and `permissions.fs` correctly, and add the merge if not. This is a small clarification, not a redesign.)
+**Override mechanism extension required:** the existing TaskSet `Overrides` struct in [pkg/taskset/spec.go:135-155](../../pkg/taskset/spec.go#L135) and the `mergeDicodePerms` helper in [pkg/taskset/override.go:153-178](../../pkg/taskset/override.go#L153) merge a fixed set of dicode permission flags and do not accept `permissions.fs` overrides. This work expands them:
+
+- Add `Fs []FsPermission` to the `Overrides` struct (full-replace at the entry level).
+- Add the new dicode permission flags listed below to `mergeDicodePerms`.
+- Extend `permissions.dicode.tasks` merge to be a *union* (so the override entry can append `git-pr` to whatever ai-agent already declares).
+
+These are localized changes to two files (`spec.go`, `override.go`) plus tests, not a new mechanism. Tracked as part of child issue (4) acceptance criteria.
 
 **Auto-fix-specific config** (`mode`, `max_iterations`, `max_iteration_seconds`, `max_tokens`, `branch_prefix`, `pr_task`, `base_branch`) does NOT live in `params:` declarations — it arrives via the **chain trigger params merge** described in § 4.5. The engine fires `auto-fix` with an input map of `{ taskID, runID, status, output, _chain_depth, mode, max_iterations, ... }`. The `dicode-auto-fix` skill prompt instructs the agent to read these from the input map.
 
@@ -497,15 +530,15 @@ The agent loop is implemented as a new buildin skill (`dicode-auto-fix`, a markd
 4. Generate fix branch name (review: `${branch_prefix}${runID}`; autonomous: `base_branch || sourceTrackedBranch`).
 5. `dicode.sources.set_dev_mode(<source>, { enabled: true, branch: <fixBranch>, base: <base> })`.
 6. Iterate (capped at `max_iterations`, each iteration capped at `max_iteration_seconds`):
-   - Read failing task's source files via `Deno.readTextFile` from the worktree path.
-   - Edit via `Deno.writeTextFile` to the same worktree path. (Permissions: `fs.rw: ${DATADIR}/dev-worktrees`.) The agent's edit scope is enforced by the path it writes to — cross-task edits are explicitly out of scope and the loop's prompt forbids them.
+   - Read failing task's source files via `Deno.readTextFile` from the clone path.
+   - Edit via `Deno.writeTextFile` to the same clone path. (Permissions: `fs.rw: ${DATADIR}/dev-clones`.) The agent's edit scope is enforced by the path it writes to — cross-task edits are explicitly out of scope and the loop's prompt forbids them.
    - Validate by inline YAML/schema parse.
    - Test via `dicode.tasks.test(<failingTaskID>)` (runs `task.test.{ts,js}` if present; if absent, the agent is instructed to write one as part of the fix).
    - Replay via `dicode.runs.replay(<failedRunID>)`. Wait for the new run to finish; check status.
    - If both green → exit loop.
 7. On success: `dicode.git.commit_push(<source>, <message>, branch=<fixBranch>)`. Engine validates the branch matches the `branch_prefix` allow-list (or is the source's tracked branch in autonomous mode), refuses force-push.
 8. If `mode == "review"`: invoke the PR task via `dicode.run_task(params.pr_task, { source_id, branch: fixBranch, base: base, title, body })`.
-9. `dicode.sources.set_dev_mode(<source>, { enabled: false })` — engine removes the worktree; branch retained.
+9. `dicode.sources.set_dev_mode(<source>, { enabled: false })` — engine removes the local clone; remote branch retained.
 10. Unpin the failed run's input.
 
 Loop terminator conditions:
@@ -518,9 +551,13 @@ Loop terminator conditions:
 
 #### 4.6.1 Why no shell-out to `git`
 
-dicode's "no git binary" key constraint ([CLAUDE.md](../../CLAUDE.md)) says the daemon uses go-git for all git operations. The auto-fix task respects this by routing commit/push through a new `dicode.git.commit_push` SDK call that the Go core implements via go-git.
+dicode's "no git binary" key constraint ([CLAUDE.md](../../CLAUDE.md)) says the daemon uses go-git for all git operations. The auto-fix task respects this end-to-end:
 
-The single deliberate exception is the `dev-worktrees-cleanup` task (§ 4.2), which uses `git worktree prune` because go-git's worktree support is more limited and cleanup is a sysadmin operation rather than user-facing. This is documented at the task and limited to that one task's permissions.
+- **Clone (per-fix workspace):** go-git `Clone` into `${DATADIR}/dev-clones/<source>/<runID>/`. Pure go-git, no `git` binary.
+- **Commit + push:** new `dicode.git.commit_push` SDK call wrapping go-git's `Add`/`Commit`/`Push`.
+- **Cleanup:** plain filesystem `rm -rf` on the clone dir (Deno fs APIs in the cleanup task; `os.RemoveAll` on the Go side).
+
+There is **no exception** to the no-git-binary rule. (An earlier draft of this spec proposed using `git worktree` for isolation; that has been replaced by the per-fix fresh-clone model — see § 4.4 — because go-git v5 does not implement `git worktree add`.)
 
 #### 4.6.2 git_commit_push contract
 
@@ -528,16 +565,37 @@ The single deliberate exception is the `dev-worktrees-cleanup` task (§ 4.2), wh
 dicode.git.commit_push(sourceID: string, opts: {
     message: string,
     branch?: string,        // default: source's currently-active dev mode branch (if any)
-    files?: string[],       // default: all tracked changes in the worktree
+    files?: string[],       // default: all tracked changes in the clone
     allow_main: boolean,    // default false; must be true for autonomous mode
 }): Promise<{ commit: string, pushed: boolean }>
 ```
 
 Engine enforces:
 
-- The branch must match `${branch_prefix}*` patterns (read from per-task config) OR equal the source's tracked branch when `allow_main=true`.
+- The branch name passes the validation in § 4.6.3 (`git check-ref-format` + `branch_prefix` literal-prefix match, OR equals the source's tracked branch when `allow_main=true`).
+- The match against `branch_prefix` is **literal prefix** (`strings.HasPrefix(branch, prefix)` after both sides are validated), NOT a glob — `fix/` matches `fix/abc-123` but never `fix-abc-123` or `prefix-fix/abc`.
 - Never `--force`. A diverged branch causes the call to error out; the driver's recovery is to abandon the loop with a structured error.
 - Push uses the source's existing auth (env-injected forge token, same as reconciler pulls).
+
+#### 4.6.3 Branch name validation and path safety
+
+A central function in core (`pkg/taskset.ValidateBranchName(branch, prefix string) error`) enforces:
+
+1. **`git check-ref-format`-equivalent** (Go-side reimplementation; `pkg/source/git` already needs ref validation):
+   - No path components starting with `.`
+   - No double-dot `..`
+   - No control characters (ASCII < 0x20), `:`, `?`, `[`, `\`, `^`, `~`, space
+   - No leading or trailing `/`
+   - No `//`
+   - Not equal to `@`
+   - No trailing `.lock`
+2. **Literal prefix match** against the per-task `branch_prefix` config (default `"fix/"`). Glob/regex characters in `branch_prefix` are rejected at config-load time; only `[A-Za-z0-9_./-]+` is allowed.
+3. **Path-component sanitization for the clone dir is unnecessary** because the clone dir name is the *run ID* (UUID), not the branch name. The branch is materialised inside the clone via `git checkout`, where git itself enforces ref-format rules. A malicious `branch_prefix` (e.g., `../`) is rejected at config-load.
+
+This validation is invoked at:
+- Config load (validates `branch_prefix` per task).
+- `dicode.sources.set_dev_mode` (validates `Branch` against the resolved per-task `branch_prefix`).
+- `dicode.git.commit_push` (re-validates the branch in case the agent drifted).
 
 ### 4.7 Loop guardrails (engine-level)
 
@@ -583,7 +641,7 @@ permissions:
                                   # to {contents:write, pull_requests:write} on the
                                   # specific repo; do NOT reuse an admin token.
   fs:
-    - path: "${DATADIR}/dev-worktrees"
+    - path: "${DATADIR}/dev-clones"
       permission: r
 timeout: 60s
 ```
@@ -606,13 +664,13 @@ A webhook task `process-payment` fails with a 500 from a downstream API.
 2. **t=0+1s:** task runs, fails. `FireChain` checks `defaults.on_failure_chain` — set to `{ task: auto-fix, params: { mode: review } }`.
 3. Engine fires `auto-fix` with input `{ taskID: "process-payment", runID: "<id>", status: "failure", output: <500 body>, mode: "review", _chain_depth: 1 }`.
 4. **t=0+2s:** `auto-fix` driver pins input via `dicode.runs.pin_input("<id>")`, picks branch `fix/<runID>`, calls `dicode.sources.set_dev_mode("user-tasks", { enabled: true, branch: "fix/<runID>", base: "main" })`.
-5. Engine: go-git `Worktree.Checkout` on `${DATADIR}/dev-worktrees/user-tasks/fix-<runID>/` (created from main since branch didn't exist), resolver swaps source root, registry reloads tasks from worktree.
-6. **t=0+5s:** driver builds prompt with failure context (`{ logs, output, input, redacted_fields: ["headers.authorization", "headers.x-stripe-signature"] }`) plus reads task source via `Deno.readTextFile`. Hands off to the underlying `ai-agent` runtime. Agent reads logs, sees "500 from upstream", proposes adding a retry-with-backoff. Calls `Deno.writeTextFile` to the worktree's `process-payment/task.ts`.
+5. Engine: go-git `Clone` into `${DATADIR}/dev-clones/user-tasks/<autoFixRunID>/`, checks out `fix/<runID>` (created locally from main since branch didn't exist remotely). Resolver swaps source root to the clone, registry reloads tasks from the clone.
+6. **t=0+5s:** driver builds prompt with failure context (`{ logs, output, input, redacted_fields: ["headers.authorization", "headers.x-stripe-signature"] }`) plus reads task source via `Deno.readTextFile`. Hands off to the underlying `ai-agent` runtime. Agent reads logs, sees "500 from upstream", proposes adding a retry-with-backoff. Calls `Deno.writeTextFile` to the clone's `process-payment/task.ts`.
 7. Agent calls `dicode.tasks.test("process-payment")` — sees no test; writes `task.test.ts` with a regression test for the 500 case using a mocked fetch; reruns — passes.
-8. Agent calls `dicode.runs.replay("<id>")` — engine decrypts the original webhook body (sans Stripe signature), fires a new run on the worktree code with retry. The replay run does NOT fire `on_failure_chain` (we suppressed it for `triggerSource == "replay"`). Replay run passes (no auth check exercised because of redaction; agent was warned via `redacted_fields`).
+8. Agent calls `dicode.runs.replay("<id>")` — engine decrypts the original webhook body (sans Stripe signature), fires a new run against the cloned source with retry. The replay run does NOT fire `on_failure_chain` (we suppressed it for `triggerSource == "replay"`). Replay run passes (no auth check exercised because of redaction; agent was warned via `redacted_fields`).
 9. Agent calls `dicode.git.commit_push("user-tasks", { message: "auto-fix: process-payment retry on 5xx", branch: "fix/<runID>" })`. Engine validates `fix/<runID>` matches `${branch_prefix}*`, runs go-git `Add` + `Commit` + `Push` (no `--force`).
 10. Driver invokes the PR task via `dicode.run_task("git-pr", { source_id, branch: "fix/<runID>", base: "main", title, body })`. `gh pr create` returns URL.
-11. Driver calls `dicode.sources.set_dev_mode("user-tasks", { enabled: false })`. Engine removes worktree, source resumes pulling main.
+11. Driver calls `dicode.sources.set_dev_mode("user-tasks", { enabled: false })`. Engine `os.RemoveAll`s the clone dir, source resumes pulling main.
 12. Driver unpins via `dicode.runs.unpin_input("<id>")`, returns `{ ok: true, pr_url: "..." }`.
 13. Operator gets notification "auto-fix opened PR <url> for process-payment runID=...". Reviews, sees the PR mentions "redacted_fields contained Stripe signature — please verify the retry logic doesn't bypass signature validation" in the auto-generated body. Reviews carefully and merges. Reconciler picks up the change on the next poll.
 
@@ -624,7 +682,7 @@ Filed under epic [#207](https://github.com/dicode-ayo/dicode-core/issues/207); t
 
 2. **Auto-fix SDK surface** — `dicode.runs.replay`, `dicode.tasks.test`, `dicode.sources.set_dev_mode` (with branch+base support), `dicode.git.commit_push` (go-git, refspec scoping, no `--force`). REST mirrors. Permissions for each (`runs_replay`, `tasks_test`, `sources_set_dev_mode`, `git_commit_push`). Depends on (1) for replay's input read.
 
-3. **Dev mode `branch` lifecycle + `on_failure_chain` parameter passing** — `SetDevMode` opts struct with `Branch`/`Base`, go-git worktree create/remove, dev-worktrees-cleanup buildin, `on_failure_chain` structured form with reserved-key + autonomous-at-defaults config-load errors. Independent of (1) and (2) — usable by humans without auto-fix.
+3. **Dev mode `branch` lifecycle + `on_failure_chain` parameter passing** — `SetDevMode` opts struct with `Branch`/`Base`/`RunID`, go-git clone create/remove, branch-name validator (`pkg/taskset.ValidateBranchName`), `dev-clones-cleanup` buildin, `on_failure_chain` structured form with reserved-key + autonomous-at-defaults config-load errors. Independent of (1) and (2) — usable by humans without auto-fix.
 
 4. **Auto-fix taskset override + git-pr buildin + engine guardrails + auto-fix skill** — add `auto-fix` to `tasks/buildin/taskset.yaml` as a `dicodai` override, `git-pr` reference impl, the engine-side guardrails (cooldown, concurrency, chain depth, storm circuit breaker, replay→chain suppression, push refspec scoping), the `dicode-auto-fix` skill markdown. Depends on (1), (2), (3).
 
@@ -635,9 +693,9 @@ Recommend shipping in this order so v0.2.0 can include (1)+(2)+(3) — replay-fr
 ## 7. Open questions / explicitly deferred
 
 - **Auto-revert on monitoring signals from a successful deploy.** The LP "When AI is wrong" copy implies that a *successful* deploy that subsequently breaks production is also auto-fixed. v1 covers the on-failure path only; revert-on-regression is a follow-up under the same epic.
-- **Multi-task fixes.** v1 restricts the agent to writing inside the failed task's directory. A failure rooted in a *dependency* task is detectable by the agent (it can read other tasks' source) but the fix would have to be outside its write scope. v1 punts this with a clear error from the prompt and the worktree's path-scoped permissions.
+- **Multi-task fixes.** v1 restricts the agent to writing inside the failed task's directory. A failure rooted in a *dependency* task is detectable by the agent (it can read other tasks' source) but the fix would have to be outside its write scope. v1 punts this with a clear error from the prompt and the clone's path-scoped permissions.
 - **Forge auth UX.** `git-pr` ships with `GH_TOKEN_AUTOFIX` env. A first-launch onboarding step that prompts for a fine-grained PAT (similar to the OpenAI key prompt) is desirable but out of scope here.
-- **WebUI surfacing.** The fix worktree's branch and the in-flight auto-fix's progress should appear in the WebUI runs view. Concrete UI design is deferred.
+- **WebUI surfacing.** The fix branch and the in-flight auto-fix's progress should appear in the WebUI runs view. Concrete UI design is deferred.
 - **Cost telemetry.** Token spend per auto-fix should be aggregated and surfaced. Deferred — first ship the loop, then add accounting.
 - **Subcommand-scoped `gh` shim.** Wrapping `gh` invocation to whitelist `pr create` / `pr view` / `pr list` only. Hardening, not v1.
 - **MCP-tool extensions** (`write_task_file`, `validate_task`, `commit_task`, `dry_run_task`, `read_task_file`) for external agents. Tracked separately under epic #207.
@@ -649,12 +707,14 @@ Recommend shipping in this order so v0.2.0 can include (1)+(2)+(3) — replay-fr
 - AEAD additional data binds each ciphertext to its `runID + stored_at`. Splicing across rows fails decryption.
 - Header/query/body redaction is name-based deny-list with substring matching on `signature`, `token`, `secret`, `password`, `key`. Over-redaction is the safe failure mode. Users with sensitive non-standard field names set `auto_fix.include_input: false` per task.
 - Multipart and binary bodies are stored as `BodyKind + BodyHash`, not contents.
-- The agent runs with a curated SDK permission set (`runs_replay`, `tasks_test`, `git_commit_push`, etc.). It cannot escalate to filesystem or network access beyond what the override declares. Worktree path-scoping prevents cross-task edits.
+- The agent runs with a curated SDK permission set (`runs_replay`, `tasks_test`, `git_commit_push`, etc.). It cannot escalate to filesystem or network access beyond what the override declares. Clone path-scoping (the clone dir is named by the auto-fix run ID, a UUID) prevents cross-task and cross-fix edits.
 - **Autonomous mode requires per-task opt-in.** A `defaults.on_failure_chain.params.mode: autonomous` is a config-load error. Users must explicitly opt each task in by setting `on_failure_chain.params.mode: autonomous` in that task's `task.yaml`. Documented in onboarding: pair with branch protection on the source's tracked branch — the agent should never be the only review for direct-to-main pushes.
 - `git-pr` uses `permissions.run: [gh]`. Rationale + threat model documented in § 4.8. Recommend a fine-grained PAT.
-- `dev-worktrees-cleanup` uses `permissions.run: [git]` for `git worktree prune` only. Documented narrow exception to the "no git binary" constraint, isolated to one task.
-- Replay-fidelity: a replay validates against post-redaction input, not the original sender's request. The agent prompt explicitly surfaces `redacted_fields`. PRs include a "redacted fields were [...]" line in their body so reviewers can sanity-check the agent's reasoning.
+- The "no git binary" constraint is honoured end-to-end: clone, commit, push, and cleanup all go through go-git or plain filesystem operations. There is no `permissions.run: [git]` anywhere in the auto-fix path.
+- Replay-fidelity: a replay validates against post-redaction input, not the original sender's request. The agent prompt explicitly surfaces `redacted_fields` (when `auto_fix.show_redacted_field_names: true`, the default). PRs include a "redacted fields were [...]" line in their body so reviewers can sanity-check the agent's reasoning. For tasks where field names are themselves sensitive, set `auto_fix.show_redacted_field_names: false`.
+- `body_full_textual: true` bypasses name-based redaction and is logged at config-load (see § 4.1.3). This is documented as a deliberate footgun: tasks with non-sensitive textual bodies (internal cron heartbeats, RSS payloads, etc.) opt in; tasks with possibly-sensitive XML/text bodies stay at the conservative default.
 - Stale pin recovery on engine startup prevents indefinite `input_pinned = 1` lingering from a crashed driver.
+- `triggerSource` is a typed enum on the Go side (not a string compared at the call site), so the replay-suppression check (`triggerSource == "replay"` in the spec text) is type-safe at impl time. Tracked as a small implementation detail in child issue (3).
 
 ## 9. Landing-page mapping
 


### PR DESCRIPTION
Spec doc for the LP "fix" arc — companion to issue #228 (filed under epic #207).

## Summary

- Designs the AI auto-fix loop covering persisted+encrypted run inputs, replay primitive, dev-mode-with-branch (engine-managed worktree), chain-trigger param-passing, the auto-fix buildin task with review/autonomous modes, and engine-side guardrails (cooldown, concurrency, chain-depth, storm circuit-breaker).
- Decomposes into four mergeable child issues; (1)-(2)-(3) ship in v0.2.0 (also useful to humans alone), (4) wires the loop in v0.3.0.
- No code — spec only.

## Test plan

- [ ] User reviews [the spec](https://github.com/dicode-ayo/dicode-core/blob/spec/auto-fix-loop/docs/superpowers/specs/2026-04-28-on-failure-auto-fix-loop-design.md) for missing or wrong assumptions.
- [ ] `/review` and `/security-review` agents pass.
- [ ] Once approved, four child issues are filed and #228 is updated with the links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)