### PR TITLE
ci: install Deno so integration tests don't silently skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,14 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      # Deno is required for pkg/runtime/deno integration tests (e.g.
+      # TestRun_SecretOutputRoutedToChannel). Without it those tests t.Skip
+      # silently and a regression in the runtime IPC path goes uncaught.
+      # See issue #237.
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
       - name: Run tests
         run: go test -timeout 300s -race ./...
 


### PR DESCRIPTION
Closes #237. Adds denoland/setup-deno@v2 to the test job(s) so TestRun_SecretOutputRoutedToChannel runs end-to-end instead of skipping.

## Test plan
- [ ] After merge, the GitHub Actions run shows the test as PASS (not SKIP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)