### PR TITLE
refactor(envresolve): single resolution per consumer launch

### DIFF
--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -56,6 +56,12 @@ type RunOptions struct {
 	Params      map[string]string
 	Input       interface{}
 	ParentRunID string
+
+	// PreResolvedEnv, when set, is the result of an env-resolver pass run
+	// by the trigger engine before dispatch (issue #235). Run uses these
+	// values directly instead of constructing its own resolver. Nil falls
+	// back to the inline resolver path.
+	PreResolvedEnv *envresolve.Resolved
 }
 
 // RunResult is returned by Run.
@@ -197,15 +203,23 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		}
 	}()
 
-	// Resolve declared env permissions via the shared resolver. Provider
-	// tasks (from: task:<id>) are spawned and batched at most once per
-	// provider per launch; legacy paths (secret:, env:NAME, bare) are
-	// preserved.
-	resolvedRes, err := rt.envresolver().Resolve(ctx, spec)
-	if err != nil {
-		status = registry.StatusFailure
-		result.Error = err
-		return result, nil
+	// Resolve declared env permissions. When the trigger engine ran
+	// preflight (issue #235), it forwards the *Resolved here so we don't
+	// re-spawn provider tasks. When opts.PreResolvedEnv is nil (legacy
+	// callers, tests that bypass the engine), fall back to inline
+	// resolution. Provider tasks (from: task:<id>) are spawned and batched
+	// at most once per provider per launch; legacy paths (secret:,
+	// env:NAME, bare) are preserved.
+	var resolvedRes *envresolve.Resolved
+	if opts.PreResolvedEnv != nil {
+		resolvedRes = opts.PreResolvedEnv
+	} else {
+		resolvedRes, err = rt.envresolver().Resolve(ctx, spec)
+		if err != nil {
+			status = registry.StatusFailure
+			result.Error = err
+			return result, nil
+		}
 	}
 	resolved := resolvedRes.Env
 	redactor := secrets.NewRedactor(resolvedRes.Secrets)
@@ -524,10 +538,11 @@ func (rt *Runtime) envresolver() *envresolve.Resolver {
 // Execute implements runtime.Executor.
 func (rt *Runtime) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
 	result, err := rt.Run(ctx, spec, RunOptions{
-		RunID:       opts.RunID,
-		ParentRunID: opts.ParentRunID,
-		Params:      opts.Params,
-		Input:       opts.Input,
+		RunID:          opts.RunID,
+		ParentRunID:    opts.ParentRunID,
+		Params:         opts.Params,
+		Input:          opts.Input,
+		PreResolvedEnv: opts.PreResolvedEnv,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/runtime/deno/runtime_test.go
+++ b/pkg/runtime/deno/runtime_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/dicode/dicode/pkg/db"
 	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/runtime/envresolve"
 	"github.com/dicode/dicode/pkg/secrets"
 	"github.com/dicode/dicode/pkg/task"
 	"go.uber.org/zap"
@@ -134,6 +135,55 @@ func TestRuntime_Log(t *testing.T) {
 }
 
 // ── permissions tests ─────────────────────────────────────────────────────────
+
+// failingProviderRunner fails the test the moment the runtime invokes it.
+// Used to pin issue #235: when opts.PreResolvedEnv is set, the runtime must
+// reuse that value and must NOT construct its own resolver (which would
+// double-spawn provider tasks).
+type failingProviderRunner struct{ t *testing.T }
+
+func (f failingProviderRunner) Run(_ context.Context, providerID string, _ []envresolve.ProviderRequest) (*envresolve.ProviderResult, error) {
+	f.t.Errorf("regression #235: runtime invoked provider runner for %q despite opts.PreResolvedEnv being set", providerID)
+	return &envresolve.ProviderResult{Values: map[string]string{}}, nil
+}
+
+// TestRuntime_PreResolvedEnv_BypassesResolver: when the trigger engine has
+// already run preflight and threaded *Resolved through opts.PreResolvedEnv,
+// the runtime must use that value directly instead of running the resolver
+// (which would re-spawn provider tasks). Verifies (a) no provider call is
+// made and (b) the consumer's env actually contains the pre-resolved value.
+func TestRuntime_PreResolvedEnv_BypassesResolver(t *testing.T) {
+	e := newTestEnv(t)
+	// Wire a runner that fails the test on any call. With PreResolvedEnv
+	// set, the runtime must never reach the resolver.
+	e.rt.SetProviderRunner(failingProviderRunner{t: t})
+
+	spec := &task.Spec{
+		ID: "preresolved-bypass", Name: "preresolved-bypass", Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true}, Timeout: 30 * time.Second,
+		Permissions: task.Permissions{
+			// from: task:<id> — would normally trigger a provider call. With
+			// PreResolvedEnv it must be skipped.
+			Env: []task.EnvEntry{{Name: "PG_URL", From: "task:doppler"}},
+		},
+	}
+	pre := &envresolve.Resolved{
+		Env:     map[string]string{"PG_URL": "postgres://from-preresolved"},
+		Secrets: map[string]string{"PG_URL": "postgres://from-preresolved"},
+	}
+
+	r := e.runSpec(t,
+		`export default async function main() { return Deno.env.get("PG_URL") ?? null }`,
+		spec,
+		RunOptions{PreResolvedEnv: pre},
+	)
+	if r.Error != nil {
+		t.Fatalf("error: %v", r.Error)
+	}
+	if r.ReturnValue != "postgres://from-preresolved" {
+		t.Errorf("expected pre-resolved value, got %v", r.ReturnValue)
+	}
+}
 
 // TestRuntime_Env_BarePassthrough: bare name allowlists the var so the script
 // can read it from the host env — no injection, no secrets.

--- a/pkg/runtime/executor.go
+++ b/pkg/runtime/executor.go
@@ -4,6 +4,7 @@ package runtime
 import (
 	"context"
 
+	"github.com/dicode/dicode/pkg/runtime/envresolve"
 	"github.com/dicode/dicode/pkg/task"
 )
 
@@ -13,6 +14,15 @@ type RunOptions struct {
 	ParentRunID string
 	Params      map[string]string
 	Input       interface{}
+
+	// PreResolvedEnv, when set, is the result of an env-resolver pass run
+	// by the trigger engine before dispatch. The runtime uses these values
+	// directly instead of calling the resolver itself, avoiding the
+	// double-resolve that would otherwise re-spawn provider tasks.
+	//
+	// When nil (e.g. legacy callers, tests that bypass the engine), the
+	// runtime falls back to its own inline-resolver path.
+	PreResolvedEnv *envresolve.Resolved
 }
 
 // RunResult is returned by every Executor.

--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -185,15 +185,24 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 		}
 	}()
 
-	// Resolve declared env permissions via the shared resolver. Provider
-	// tasks (from: task:<id>) are spawned and batched at most once per
-	// provider per launch; legacy paths (secret:, env:NAME, bare) are
-	// preserved.
-	resolvedRes, err := envresolve.New(e.reg, e.secrets, e.providerRunner).Resolve(ctx, spec)
-	if err != nil {
-		status = registry.StatusFailure
-		result.Error = err
-		return result, nil
+	// Resolve declared env permissions. When the trigger engine ran
+	// preflight (issue #235), it forwards the *Resolved here so we don't
+	// re-spawn provider tasks. When opts.PreResolvedEnv is nil (legacy
+	// callers, tests that bypass the engine), fall back to inline
+	// resolution. Provider tasks (from: task:<id>) are spawned and batched
+	// at most once per provider per launch; legacy paths (secret:,
+	// env:NAME, bare) are preserved.
+	var resolvedRes *envresolve.Resolved
+	var err error
+	if opts.PreResolvedEnv != nil {
+		resolvedRes = opts.PreResolvedEnv
+	} else {
+		resolvedRes, err = envresolve.New(e.reg, e.secrets, e.providerRunner).Resolve(ctx, spec)
+		if err != nil {
+			status = registry.StatusFailure
+			result.Error = err
+			return result, nil
+		}
 	}
 	resolved := resolvedRes.Env
 	redactor := secrets.NewRedactor(resolvedRes.Secrets)

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -726,30 +726,41 @@ func (e *Engine) Run(ctx context.Context, providerID string, reqs []envresolve.P
 // preflightEnv runs the env resolver once before dispatch so that typed
 // provider failures (provider_unavailable / required_secret_missing /
 // provider_misconfigured) can be recorded as the run's fail_reason
-// instead of surfacing as opaque dispatch errors. Returns ("", "") on
-// success or non-typed error — the resolver runs again inside the
-// runtime, but that's acceptable for MVP (issue #119).
-func (e *Engine) preflightEnv(ctx context.Context, spec *task.Spec) (status, reason string) {
+// instead of surfacing as opaque dispatch errors.
+//
+// On success, it returns the *Resolved so dispatch can hand it to the
+// runtime via RunOptions.PreResolvedEnv, ensuring provider tasks fire
+// exactly once per consumer launch instead of twice (issue #235).
+//
+// Return contract:
+//   - success: (resolved, "", "")
+//   - typed envresolve failure: (nil, registry.StatusFailure, "<reason>")
+//   - non-typed error or skipped (no secrets chain / no env entries):
+//     (nil, "", "") — dispatch proceeds and the runtime resolves inline.
+func (e *Engine) preflightEnv(ctx context.Context, spec *task.Spec) (*envresolve.Resolved, string, string) {
 	// Skip preflight when secrets chain isn't wired (test fixtures) or
 	// when the spec has no env entries the resolver could fail on.
 	if e.secrets == nil || len(spec.Permissions.Env) == 0 {
-		return "", ""
+		return nil, "", ""
 	}
 	r := envresolve.New(e.registry, e.secrets, e)
-	if _, err := r.Resolve(ctx, spec); err != nil {
+	resolved, err := r.Resolve(ctx, spec)
+	if err != nil {
 		var pu *envresolve.ErrProviderUnavailable
 		var rsm *envresolve.ErrRequiredSecretMissing
 		var mis *envresolve.ErrProviderMisconfigured
 		switch {
 		case errors.As(err, &pu):
-			return registry.StatusFailure, "provider_unavailable: " + pu.ProviderID
+			return nil, registry.StatusFailure, "provider_unavailable: " + pu.ProviderID
 		case errors.As(err, &rsm):
-			return registry.StatusFailure, "required_secret_missing: " + rsm.Key + " from " + rsm.ProviderID
+			return nil, registry.StatusFailure, "required_secret_missing: " + rsm.Key + " from " + rsm.ProviderID
 		case errors.As(err, &mis):
-			return registry.StatusFailure, "provider_misconfigured: " + mis.ProviderID
+			return nil, registry.StatusFailure, "provider_misconfigured: " + mis.ProviderID
 		}
+		// Non-typed error: let dispatch surface it normally.
+		return nil, "", ""
 	}
-	return "", ""
+	return resolved, "", ""
 }
 
 // KillRun cancels a running task by its run ID.
@@ -1317,12 +1328,17 @@ func (e *Engine) runTask(runCtx context.Context, spec *task.Spec, opts pkgruntim
 	// Preflight env-resolver: typed envresolve failures
 	// (provider_unavailable / required_secret_missing / provider_misconfigured)
 	// are recorded as the run's fail_reason BEFORE dispatch so the operator
-	// gets a categorized reason instead of an opaque executor error. On
-	// preflight success this is a no-op (resolver returns nil); the runtime
-	// then re-resolves with its own cache before spawning the consumer.
+	// gets a categorized reason instead of an opaque executor error.
+	//
+	// On preflight success the *Resolved is forwarded to the runtime via
+	// opts.PreResolvedEnv so provider tasks fire exactly once per consumer
+	// launch (issue #235). When preflight is skipped (no secrets chain /
+	// no env entries) preResolved is nil and the runtime falls back to its
+	// inline-resolver path.
 	var status string
 	var result *pkgruntime.RunResult
-	if preStatus, preReason := e.preflightEnv(runCtx, spec); preStatus != "" {
+	preResolved, preStatus, preReason := e.preflightEnv(runCtx, spec)
+	if preStatus != "" {
 		_ = e.registry.FinishRunWithReason(context.Background(), opts.RunID, preStatus, preReason)
 		// dispatch normally fires FireChain; on the preflight short-circuit
 		// we replicate it so chain triggers still observe the failure.
@@ -1330,6 +1346,7 @@ func (e *Engine) runTask(runCtx context.Context, spec *task.Spec, opts pkgruntim
 		status = preStatus
 		result = &pkgruntime.RunResult{RunID: opts.RunID, Error: errors.New(preReason)}
 	} else {
+		opts.PreResolvedEnv = preResolved
 		status, result = e.dispatch(runCtx, spec, opts)
 	}
 	elapsed := time.Since(start)

--- a/pkg/trigger/preflight_resolve_once_test.go
+++ b/pkg/trigger/preflight_resolve_once_test.go
@@ -1,0 +1,171 @@
+package trigger
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+	"github.com/dicode/dicode/pkg/secrets"
+	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
+)
+
+// fakeDenoRuntimeForChannel is the minimal DenoRuntimeAPI the engine's
+// ProviderRunner method needs: it captures whatever SetSecretOutputChannel
+// is given so the test can publish the provider's secret map into it.
+type fakeDenoRuntimeForChannel struct {
+	ch atomic.Pointer[chan map[string]string]
+}
+
+func (f *fakeDenoRuntimeForChannel) SetSecretOutputChannel(c chan map[string]string) {
+	if c == nil {
+		f.ch.Store(nil)
+		return
+	}
+	f.ch.Store(&c)
+}
+
+// providerCountingExecutor counts how many times each task ID is dispatched.
+// When the provider task is dispatched, it pushes the canned secret map onto
+// the channel the engine wired into the (fake) deno runtime. Consumer task
+// dispatches are recorded too — and the most recent opts.PreResolvedEnv is
+// captured so the test can verify the engine threaded it through.
+//
+// Real runtimes mark the run finished via their deferred reg.FinishRun; this
+// mock does the same so engine.Engine.WaitRun (used by the engine's own
+// ProviderRunner.Run method) sees a terminal status.
+type providerCountingExecutor struct {
+	providerID  string
+	providerVal map[string]string
+	denoRT      *fakeDenoRuntimeForChannel
+	reg         *registry.Registry
+
+	providerCalls           atomic.Int64
+	consumerCalls           atomic.Int64
+	lastConsumerPreResolved atomic.Pointer[pkgruntime.RunOptions]
+}
+
+func (p *providerCountingExecutor) Execute(_ context.Context, spec *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
+	defer func() {
+		// Match the runtime contract: the run record must reach a terminal
+		// state by the time the executor returns or WaitRun blocks forever.
+		_ = p.reg.FinishRun(context.Background(), opts.RunID, registry.StatusSuccess)
+	}()
+
+	if spec.ID == p.providerID {
+		p.providerCalls.Add(1)
+		// Mimic the IPC-server-side behaviour: when the provider task calls
+		// dicode.output(map, { secret: true }), the runtime's secretOutputCh
+		// receives the map. The engine's ProviderRunner blocks on that
+		// channel; we publish to it here so its WaitRun unblocks cleanly.
+		if chPtr := p.denoRT.ch.Load(); chPtr != nil {
+			select {
+			case (*chPtr) <- p.providerVal:
+			default:
+				// Channel was unbuffered or full — fall back to a goroutine
+				// so we don't deadlock the executor goroutine.
+				go func(c chan map[string]string) { c <- p.providerVal }(*chPtr)
+			}
+		}
+		return &pkgruntime.RunResult{RunID: opts.RunID}, nil
+	}
+	// Consumer dispatch.
+	p.consumerCalls.Add(1)
+	captured := opts
+	p.lastConsumerPreResolved.Store(&captured)
+	return &pkgruntime.RunResult{RunID: opts.RunID}, nil
+}
+
+// TestPreflight_ProviderFiresOnceAcrossPreflightAndDispatch is the regression
+// test for issue #235. Before the fix, env resolution ran twice per consumer
+// launch (once in Engine.preflightEnv, once inside the runtime), so a fresh
+// provider lookup spawned the provider task twice. After the fix the engine
+// hands the *Resolved to dispatch via opts.PreResolvedEnv and the runtime
+// reuses it instead of re-running the resolver.
+//
+// The contract this test pins:
+//  1. provider task fires exactly once per consumer launch
+//  2. consumer dispatch sees a non-nil opts.PreResolvedEnv carrying the
+//     resolved values
+func TestPreflight_ProviderFiresOnceAcrossPreflightAndDispatch(t *testing.T) {
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+
+	denoRT := &fakeDenoRuntimeForChannel{}
+	exec := &providerCountingExecutor{
+		providerID:  "doppler",
+		providerVal: map[string]string{"PG_URL": "postgres://x"},
+		denoRT:      denoRT,
+		reg:         reg,
+	}
+
+	eng := New(reg, exec, zap.NewNop())
+	eng.SetSecrets(secrets.Chain{}) // non-nil so preflightEnv doesn't short-circuit
+	eng.SetDenoRuntime(denoRT)
+
+	provider := &task.Spec{
+		ID:       "doppler",
+		Name:     "doppler",
+		Runtime:  task.RuntimeDeno,
+		Trigger:  task.TriggerConfig{Manual: true},
+		Provider: &task.ProviderConfig{CacheTTL: 0},
+		Timeout:  10 * time.Second,
+	}
+	if err := reg.Register(provider); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+
+	consumer := &task.Spec{
+		ID:      "consumer",
+		Name:    "consumer",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Timeout: 10 * time.Second,
+		Permissions: task.Permissions{
+			Env: []task.EnvEntry{
+				{Name: "PG_URL", From: "task:doppler"},
+			},
+		},
+	}
+	if err := reg.Register(consumer); err != nil {
+		t.Fatalf("register consumer: %v", err)
+	}
+
+	// fireSync drives the full runTask flow synchronously: preflight + dispatch.
+	runID, result, err := eng.fireSync(consumer, pkgruntime.RunOptions{}, "manual")
+	if err != nil {
+		t.Fatalf("fireSync: %v", err)
+	}
+	if result != nil && result.Error != nil {
+		t.Fatalf("consumer run errored: %v", result.Error)
+	}
+	if runID == "" {
+		t.Fatal("empty run ID")
+	}
+
+	if got := exec.providerCalls.Load(); got != 1 {
+		t.Errorf("regression: provider must fire exactly once per consumer launch, got %d", got)
+	}
+	if got := exec.consumerCalls.Load(); got != 1 {
+		t.Errorf("expected 1 consumer dispatch, got %d", got)
+	}
+
+	pre := exec.lastConsumerPreResolved.Load()
+	if pre == nil {
+		t.Fatal("consumer dispatch did not capture opts")
+	}
+	if pre.PreResolvedEnv == nil {
+		t.Fatal("opts.PreResolvedEnv must be forwarded to dispatch (issue #235)")
+	}
+	if got := pre.PreResolvedEnv.Env["PG_URL"]; got != "postgres://x" {
+		t.Errorf("PreResolvedEnv missing PG_URL value: got %q", got)
+	}
+}


### PR DESCRIPTION
Closes #235. Stacks on #232.

## Summary
- Adds `RunOptions.PreResolvedEnv` so the engine's preflight resolution carries forward to dispatch.
- Deno + Python runtimes use the pre-resolved Env+Secrets when present, fall back to inline resolution otherwise.
- Regression test pinning `runner.calls == 1`.

## Test plan
- [ ] go test ./... -timeout 90s -short
- [ ] Provider task spawn count test passes
- [ ] No regression on legacy paths (secret:, env:, bare)

🤖 Generated with [Claude Code](https://claude.com/claude-code)