### PR TITLE
feat: auto-fix loop — engine guardrails + git-pr + dicode-auto-fix skill + auto-fix taskset entry (#238)

### DIFF
--- a/docs/deno-runtime.md
+++ b/docs/deno-runtime.md
@@ -289,25 +289,89 @@ while (true) {
 A task can declare a failure handler that runs automatically when it fails:
 
 ```yaml
-on_failure_chain: failure-monitor   # override for this task
+on_failure_chain: failure-monitor   # short form — override for this task
 # on_failure_chain: ""              # disable global default for this task
 ```
 
-A global default can be set in `dicode.yaml`:
+The structured form accepts engine guardrails and chain params:
+
+```yaml
+on_failure_chain:
+  task: buildin/auto-fix
+  params:                           # forwarded into the chained run's input
+    mode: review                    # auto-fix preset: "review" (open PR) | "autonomous" (push)
+    branch_prefix: "fix/"
+  cooldown: 10m                     # min interval between two chain fires for this task; default 10m
+  max_concurrent: 1                 # in-flight chain runs per failing task; default 1
+  max_depth: 2                      # chain hops before suppression; default 2
+```
+
+A global default lives in `dicode.yaml`:
 
 ```yaml
 defaults:
-  on_failure_chain: failure-monitor
+  on_failure_chain:
+    task: failure-monitor
+    max_concurrent_global: 3        # ceiling across ALL tasks; defaults-only
+    storm:                          # circuit-breaker — defaults-only
+      rate: 10                      # if > rate fires
+      window: 1m                    # within window
+      suppress: 30m                 # suppress that source for this duration
 ```
+
+`max_concurrent_global` and `storm` are **operator policy** — only honored at the defaults level. Per-task blocks that set them get a config-load WARN and the fields are zeroed.
+
+Per-task `on_failure_chain` **fully replaces** the defaults block (no deep merge). To inherit + extend, restate the full structure.
 
 The failure handler receives:
 
 ```typescript
 // input to the failure handler task:
-// { taskID, runID, status, output }
-const { taskID, runID } = input
-console.log(`Task ${taskID} failed — run ${runID}`)
+// { taskID, runID, status, output, _chain_depth, ...params }
+export default async function main({ input }: any) {
+  const { taskID, runID, status, _chain_depth } = input
+  console.log(`Task ${taskID} failed (depth ${_chain_depth}) — run ${runID}`)
+}
 ```
+
+A replay-fired run that fails does NOT trigger `on_failure_chain` — replay is human/agent-initiated and has no auto-recovery semantics.
+
+---
+
+## Auto-fix loop (`buildin/auto-fix`)
+
+The `buildin/auto-fix` taskset entry is a preset that overrides `ai-agent` with the `dicode-auto-fix` skill loaded into the system prompt. When a task with `on_failure_chain: buildin/auto-fix` fails, an AI agent diagnoses the failure, edits source on a fix branch in a per-fix clone of the source repo, validates via `dicode.tasks.test` + `dicode.runs.replay`, then either pushes (autonomous) or opens a PR via `buildin/git-pr` (review).
+
+```yaml
+# tasks/my-task/task.yaml
+on_failure_chain:
+  task: buildin/auto-fix
+  params:
+    mode: review                    # default — opens a PR
+    # mode: autonomous              # alternative — pushes directly to tracked branch
+```
+
+Permissions the auto-fix task needs (set via the `buildin/auto-fix` taskset entry — users typically don't touch these):
+
+```yaml
+permissions:
+  env:
+    - GH_TOKEN_AUTOFIX              # fine-grained PAT for git-pr; contents+pull_requests scope
+  fs:
+    - path: "${DATADIR}/dev-clones"
+      permission: rw
+  dicode:
+    runs_get_input: true            # read failed run's persisted input (subject to redaction)
+    runs_replay: true
+    runs_pin_input: true
+    runs_unpin_input: true
+    sources_set_dev_mode: true      # clone the source onto a fix branch
+    tasks_test: true
+    git_commit_push: true
+    tasks: ["git-pr"]               # call buildin/git-pr to open PRs
+```
+
+`runs_get_input` is gated by a lineage check: the auto-fix run can only read inputs of runs whose ID matches its own `parent_run_id` (the failed run that fired it) OR runs of its own task. Users can grant `runs_get_input: true` to other tasks to build their own replayer / fixer / auditor — the redaction layer (deny-listed fields are never persisted) is what bounds the surface.
 
 ---
 

--- a/pkg/ipc/capability.go
+++ b/pkg/ipc/capability.go
@@ -53,10 +53,8 @@ const (
 	CapRunsDeleteInput = "runs.delete_input" // dicode.runs.delete_input
 	CapRunsPinInput    = "runs.pin_input"    // dicode.runs.pin_input
 	CapRunsUnpinInput  = "runs.unpin_input"  // dicode.runs.unpin_input
-	// CapRunsGetInput is reserved for programmatic grant only (e.g., the
-	// buildin/auto-fix preset in #238). It is intentionally not derivable
-	// from any task.yaml YAML field — tasks cannot self-grant decrypted
-	// cross-task input access via their permission spec.
+	// CapRunsGetInput is granted via permissions.dicode.runs_get_input. Sensitive —
+	// grants cross-task input read. Redaction at write time (#233) bounds the surface.
 	CapRunsGetInput      = "runs.get_input"
 	CapRunsReplay        = "runs.replay"          // dicode.runs.replay — re-fire a persisted run
 	CapTasksTest         = "tasks.test"           // dicode.tasks.test — run a task's sibling test file

--- a/pkg/ipc/replay_ownership_test.go
+++ b/pkg/ipc/replay_ownership_test.go
@@ -1,0 +1,151 @@
+package ipc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+// ipcFakeReplayRunner satisfies registry.ReplayRunner for IPC ownership tests.
+// It always returns a new run ID and records calls.
+type ipcFakeReplayRunner struct{}
+
+func (ipcFakeReplayRunner) FireForReplay(_ context.Context, _, _ string, _ any) (string, error) {
+	return uuid.New().String(), nil
+}
+
+// ipcFakeTaskRunner satisfies registry.TaskRunner for the InputStore.
+type ipcFakeTaskRunner struct{}
+
+func (ipcFakeTaskRunner) RunTaskSync(_ context.Context, _ string, _ map[string]string) (any, error) {
+	return map[string]any{"ok": true}, nil
+}
+
+// newTestReplayer returns a registry.Replayer backed by the given registry.
+func newTestReplayer(reg *registry.Registry) *registry.Replayer {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	is := registry.NewInputStore(registry.NewInputCrypto(key), ipcFakeTaskRunner{}, "fake-storage")
+	return registry.NewReplayer(reg, is, ipcFakeReplayRunner{})
+}
+
+// insertRunWithTask inserts a run row owned by taskID with a non-empty
+// InputStorageKey so the replay ownership check is reached.
+func insertRunWithTask(t *testing.T, reg *registry.Registry, d interface {
+	Exec(ctx context.Context, query string, args ...any) error
+}, runID, taskID string) {
+	t.Helper()
+	err := d.Exec(context.Background(),
+		`INSERT INTO runs(id, task_id, status, started_at, parent_run_id, trigger_source, input_storage_key, input_stored_at)
+		 VALUES (?,?,?,?,NULL,?,?,?)`,
+		runID, taskID, "success", 0, "manual", "key1", 0)
+	if err != nil {
+		t.Fatalf("insertRunWithTask: %v", err)
+	}
+}
+
+// TestIPC_Replay_RejectsCrossTaskWithoutLineage verifies that a server whose
+// taskID is "task-b" cannot replay a run owned by "task-a" when there is no
+// parent-run lineage. The IPC handler must return an error containing
+// "not permitted".
+func TestIPC_Replay_RejectsCrossTaskWithoutLineage(t *testing.T) {
+	e := newTestEnv(t)
+
+	// Insert a run owned by task-a with a non-empty input storage key.
+	targetRunID := fmt.Sprintf("target-run-%d", time.Now().UnixNano())
+	insertRunWithTask(t, e.reg, e.db, targetRunID, "task-a")
+
+	// Build a spec with RunsReplay granted.
+	spec := &task.Spec{
+		Permissions: task.Permissions{
+			Dicode: &task.DicodePermissions{
+				RunsReplay: true,
+			},
+		},
+	}
+
+	// Create the server with taskID = "task-b" directly (startWithSpec always
+	// uses "test-task"). The server's own runID is not in the registry so
+	// GetRun will fail → callerParentRunID stays "".
+	callerRunID := fmt.Sprintf("caller-run-%d", time.Now().UnixNano())
+	srv := New(callerRunID, "task-b", e.secret, e.reg, e.db, nil, nil, zap.NewNop(), spec, nil)
+	srv.SetReplayer(newTestReplayer(e.reg))
+
+	socketPath, token, err := srv.Start(context.Background())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(srv.Stop)
+
+	conn := dial(t, socketPath)
+	t.Cleanup(func() { conn.Close() })
+	doHandshake(t, conn, token)
+
+	// Attempt to replay a run owned by task-a from task-b with no lineage.
+	sendMsg(t, conn, map[string]any{
+		"id":     "replay-cross",
+		"method": "dicode.runs.replay",
+		"runID":  targetRunID,
+	})
+	resp := recvMsg(t, conn)
+	errMsg, _ := resp["error"].(string)
+	// ErrReplayNotPermitted message: "replay: caller task may not replay this run"
+	if !strings.Contains(errMsg, "may not replay") {
+		t.Errorf("expected 'may not replay' error, got %q (full resp: %#v)", errMsg, resp)
+	}
+}
+
+// TestIPC_Replay_AllowsSelfTask verifies that a server whose taskID is
+// "task-a" can replay a run owned by "task-a" (same task, self-replay).
+func TestIPC_Replay_AllowsSelfTask(t *testing.T) {
+	e := newTestEnv(t)
+
+	targetRunID := fmt.Sprintf("target-run-self-%d", time.Now().UnixNano())
+	insertRunWithTask(t, e.reg, e.db, targetRunID, "task-a")
+
+	spec := &task.Spec{
+		Permissions: task.Permissions{
+			Dicode: &task.DicodePermissions{
+				RunsReplay: true,
+			},
+		},
+	}
+
+	callerRunID := fmt.Sprintf("caller-run-self-%d", time.Now().UnixNano())
+	srv := New(callerRunID, "task-a", e.secret, e.reg, e.db, nil, nil, zap.NewNop(), spec, nil)
+	srv.SetReplayer(newTestReplayer(e.reg))
+
+	socketPath, token, err := srv.Start(context.Background())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(srv.Stop)
+
+	conn := dial(t, socketPath)
+	t.Cleanup(func() { conn.Close() })
+	doHandshake(t, conn, token)
+
+	sendMsg(t, conn, map[string]any{
+		"id":     "replay-self",
+		"method": "dicode.runs.replay",
+		"runID":  targetRunID,
+	})
+	resp := recvMsg(t, conn)
+	errMsg, _ := resp["error"].(string)
+	// The ownership check passes (same task), but the stored input is not
+	// actually accessible via the fake store, so we expect a fetch/storage
+	// error — NOT the ownership sentinel. This confirms the ownership check
+	// did not reject the call.
+	if strings.Contains(errMsg, "may not replay") {
+		t.Errorf("self-task replay was incorrectly rejected by ownership check: %q", errMsg)
+	}
+}

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -848,7 +848,14 @@ func (s *Server) handleConn(conn net.Conn) {
 				reply(req.ID, nil, "ipc: runID required")
 				continue
 			}
-			newRunID, err := s.replayer.Replay(s.ctx, req.RunID, req.TaskID)
+			// Look up the calling run's parent_run_id for the lineage check (#246).
+			var callerParentRunID string
+			if s.runID != "" {
+				if callerRun, err := s.registry.GetRun(s.ctx, s.runID); err == nil {
+					callerParentRunID = callerRun.ParentRunID
+				}
+			}
+			newRunID, err := s.replayer.Replay(s.ctx, req.RunID, req.TaskID, s.taskID, callerParentRunID)
 			if err != nil {
 				reply(req.ID, nil, err.Error())
 				continue

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -804,9 +804,13 @@ func (s *Server) handleConn(conn net.Conn) {
 			reply(req.ID, map[string]any{"ok": true}, "")
 
 		case "dicode.runs.get_input":
-			// Internal-only: gated behind CapRunsGetInput which is not granted
-			// to any task today. Wired now so #234's auto-fix driver can use it
-			// once the capability is granted to that task.
+			// Granted via permissions.dicode.runs_get_input. Subject to a
+			// caller-scope ownership check (#246) symmetric to
+			// dicode.runs.replay: a task may read a run's input only when
+			// (a) the run belongs to the caller's task, OR (b) the caller's
+			// own run was fired with parent_run_id == requested run id —
+			// the auto-fix lineage where a chain-fired task reads its
+			// failed parent.
 			if !hasCap(caps, CapRunsGetInput) {
 				reply(req.ID, nil, "ipc: permission denied (runs.get_input)")
 				continue
@@ -827,6 +831,20 @@ func (s *Server) handleConn(conn net.Conn) {
 			if run.InputStorageKey == "" {
 				reply(req.ID, nil, "ipc: no persisted input for run "+req.RunID)
 				continue
+			}
+			// Ownership / lineage check.
+			if s.taskID != "" {
+				ownsRun := run.TaskID == s.taskID
+				lineageOK := false
+				if !ownsRun && s.runID != "" {
+					if callerRun, cerr := s.registry.GetRun(s.ctx, s.runID); cerr == nil {
+						lineageOK = callerRun.ParentRunID == req.RunID
+					}
+				}
+				if !ownsRun && !lineageOK {
+					reply(req.ID, nil, "ipc: caller task may not read this run's input")
+					continue
+				}
 			}
 			fetched, err := s.inputStore.Fetch(s.ctx, req.RunID, run.InputStorageKey, run.InputStoredAt)
 			if err != nil {

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -274,6 +274,9 @@ func (s *Server) Start(ctx context.Context) (socketPath, token string, err error
 		if dp.RunsReplay {
 			caps = append(caps, CapRunsReplay)
 		}
+		if dp.RunsGetInput {
+			caps = append(caps, CapRunsGetInput)
+		}
 		if dp.TasksTest {
 			caps = append(caps, CapTasksTest)
 		}

--- a/pkg/ipc/server_test.go
+++ b/pkg/ipc/server_test.go
@@ -1367,24 +1367,20 @@ func TestServer_SecretOutputRejectsNestedMap(t *testing.T) {
 	}
 }
 
-// TestCapRunsGetInput_NotGrantedFromYAML verifies Finding 3 (security):
-// A task.Spec that previously declared permissions.dicode.runs_get_input:true
-// in its YAML must NOT receive CapRunsGetInput during the IPC handshake. The
-// field has been removed from DicodePermissions; this test confirms the
-// cap-derivation path no longer has a YAML opt-in vector for runs.get_input.
-//
-// CapRunsGetInput is reserved for programmatic grant only (e.g., the
-// buildin/auto-fix preset in #238). Allowing any task source to self-grant
-// this capability would expose decrypted cross-task input access.
-func TestCapRunsGetInput_NotGrantedFromYAML(t *testing.T) {
+// TestCapRunsGetInput_GrantedFromYAML verifies that a task whose YAML sets
+// permissions.dicode.runs_get_input: true DOES receive CapRunsGetInput during
+// the IPC handshake. RunsGetInput is now YAML-grantable — the redaction layer
+// from #233 bounds the surface, so there is no need to gate it behind a
+// programmatic-only grant. Users can build their own replayer / fixer / auditor
+// tasks without depending on the buildin auto-fix preset.
+func TestCapRunsGetInput_GrantedFromYAML(t *testing.T) {
 	e := newTestEnv(t)
 
-	// Build a spec with every dicode permission enabled, including a
-	// hypothetical runs_get_input (the field was removed from
-	// DicodePermissions, so we can only set the remaining ones).
+	// Build a spec with runs_get_input: true in the YAML-parsed permissions.
 	spec := &task.Spec{
 		Permissions: task.Permissions{
 			Dicode: &task.DicodePermissions{
+				RunsGetInput:    true,
 				RunsListExpired: true,
 				RunsDeleteInput: true,
 				RunsPinInput:    true,
@@ -1411,10 +1407,14 @@ func TestCapRunsGetInput_NotGrantedFromYAML(t *testing.T) {
 	t.Cleanup(func() { conn2.Close() })
 	caps := doHandshake(t, conn2, token)
 
+	found := false
 	for _, c := range caps {
 		if c == CapRunsGetInput {
-			t.Errorf("CapRunsGetInput granted via YAML spec — security regression; caps = %v", caps)
+			found = true
 		}
+	}
+	if !found {
+		t.Errorf("CapRunsGetInput not granted via YAML; caps = %v", caps)
 	}
 
 	// Sanity: the other caps must be present so we know the derivation ran.

--- a/pkg/registry/reconciler.go
+++ b/pkg/registry/reconciler.go
@@ -161,6 +161,13 @@ func (rc *Reconciler) handle(ev source.Event) {
 				return
 			}
 		}
+		for _, w := range spec.Warnings {
+			rc.log.Warn("task config warning",
+				zap.String("task", ev.TaskID),
+				zap.String("source", ev.Source),
+				zap.String("warning", w),
+			)
+		}
 		if err := rc.validateTaskProviders(spec); err != nil {
 			rc.log.Warn("task references unknown provider",
 				zap.String("task", ev.TaskID),

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -34,7 +34,7 @@ type Run struct {
 	StartedAt     time.Time
 	FinishedAt    *time.Time
 	ParentRunID   string
-	TriggerSource string
+	TriggerSource TriggerSource
 	ReturnValue   string // JSON-encoded return value; empty if none
 
 	// Structured output produced by output.html() / output.text().
@@ -256,14 +256,16 @@ func (r *Registry) GetRun(ctx context.Context, runID string) (*Run, error) {
 				var finishedMs *int64
 				var parentID *string
 				var redactedFieldsJSON string
+				var tsStr string
 				if err := rows.Scan(
 					&run.ID, &run.TaskID, &run.Status, &startedMs, &finishedMs, &parentID,
-					&run.TriggerSource, &run.ReturnValue, &run.OutputContentType, &run.OutputContent,
+					&tsStr, &run.ReturnValue, &run.OutputContentType, &run.OutputContent,
 					&run.FailureReason,
 					&run.InputStorageKey, &run.InputSize, &run.InputStoredAt, &redactedFieldsJSON, &run.InputPinned,
 				); err != nil {
 					return err
 				}
+				run.TriggerSource = TriggerSource(tsStr)
 				run.StartedAt = time.UnixMilli(startedMs)
 				if finishedMs != nil {
 					t := time.UnixMilli(*finishedMs)
@@ -321,9 +323,11 @@ func (r *Registry) ListRuns(ctx context.Context, taskID string, limit int) ([]*R
 				var startedMs int64
 				var finishedMs *int64
 				var parentID *string
-				if err := rows.Scan(&run.ID, &run.TaskID, &run.Status, &startedMs, &finishedMs, &parentID, &run.TriggerSource, &run.ReturnValue, &run.OutputContentType, &run.OutputContent, &run.FailureReason); err != nil {
+				var tsStr string
+				if err := rows.Scan(&run.ID, &run.TaskID, &run.Status, &startedMs, &finishedMs, &parentID, &tsStr, &run.ReturnValue, &run.OutputContentType, &run.OutputContent, &run.FailureReason); err != nil {
 					return err
 				}
+				run.TriggerSource = TriggerSource(tsStr)
 				run.StartedAt = time.UnixMilli(startedMs)
 				if finishedMs != nil {
 					t := time.UnixMilli(*finishedMs)

--- a/pkg/registry/replay.go
+++ b/pkg/registry/replay.go
@@ -2,8 +2,14 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
+
+// ErrReplayNotPermitted is returned by Replay when the caller's task identity
+// does not match the run's task and there is no parent-run lineage that would
+// allow it. See ownership policy in Replay's doc comment.
+var ErrReplayNotPermitted = errors.New("replay: caller task may not replay this run")
 
 // ReplayRunner abstracts the trigger engine's ability to fire a task with a
 // given input as a "replay" source. Decoupled from pkg/trigger via this
@@ -17,36 +23,58 @@ type ReplayRunner interface {
 	FireForReplay(ctx context.Context, taskID, parentRunID string, input any) (string, error)
 }
 
+// fetcher abstracts InputStore.Fetch for testability. *InputStore satisfies
+// this interface without modification.
+type fetcher interface {
+	Fetch(ctx context.Context, runID, key string, storedAt int64) (PersistedInput, error)
+}
+
 // Replayer fetches a persisted input and re-fires its task (or an override
 // task) with that input. The new run carries triggerSource = "replay" so
 // the trigger engine skips chain-firing on its failure (per spec § 4.3).
 type Replayer struct {
 	registry *Registry
-	store    *InputStore
+	store    fetcher
 	runner   ReplayRunner
 }
 
 // NewReplayer returns a Replayer wired against the given registry, input
 // store, and runner.
-func NewReplayer(reg *Registry, store *InputStore, runner ReplayRunner) *Replayer {
+func NewReplayer(reg *Registry, store fetcher, runner ReplayRunner) *Replayer {
 	return &Replayer{registry: reg, store: store, runner: runner}
 }
 
 // Replay fetches runID's persisted input and fires it against the original
 // task (or override taskName when non-empty). Returns the new run ID.
 //
+// Ownership policy (#246): when callerTaskID or callerParentRunID is non-empty,
+// the caller is a task-scoped IPC client and the call is permitted only when:
+//   - run.TaskID == callerTaskID (a task replaying its own historical run), OR
+//   - callerParentRunID == runID  (a chain-fired task replaying its parent run).
+//
+// When both fields are empty the ownership check is bypassed — backwards
+// compatible for REST handlers and tests that have no task scope.
+//
 // Errors:
 //   - run not found → wrapped GetRun error
 //   - run has no persisted input → ErrInputUnavailable
+//   - ownership check fails → ErrReplayNotPermitted
 //   - fetch/decrypt failure → wrapped fetch error
 //   - runner failure → wrapped fire error
-func (r *Replayer) Replay(ctx context.Context, runID, taskName string) (string, error) {
+func (r *Replayer) Replay(ctx context.Context, runID, taskName, callerTaskID, callerParentRunID string) (string, error) {
 	run, err := r.registry.GetRun(ctx, runID)
 	if err != nil {
 		return "", fmt.Errorf("get run: %w", err)
 	}
 	if run.InputStorageKey == "" {
 		return "", ErrInputUnavailable
+	}
+
+	// Ownership check: only enforce when the caller has a task identity.
+	if callerTaskID != "" || callerParentRunID != "" {
+		if run.TaskID != callerTaskID && callerParentRunID != runID {
+			return "", ErrReplayNotPermitted
+		}
 	}
 
 	in, err := r.store.Fetch(ctx, runID, run.InputStorageKey, run.InputStoredAt)

--- a/pkg/registry/replay_ownership_test.go
+++ b/pkg/registry/replay_ownership_test.go
@@ -1,0 +1,108 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/google/uuid"
+)
+
+// stubFetcher satisfies the fetcher interface for ownership tests.
+// It does not touch real storage.
+type stubFetcher struct{}
+
+func (stubFetcher) Fetch(_ context.Context, _, _ string, _ int64) (PersistedInput, error) {
+	return PersistedInput{Source: "stub"}, nil
+}
+
+// insertRun inserts a minimal run row with the given runID and taskID.
+// parent_run_id is NULL.
+func insertRun(t *testing.T, d db.DB, runID, taskID string) {
+	t.Helper()
+	err := d.Exec(context.Background(),
+		`INSERT INTO runs(id, task_id, status, started_at, parent_run_id, trigger_source, input_storage_key, input_stored_at)
+		 VALUES (?,?,?,?,NULL,?,?,?)`,
+		runID, taskID, "success", 0, "manual", "key1", 0)
+	if err != nil {
+		t.Fatalf("insertRun: %v", err)
+	}
+}
+
+func TestReplay_OwnershipAllowsSelfTask(t *testing.T) {
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	reg := New(d)
+
+	runID := uuid.New().String()
+	insertRun(t, d, runID, "task-a")
+
+	r := &Replayer{registry: reg, store: stubFetcher{}, runner: &fakeReplayRunner{}}
+
+	// caller task-a replays its own run — allowed.
+	if _, err := r.Replay(context.Background(), runID, "", "task-a", ""); err != nil {
+		t.Errorf("self-task replay rejected: %v", err)
+	}
+}
+
+func TestReplay_OwnershipBlocksCrossTask(t *testing.T) {
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	reg := New(d)
+
+	runID := uuid.New().String()
+	insertRun(t, d, runID, "task-a")
+
+	r := &Replayer{registry: reg, store: stubFetcher{}, runner: &fakeReplayRunner{}}
+
+	// caller task-b, no lineage → must be rejected.
+	_, replayErr := r.Replay(context.Background(), runID, "", "task-b", "")
+	if !errors.Is(replayErr, ErrReplayNotPermitted) {
+		t.Errorf("expected ErrReplayNotPermitted, got %v", replayErr)
+	}
+}
+
+func TestReplay_OwnershipAllowsParentRun(t *testing.T) {
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	reg := New(d)
+
+	runID := uuid.New().String()
+	insertRun(t, d, runID, "task-a")
+
+	r := &Replayer{registry: reg, store: stubFetcher{}, runner: &fakeReplayRunner{}}
+
+	// caller task-b whose parent_run_id == runID — auto-fix lineage, allowed.
+	if _, err := r.Replay(context.Background(), runID, "", "task-b", runID); err != nil {
+		t.Errorf("parent-run replay rejected: %v", err)
+	}
+}
+
+func TestReplay_OwnershipEmptyCallerBypasses(t *testing.T) {
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	reg := New(d)
+
+	runID := uuid.New().String()
+	insertRun(t, d, runID, "task-a")
+
+	r := &Replayer{registry: reg, store: stubFetcher{}, runner: &fakeReplayRunner{}}
+
+	// Empty caller fields — REST-handler / backwards-compat bypass.
+	if _, err := r.Replay(context.Background(), runID, "", "", ""); err != nil {
+		t.Errorf("empty-caller replay rejected: %v", err)
+	}
+}

--- a/pkg/registry/replay_test.go
+++ b/pkg/registry/replay_test.go
@@ -59,7 +59,7 @@ func TestReplay_FetchesInputAndFires(t *testing.T) {
 	runner := &fakeReplayRunner{}
 	replayer := NewReplayer(r, is, runner)
 
-	newRunID, err := replayer.Replay(ctx, originalRunID, "")
+	newRunID, err := replayer.Replay(ctx, originalRunID, "", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +107,7 @@ func TestReplay_TaskNameOverride(t *testing.T) {
 	runner := &fakeReplayRunner{}
 	replayer := NewReplayer(r, is, runner)
 
-	if _, err := replayer.Replay(ctx, originalRunID, "different-task"); err != nil {
+	if _, err := replayer.Replay(ctx, originalRunID, "different-task", "", ""); err != nil {
 		t.Fatal(err)
 	}
 	if runner.calls[0].taskID != "different-task" {
@@ -131,7 +131,7 @@ func TestReplay_NoStoredInput_ReturnsErrInputUnavailable(t *testing.T) {
 	runner := &fakeReplayRunner{}
 	replayer := NewReplayer(r, is, runner)
 
-	_, err := replayer.Replay(ctx, originalRunID, "")
+	_, err := replayer.Replay(ctx, originalRunID, "", "", "")
 	if !errors.Is(err, ErrInputUnavailable) {
 		t.Errorf("got %v, want ErrInputUnavailable", err)
 	}
@@ -145,7 +145,7 @@ func TestReplay_RunNotFound(t *testing.T) {
 	runner := &fakeReplayRunner{}
 	replayer := NewReplayer(r, is, runner)
 
-	_, err := replayer.Replay(ctx, uuid.New().String(), "")
+	_, err := replayer.Replay(ctx, uuid.New().String(), "", "", "")
 	if err == nil {
 		t.Error("expected error for unknown run ID")
 	}

--- a/pkg/registry/trigger_source.go
+++ b/pkg/registry/trigger_source.go
@@ -16,4 +16,6 @@ const (
 	TriggerDaemon      TriggerSource = "daemon"
 	TriggerReplay      TriggerSource = "replay"
 	TriggerCronCatchup TriggerSource = "cron-catchup"
+	TriggerProvider    TriggerSource = "provider"
+	TriggerIfMissing   TriggerSource = "if_missing"
 )

--- a/pkg/registry/trigger_source.go
+++ b/pkg/registry/trigger_source.go
@@ -1,0 +1,19 @@
+package registry
+
+// TriggerSource is the typed enum identifying how a run was started.
+// JSON wire value is the underlying string (preserves API compatibility
+// with the prior string-typed Run.TriggerSource field). DB scan paths
+// use a string intermediary and cast on assignment to avoid driver
+// type-assertion failures.
+type TriggerSource string
+
+const (
+	TriggerUnknown     TriggerSource = ""
+	TriggerWebhook     TriggerSource = "webhook"
+	TriggerCron        TriggerSource = "cron"
+	TriggerManual      TriggerSource = "manual"
+	TriggerChain       TriggerSource = "chain"
+	TriggerDaemon      TriggerSource = "daemon"
+	TriggerReplay      TriggerSource = "replay"
+	TriggerCronCatchup TriggerSource = "cron-catchup"
+)

--- a/pkg/registry/trigger_source_test.go
+++ b/pkg/registry/trigger_source_test.go
@@ -1,0 +1,46 @@
+package registry
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTriggerSource_StringValues(t *testing.T) {
+	cases := []struct {
+		ts   TriggerSource
+		want string
+	}{
+		{TriggerWebhook, "webhook"},
+		{TriggerCron, "cron"},
+		{TriggerManual, "manual"},
+		{TriggerChain, "chain"},
+		{TriggerDaemon, "daemon"},
+		{TriggerReplay, "replay"},
+	}
+	for _, c := range cases {
+		if string(c.ts) != c.want {
+			t.Errorf("TriggerSource %q != %q", c.ts, c.want)
+		}
+	}
+}
+
+func TestTriggerSource_JSONRoundtrip(t *testing.T) {
+	type wrapper struct {
+		TS TriggerSource `json:"trigger_source"`
+	}
+	w := wrapper{TS: TriggerReplay}
+	b, err := json.Marshal(w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != `{"trigger_source":"replay"}` {
+		t.Errorf("got %s", b)
+	}
+	var back wrapper
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.TS != TriggerReplay {
+		t.Errorf("roundtrip: %q", back.TS)
+	}
+}

--- a/pkg/runtime/executor.go
+++ b/pkg/runtime/executor.go
@@ -44,6 +44,11 @@ type RunOptions struct {
 	// Used by the run-input persistence layer to call content-type-aware
 	// redaction on the raw body and to populate Method/Path/Headers/Query.
 	WebhookCtx *WebhookContext
+
+	// ChainParentTask is the failing-task ID that fired this run via
+	// on_failure_chain. Empty for non-chained runs. Used by the trigger
+	// engine to release the chainGuards slot on completion.
+	ChainParentTask string
 }
 
 // RunResult is returned by every Executor.

--- a/pkg/task/onfailurechain.go
+++ b/pkg/task/onfailurechain.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"fmt"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -18,8 +19,53 @@ import (
 //
 // The bare-string form is equivalent to {task: <string>, params: nil}.
 type OnFailureChainSpec struct {
-	Task   string         `yaml:"task"`
-	Params map[string]any `yaml:"params,omitempty"`
+	Task   string         `yaml:"task"                     json:"task"`
+	Params map[string]any `yaml:"params,omitempty"         json:"params,omitempty"`
+
+	// MaxDepth caps the number of chained on_failure_chain hops. When the
+	// incoming run's _chain_depth >= MaxDepth, the chain is suppressed with a
+	// structured WARN. Default 2 (see EffectiveMaxDepth).
+	MaxDepth int `yaml:"max_depth,omitempty" json:"max_depth,omitempty"`
+
+	// Cooldown is the minimum wall-clock interval between two on_failure_chain
+	// fires for the same failing task. Default 10m. Zero = unlimited (no cooldown).
+	// Wired by Task 4.
+	Cooldown time.Duration `yaml:"cooldown,omitempty" json:"cooldown,omitempty"`
+
+	// MaxConcurrent caps the number of on_failure_chain runs in flight per
+	// failing task. Default 1. Wired by Task 5.
+	MaxConcurrent int `yaml:"max_concurrent,omitempty" json:"max_concurrent,omitempty"`
+
+	// MaxConcurrentGlobal caps total on_failure_chain runs in flight across all
+	// tasks. Applies only at the defaults.on_failure_chain site; per-task values
+	// are ignored (enforced at config load in a future work item). Default 3.
+	// Wired by Task 6.
+	MaxConcurrentGlobal int `yaml:"max_concurrent_global,omitempty" json:"max_concurrent_global,omitempty"`
+
+	// Storm configures the per-source-namespace circuit breaker. Applies only at
+	// the defaults site. Zero rate = disabled. Wired by Task 7.
+	Storm StormSpec `yaml:"storm,omitempty" json:"storm,omitempty"`
+}
+
+// StormSpec is the failure-storm circuit breaker configuration.
+type StormSpec struct {
+	// Rate is the number of chain fires within Window that trip the breaker.
+	Rate int `yaml:"rate,omitempty" json:"rate,omitempty"`
+	// Window is the observation period for the rate counter.
+	Window time.Duration `yaml:"window,omitempty" json:"window,omitempty"`
+	// Suppress is the duration for which chain fires are suppressed after the
+	// breaker trips.
+	Suppress time.Duration `yaml:"suppress,omitempty" json:"suppress,omitempty"`
+	// Scope is "source" (default) or "global".
+	Scope string `yaml:"scope,omitempty" json:"scope,omitempty"`
+}
+
+// EffectiveMaxDepth returns the configured MaxDepth, or 2 if MaxDepth <= 0.
+func (s OnFailureChainSpec) EffectiveMaxDepth() int {
+	if s.MaxDepth > 0 {
+		return s.MaxDepth
+	}
+	return 2
 }
 
 // UnmarshalYAML decodes either a scalar (bare task ID) or a mapping into the

--- a/pkg/task/onfailurechain.go
+++ b/pkg/task/onfailurechain.go
@@ -110,24 +110,47 @@ var reservedChainParamKeys = map[string]struct{}{
 	"_chain_depth": {},
 }
 
-// Validate enforces reserved-key constraints. Called from both
-// the defaults site (Defaults.OnFailureChain) and per-task sites
-// (Task.Spec.OnFailureChain).
-func (s OnFailureChainSpec) Validate() error {
+// Validate enforces reserved-key constraints and strips per-task-only fields
+// (MaxConcurrentGlobal, Storm) that must not be set at the individual task
+// level. Called from per-task sites (Spec.validate); not called directly for
+// the defaults block — use ValidateAtDefaults for that.
+//
+// Mutates s in place (zeroes any stripped fields) and returns non-fatal
+// warnings that callers should surface via their structured logger.
+func (s *OnFailureChainSpec) Validate() (warnings []string, err error) {
 	for k := range s.Params {
 		if _, reserved := reservedChainParamKeys[k]; reserved {
-			return fmt.Errorf("on_failure_chain.params: %q is a reserved key (used by the engine)", k)
+			return nil, fmt.Errorf("on_failure_chain.params: %q is a reserved key (used by the engine)", k)
 		}
 	}
-	return nil
+	// MaxConcurrentGlobal and Storm are operator-policy fields that apply only
+	// at the defaults.on_failure_chain level. A per-task value would bypass the
+	// global guard via the full-replace merge in FireChain; zero it out and warn.
+	if s.MaxConcurrentGlobal != 0 {
+		warnings = append(warnings,
+			fmt.Sprintf("on_failure_chain.max_concurrent_global is an operator-policy field and is ignored at the per-task level (task had %d); set it in defaults.on_failure_chain instead", s.MaxConcurrentGlobal))
+		s.MaxConcurrentGlobal = 0
+	}
+	if s.Storm.Rate != 0 || s.Storm.Window != 0 || s.Storm.Suppress != 0 || s.Storm.Scope != "" {
+		warnings = append(warnings,
+			"on_failure_chain.storm is an operator-policy field and is ignored at the per-task level; set it in defaults.on_failure_chain instead")
+		s.Storm = StormSpec{}
+	}
+	return warnings, nil
 }
 
 // ValidateAtDefaults runs at the defaults.on_failure_chain site only.
 // Adds the rule: mode: autonomous is rejected at the defaults level — must be
 // opted into per-task, paired with branch protection on the source's tracked
 // branch.
+//
+// Does NOT strip MaxConcurrentGlobal or Storm — those are valid here.
 func (s OnFailureChainSpec) ValidateAtDefaults() error {
-	if err := s.Validate(); err != nil {
+	// Use a pointer receiver call on a local copy to avoid mutating the caller's
+	// value; at the defaults site stripping is not needed, but we still need the
+	// reserved-key check.
+	copy := s
+	if _, err := copy.Validate(); err != nil {
 		return err
 	}
 	if mode, ok := s.Params["mode"].(string); ok && mode == "autonomous" {

--- a/pkg/task/onfailurechain.go
+++ b/pkg/task/onfailurechain.go
@@ -149,8 +149,8 @@ func (s OnFailureChainSpec) ValidateAtDefaults() error {
 	// Use a pointer receiver call on a local copy to avoid mutating the caller's
 	// value; at the defaults site stripping is not needed, but we still need the
 	// reserved-key check.
-	copy := s
-	if _, err := copy.Validate(); err != nil {
+	scratch := s
+	if _, err := scratch.Validate(); err != nil {
 		return err
 	}
 	if mode, ok := s.Params["mode"].(string); ok && mode == "autonomous" {

--- a/pkg/task/onfailurechain_test.go
+++ b/pkg/task/onfailurechain_test.go
@@ -81,7 +81,7 @@ func TestOnFailureChainSpec_Validate_ReservedKeyCollision(t *testing.T) {
 				Task:   "auto-fix",
 				Params: map[string]any{key: "x"},
 			}
-			err := s.Validate()
+			_, err := s.Validate()
 			if err == nil {
 				t.Fatal("expected error for reserved key collision")
 			}
@@ -111,7 +111,7 @@ func TestOnFailureChainSpec_Validate_AcceptsAutonomousAtTaskLevel(t *testing.T) 
 		Task:   "auto-fix",
 		Params: map[string]any{"mode": "autonomous"},
 	}
-	if err := s.Validate(); err != nil {
+	if _, err := s.Validate(); err != nil {
 		t.Errorf("per-task autonomous should be accepted by Validate(); got %v", err)
 	}
 }
@@ -123,5 +123,60 @@ func TestOnFailureChainSpec_ValidateAtDefaults_AcceptsReview(t *testing.T) {
 	}
 	if err := s.ValidateAtDefaults(); err != nil {
 		t.Errorf("review at defaults should be accepted; got %v", err)
+	}
+}
+
+// TestOnFailureChainSpec_StripsGlobalFieldsForPerTask verifies that
+// MaxConcurrentGlobal and Storm are zeroed by Validate() when set at the
+// per-task level, and that a structured warning is returned for each.
+func TestOnFailureChainSpec_StripsGlobalFieldsForPerTask(t *testing.T) {
+	s := OnFailureChainSpec{
+		Task:                "auto-fix",
+		MaxConcurrentGlobal: 5,
+		Storm: StormSpec{
+			Rate:     10,
+			Window:   60 * 1e9, // 60s as nanoseconds
+			Suppress: 300 * 1e9,
+			Scope:    "global",
+		},
+	}
+
+	warns, err := s.Validate()
+	if err != nil {
+		t.Fatalf("Validate() returned unexpected error: %v", err)
+	}
+	if len(warns) != 2 {
+		t.Fatalf("expected 2 warnings (MaxConcurrentGlobal + Storm), got %d: %v", len(warns), warns)
+	}
+	for _, w := range warns {
+		if !strings.Contains(w, "operator-policy") {
+			t.Errorf("warning should mention 'operator-policy'; got %q", w)
+		}
+	}
+	if s.MaxConcurrentGlobal != 0 {
+		t.Errorf("MaxConcurrentGlobal should be zeroed after Validate(); got %d", s.MaxConcurrentGlobal)
+	}
+	if s.Storm != (StormSpec{}) {
+		t.Errorf("Storm should be zeroed after Validate(); got %+v", s.Storm)
+	}
+}
+
+// TestOnFailureChainSpec_ValidateAtDefaults_KeepsGlobalFields verifies that
+// ValidateAtDefaults does NOT strip MaxConcurrentGlobal or Storm — those are
+// valid at the defaults site.
+func TestOnFailureChainSpec_ValidateAtDefaults_KeepsGlobalFields(t *testing.T) {
+	s := OnFailureChainSpec{
+		Task:                "auto-fix",
+		MaxConcurrentGlobal: 5,
+		Storm: StormSpec{
+			Rate:   10,
+			Window: 60 * 1e9,
+		},
+	}
+	if err := s.ValidateAtDefaults(); err != nil {
+		t.Fatalf("ValidateAtDefaults() rejected valid defaults-level spec: %v", err)
+	}
+	if s.MaxConcurrentGlobal != 5 {
+		t.Errorf("ValidateAtDefaults should not zero MaxConcurrentGlobal; got %d", s.MaxConcurrentGlobal)
 	}
 }

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -479,6 +479,10 @@ func (s *Spec) Script() (string, error) {
 }
 
 func (s *Spec) validate() error {
+	// Clear stale warnings so re-validation (e.g. on a reloaded spec) starts
+	// from a clean slate; otherwise warnings accumulate across validate
+	// calls.
+	s.Warnings = nil
 	if s.Name == "" {
 		return fmt.Errorf("name is required")
 	}

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -360,6 +360,10 @@ type Spec struct {
 	TaskDir string `yaml:"-" json:"-"`
 	// ID is derived from the directory name (not stored in YAML).
 	ID string `yaml:"-" json:"id"`
+	// Warnings holds non-fatal config-load warnings emitted during validate().
+	// Callers (reconciler, taskset resolver) should log these via their zap
+	// logger after LoadDir / LoadDirWithVars returns.
+	Warnings []string `yaml:"-" json:"-"`
 }
 
 // RunInputsTaskOverride is the per-task override for run-input persistence.
@@ -516,9 +520,11 @@ func (s *Spec) validate() error {
 		return fmt.Errorf("only one trigger type is allowed per task")
 	}
 	if s.OnFailureChain != nil {
-		if err := s.OnFailureChain.Validate(); err != nil {
+		warns, err := s.OnFailureChain.Validate()
+		if err != nil {
 			return fmt.Errorf("on_failure_chain: %w", err)
 		}
+		s.Warnings = append(s.Warnings, warns...)
 	}
 	switch s.Runtime {
 	case RuntimeDeno, "js", "":

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -294,6 +294,13 @@ type DicodePermissions struct {
 	// RunsReplay enables dicode.runs.replay() — re-fires a previously
 	// persisted run with its stored input.
 	RunsReplay bool `yaml:"runs_replay,omitempty" json:"runs_replay,omitempty"`
+	// RunsGetInput enables dicode.runs.get_input() — read another task's
+	// persisted run input. Sensitive: grants cross-task input access.
+	// Persisted inputs are redacted at write time (see #233's deny-list),
+	// so the surface is bounded but still grants visibility into anything
+	// not on the deny-list. Grant only to tasks that legitimately need to
+	// inspect failed runs (auto-fix, audit, replay-tooling).
+	RunsGetInput bool `yaml:"runs_get_input,omitempty" json:"runs_get_input,omitempty"`
 	// TasksTest enables dicode.tasks.test() — runs a task's sibling test file
 	// via pkg/tasktest.
 	TasksTest bool `yaml:"tasks_test,omitempty" json:"tasks_test,omitempty"`

--- a/pkg/taskset/auto_fix_entry_test.go
+++ b/pkg/taskset/auto_fix_entry_test.go
@@ -1,0 +1,58 @@
+package taskset_test
+
+import (
+	"testing"
+
+	"github.com/dicode/dicode/pkg/taskset"
+)
+
+func TestAutoFixEntry_HasExpectedDicodePerms(t *testing.T) {
+	// Load the buildin taskset and inspect the "auto-fix" entry.
+	// The API is LoadTaskSet which returns *TaskSetSpec; we then inspect
+	// entry.Overrides.Dicode directly (the resolved merge would require
+	// loading the ai-agent task.yaml, which needs a real data dir).
+	ts, err := taskset.LoadTaskSet("../../tasks/buildin/taskset.yaml")
+	if err != nil {
+		t.Fatalf("load taskset: %v", err)
+	}
+
+	entry, ok := ts.Spec.Entries["auto-fix"]
+	if !ok {
+		t.Fatal("auto-fix entry not found in buildin taskset")
+	}
+	if entry.Overrides == nil {
+		t.Fatal("auto-fix entry has no overrides")
+	}
+	d := entry.Overrides.Dicode
+	if d == nil {
+		t.Fatal("auto-fix overrides.dicode is nil")
+	}
+
+	want := map[string]bool{
+		"RunsReplay":        d.RunsReplay,
+		"RunsGetInput":      d.RunsGetInput,
+		"RunsPinInput":      d.RunsPinInput,
+		"RunsUnpinInput":    d.RunsUnpinInput,
+		"SourcesSetDevMode": d.SourcesSetDevMode,
+		"TasksTest":         d.TasksTest,
+		"GitCommitPush":     d.GitCommitPush,
+		"ListTasks":         d.ListTasks,
+		"GetRuns":           d.GetRuns,
+	}
+	for name, v := range want {
+		if !v {
+			t.Errorf("%s expected true in auto-fix overrides.dicode", name)
+		}
+	}
+
+	// Tasks union must include git-pr.
+	hasGitPR := false
+	for _, taskID := range d.Tasks {
+		if taskID == "git-pr" {
+			hasGitPR = true
+		}
+	}
+	if !hasGitPR {
+		t.Errorf("auto-fix tasks slice missing git-pr; got %v", d.Tasks)
+	}
+}

--- a/pkg/taskset/override.go
+++ b/pkg/taskset/override.go
@@ -36,6 +36,9 @@ func applyLayer(spec *task.Spec, o *Overrides) {
 	if len(o.Net) > 0 {
 		spec.Permissions.Net = o.Net
 	}
+	if len(o.Fs) > 0 {
+		spec.Permissions.FS = o.Fs
+	}
 	if o.Dicode != nil {
 		spec.Permissions.Dicode = mergeDicodePerms(spec.Permissions.Dicode, o.Dicode)
 	}
@@ -150,6 +153,8 @@ func mergeEnvEntries(base, overlay []task.EnvEntry) []task.EnvEntry {
 }
 
 // mergeDicodePerms merges overlay on top of base, with overlay winning non-zero fields.
+// Tasks is merged via union (preserving order, deduping) so an override can append
+// entries without clobbering the base list.
 func mergeDicodePerms(base, overlay *task.DicodePermissions) *task.DicodePermissions {
 	if overlay == nil {
 		return base
@@ -160,7 +165,17 @@ func mergeDicodePerms(base, overlay *task.DicodePermissions) *task.DicodePermiss
 	}
 	out := *base
 	if len(overlay.Tasks) > 0 {
-		out.Tasks = overlay.Tasks
+		// UNION (was full-replace) — append unique entries from overlay.
+		existing := make(map[string]struct{}, len(out.Tasks))
+		for _, t := range out.Tasks {
+			existing[t] = struct{}{}
+		}
+		for _, t := range overlay.Tasks {
+			if _, ok := existing[t]; !ok {
+				out.Tasks = append(out.Tasks, t)
+				existing[t] = struct{}{}
+			}
+		}
 	}
 	if len(overlay.MCP) > 0 {
 		out.MCP = overlay.MCP
@@ -173,6 +188,42 @@ func mergeDicodePerms(base, overlay *task.DicodePermissions) *task.DicodePermiss
 	}
 	if overlay.SecretsWrite {
 		out.SecretsWrite = true
+	}
+	if overlay.OAuthInit {
+		out.OAuthInit = true
+	}
+	if overlay.OAuthStore {
+		out.OAuthStore = true
+	}
+	if overlay.OAuthStatus {
+		out.OAuthStatus = true
+	}
+	if overlay.RunsListExpired {
+		out.RunsListExpired = true
+	}
+	if overlay.RunsDeleteInput {
+		out.RunsDeleteInput = true
+	}
+	if overlay.RunsPinInput {
+		out.RunsPinInput = true
+	}
+	if overlay.RunsUnpinInput {
+		out.RunsUnpinInput = true
+	}
+	if overlay.RunsReplay {
+		out.RunsReplay = true
+	}
+	if overlay.RunsGetInput {
+		out.RunsGetInput = true
+	}
+	if overlay.TasksTest {
+		out.TasksTest = true
+	}
+	if overlay.SourcesSetDevMode {
+		out.SourcesSetDevMode = true
+	}
+	if overlay.GitCommitPush {
+		out.GitCommitPush = true
 	}
 	return &out
 }

--- a/pkg/taskset/override_test.go
+++ b/pkg/taskset/override_test.go
@@ -1,6 +1,8 @@
 package taskset
 
 import (
+	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -356,6 +358,69 @@ func TestDefaultsToOverrides_Fields(t *testing.T) {
 	}
 	if o.Enabled != nil {
 		t.Error("enabled should not be set from defaults")
+	}
+}
+
+// ── applyOverrides: FS / Tasks union / new bool flags ────────────────────────
+
+func TestApplyOverrides_FSReplace(t *testing.T) {
+	base := &task.Spec{
+		Permissions: task.Permissions{
+			FS: []task.FSEntry{{Path: "/base/path", Permission: "r"}},
+		},
+	}
+	overlay := &Overrides{
+		Fs: []task.FSEntry{{Path: "/clones", Permission: "rw"}},
+	}
+	out := applyOverrides(base, overlay)
+	want := []task.FSEntry{{Path: "/clones", Permission: "rw"}}
+	if !reflect.DeepEqual(out.Permissions.FS, want) {
+		t.Errorf("Fs override: got %+v, want %+v", out.Permissions.FS, want)
+	}
+}
+
+func TestApplyOverrides_DicodeTasksUnion(t *testing.T) {
+	base := &task.Spec{
+		Permissions: task.Permissions{
+			Dicode: &task.DicodePermissions{
+				Tasks: []string{"task-a", "task-b"},
+			},
+		},
+	}
+	overlay := &Overrides{
+		Dicode: &task.DicodePermissions{
+			Tasks: []string{"git-pr", "task-b"}, // task-b duplicate; git-pr is new
+		},
+	}
+	out := applyOverrides(base, overlay)
+	got := out.Permissions.Dicode.Tasks
+	sort.Strings(got)
+	want := []string{"git-pr", "task-a", "task-b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Tasks union: got %+v, want %+v", got, want)
+	}
+}
+
+func TestApplyOverrides_DicodeNewBoolFlags(t *testing.T) {
+	base := &task.Spec{Permissions: task.Permissions{Dicode: &task.DicodePermissions{}}}
+	overlay := &Overrides{
+		Dicode: &task.DicodePermissions{
+			RunsReplay: true, RunsGetInput: true, TasksTest: true, SourcesSetDevMode: true,
+			GitCommitPush: true, RunsPinInput: true, RunsUnpinInput: true,
+			RunsListExpired: true, RunsDeleteInput: true,
+		},
+	}
+	out := applyOverrides(base, overlay)
+	d := out.Permissions.Dicode
+	for name, v := range map[string]bool{
+		"RunsReplay": d.RunsReplay, "RunsGetInput": d.RunsGetInput, "TasksTest": d.TasksTest,
+		"SourcesSetDevMode": d.SourcesSetDevMode, "GitCommitPush": d.GitCommitPush,
+		"RunsPinInput": d.RunsPinInput, "RunsUnpinInput": d.RunsUnpinInput,
+		"RunsListExpired": d.RunsListExpired, "RunsDeleteInput": d.RunsDeleteInput,
+	} {
+		if !v {
+			t.Errorf("flag %s not propagated by override", name)
+		}
 	}
 }
 

--- a/pkg/taskset/resolver.go
+++ b/pkg/taskset/resolver.go
@@ -219,6 +219,12 @@ func (r *Resolver) resolveBody(
 					zap.String("entry", fullID), zap.Error(err))
 				continue
 			}
+			for _, w := range spec.Warnings {
+				r.log.Warn("taskset: task config warning",
+					zap.String("entry", fullID),
+					zap.String("warning", w),
+				)
+			}
 			layers := buildOverrideLayers(ts.Spec.Defaults, parentEntryOverride, entry.Overrides)
 			resolved := applyOverrides(spec, layers...)
 			resolved.ID = fullID

--- a/pkg/taskset/skill_loader_test.go
+++ b/pkg/taskset/skill_loader_test.go
@@ -1,0 +1,31 @@
+package taskset_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestAutoFixSkill_FileExists(t *testing.T) {
+	path := "../../tasks/skills/dicode-auto-fix.md"
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read skill: %v", err)
+	}
+	required := []string{
+		"dicode.runs.get_input",
+		"dicode.runs.pin_input",
+		"dicode.runs.unpin_input",
+		"dicode.sources.set_dev_mode",
+		"dicode.git.commit_push",
+		"dicode.tasks.test",
+		"dicode.runs.replay",
+		"max_iterations",
+		"defer cleanup",
+	}
+	for _, r := range required {
+		if !strings.Contains(string(body), r) {
+			t.Errorf("skill missing required term %q", r)
+		}
+	}
+}

--- a/pkg/taskset/spec.go
+++ b/pkg/taskset/spec.go
@@ -141,6 +141,8 @@ type Overrides struct {
 	// Env accepts full EnvEntry mappings (name/secret/from/value/optional) or bare "KEY" / "KEY=value" strings.
 	Env     []task.EnvEntry         `yaml:"env,omitempty"`
 	Net     []string                `yaml:"net,omitempty"` // replaces permissions.net
+	// Fs replaces permissions.fs entirely (matches Net's full-replace pattern).
+	Fs []task.FSEntry `yaml:"fs,omitempty"`
 	Timeout time.Duration           `yaml:"timeout,omitempty"`
 	Retry   *RetryConfig            `yaml:"retry,omitempty"`
 	Runtime string                  `yaml:"runtime,omitempty"`

--- a/pkg/taskset/spec.go
+++ b/pkg/taskset/spec.go
@@ -139,10 +139,10 @@ type Overrides struct {
 	Trigger     *TriggerPatch  `yaml:"trigger,omitempty"`
 	Params      ParamOverrides `yaml:"params,omitempty"`
 	// Env accepts full EnvEntry mappings (name/secret/from/value/optional) or bare "KEY" / "KEY=value" strings.
-	Env     []task.EnvEntry         `yaml:"env,omitempty"`
-	Net     []string                `yaml:"net,omitempty"` // replaces permissions.net
+	Env []task.EnvEntry `yaml:"env,omitempty"`
+	Net []string        `yaml:"net,omitempty"` // replaces permissions.net
 	// Fs replaces permissions.fs entirely (matches Net's full-replace pattern).
-	Fs []task.FSEntry `yaml:"fs,omitempty"`
+	Fs      []task.FSEntry          `yaml:"fs,omitempty"`
 	Timeout time.Duration           `yaml:"timeout,omitempty"`
 	Retry   *RetryConfig            `yaml:"retry,omitempty"`
 	Runtime string                  `yaml:"runtime,omitempty"`

--- a/pkg/trigger/auto_fix_e2e_test.go
+++ b/pkg/trigger/auto_fix_e2e_test.go
@@ -1,0 +1,98 @@
+// pkg/trigger/auto_fix_e2e_test.go
+package trigger
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// TestAutoFix_E2E_HappyPath wires the engine, registry, input store, and chain
+// dispatcher through a controlled-failure path:
+//  1. A webhook task fails (controlled).
+//  2. on_failure_chain fires buildin/auto-fix.
+//  3. The chain dispatcher fires the stub auto-fix task.
+//  4. Assert: the original run has StatusFailure, auto-fix runs and succeeds,
+//     and its return value contains "pr_url".
+//
+// The full agent loop (real AI, Deno, LLM) is exercised by manual smoke testing.
+// This test stubs out buildin/auto-fix to a trivially-passing task so no
+// external dependencies are required.
+//
+// Gated on DICODE_E2E=1 so default unit-test runs are unaffected.
+func TestAutoFix_E2E_HappyPath(t *testing.T) {
+	if os.Getenv("DICODE_E2E") == "" {
+		t.Skip("DICODE_E2E not set — skipping integration test")
+	}
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	// Stub gh on PATH so any shell invocation of `gh` returns a fake PR URL.
+	stubDir := filepath.Join(dir, "stub-bin")
+	if err := os.MkdirAll(stubDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ghStub := filepath.Join(stubDir, "gh")
+	if err := os.WriteFile(ghStub,
+		[]byte("#!/bin/sh\necho https://github.com/example/repo/pull/1\n"),
+		0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	// Wire input store so the persist-hook and IPC server share the same store.
+	runner := &fakeRunner{store: map[string]string{}}
+	is := newFakeInputStore(runner, "fake-storage")
+	e.engine.SetInputStore(is)
+	e.denoRT.SetInputStore(is)
+
+	// Register a controlled-failure task with on_failure_chain pointing at
+	// buildin/auto-fix.
+	failing := writeTask(t, dir, "process-payment",
+		`export default async () => { throw new Error("boom") }`,
+		task.TriggerConfig{Manual: true})
+	failing.OnFailureChain = &task.OnFailureChainSpec{
+		Task:   "buildin/auto-fix",
+		Params: map[string]any{"mode": "review"},
+	}
+	if err := e.reg.Register(failing); err != nil {
+		t.Fatalf("register failing task: %v", err)
+	}
+
+	// Register a stub buildin/auto-fix that returns a fake pr_url immediately.
+	// A full agent loop is exercised by manual smoke testing, not by this unit test.
+	autoFix := writeTask(t, dir, "buildin/auto-fix",
+		`export default async () => { return { ok: true, pr_url: "https://github.com/example/repo/pull/1" } }`,
+		task.TriggerConfig{Manual: true})
+	if err := e.reg.Register(autoFix); err != nil {
+		t.Fatalf("register auto-fix stub: %v", err)
+	}
+
+	// Fire the failing task and wait for it to reach a terminal state.
+	runID, err := e.engine.FireManual(context.Background(), "process-payment", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := waitForTerminal(t, e.engine, runID, 30*time.Second)
+	if r.Status != registry.StatusFailure {
+		t.Fatalf("primary run status = %q, want failure", r.Status)
+	}
+
+	// Wait for the chain dispatcher to fire buildin/auto-fix.
+	autoFixRun := waitForRunOfTask(t, e.engine, "buildin/auto-fix", 15*time.Second)
+	if autoFixRun == nil {
+		t.Fatal("buildin/auto-fix was never fired by the on_failure_chain dispatcher")
+	}
+	if autoFixRun.Status != registry.StatusSuccess {
+		t.Errorf("auto-fix run status = %q, want success", autoFixRun.Status)
+	}
+	if !strings.Contains(autoFixRun.ReturnValue, "pr_url") {
+		t.Errorf("auto-fix did not return pr_url; ReturnValue=%q", autoFixRun.ReturnValue)
+	}
+}

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -868,7 +868,7 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 
 				// 1. Storm check — per-source namespace.
 				scope := stormScope(completedTaskID)
-				if e.guards.stormSuppressed(scope, chainSpec.Storm.Suppress, now) {
+				if e.guards.stormSuppressed(scope, now) {
 					e.log.Warn("on_failure_chain suppressed: storm circuit breaker tripped",
 						zap.String("scope", scope),
 						zap.String("from", completedTaskID),
@@ -904,11 +904,6 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 					return
 				}
 
-				// 4. Record this fire (cooldown + storm).
-				e.guards.recordChainFire(completedTaskID, now)
-				e.guards.observeChainFire(scope, chainSpec.Storm.Rate, chainSpec.Storm.Window,
-					chainSpec.Storm.Suppress, now)
-
 				e.log.Info("on_failure_chain trigger",
 					zap.String("from", completedTaskID),
 					zap.String("to", targetID),
@@ -926,18 +921,48 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 				for k, v := range chainSpec.Params {
 					input[k] = v
 				}
+				// Auto-fix safety default: when the chain target is the
+				// buildin auto-fix preset, force mode=review unless the
+				// operator explicitly set it. Autonomous-by-default would
+				// be a foot-gun (the agent could push directly to main
+				// without human review).
+				if targetID == "buildin/auto-fix" {
+					if _, ok := input["mode"]; !ok {
+						input["mode"] = "review"
+					}
+				}
 				input["taskID"] = completedTaskID
 				input["runID"] = runID
 				input["status"] = runStatus
 				input["output"] = output
 				input["_chain_depth"] = nextDepth
-				// Slot is held until the chained run terminates.
-				// Released in startRun's cleanup via ChainParentTask.
-				go e.fireAsync(ctx, targetSpec, pkgruntime.RunOptions{ //nolint:errcheck
+
+				// Synchronously invoke fireAsync — it returns once startRun
+				// completes, then continues the run on its own goroutine.
+				// Doing this sync (rather than `go fireAsync(...)`) lets us
+				// release the chainGuards slot if startRun fails and avoids
+				// recording cooldown / storm counters for runs that never
+				// executed (false-trip risk under DB flapping).
+				if _, err := e.fireAsync(ctx, targetSpec, pkgruntime.RunOptions{
 					ParentRunID:     runID,
 					Input:           input,
 					ChainParentTask: completedTaskID,
-				}, registry.TriggerChain)
+				}, registry.TriggerChain); err != nil {
+					e.guards.releaseSlot(completedTaskID)
+					e.log.Error("on_failure_chain fireAsync failed; released slot",
+						zap.String("from", completedTaskID),
+						zap.String("to", targetID),
+						zap.Error(err),
+					)
+					return
+				}
+
+				// startRun succeeded. Record cooldown timestamp and storm
+				// fire — both delayed until here so a failed startRun cannot
+				// false-trip the storm breaker or extend the cooldown.
+				e.guards.recordChainFire(completedTaskID, now)
+				e.guards.observeChainFire(scope, chainSpec.Storm.Rate, chainSpec.Storm.Window,
+					chainSpec.Storm.Suppress, now)
 			}
 		}
 	}
@@ -1928,13 +1953,19 @@ func (e *Engine) dispatch(ctx context.Context, spec *task.Spec, opts pkgruntime.
 	return status, result
 }
 
-// stormScope returns the namespace prefix used for per-source storm tracking:
-// everything before the last '/' in taskID, or "global" if there is no slash.
+// stormScope returns the namespace used for per-source storm tracking:
+// everything before the last '/' in taskID, OR taskID itself for a flat
+// (no-slash) task. Flat tasks get their own per-task scope so a single
+// flapping flat task cannot suppress on_failure_chain for unrelated
+// flat tasks under a shared "global" scope.
 func stormScope(taskID string) string {
 	if i := strings.LastIndex(taskID, "/"); i > 0 {
 		return taskID[:i]
 	}
-	return "global"
+	if taskID == "" {
+		return "global"
+	}
+	return taskID
 }
 
 // effectiveCooldown returns the configured cooldown or 10 minutes when zero.

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -53,7 +53,7 @@ type Engine struct {
 
 	runCancels       sync.Map // runID → context.CancelFunc
 	runDone          sync.Map // runID (string) → chan struct{}, closed when the run reaches a terminal state
-	runTriggerSource sync.Map // runID (string) → triggerSource (string)
+	runTriggerSource sync.Map // runID (string) → triggerSource (registry.TriggerSource)
 
 	shutdownMu  sync.RWMutex
 	shutdownCtx context.Context
@@ -330,7 +330,7 @@ func (e *Engine) Register(spec *task.Spec) {
 	}
 	e.log.Info("task registered",
 		zap.String("task", spec.ID),
-		zap.String("trigger", triggerSource(spec)),
+		zap.String("trigger", string(triggerSource(spec))),
 		zap.String("runtime", string(spec.Runtime)),
 	)
 }
@@ -389,7 +389,7 @@ func (e *Engine) registerCron(spec *task.Spec) {
 		// Advance next_run_at AFTER fireAsync so that a failed dispatch does not
 		// silently advance the schedule and cause the missed run to be invisible
 		// on the next restart.
-		if _, ferr := e.fireAsync(context.Background(), s, pkgruntime.RunOptions{}, "cron"); ferr == nil && e.db != nil {
+		if _, ferr := e.fireAsync(context.Background(), s, pkgruntime.RunOptions{}, registry.TriggerCron); ferr == nil && e.db != nil {
 			if next, nerr := cronNextRun(spec.Trigger.Cron); nerr == nil {
 				if dbErr := e.db.Exec(context.Background(),
 					`UPDATE cron_jobs SET last_run_at=?, next_run_at=? WHERE task_id=?`,
@@ -505,7 +505,7 @@ func (e *Engine) catchupMissedCronRuns(ctx context.Context) {
 			zap.String("task", m.taskID),
 			zap.Time("was_due", time.Unix(m.nextAt, 0)),
 		)
-		e.fireAsync(ctx, spec, pkgruntime.RunOptions{}, "cron-catchup") //nolint:errcheck
+		e.fireAsync(ctx, spec, pkgruntime.RunOptions{}, registry.TriggerCronCatchup) //nolint:errcheck
 	}
 }
 
@@ -541,7 +541,7 @@ func (e *Engine) registerDaemon(spec *task.Spec) {
 }
 
 func (e *Engine) startDaemon(spec *task.Spec) {
-	runID, err := e.fireAsync(context.Background(), spec, pkgruntime.RunOptions{}, "daemon")
+	runID, err := e.fireAsync(context.Background(), spec, pkgruntime.RunOptions{}, registry.TriggerDaemon)
 	if err != nil {
 		e.log.Error("daemon start failed", zap.String("task", spec.ID), zap.Error(err))
 		return
@@ -631,7 +631,7 @@ func (e *Engine) FireManual(ctx context.Context, taskID string, params map[strin
 		return "", fmt.Errorf("task %q not found", taskID)
 	}
 	e.log.Info("manual trigger", zap.String("task", taskID))
-	return e.fireAsync(context.Background(), spec, pkgruntime.RunOptions{Params: params}, "manual")
+	return e.fireAsync(context.Background(), spec, pkgruntime.RunOptions{Params: params}, registry.TriggerManual)
 }
 
 // WaitRun blocks until the run identified by runID reaches a terminal state,
@@ -827,13 +827,26 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 		}
 		targetID := chainSpec.Task
 		if targetID != "" && targetID != completedTaskID {
+			// Replay-source guard: a replay-fired run that fails must not
+			// trigger on_failure_chain — preserves the semantics that replay
+			// is a manual / agent-initiated action with no auto-recovery loop.
+			// (Spec § 4.3 #5.)
+			if src, ok := e.runTriggerSource.Load(runID); ok {
+				if ts, _ := src.(registry.TriggerSource); ts == registry.TriggerReplay {
+					e.log.Debug("on_failure_chain skipped: replay source",
+						zap.String("from", completedTaskID),
+						zap.String("run", runID),
+					)
+					return
+				}
+			}
 			// Chain-of-chains suppression: refuse to fire if the completed run
 			// was itself chain-fired. This prevents infinite recursion when a
 			// chain target also has on_failure_chain set (or fails and would
 			// re-trigger itself via defaults).
 			// TODO(#238): replace with proper _chain_depth tracking.
 			if src, ok := e.runTriggerSource.Load(runID); ok {
-				if srcStr, _ := src.(string); srcStr == "chain" {
+				if ts, _ := src.(registry.TriggerSource); ts == registry.TriggerChain {
 					e.log.Warn("on_failure_chain suppressed: completed run was itself chain-fired (would loop)",
 						zap.String("from", completedTaskID),
 						zap.String("run", runID),
@@ -871,7 +884,7 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 				go e.fireAsync(ctx, targetSpec, pkgruntime.RunOptions{ //nolint:errcheck
 					ParentRunID: runID,
 					Input:       input,
-				}, "chain")
+				}, registry.TriggerChain)
 			}
 		}
 	}
@@ -1147,7 +1160,7 @@ func (e *Engine) WebhookHandler() http.Handler {
 		async := r.URL.Query().Get("wait") == "false"
 
 		if async {
-			runID, err := e.fireAsync(r.Context(), spec, pkgruntime.RunOptions{Input: input, Params: params, WebhookCtx: webhookCtx}, "webhook")
+			runID, err := e.fireAsync(r.Context(), spec, pkgruntime.RunOptions{Input: input, Params: params, WebhookCtx: webhookCtx}, registry.TriggerWebhook)
 			if err != nil {
 				http.Error(w, "task failed to start", http.StatusInternalServerError)
 				return
@@ -1158,7 +1171,7 @@ func (e *Engine) WebhookHandler() http.Handler {
 			return
 		}
 
-		runID, result, err := e.fireSync(spec, pkgruntime.RunOptions{Input: input, Params: params, WebhookCtx: webhookCtx}, "webhook")
+		runID, result, err := e.fireSync(spec, pkgruntime.RunOptions{Input: input, Params: params, WebhookCtx: webhookCtx}, registry.TriggerWebhook)
 		if err != nil {
 			http.Error(w, "task failed to start", http.StatusInternalServerError)
 			return
@@ -1354,8 +1367,8 @@ func (e *Engine) serveTaskAsset(w http.ResponseWriter, r *http.Request, taskDir,
 // startRun creates the DB record, stores the cancel func, fires the started
 // hook, and returns a ready-to-run context. The caller is responsible for
 // calling the returned cleanup func when the run finishes.
-func (e *Engine) startRun(spec *task.Spec, opts *pkgruntime.RunOptions, source string) (runCtx context.Context, cleanup func(), err error) {
-	if _, err = e.registry.StartRunWithID(context.Background(), opts.RunID, spec.ID, opts.ParentRunID, source); err != nil {
+func (e *Engine) startRun(spec *task.Spec, opts *pkgruntime.RunOptions, source registry.TriggerSource) (runCtx context.Context, cleanup func(), err error) {
+	if _, err = e.registry.StartRunWithID(context.Background(), opts.RunID, spec.ID, opts.ParentRunID, string(source)); err != nil {
 		return nil, nil, fmt.Errorf("start run record: %w", err)
 	}
 
@@ -1378,7 +1391,7 @@ func (e *Engine) startRun(spec *task.Spec, opts *pkgruntime.RunOptions, source s
 				BodyFullTextual: bft,
 			}
 		}
-		in := registry.BuildPersistedInputFromRunOpts(source, opts.Params, opts.Input, web)
+		in := registry.BuildPersistedInputFromRunOpts(string(source), opts.Params, opts.Input, web)
 		key, size, storedAt, perr := e.inputStore.Persist(context.Background(), opts.RunID, in)
 		if perr != nil {
 			// Log only a sanitized error category. The full perr chain may
@@ -1409,7 +1422,7 @@ func (e *Engine) startRun(spec *task.Spec, opts *pkgruntime.RunOptions, source s
 	}
 
 	if h := e.runStartedHook; h != nil {
-		h(spec.ID, opts.RunID, source)
+		h(spec.ID, opts.RunID, string(source))
 	}
 	var cancel context.CancelFunc
 	runCtx, cancel = context.WithCancel(context.Background())
@@ -1454,11 +1467,11 @@ func (e *Engine) shouldPersistInput(spec *task.Spec) bool {
 
 // runTask executes a task synchronously and handles all post-run bookkeeping
 // (logging, notifications, hooks, daemon restart). Returns status and result.
-func (e *Engine) runTask(runCtx context.Context, spec *task.Spec, opts pkgruntime.RunOptions, source string) (string, *pkgruntime.RunResult) {
+func (e *Engine) runTask(runCtx context.Context, spec *task.Spec, opts pkgruntime.RunOptions, source registry.TriggerSource) (string, *pkgruntime.RunResult) {
 	e.log.Info("run started",
 		zap.String("task", spec.ID),
 		zap.String("run", opts.RunID),
-		zap.String("trigger", source),
+		zap.String("trigger", string(source)),
 		zap.String("runtime", string(spec.Runtime)),
 	)
 
@@ -1494,7 +1507,7 @@ func (e *Engine) runTask(runCtx context.Context, spec *task.Spec, opts pkgruntim
 		zap.String("task", spec.ID),
 		zap.String("run", opts.RunID),
 		zap.String("status", status),
-		zap.String("trigger", source),
+		zap.String("trigger", string(source)),
 		zap.Duration("duration", elapsed.Truncate(time.Millisecond)),
 	}
 	if status == registry.StatusSuccess {
@@ -1525,7 +1538,7 @@ func (e *Engine) runTask(runCtx context.Context, spec *task.Spec, opts pkgruntim
 	}
 
 	if h := e.runFinishedHook; h != nil {
-		h(spec.ID, opts.RunID, status, source, elapsed.Milliseconds(), notifyOnSuccess, notifyOnFailure)
+		h(spec.ID, opts.RunID, status, string(source), elapsed.Milliseconds(), notifyOnSuccess, notifyOnFailure)
 	}
 
 	if spec.Trigger.Daemon {
@@ -1541,7 +1554,7 @@ func (e *Engine) runTask(runCtx context.Context, spec *task.Spec, opts pkgruntim
 // hook so websocket subscribers see a matching started/finished pair.
 // Safe to call even on the hot shutdown path: the DB write is bounded by a
 // short timeout so a stuck SQLite connection cannot block the goroutine.
-func (e *Engine) finalizeCancelled(spec *task.Spec, opts pkgruntime.RunOptions, source string) {
+func (e *Engine) finalizeCancelled(spec *task.Spec, opts pkgruntime.RunOptions, source registry.TriggerSource) {
 	finishCtx, finishCancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer finishCancel()
 	if err := e.registry.FinishRun(finishCtx, opts.RunID, registry.StatusCancelled); err != nil {
@@ -1555,7 +1568,7 @@ func (e *Engine) finalizeCancelled(spec *task.Spec, opts pkgruntime.RunOptions, 
 		// a separate path in runTask) only fires on Success/Failure, so
 		// cancelled runs do not send spurious notifications.
 		notifyOnSuccess, notifyOnFailure := e.resolveNotify(spec)
-		h(spec.ID, opts.RunID, registry.StatusCancelled, source, 0, notifyOnSuccess, notifyOnFailure)
+		h(spec.ID, opts.RunID, registry.StatusCancelled, string(source), 0, notifyOnSuccess, notifyOnFailure)
 	}
 }
 
@@ -1565,7 +1578,7 @@ func (e *Engine) finalizeCancelled(spec *task.Spec, opts pkgruntime.RunOptions, 
 // When a MaxConcurrentTasks semaphore is configured, the goroutine blocks
 // until a slot is available or the shutdown context is cancelled — ensuring
 // shutdown never deadlocks waiting tasks.
-func (e *Engine) fireAsync(ctx context.Context, spec *task.Spec, opts pkgruntime.RunOptions, source string) (string, error) {
+func (e *Engine) fireAsync(ctx context.Context, spec *task.Spec, opts pkgruntime.RunOptions, source registry.TriggerSource) (string, error) {
 	opts.RunID = uuid.New().String()
 
 	runCtx, cleanup, err := e.startRun(spec, &opts, source)
@@ -1624,7 +1637,7 @@ func (e *Engine) fireAsync(ctx context.Context, spec *task.Spec, opts pkgruntime
 // The caller's context is used only for cancellation of the run setup; the
 // run itself uses an independent context so it is not cancelled when the HTTP
 // request context ends mid-execution.
-func (e *Engine) fireSync(spec *task.Spec, opts pkgruntime.RunOptions, source string) (string, *pkgruntime.RunResult, error) {
+func (e *Engine) fireSync(spec *task.Spec, opts pkgruntime.RunOptions, source registry.TriggerSource) (string, *pkgruntime.RunResult, error) {
 	opts.RunID = uuid.New().String()
 
 	runCtx, cleanup, err := e.startRun(spec, &opts, source)
@@ -1843,18 +1856,18 @@ func (e *Engine) dispatch(ctx context.Context, spec *task.Spec, opts pkgruntime.
 	return status, result
 }
 
-// triggerSource returns a short string identifying the trigger type of a spec.
-func triggerSource(spec *task.Spec) string {
+// triggerSource returns a typed TriggerSource identifying the trigger type of a spec.
+func triggerSource(spec *task.Spec) registry.TriggerSource {
 	switch {
 	case spec.Trigger.Cron != "":
-		return "cron"
+		return registry.TriggerCron
 	case spec.Trigger.Webhook != "":
-		return "webhook"
+		return registry.TriggerWebhook
 	case spec.Trigger.Daemon:
-		return "daemon"
+		return registry.TriggerDaemon
 	case spec.Trigger.Chain != nil:
-		return "chain"
+		return registry.TriggerChain
 	default:
-		return "manual"
+		return registry.TriggerManual
 	}
 }

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -54,6 +54,7 @@ type Engine struct {
 	runCancels       sync.Map // runID → context.CancelFunc
 	runDone          sync.Map // runID (string) → chan struct{}, closed when the run reaches a terminal state
 	runTriggerSource sync.Map // runID (string) → triggerSource (registry.TriggerSource)
+	runChainDepth    sync.Map // runID (string) → int; _chain_depth from the run's input
 
 	shutdownMu  sync.RWMutex
 	shutdownCtx context.Context
@@ -840,25 +841,31 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 					return
 				}
 			}
-			// Chain-of-chains suppression: refuse to fire if the completed run
-			// was itself chain-fired. This prevents infinite recursion when a
-			// chain target also has on_failure_chain set (or fails and would
-			// re-trigger itself via defaults).
-			// TODO(#238): replace with proper _chain_depth tracking.
-			if src, ok := e.runTriggerSource.Load(runID); ok {
-				if ts, _ := src.(registry.TriggerSource); ts == registry.TriggerChain {
-					e.log.Warn("on_failure_chain suppressed: completed run was itself chain-fired (would loop)",
-						zap.String("from", completedTaskID),
-						zap.String("run", runID),
-					)
-					return
-				}
+			// Depth-tracking ceiling: read the incoming run's chain depth and
+			// refuse to fire when the next hop would exceed MaxDepth (default 2).
+			// This replaces the old chain-of-chains suppression that blocked all
+			// chaining beyond depth 1.
+			incomingDepth := 0
+			if d, ok := e.runChainDepth.Load(runID); ok {
+				incomingDepth, _ = d.(int)
+			}
+			nextDepth := incomingDepth + 1
+			maxDepth := chainSpec.EffectiveMaxDepth()
+			if nextDepth > maxDepth {
+				e.log.Warn("on_failure_chain suppressed: max_depth exceeded",
+					zap.Int("depth", nextDepth),
+					zap.Int("max_depth", maxDepth),
+					zap.String("from", completedTaskID),
+					zap.String("run", runID),
+				)
+				return
 			}
 			if targetSpec, ok := e.registry.Get(targetID); ok {
 				e.log.Info("on_failure_chain trigger",
 					zap.String("from", completedTaskID),
 					zap.String("to", targetID),
 					zap.String("run", runID),
+					zap.Int("depth", nextDepth),
 				)
 				// Build input. Reserved keys (taskID, runID, status, output,
 				// _chain_depth) are populated by the engine and are NOT
@@ -867,10 +874,6 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 				// can safely overlay user params first and then stamp the
 				// reserved keys — collisions cannot reach here in a
 				// well-validated config.
-				// _chain_depth is hardcoded to 1 here; full depth tracking is
-				// engine-level guardrail work tracked in #238. Recursive
-				// fan-out is mitigated for v1 by the chain-of-chains
-				// suppression above (see runTriggerSource).
 				input := map[string]any{}
 				for k, v := range chainSpec.Params {
 					input[k] = v
@@ -879,8 +882,7 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 				input["runID"] = runID
 				input["status"] = runStatus
 				input["output"] = output
-				// TODO(#238): increment from incoming run input; current always-1 means chain-of-chains can recurse.
-				input["_chain_depth"] = 1
+				input["_chain_depth"] = nextDepth
 				go e.fireAsync(ctx, targetSpec, pkgruntime.RunOptions{ //nolint:errcheck
 					ParentRunID: runID,
 					Input:       input,
@@ -1437,6 +1439,7 @@ func (e *Engine) startRun(spec *task.Spec, opts *pkgruntime.RunOptions, source r
 	cleanup = func() {
 		e.runCancels.Delete(opts.RunID)
 		e.runTriggerSource.Delete(opts.RunID)
+		e.runChainDepth.Delete(opts.RunID)
 		cancel()
 		// Signal all waiters that the run has finished, then remove the entry.
 		if v, ok := e.runDone.LoadAndDelete(opts.RunID); ok {
@@ -1584,6 +1587,21 @@ func (e *Engine) fireAsync(ctx context.Context, spec *task.Spec, opts pkgruntime
 	runCtx, cleanup, err := e.startRun(spec, &opts, source)
 	if err != nil {
 		return "", err
+	}
+
+	// If this run carries a _chain_depth in its input (set by FireChain), record
+	// it in runChainDepth so FireChain can read the depth when this run completes.
+	if m, ok := opts.Input.(map[string]any); ok {
+		if d, ok2 := m["_chain_depth"]; ok2 {
+			switch v := d.(type) {
+			case int:
+				e.runChainDepth.Store(opts.RunID, v)
+			case int64:
+				e.runChainDepth.Store(opts.RunID, int(v))
+			case float64:
+				e.runChainDepth.Store(opts.RunID, int(v))
+			}
+		}
 	}
 
 	go func() {

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -99,6 +99,8 @@ type Engine struct {
 	// Set via SetInputStore after the daemon has initialised secrets so the
 	// derived sub-key is available.
 	inputStore *registry.InputStore
+
+	guards *chainGuards
 }
 
 // DenoRuntimeAPI is the minimal subset of *deno.Runtime the engine's
@@ -126,6 +128,7 @@ func New(r *registry.Registry, defaultExec pkgruntime.Executor, log *zap.Logger)
 		webhooks:    make(map[string]string),
 		daemonRuns:  make(map[string]string),
 		daemonSpecs: make(map[string]*task.Spec),
+		guards:      newChainGuards(),
 	}
 	e.executors[task.RuntimeDeno] = defaultExec
 	return e
@@ -861,6 +864,51 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 				return
 			}
 			if targetSpec, ok := e.registry.Get(targetID); ok {
+				now := time.Now()
+
+				// 1. Storm check — per-source namespace.
+				scope := stormScope(completedTaskID)
+				if e.guards.stormSuppressed(scope, chainSpec.Storm.Suppress, now) {
+					e.log.Warn("on_failure_chain suppressed: storm circuit breaker tripped",
+						zap.String("scope", scope),
+						zap.String("from", completedTaskID),
+					)
+					return
+				}
+
+				// 2. Cooldown check.
+				cd := effectiveCooldown(chainSpec)
+				if e.guards.cooldownActive(completedTaskID, cd, now) {
+					e.log.Warn("on_failure_chain suppressed: cooldown active",
+						zap.String("from", completedTaskID),
+						zap.Duration("cooldown", cd),
+					)
+					return
+				}
+
+				// 3. Concurrency check.
+				perTask := chainSpec.MaxConcurrent
+				if perTask <= 0 {
+					perTask = 1
+				}
+				global := e.defaultsOnFailureChain.MaxConcurrentGlobal
+				if global <= 0 {
+					global = 3
+				}
+				if !e.guards.acquireSlot(completedTaskID, perTask, global) {
+					e.log.Warn("on_failure_chain suppressed: concurrency cap reached",
+						zap.String("from", completedTaskID),
+						zap.Int("cap_per_task", perTask),
+						zap.Int("cap_global", global),
+					)
+					return
+				}
+
+				// 4. Record this fire (cooldown + storm).
+				e.guards.recordChainFire(completedTaskID, now)
+				e.guards.observeChainFire(scope, chainSpec.Storm.Rate, chainSpec.Storm.Window,
+					chainSpec.Storm.Suppress, now)
+
 				e.log.Info("on_failure_chain trigger",
 					zap.String("from", completedTaskID),
 					zap.String("to", targetID),
@@ -883,9 +931,12 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 				input["status"] = runStatus
 				input["output"] = output
 				input["_chain_depth"] = nextDepth
+				// Slot is held until the chained run terminates.
+				// Released in startRun's cleanup via ChainParentTask.
 				go e.fireAsync(ctx, targetSpec, pkgruntime.RunOptions{ //nolint:errcheck
-					ParentRunID: runID,
-					Input:       input,
+					ParentRunID:     runID,
+					Input:           input,
+					ChainParentTask: completedTaskID,
 				}, registry.TriggerChain)
 			}
 		}
@@ -1437,6 +1488,9 @@ func (e *Engine) startRun(spec *task.Spec, opts *pkgruntime.RunOptions, source r
 	e.runDone.Store(opts.RunID, doneCh)
 
 	cleanup = func() {
+		if opts.ChainParentTask != "" {
+			e.guards.releaseSlot(opts.ChainParentTask)
+		}
 		e.runCancels.Delete(opts.RunID)
 		e.runTriggerSource.Delete(opts.RunID)
 		e.runChainDepth.Delete(opts.RunID)
@@ -1872,6 +1926,23 @@ func (e *Engine) dispatch(ctx context.Context, spec *task.Spec, opts pkgruntime.
 
 	e.FireChain(context.Background(), spec.ID, opts.RunID, status, result.ChainInput)
 	return status, result
+}
+
+// stormScope returns the namespace prefix used for per-source storm tracking:
+// everything before the last '/' in taskID, or "global" if there is no slash.
+func stormScope(taskID string) string {
+	if i := strings.LastIndex(taskID, "/"); i > 0 {
+		return taskID[:i]
+	}
+	return "global"
+}
+
+// effectiveCooldown returns the configured cooldown or 10 minutes when zero.
+func effectiveCooldown(s task.OnFailureChainSpec) time.Duration {
+	if s.Cooldown > 0 {
+		return s.Cooldown
+	}
+	return 10 * time.Minute
 }
 
 // triggerSource returns a typed TriggerSource identifying the trigger type of a spec.

--- a/pkg/trigger/engine_failure_chain_test.go
+++ b/pkg/trigger/engine_failure_chain_test.go
@@ -267,3 +267,39 @@ func TestEngine_OnFailureChain_NoLoopSelfReference(t *testing.T) {
 		t.Errorf("self-loop produced %d runs (want 1): %s", len(runs), strings.Join(ids, ", "))
 	}
 }
+
+// TestEngine_ChainDepth_StopsAtCeiling verifies that on_failure_chain hops are
+// capped at EffectiveMaxDepth() (default 2). A → B → A loop with always-failing
+// tasks must produce at most 2 runs of task-b before the ceiling halts the chain.
+func TestEngine_ChainDepth_StopsAtCeiling(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	// Create a chain B → A with always-fail tasks. With max_depth=2, the third
+	// link must be suppressed.
+	a := writeTask(t, dir, "task-a",
+		`export default async () => { throw new Error("a-fail") }`,
+		task.TriggerConfig{Manual: true})
+	a.OnFailureChain = &task.OnFailureChainSpec{Task: "task-b"}
+	_ = e.reg.Register(a)
+
+	b := writeTask(t, dir, "task-b",
+		`export default async () => { throw new Error("b-fail") }`,
+		task.TriggerConfig{Manual: true})
+	b.OnFailureChain = &task.OnFailureChainSpec{Task: "task-a"} // would re-loop without the ceiling
+	_ = e.reg.Register(b)
+
+	runID, err := e.engine.FireManual(context.Background(), "task-a", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForTerminal(t, e.engine, runID, 30*time.Second)
+
+	// Wait for the chain to settle; with depth ceiling=2, we expect at most
+	// 2 distinct runs of task-b and 1 of task-a (the original).
+	time.Sleep(3 * time.Second)
+	bRuns, _ := e.reg.ListRuns(context.Background(), "task-b", 10)
+	if len(bRuns) > 2 {
+		t.Errorf("max_depth=2 violated: task-b fired %d times", len(bRuns))
+	}
+}

--- a/pkg/trigger/engine_failure_chain_test.go
+++ b/pkg/trigger/engine_failure_chain_test.go
@@ -201,6 +201,37 @@ func TestEngine_OnFailureChain_EmptyStringDisablesDefault(t *testing.T) {
 	}
 }
 
+// TestEngine_ChainSuppression_UsesTypedReplaySource verifies that a failing run
+// fired with TriggerSource = replay does NOT trigger on_failure_chain. This is
+// a regression guard for the typed-enum migration (Task 2 of #238).
+func TestEngine_ChainSuppression_UsesTypedReplaySource(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	fallback := writeTask(t, dir, "fallback", `export default async () => "ok"`, task.TriggerConfig{Manual: true})
+	failing := writeTask(t, dir, "fail", `throw new Error("boom")`, task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(fallback)
+	_ = e.reg.Register(failing)
+
+	if err := e.engine.SetDefaultsOnFailureChain(task.OnFailureChainSpec{Task: "fallback"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fire the failing task with TriggerSource = replay; assert no chain fires.
+	runner := NewReplayRunner(e.engine)
+	replayedRunID, err := runner.FireForReplay(context.Background(), "fail", "parent-run", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForTerminal(t, e.engine, replayedRunID, 30*time.Second)
+
+	time.Sleep(2 * time.Second)
+	runs, _ := e.reg.ListRuns(context.Background(), "fallback", 5)
+	if len(runs) > 0 {
+		t.Errorf("fallback should not fire when source=replay; got %d runs", len(runs))
+	}
+}
+
 // TestEngine_OnFailureChain_NoLoopSelfReference verifies the engine refuses
 // to chain a task to itself on failure (infinite-loop guard in FireChain:
 // `targetID != completedTaskID`).

--- a/pkg/trigger/engine_failure_chain_test.go
+++ b/pkg/trigger/engine_failure_chain_test.go
@@ -303,3 +303,36 @@ func TestEngine_ChainDepth_StopsAtCeiling(t *testing.T) {
 		t.Errorf("max_depth=2 violated: task-b fired %d times", len(bRuns))
 	}
 }
+
+func TestEngine_OnFailureChain_CooldownSuppressesSecondFire(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	fallback := writeTask(t, dir, "fb-cool", `export default async () => "ok"`, task.TriggerConfig{Manual: true})
+	failing := writeTask(t, dir, "f-cool", `throw new Error("fail")`, task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(fallback)
+	_ = e.reg.Register(failing)
+
+	if err := e.engine.SetDefaultsOnFailureChain(task.OnFailureChainSpec{
+		Task: "fb-cool", Cooldown: 10 * time.Minute,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fire #1: fallback runs.
+	r1, _ := e.engine.FireManual(context.Background(), "f-cool", nil)
+	waitForTerminal(t, e.engine, r1, 30*time.Second)
+	first := waitForRunOfTask(t, e.engine, "fb-cool", 15*time.Second)
+	if first == nil {
+		t.Fatal("first fallback should have fired")
+	}
+
+	// Fire #2: should be suppressed.
+	r2, _ := e.engine.FireManual(context.Background(), "f-cool", nil)
+	waitForTerminal(t, e.engine, r2, 30*time.Second)
+	time.Sleep(2 * time.Second)
+	runs, _ := e.reg.ListRuns(context.Background(), "fb-cool", 10)
+	if len(runs) != 1 {
+		t.Errorf("cooldown should suppress 2nd fire; got %d fb-cool runs", len(runs))
+	}
+}

--- a/pkg/trigger/engine_guardrails.go
+++ b/pkg/trigger/engine_guardrails.go
@@ -120,7 +120,10 @@ func (g *chainGuards) observeChainFire(scope string, rate int, window, suppress 
 	}
 }
 
-func (g *chainGuards) stormSuppressed(scope string, _ time.Duration, now time.Time) bool {
+// stormSuppressed reports whether scope is in a tripped-breaker suppression
+// window. The suppress duration was applied when the breaker tripped (in
+// observeChainFire); this query just reads the cached deadline.
+func (g *chainGuards) stormSuppressed(scope string, now time.Time) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	until, ok := g.stormSuppressedUntil[scope]

--- a/pkg/trigger/engine_guardrails.go
+++ b/pkg/trigger/engine_guardrails.go
@@ -1,0 +1,135 @@
+// pkg/trigger/engine_guardrails.go
+package trigger
+
+import (
+	"sync"
+	"time"
+)
+
+// chainGuards holds the in-memory state for engine-level on_failure_chain
+// guardrails: cooldown timestamps, per-task and global concurrency counters,
+// and per-source storm counters. Survives daemon process lifetime only —
+// resets on restart (documented trade-off for v1).
+type chainGuards struct {
+	mu sync.Mutex
+
+	// lastFire[taskID] = time.Time of the most recent on_failure_chain fire
+	// originating from a failure of taskID.
+	lastFire map[string]time.Time
+
+	// inFlightPerTask[taskID] = count of currently-running on_failure_chain
+	// runs whose parent failed-task is taskID.
+	inFlightPerTask map[string]int
+
+	// inFlightGlobal = total currently-running on_failure_chain runs.
+	inFlightGlobal int
+
+	// stormFires[sourceNs] = sliding window of fire timestamps. Trimmed on
+	// each query to drop entries older than the configured window.
+	stormFires map[string][]time.Time
+
+	// stormSuppressedUntil[sourceNs] = time after which fires from this source
+	// resume.
+	stormSuppressedUntil map[string]time.Time
+}
+
+func newChainGuards() *chainGuards {
+	return &chainGuards{
+		lastFire:             make(map[string]time.Time),
+		inFlightPerTask:      make(map[string]int),
+		stormFires:           make(map[string][]time.Time),
+		stormSuppressedUntil: make(map[string]time.Time),
+	}
+}
+
+func (g *chainGuards) recordChainFire(taskID string, now time.Time) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.lastFire[taskID] = now
+}
+
+func (g *chainGuards) cooldownActive(taskID string, cooldown time.Duration, now time.Time) bool {
+	if cooldown <= 0 {
+		return false
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	last, ok := g.lastFire[taskID]
+	if !ok {
+		return false
+	}
+	return now.Sub(last) < cooldown
+}
+
+// acquireSlot atomically reserves a chain-fire slot for taskID if both the
+// per-task and global caps have headroom. Returns false (and acquires
+// nothing) on contention.
+func (g *chainGuards) acquireSlot(taskID string, perTaskCap, globalCap int) bool {
+	if perTaskCap <= 0 {
+		perTaskCap = 1
+	}
+	if globalCap <= 0 {
+		globalCap = 3
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.inFlightPerTask[taskID] >= perTaskCap {
+		return false
+	}
+	if g.inFlightGlobal >= globalCap {
+		return false
+	}
+	g.inFlightPerTask[taskID]++
+	g.inFlightGlobal++
+	return true
+}
+
+// releaseSlot decrements counters for a chain-fire slot. Idempotent at zero
+// (clamped) so a double-release does not underflow.
+func (g *chainGuards) releaseSlot(taskID string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.inFlightPerTask[taskID] > 0 {
+		g.inFlightPerTask[taskID]--
+	}
+	if g.inFlightGlobal > 0 {
+		g.inFlightGlobal--
+	}
+}
+
+// observeChainFire records a fire for the given scope and trips the breaker
+// when the count within the window exceeds rate.
+func (g *chainGuards) observeChainFire(scope string, rate int, window, suppress time.Duration, now time.Time) {
+	if rate <= 0 || window <= 0 {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	cutoff := now.Add(-window)
+	fires := g.stormFires[scope]
+	pruned := fires[:0]
+	for _, t := range fires {
+		if t.After(cutoff) {
+			pruned = append(pruned, t)
+		}
+	}
+	pruned = append(pruned, now)
+	g.stormFires[scope] = pruned
+	if len(pruned) > rate {
+		g.stormSuppressedUntil[scope] = now.Add(suppress)
+	}
+}
+
+func (g *chainGuards) stormSuppressed(scope string, _ time.Duration, now time.Time) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	until, ok := g.stormSuppressedUntil[scope]
+	if !ok {
+		return false
+	}
+	if now.After(until) {
+		delete(g.stormSuppressedUntil, scope)
+		return false
+	}
+	return true
+}

--- a/pkg/trigger/engine_guardrails_test.go
+++ b/pkg/trigger/engine_guardrails_test.go
@@ -80,7 +80,7 @@ func TestChainGuards_StormTrip(t *testing.T) {
 
 	now := time.Now()
 	for i := 0; i < 3; i++ {
-		if g.stormSuppressed(scope, suppress, now) {
+		if g.stormSuppressed(scope, now) {
 			t.Fatalf("breaker tripped early at i=%d", i)
 		}
 		g.observeChainFire(scope, rate, window, suppress, now)
@@ -88,18 +88,18 @@ func TestChainGuards_StormTrip(t *testing.T) {
 
 	// 4th observation in the window trips the breaker.
 	g.observeChainFire(scope, rate, window, suppress, now)
-	if !g.stormSuppressed(scope, suppress, now) {
+	if !g.stormSuppressed(scope, now) {
 		t.Error("breaker should be tripped after 4 fires in window")
 	}
 
 	// 31 minutes later: untripped.
 	later := now.Add(31 * time.Minute)
-	if g.stormSuppressed(scope, suppress, later) {
+	if g.stormSuppressed(scope, later) {
 		t.Error("breaker should clear after suppress duration")
 	}
 
 	// Different scope: independent.
-	if g.stormSuppressed("other-source", suppress, now) {
+	if g.stormSuppressed("other-source", now) {
 		t.Error("storm scope should isolate sources")
 	}
 }

--- a/pkg/trigger/engine_guardrails_test.go
+++ b/pkg/trigger/engine_guardrails_test.go
@@ -1,0 +1,105 @@
+// pkg/trigger/engine_guardrails_test.go
+package trigger
+
+import (
+	"testing"
+	"time"
+)
+
+func TestChainGuards_CooldownActive(t *testing.T) {
+	g := newChainGuards()
+	taskID := "process-payment"
+
+	// First fire: cooldown not active.
+	if g.cooldownActive(taskID, 10*time.Minute, time.Now()) {
+		t.Error("cooldown should not be active before any fire")
+	}
+	g.recordChainFire(taskID, time.Now())
+
+	// Same instant: active.
+	if !g.cooldownActive(taskID, 10*time.Minute, time.Now()) {
+		t.Error("cooldown must be active immediately after fire")
+	}
+
+	// 11 minutes later: lapsed.
+	later := time.Now().Add(11 * time.Minute)
+	if g.cooldownActive(taskID, 10*time.Minute, later) {
+		t.Error("cooldown should expire after window")
+	}
+
+	// Different task: independent.
+	if g.cooldownActive("other-task", 10*time.Minute, time.Now()) {
+		t.Error("cooldown is per-task; other-task should be free")
+	}
+}
+
+func TestChainGuards_ConcurrencyPerTask(t *testing.T) {
+	g := newChainGuards()
+	failingTask := "process-payment"
+
+	// Cap=1: first acquire succeeds, second is denied.
+	if !g.acquireSlot(failingTask, 1, 3) {
+		t.Error("first acquire should succeed")
+	}
+	if g.acquireSlot(failingTask, 1, 3) {
+		t.Error("second acquire should be denied at per-task cap=1")
+	}
+
+	// Release one, acquire succeeds again.
+	g.releaseSlot(failingTask)
+	if !g.acquireSlot(failingTask, 1, 3) {
+		t.Error("post-release acquire should succeed")
+	}
+}
+
+func TestChainGuards_ConcurrencyGlobal(t *testing.T) {
+	g := newChainGuards()
+
+	// Per-task cap=10 (effectively no per-task limit). Global cap=2.
+	if !g.acquireSlot("a", 10, 2) {
+		t.Fatal("a-1 acquire should succeed")
+	}
+	if !g.acquireSlot("b", 10, 2) {
+		t.Fatal("b-1 acquire should succeed")
+	}
+	if g.acquireSlot("c", 10, 2) {
+		t.Error("c-1 should be denied at global=2 (a+b in flight)")
+	}
+	g.releaseSlot("a")
+	if !g.acquireSlot("c", 10, 2) {
+		t.Error("c-1 should succeed after a releases")
+	}
+}
+
+func TestChainGuards_StormTrip(t *testing.T) {
+	g := newChainGuards()
+	scope := "user-tasks"
+	rate := 3
+	window := 1 * time.Minute
+	suppress := 30 * time.Minute
+
+	now := time.Now()
+	for i := 0; i < 3; i++ {
+		if g.stormSuppressed(scope, suppress, now) {
+			t.Fatalf("breaker tripped early at i=%d", i)
+		}
+		g.observeChainFire(scope, rate, window, suppress, now)
+	}
+
+	// 4th observation in the window trips the breaker.
+	g.observeChainFire(scope, rate, window, suppress, now)
+	if !g.stormSuppressed(scope, suppress, now) {
+		t.Error("breaker should be tripped after 4 fires in window")
+	}
+
+	// 31 minutes later: untripped.
+	later := now.Add(31 * time.Minute)
+	if g.stormSuppressed(scope, suppress, later) {
+		t.Error("breaker should clear after suppress duration")
+	}
+
+	// Different scope: independent.
+	if g.stormSuppressed("other-source", suppress, now) {
+		t.Error("storm scope should isolate sources")
+	}
+}

--- a/pkg/trigger/replay_e2e_test.go
+++ b/pkg/trigger/replay_e2e_test.go
@@ -53,7 +53,7 @@ func TestReplay_FullPipeline(t *testing.T) {
 
 	// Replay via the Replayer + adapter.
 	replayer := registry.NewReplayer(e.reg, is, NewReplayRunner(e.engine))
-	newRunID, err := replayer.Replay(context.Background(), originalRunID, "")
+	newRunID, err := replayer.Replay(context.Background(), originalRunID, "", "", "")
 	if err != nil {
 		t.Fatalf("Replay: %v", err)
 	}

--- a/pkg/trigger/replay_runner.go
+++ b/pkg/trigger/replay_runner.go
@@ -32,7 +32,7 @@ func (a *ReplayRunnerAdapter) FireForReplay(ctx context.Context, taskID, parentR
 	return a.engine.fireAsync(ctx, spec, pkgruntime.RunOptions{
 		ParentRunID: parentRunID,
 		Input:       input,
-	}, "replay")
+	}, registry.TriggerReplay)
 }
 
 // TaskNotFoundError signals that the requested replay target task is not

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -1673,7 +1673,7 @@ func (s *Server) apiReplayRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	newRunID, err := s.replayer.Replay(r.Context(), runID, req.TaskName)
+	newRunID, err := s.replayer.Replay(r.Context(), runID, req.TaskName, "", "")
 	if err != nil {
 		var taskNotFound *trigger.TaskNotFoundError
 		switch {

--- a/tasks/buildin/git-pr/README.md
+++ b/tasks/buildin/git-pr/README.md
@@ -1,0 +1,15 @@
+# git-pr (buildin)
+
+Opens a GitHub pull request via the `gh` CLI. Used by the auto-fix flow
+when `params.mode == "review"`.
+
+## PAT prerequisite
+
+Create a fine-grained Personal Access Token scoped to:
+- Repository: only the repo you want auto-fix to PR into
+- Permissions: **Contents → Read & write**, **Pull requests → Read & write**
+
+Set as `GH_TOKEN_AUTOFIX` in dicode's secrets store. Do NOT reuse your
+default `gh auth login` token — that often has admin scope and the
+binary-name `permissions.run: [gh]` cannot prevent `gh repo delete`,
+`gh secret set`, etc. The PAT is the defense.

--- a/tasks/buildin/git-pr/task.test.ts
+++ b/tasks/buildin/git-pr/task.test.ts
@@ -42,6 +42,62 @@ echo "https://github.com/example/repo/pull/123"
     }
 });
 
+Deno.test("git-pr: rejects path-traversal source_id", async () => {
+    Deno.env.set("GH_TOKEN", "stub-token");
+    Deno.env.set("DICODE_DATA_DIR", await Deno.makeTempDir());
+    const result = await main({
+        params: new Map(Object.entries({
+            source_id: "../../etc",
+            branch: "fix/abc",
+            base: "main",
+            title: "x",
+            body: "",
+        })),
+    } as any);
+    assertEquals(result.ok, false);
+    if (!String(result.error ?? "").includes("invalid characters")) {
+        throw new Error(`expected invalid-characters error, got ${result.error}`);
+    }
+});
+
+Deno.test("git-pr: refuses to run without GH_TOKEN", async () => {
+    Deno.env.delete("GH_TOKEN");
+    Deno.env.set("DICODE_DATA_DIR", await Deno.makeTempDir());
+    const result = await main({
+        params: new Map(Object.entries({
+            source_id: "user-tasks",
+            branch: "fix/abc",
+            base: "main",
+            title: "x",
+            body: "",
+        })),
+    } as any);
+    assertEquals(result.ok, false);
+    if (!String(result.error ?? "").includes("GH_TOKEN")) {
+        throw new Error(`expected GH_TOKEN error, got ${result.error}`);
+    }
+});
+
+Deno.test("git-pr: rejects clone_path outside dev-clones", async () => {
+    Deno.env.set("GH_TOKEN", "stub-token");
+    const dataDir = await Deno.makeTempDir();
+    Deno.env.set("DICODE_DATA_DIR", dataDir);
+    const result = await main({
+        params: new Map(Object.entries({
+            source_id: "user-tasks",
+            branch: "fix/abc",
+            base: "main",
+            title: "x",
+            body: "",
+            clone_path: "/etc/passwd",
+        })),
+    } as any);
+    assertEquals(result.ok, false);
+    if (!String(result.error ?? "").includes("clone_path must be rooted")) {
+        throw new Error(`expected clone_path-rooted error, got ${result.error}`);
+    }
+});
+
 Deno.test("git-pr: returns ok=false when gh fails", async () => {
     const tmp = await Deno.makeTempDir();
     const ghPath = `${tmp}/gh`;

--- a/tasks/buildin/git-pr/task.test.ts
+++ b/tasks/buildin/git-pr/task.test.ts
@@ -1,0 +1,74 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import main from "./task.ts";
+
+// Stub `gh` by setting PATH to a temp dir containing a wrapper that prints
+// a known URL. The task runs gh with the project's working dir = clone path.
+Deno.test("git-pr: returns ok with url on gh success", async () => {
+    // Create a stub gh script.
+    const tmp = await Deno.makeTempDir();
+    const ghPath = `${tmp}/gh`;
+    await Deno.writeTextFile(ghPath, `#!/bin/sh
+echo "https://github.com/example/repo/pull/123"
+`);
+    await Deno.chmod(ghPath, 0o755);
+
+    // Stub the dicode shim's params/return; call main.
+    const origPath = Deno.env.get("PATH") ?? "";
+    Deno.env.set("PATH", `${tmp}:${origPath}`);
+    Deno.env.set("GH_TOKEN", "stub-token");
+
+    // Create a stub clone directory so readDir doesn't fail
+    const dataDir = await Deno.makeTempDir();
+    const cloneRoot = `${dataDir}/dev-clones/user-tasks`;
+    const cloneDir = `${cloneRoot}/run-123`;
+    await Deno.mkdir(cloneDir, { recursive: true });
+    Deno.env.set("DICODE_DATA_DIR", dataDir);
+
+    try {
+        const result = await main({
+            params: new Map(Object.entries({
+                source_id: "user-tasks",
+                branch: "fix/abc",
+                base: "main",
+                title: "auto-fix",
+                body: "",
+            })),
+            // dicode shim mock — task.ts should not call dicode.* in this test
+        } as any);
+        assertEquals(result.ok, true);
+        assertEquals(result.url, "https://github.com/example/repo/pull/123");
+    } finally {
+        Deno.env.set("PATH", origPath);
+    }
+});
+
+Deno.test("git-pr: returns ok=false when gh fails", async () => {
+    const tmp = await Deno.makeTempDir();
+    const ghPath = `${tmp}/gh`;
+    await Deno.writeTextFile(ghPath, `#!/bin/sh
+echo "gh: permission denied" >&2
+exit 1
+`);
+    await Deno.chmod(ghPath, 0o755);
+
+    const origPath = Deno.env.get("PATH") ?? "";
+    Deno.env.set("PATH", `${tmp}:${origPath}`);
+
+    // Create a stub clone directory so readDir doesn't fail
+    const dataDir = await Deno.makeTempDir();
+    const cloneRoot = `${dataDir}/dev-clones/user-tasks`;
+    const cloneDir = `${cloneRoot}/run-456`;
+    await Deno.mkdir(cloneDir, { recursive: true });
+    Deno.env.set("DICODE_DATA_DIR", dataDir);
+
+    try {
+        const result = await main({
+            params: new Map(Object.entries({
+                source_id: "user-tasks", branch: "fix/abc", base: "main", title: "x", body: "",
+            })),
+        } as any);
+        assertEquals(result.ok, false);
+    } finally {
+        Deno.env.set("PATH", origPath);
+    }
+});

--- a/tasks/buildin/git-pr/task.ts
+++ b/tasks/buildin/git-pr/task.ts
@@ -1,0 +1,47 @@
+// deno-lint-ignore-file no-explicit-any
+export default async function main(opts: { params: Map<string, string> }) {
+    const sourceID = opts.params.get("source_id") ?? "";
+    const branch   = opts.params.get("branch")    ?? "";
+    const base     = opts.params.get("base")      ?? "main";
+    const title    = opts.params.get("title")     ?? "";
+    const body     = opts.params.get("body")      ?? "";
+
+    if (!sourceID || !branch || !title) {
+        return { ok: false, error: "source_id, branch, and title are required" };
+    }
+
+    // Resolve the dev-clone working directory for this source.
+    // The auto-fix flow already cloned to ${DATADIR}/dev-clones/<source_id>/<runID>.
+    // The clone path for the active dev session is recorded by the engine in the
+    // run's parent input under "_clone_path" (set by sources.set_dev_mode).
+    // For this task, we accept the simpler contract: the caller passes a working
+    // directory implicitly via Deno.cwd() OR we stat the dev-clones tree.
+    const dataDir = Deno.env.get("DICODE_DATA_DIR") ??
+                    `${Deno.env.get("HOME")}/.dicode`;
+    const cloneRoot = `${dataDir}/dev-clones/${sourceID}`;
+    let workdir = cloneRoot;
+    try {
+        for await (const entry of Deno.readDir(cloneRoot)) {
+            if (entry.isDirectory) { workdir = `${cloneRoot}/${entry.name}`; break; }
+        }
+    } catch (e) {
+        return { ok: false, error: `clone root unreadable: ${e}` };
+    }
+
+    const cmd = new Deno.Command("gh", {
+        args: ["pr", "create",
+               "--title", title,
+               "--body",  body,
+               "--base",  base,
+               "--head",  branch],
+        cwd:    workdir,
+        stdout: "piped",
+        stderr: "piped",
+    });
+    const { success, stdout, stderr } = await cmd.output();
+    const out = new TextDecoder().decode(stdout).trim();
+    if (!success) {
+        return { ok: false, error: new TextDecoder().decode(stderr).trim() };
+    }
+    return { ok: true, url: out };
+}

--- a/tasks/buildin/git-pr/task.ts
+++ b/tasks/buildin/git-pr/task.ts
@@ -1,31 +1,74 @@
 // deno-lint-ignore-file no-explicit-any
+
+// SOURCE_ID_RE constrains source_id to a flat identifier — the same
+// character class that pkg/taskset/branch_validate.go's ValidateRunID
+// uses for clone-dir name components. Any path-traversal sequence
+// (`..`, `/`, leading `-`) is rejected before we touch the filesystem.
+const SOURCE_ID_RE = /^[A-Za-z0-9_][A-Za-z0-9_-]{0,63}$/;
+
 export default async function main(opts: { params: Map<string, string> }) {
-    const sourceID = opts.params.get("source_id") ?? "";
-    const branch   = opts.params.get("branch")    ?? "";
-    const base     = opts.params.get("base")      ?? "main";
-    const title    = opts.params.get("title")     ?? "";
-    const body     = opts.params.get("body")      ?? "";
+    const sourceID  = opts.params.get("source_id")  ?? "";
+    const branch    = opts.params.get("branch")     ?? "";
+    const base      = opts.params.get("base")       ?? "main";
+    const title     = opts.params.get("title")      ?? "";
+    const body      = opts.params.get("body")       ?? "";
+    // clone_path is the explicit working directory passed by the caller
+    // (the auto-fix skill knows this from the value it returned from
+    // dicode.sources.set_dev_mode). Falling back to readDir under
+    // dev-clones is a legacy path; new callers should always pass it.
+    const clonePath = opts.params.get("clone_path") ?? "";
 
     if (!sourceID || !branch || !title) {
         return { ok: false, error: "source_id, branch, and title are required" };
     }
+    if (!SOURCE_ID_RE.test(sourceID)) {
+        return { ok: false, error: `source_id ${JSON.stringify(sourceID)} contains invalid characters; expected ^[A-Za-z0-9_][A-Za-z0-9_-]{0,63}$` };
+    }
 
-    // Resolve the dev-clone working directory for this source.
-    // The auto-fix flow already cloned to ${DATADIR}/dev-clones/<source_id>/<runID>.
-    // The clone path for the active dev session is recorded by the engine in the
-    // run's parent input under "_clone_path" (set by sources.set_dev_mode).
-    // For this task, we accept the simpler contract: the caller passes a working
-    // directory implicitly via Deno.cwd() OR we stat the dev-clones tree.
+    // Refuse to invoke gh without an explicit token. Without this guard
+    // the gh binary would fall back to an ambient `gh auth login` token
+    // (potentially admin-scoped), leaking authorization beyond what the
+    // task spec declares. permissions.env declares GH_TOKEN_AUTOFIX
+    // mapped onto GH_TOKEN; if the operator hasn't set the secret we
+    // refuse loudly rather than silently borrowing credentials.
+    const ghToken = Deno.env.get("GH_TOKEN") ?? "";
+    if (!ghToken) {
+        return { ok: false, error: "GH_TOKEN is not set; refusing to invoke gh with ambient credentials. Configure the GH_TOKEN_AUTOFIX secret." };
+    }
+
     const dataDir = Deno.env.get("DICODE_DATA_DIR") ??
                     `${Deno.env.get("HOME")}/.dicode`;
     const cloneRoot = `${dataDir}/dev-clones/${sourceID}`;
-    let workdir = cloneRoot;
-    try {
-        for await (const entry of Deno.readDir(cloneRoot)) {
-            if (entry.isDirectory) { workdir = `${cloneRoot}/${entry.name}`; break; }
+
+    let workdir: string;
+    if (clonePath) {
+        // Validate that the explicit path is rooted inside cloneRoot —
+        // defense-in-depth even though the caller is normally trusted.
+        if (!clonePath.startsWith(cloneRoot + "/") && clonePath !== cloneRoot) {
+            return { ok: false, error: `clone_path must be rooted at ${cloneRoot}; got ${clonePath}` };
         }
-    } catch (e) {
-        return { ok: false, error: `clone root unreadable: ${e}` };
+        workdir = clonePath;
+    } else {
+        // Legacy fallback: scan dev-clones/<source_id>/* for the first
+        // directory entry. Brittle if a previous run left an orphan
+        // clone; warn loudly so the caller migrates.
+        workdir = cloneRoot;
+        let found = false;
+        try {
+            for await (const entry of Deno.readDir(cloneRoot)) {
+                if (entry.isDirectory) {
+                    workdir = `${cloneRoot}/${entry.name}`;
+                    found = true;
+                    break;
+                }
+            }
+        } catch (e) {
+            return { ok: false, error: `clone root unreadable: ${e}` };
+        }
+        if (!found) {
+            return { ok: false, error: `no clone directory under ${cloneRoot}; pass clone_path explicitly` };
+        }
+        console.warn(`git-pr: clone_path not provided; picked ${workdir} via readDir scan. Pass clone_path explicitly to avoid orphan-clone races.`);
     }
 
     const cmd = new Deno.Command("gh", {

--- a/tasks/buildin/git-pr/task.yaml
+++ b/tasks/buildin/git-pr/task.yaml
@@ -11,11 +11,16 @@ trigger:
   manual: true
 
 params:
-  source_id: { type: string, required: true }
-  branch:    { type: string, required: true }
-  base:      { type: string, default: "main" }
-  title:     { type: string, required: true }
-  body:      { type: string, default: "" }
+  source_id:  { type: string, required: true }
+  branch:     { type: string, required: true }
+  base:       { type: string, default: "main" }
+  title:      { type: string, required: true }
+  body:       { type: string, default: "" }
+  # clone_path is the explicit working directory inside ${DATADIR}/dev-clones/<source_id>/
+  # that the caller (typically the auto-fix skill) wants gh invoked in. Strongly
+  # recommended — the legacy first-readDir fallback is brittle when previous
+  # runs left orphan clones.
+  clone_path: { type: string, default: "" }
 
 permissions:
   run: ["gh"]

--- a/tasks/buildin/git-pr/task.yaml
+++ b/tasks/buildin/git-pr/task.yaml
@@ -1,0 +1,36 @@
+apiVersion: dicode/v1
+kind: Task
+name: "Open Pull Request (GitHub)"
+description: |
+  Reference git-pr implementation. Opens a pull request via `gh pr create`
+  in the dev-clone for the given source. Replaceable: users may install
+  their own task and point auto-fix at it via params.pr_task.
+runtime: deno
+
+trigger:
+  manual: true
+
+params:
+  source_id: { type: string, required: true }
+  branch:    { type: string, required: true }
+  base:      { type: string, default: "main" }
+  title:     { type: string, required: true }
+  body:      { type: string, default: "" }
+
+permissions:
+  run: ["gh"]
+  env:
+    - name: GH_TOKEN
+      from: GH_TOKEN_AUTOFIX
+    - name: DICODE_DATA_DIR
+      from: DICODE_DATA_DIR
+    - HOME
+  fs:
+    - path: "${DATADIR}/dev-clones"
+      permission: r
+
+timeout: 60s
+
+notify:
+  on_success: false
+  on_failure: true

--- a/tasks/buildin/taskset.yaml
+++ b/tasks/buildin/taskset.yaml
@@ -111,3 +111,38 @@ spec:
     git-pr:
       ref:
         path: ./git-pr/task.yaml
+
+    auto-fix:
+      ref:
+        path: ./ai-agent/task.yaml
+      overrides:
+        name: "Auto-fix on failure"
+        description: |
+          Diagnoses a failed task run, edits source in a per-fix clone,
+          validates via task tests + replay, and either merges to main
+          (autonomous) or opens a PR (review). Fired by setting
+          on_failure_chain: auto-fix on a target task or in defaults.
+        trigger:
+          manual: true
+        params:
+          skills: "dicode-task-dev,dicode-basics,dicode-auto-fix"
+          max_tool_iterations: "30"
+        timeout: 1800s
+        notify:
+          on_success: true
+          on_failure: true
+        dicode:
+          runs_replay:           true
+          runs_get_input:        true
+          runs_pin_input:        true
+          runs_unpin_input:      true
+          sources_set_dev_mode:  true
+          tasks_test:            true
+          git_commit_push:       true
+          list_tasks:            true
+          get_runs:              true
+          tasks:
+            - "git-pr"
+        fs:
+          - path: "${DATADIR}/dev-clones"
+            permission: rw

--- a/tasks/buildin/taskset.yaml
+++ b/tasks/buildin/taskset.yaml
@@ -107,3 +107,7 @@ spec:
     run-inputs-cleanup:
       ref:
         path: ./run-inputs-cleanup/task.yaml
+
+    git-pr:
+      ref:
+        path: ./git-pr/task.yaml

--- a/tasks/skills/dicode-auto-fix.md
+++ b/tasks/skills/dicode-auto-fix.md
@@ -1,0 +1,69 @@
+---
+name: dicode-auto-fix
+description: Mandatory workflow for the on-failure auto-fix loop. Diagnose a failed run, edit source on a fix branch, validate via tests + replay, push, optionally PR.
+---
+
+# dicode auto-fix loop
+
+You are running inside the `auto-fix` task, fired by another task's failure
+via `on_failure_chain`. Your job is to diagnose the failure, write a
+narrowly-scoped fix to the failing task's source, validate it with tests
+and replay, and either push to main (autonomous) or open a PR (review).
+
+## Iteration loop (cap: `max_iterations`, default 5)
+
+1. **Read context.**
+   - Read `taskID`, `runID`, `status`, `output`, and `mode` from the input map.
+   - Call `dicode.runs.get_input(runID)` — receives `{ input, redacted_fields }`.
+     If `auto_fix.include_input: false` was set, you get only the failure logs
+     and output; respect that and reason from logs alone.
+   - Note the redacted-field names; if the failure depends on a redacted field
+     (a signature, a token), say so plainly in the PR body — reviewers need that signal.
+2. **Pin the input.**
+   - Call `dicode.runs.pin_input(runID)` — keeps the blob alive while you work.
+   - Set up `defer cleanup()`: in JavaScript terms, register a try/finally so
+     `dicode.runs.unpin_input(runID)` runs on success, error, or timeout.
+3. **Open a fix branch.**
+   - In `mode: review`: use `${branch_prefix}${runID}` (default `fix/<runID>`).
+   - In `mode: autonomous`: use the source's tracked branch (`base_branch`).
+   - Call `dicode.sources.set_dev_mode(<source>, { enabled: true, branch: <fixBranch>, base: <base> })`.
+4. **Iterate** (cap each iteration at `max_iteration_seconds`, default 300s):
+   - Read failing-task source files via `Deno.readTextFile` from `${DATADIR}/dev-clones/<source>/<runID>/`.
+   - Edit via `Deno.writeTextFile` — **only inside the failing task's directory.**
+     Do NOT write outside the failed task's directory; cross-task edits are out
+     of scope and will land you in trouble.
+   - Validate inline: re-parse `task.yaml`, re-typecheck `task.ts`.
+   - Test: `dicode.tasks.test(<failingTaskID>)`. If no test exists, write one.
+   - Replay: `dicode.runs.replay(<failedRunID>)` with the original failed run
+     ID (the engine looks it up by lineage; the replayer accepts because your
+     parent_run_id is that run). Wait for terminal status.
+   - If both green → exit loop.
+5. **Commit + push.**
+   - `dicode.git.commit_push(<source>, { message, branch: <fixBranch> })`.
+6. **Open the PR (review mode only).**
+   - `dicode.run_task("git-pr", { source_id, branch: fixBranch, base, title, body })`.
+   - Body must mention any redacted_fields you saw — reviewers need that signal.
+7. **Disable dev mode.**
+   - `dicode.sources.set_dev_mode(<source>, { enabled: false })` — engine
+     removes the local clone; the remote branch is retained.
+8. **Unpin input** (the deferred cleanup also handles the timeout/panic case).
+
+## Token / iteration budget
+
+- `max_tool_iterations: 30` (overrides ai-agent's default 10) — fix loops
+  chatter more than chat sessions.
+- `max_tokens: 50_000` per run — keep prompts focused; avoid re-reading
+  files you already have in working memory.
+
+## Hard rules
+
+- **One task, one fix.** Do not edit dependency tasks, secrets, or anything
+  outside the failing task's directory.
+- **No `--force` push.** The engine refuses it; your call will error and you
+  must abandon the iteration.
+- **Branch protection.** Autonomous mode pushes directly to the source's
+  tracked branch; this assumes branch protection is configured on the forge.
+  Review mode is the safe default.
+- **Stop on storm.** The engine's circuit breaker will refuse new fires from
+  a flapping source; if you see `storm circuit breaker tripped` errors,
+  exit cleanly and let humans triage.

--- a/tasks/skills/dicode-auto-fix.md
+++ b/tasks/skills/dicode-auto-fix.md
@@ -41,7 +41,9 @@ and replay, and either push to main (autonomous) or open a PR (review).
 5. **Commit + push.**
    - `dicode.git.commit_push(<source>, { message, branch: <fixBranch> })`.
 6. **Open the PR (review mode only).**
-   - `dicode.run_task("git-pr", { source_id, branch: fixBranch, base, title, body })`.
+   - `dicode.run_task("git-pr", { source_id, branch: fixBranch, base, title, body, clone_path: <path you cloned into> })`.
+   - Pass `clone_path` explicitly — the legacy first-readDir fallback in
+     `git-pr` is brittle when prior runs left orphan clone directories.
    - Body must mention any redacted_fields you saw — reviewers need that signal.
 7. **Disable dev mode.**
    - `dicode.sources.set_dev_mode(<source>, { enabled: false })` — engine


### PR DESCRIPTION
Closes #238. Final block of the on-failure auto-fix epic (#207 / #228). Also closes #246 (Replayer cross-task ownership).

Wires the auto-fix loop end-to-end. With this merged, the LP self-healing arc is live: a user task fails → on_failure_chain fires \`buildin/auto-fix\` → an AI agent loaded with the \`dicode-auto-fix\` skill diagnoses the failure, opens a fix branch, edits source, validates via tests + replay, then either pushes (autonomous) or opens a PR (review).

## What's in

| Chunk | Pieces |
|---|---|
| Engine guardrails | Per-task cooldown, per-task + global concurrency caps, per-source storm circuit breaker, chain-depth ceiling, replay → on_failure_chain suppression. All in-memory; restart resets state (documented v1 trade-off). Per-task \`max_concurrent_global\` / \`storm\` are stripped at config-load with a WARN — those are operator-policy. |
| Typed \`TriggerSource\` enum | Replaces ad-hoc \`"chain"\` / \`"replay"\` string compares across registry + trigger packages. Wire format preserved. |
| Override mechanism extension | \`Overrides.Fs\` (full-replace, mirrors Net), \`mergeDicodePerms\` Tasks union (so override entries can append to the base list), full propagation of #234's dicode bool flags through the merge. |
| YAML-grantable \`runs_get_input\` | Drops the \"programmatic-grant only\" carve-out. Users can now build their own replayer / fixer / auditor tasks by setting \`permissions.dicode.runs_get_input: true\`. The redaction layer (#233) is what bounds the surface, not preset gating. \`TestCapRunsGetInput_NotGrantedFromYAML\` inverted to \`TestCapRunsGetInput_GrantedFromYAML\`. |
| Replayer cross-task ownership (#246) | \`Replayer.Replay\` takes \`callerTaskID\` + \`callerParentRunID\`; rejects cross-task replay unless caller is the run's own task OR caller's \`parent_run_id\` is the requested run (auto-fix lineage). Empty caller fields preserve REST-handler bypass. |
| \`buildin/git-pr\` task | Reference Deno task wrapping \`gh pr create\`. \`permissions.run: [gh]\`, env-only PAT (\`GH_TOKEN_AUTOFIX\`), fs read scoped to dev-clones. Replaceable per-deployment via \`auto-fix.params.pr_task\`. |
| \`tasks/skills/dicode-auto-fix.md\` | Markdown skill loaded into ai-agent's system prompt. Prescribes the iteration loop: read context → pin → branch → iterate → commit_push → PR → cleanup. Iteration cap, per-iteration timeout, edit-scope rule. |
| \`auto-fix\` taskset entry | Override of \`ai-agent\` in \`tasks/buildin/taskset.yaml\` — preloaded skill, dicode caps the loop needs (incl. the now YAML-grantable \`runs_get_input\`), \`fs.rw: \${DATADIR}/dev-clones\`, \`tasks\` union appends \`git-pr\`. |

## Migration note

The \`Tasks\` slice in taskset overrides previously full-replaced; now it **unions** with the base. Any existing override that intentionally relied on full-replace semantics needs review.

## Test plan

- [x] \`go test ./... -timeout 240s\` — 21 packages green
- [x] \`go build ./...\` — clean
- [x] \`TestEngine_ChainDepth_StopsAtCeiling\` — chain-depth ceiling
- [x] \`TestEngine_OnFailureChain_CooldownSuppressesSecondFire\` — cooldown
- [x] \`TestChainGuards_*\` — cooldown / concurrency / storm predicates (4 tests)
- [x] \`TestApplyOverrides_*\` — FS override, Tasks union, new bool flag propagation
- [x] \`TestCapRunsGetInput_GrantedFromYAML\` — inverted security regression
- [x] \`TestReplay_Ownership*\` — 4 cases (self-task / cross-task / parent-lineage / empty-bypass)
- [x] \`TestIPC_Replay_*\` — IPC ownership wiring
- [x] \`TestAutoFixSkill_FileExists\` + \`TestAutoFixEntry_HasExpectedDicodePerms\`
- [x] \`TestAutoFix_E2E_HappyPath\` — gated on \`DICODE_E2E=1\`; runs green
- [x] \`TestOnFailureChainSpec_StripsGlobalFieldsForPerTask\` — config-load WARN
- [ ] CI's \"Test tasks (Deno)\" job will exercise \`tasks/buildin/git-pr/task.test.ts\` (Deno not in this worktree)
- [ ] Manual smoke: trigger a controlled failure → observe auto-fix fire → verify PR opens (mode: review)

## Out of scope

- PostgreSQL persistence for cooldown / storm counters (currently in-memory)
- GitLab / Gitea PR support (extend or replace \`buildin/git-pr\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)