### PR TITLE
feat: run grouping (#116) — parent_run_id + group + set_group SDK + REST filters

### DIFF
--- a/pkg/db/sqlite.go
+++ b/pkg/db/sqlite.go
@@ -157,12 +157,26 @@ func (s *SQLiteDB) migrate() error {
 		{"input_stored_at", "INTEGER"},
 		{"input_pinned", "INTEGER NOT NULL DEFAULT 0"},
 		{"input_redacted_fields", "TEXT"},
+		// Run grouping (#116) — free-text label set by the task itself via
+		// dicode.set_group(). Column is `run_group` (not `group`) because the
+		// latter is a SQL keyword and our migrate helper rejects quoted idents.
+		{"run_group", "TEXT NOT NULL DEFAULT ''"},
 	}
 	ctx := context.Background()
 	for _, m := range runsMigrations {
 		if err := addColumnIfMissing(ctx, s.db, "runs", m.name, m.ddl); err != nil {
 			return fmt.Errorf("migrate runs.%s: %w", m.name, err)
 		}
+	}
+
+	// Indexes supporting #116 run-grouping filters. CREATE INDEX IF NOT EXISTS
+	// is idempotent so this is safe to run on every startup.
+	_, err = s.db.Exec(`
+		CREATE INDEX IF NOT EXISTS idx_runs_parent_run_id ON runs(parent_run_id);
+		CREATE INDEX IF NOT EXISTS idx_runs_task_run_group ON runs(task_id, run_group);
+	`)
+	if err != nil {
+		return fmt.Errorf("migrate run-grouping indexes: %w", err)
 	}
 	return nil
 }

--- a/pkg/ipc/capability.go
+++ b/pkg/ipc/capability.go
@@ -31,6 +31,10 @@ const (
 	CapKVWrite     = "kv.write"
 	CapOutputWrite = "output.write"
 	CapReturn      = "return"
+	// CapSetGroup allows a task to label its own run via dicode.set_group()
+	// (#116). Self-affecting and granted to every task token by default; the
+	// cap exists only so future denial policies can revoke it.
+	CapSetGroup = "set_group"
 
 	// CapOutputSecret allows a task to call dicode.output(map, {
 	// secret: true }) — flagging values for daemon-side redaction and
@@ -102,5 +106,6 @@ func defaultTaskCaps() []string {
 		CapOutputWrite,
 		CapReturn,
 		CapOutputSecret,
+		CapSetGroup,
 	}
 }

--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -96,6 +96,9 @@ type Request struct {
 	// dicode.runs.* — run-input retention management (#233)
 	BeforeTs int64 `json:"before_ts,omitempty"` // dicode.runs.list_expired: unix timestamp cutoff
 
+	// dicode.set_group — free-text label for the caller's run (#116).
+	Group string `json:"group,omitempty"`
+
 	// dicode.sources.set_dev_mode — toggles dev mode on a configured source (#234)
 	Name      string `json:"name,omitempty"`       // source name
 	Enabled   bool   `json:"enabled,omitempty"`    // true to enable
@@ -141,6 +144,9 @@ func (o *OutputResult) IsSet() bool { return o != nil && o.ContentType != "" }
 // to avoid import cycles.
 type EngineRunner interface {
 	FireManual(ctx context.Context, taskID string, params map[string]string) (string, error)
+	// FireFromTask is FireManual with a parent run ID — used by dicode.run_task
+	// so the IPC server can stamp the caller's run ID on the new run (#116).
+	FireFromTask(ctx context.Context, taskID, parentRunID string, params map[string]string) (string, error)
 	WaitRun(ctx context.Context, runID string) (RunResult, error)
 	ActiveRunCount() int
 	ActiveTaskSlots() int

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -656,6 +656,21 @@ func (s *Server) handleConn(conn net.Conn) {
 
 		// ── dicode.* ──────────────────────────────────────────────────────
 
+		case "dicode.set_group":
+			if !hasCap(caps, CapSetGroup) {
+				reply(req.ID, nil, "ipc: permission denied (set_group)")
+				continue
+			}
+			if s.runID == "" {
+				reply(req.ID, nil, "ipc: set_group requires an active run context")
+				continue
+			}
+			if err := s.registry.SetRunGroup(context.Background(), s.runID, req.Group); err != nil {
+				reply(req.ID, nil, err.Error())
+				continue
+			}
+			reply(req.ID, true, "")
+
 		case "dicode.run_task":
 			if !hasCap(caps, CapTaskTrigger) {
 				reply(req.ID, nil, "ipc: permission denied (tasks.trigger)")
@@ -673,7 +688,10 @@ func (s *Server) handleConn(conn net.Conn) {
 			if len(req.Params) > 0 {
 				_ = json.Unmarshal(req.Params, &callParams)
 			}
-			runID, err := s.engine.FireManual(s.ctx, req.TaskID, callParams)
+			// Pass s.runID as the parent so the new run is linked to the
+			// caller (#116). When the caller is the CLI control socket
+			// s.runID is "" and FireFromTask falls back to a plain manual.
+			runID, err := s.engine.FireFromTask(s.ctx, req.TaskID, s.runID, callParams)
 			if err != nil {
 				reply(req.ID, nil, err.Error())
 				continue

--- a/pkg/ipc/server_test.go
+++ b/pkg/ipc/server_test.go
@@ -22,12 +22,17 @@ import (
 // ── test helpers ─────────────────────────────────────────────────────────────
 
 type mockEngine struct {
-	runID  string
-	result RunResult
-	err    error
+	runID    string
+	result   RunResult
+	err      error
+	parentRX string // observed parent runID on the last FireFromTask call
 }
 
 func (m *mockEngine) FireManual(_ context.Context, _ string, _ map[string]string) (string, error) {
+	return m.runID, m.err
+}
+func (m *mockEngine) FireFromTask(_ context.Context, _ string, parentRunID string, _ map[string]string) (string, error) {
+	m.parentRX = parentRunID
 	return m.runID, m.err
 }
 func (m *mockEngine) WaitRun(_ context.Context, _ string) (RunResult, error) {
@@ -711,6 +716,66 @@ func TestServer_Dicode_RunTask_Wildcard(t *testing.T) {
 	resp := recvMsg(t, conn)
 	if resp["error"] != nil {
 		t.Errorf("wildcard should allow any task, got: %v", resp["error"])
+	}
+}
+
+// ── #116 run grouping tests ──────────────────────────────────────────────────
+
+// TestServer_Dicode_RunTask_ParentLinkage verifies that dicode.run_task
+// passes the caller's runID as the new run's parent, so child runs are
+// correctly linked back to the running task that triggered them.
+func TestServer_Dicode_RunTask_ParentLinkage(t *testing.T) {
+	e := newTestEnv(t)
+	eng := &mockEngine{runID: "child-run", result: RunResult{RunID: "child-run", Status: "success"}}
+	spec := specWithDicode("caller", &task.DicodePermissions{Tasks: []string{"target-task"}})
+	conn, srv := e.startWithSpec(t, nil, nil, spec, eng)
+
+	sendMsg(t, conn, map[string]any{"id": "1", "method": "dicode.run_task", "taskID": "target-task"})
+	resp := recvMsg(t, conn)
+	if resp["error"] != nil {
+		t.Fatalf("unexpected error: %v", resp["error"])
+	}
+	if eng.parentRX == "" {
+		t.Fatal("FireFromTask never received a parent runID")
+	}
+	if eng.parentRX != srv.runID {
+		t.Errorf("parent runID = %q, want %q", eng.parentRX, srv.runID)
+	}
+}
+
+// TestServer_Dicode_SetGroup_Persists writes a group via the IPC method
+// and reads it back through the registry to verify last-write-wins.
+func TestServer_Dicode_SetGroup_Persists(t *testing.T) {
+	e := newTestEnv(t)
+	conn, srv := e.start(t, nil, nil)
+
+	// The server doesn't auto-create a runs row; do it ourselves so the
+	// UPDATE has a target. (In production fireAsync inserts the row before
+	// the task starts.)
+	if _, err := e.reg.StartRunWithID(context.Background(), srv.runID, "test-task", "", "manual"); err != nil {
+		t.Fatalf("StartRunWithID: %v", err)
+	}
+
+	sendMsg(t, conn, map[string]any{"id": "1", "method": "dicode.set_group", "group": "chat-7"})
+	resp := recvMsg(t, conn)
+	if resp["error"] != nil {
+		t.Fatalf("set_group error: %v", resp["error"])
+	}
+
+	got, err := e.reg.GetRun(context.Background(), srv.runID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if got.Group != "chat-7" {
+		t.Errorf("Group = %q, want chat-7", got.Group)
+	}
+
+	// Last write wins.
+	sendMsg(t, conn, map[string]any{"id": "2", "method": "dicode.set_group", "group": "chat-9"})
+	_ = recvMsg(t, conn)
+	got, _ = e.reg.GetRun(context.Background(), srv.runID)
+	if got.Group != "chat-9" {
+		t.Errorf("Group after overwrite = %q, want chat-9", got.Group)
 	}
 }
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -34,6 +34,10 @@ type Run struct {
 	StartedAt     time.Time
 	FinishedAt    *time.Time
 	ParentRunID   string
+	// Group is a free-text label set by the task itself via dicode.set_group().
+	// Used by the WebUI to collapse same-group siblings in the run list (#114).
+	// Column name on disk is `run_group` because GROUP is a SQL keyword.
+	Group         string
 	TriggerSource TriggerSource
 	ReturnValue   string // JSON-encoded return value; empty if none
 
@@ -246,7 +250,8 @@ func (r *Registry) GetRun(ctx context.Context, runID string) (*Run, error) {
 		        COALESCE(return_value, ''), COALESCE(output_content_type, ''), COALESCE(output_content, ''),
 		        COALESCE(fail_reason, ''),
 		        COALESCE(input_storage_key, ''), COALESCE(input_size, 0), COALESCE(input_stored_at, 0),
-		        COALESCE(input_redacted_fields, ''), COALESCE(input_pinned, 0)
+		        COALESCE(input_redacted_fields, ''), COALESCE(input_pinned, 0),
+		        COALESCE(run_group, '')
 		 FROM runs WHERE id = ?`,
 		[]any{runID},
 		func(rows db.Scanner) error {
@@ -262,6 +267,7 @@ func (r *Registry) GetRun(ctx context.Context, runID string) (*Run, error) {
 					&tsStr, &run.ReturnValue, &run.OutputContentType, &run.OutputContent,
 					&run.FailureReason,
 					&run.InputStorageKey, &run.InputSize, &run.InputStoredAt, &redactedFieldsJSON, &run.InputPinned,
+					&run.Group,
 				); err != nil {
 					return err
 				}
@@ -290,6 +296,12 @@ func (r *Registry) GetRun(ctx context.Context, runID string) (*Run, error) {
 	return run, nil
 }
 
+// SetRunGroup labels a run with a free-text group string (#116). Last write
+// wins; intended to be called by the running task itself via dicode.set_group().
+func (r *Registry) SetRunGroup(ctx context.Context, runID, group string) error {
+	return r.db.Exec(ctx, `UPDATE runs SET run_group = ? WHERE id = ?`, group, runID)
+}
+
 // SetRunInput updates the runs row with the persistence handle after the input
 // blob has been stored. Called by the trigger engine immediately after Persist
 // succeeds.
@@ -310,13 +322,37 @@ func (r *Registry) SetRunInput(ctx context.Context, runID, storageKey string, si
 
 // ListRuns returns the most recent runs for a task (newest first).
 func (r *Registry) ListRuns(ctx context.Context, taskID string, limit int) ([]*Run, error) {
+	return r.queryRuns(ctx,
+		`WHERE task_id = ? ORDER BY started_at DESC LIMIT ?`,
+		[]any{taskID, limit})
+}
+
+// ListChildren returns runs whose parent_run_id == parentID, newest first (#116).
+func (r *Registry) ListChildren(ctx context.Context, parentRunID string, limit int) ([]*Run, error) {
+	return r.queryRuns(ctx,
+		`WHERE parent_run_id = ? ORDER BY started_at DESC LIMIT ?`,
+		[]any{parentRunID, limit})
+}
+
+// ListByGroup returns runs for a task with the given group label, newest first (#116).
+// taskID scopes the query because group labels are task-local — the same label
+// from different tasks must not collide.
+func (r *Registry) ListByGroup(ctx context.Context, taskID, group string, limit int) ([]*Run, error) {
+	return r.queryRuns(ctx,
+		`WHERE task_id = ? AND run_group = ? ORDER BY started_at DESC LIMIT ?`,
+		[]any{taskID, group, limit})
+}
+
+// queryRuns runs a `SELECT … FROM runs <whereAndLimitClause>` and decodes rows
+// into Run structs. The clause must include any ORDER BY / LIMIT.
+func (r *Registry) queryRuns(ctx context.Context, whereAndLimit string, args []any) ([]*Run, error) {
 	var runs []*Run
 	err := r.db.Query(ctx,
 		`SELECT id, task_id, status, started_at, finished_at, parent_run_id, trigger_source,
 		        COALESCE(return_value, ''), COALESCE(output_content_type, ''), COALESCE(output_content, ''),
-		        COALESCE(fail_reason, '')
-		 FROM runs WHERE task_id = ? ORDER BY started_at DESC LIMIT ?`,
-		[]any{taskID, limit},
+		        COALESCE(fail_reason, ''), COALESCE(run_group, '')
+		 FROM runs `+whereAndLimit,
+		args,
 		func(rows db.Scanner) error {
 			for rows.Next() {
 				run := &Run{}
@@ -324,7 +360,7 @@ func (r *Registry) ListRuns(ctx context.Context, taskID string, limit int) ([]*R
 				var finishedMs *int64
 				var parentID *string
 				var tsStr string
-				if err := rows.Scan(&run.ID, &run.TaskID, &run.Status, &startedMs, &finishedMs, &parentID, &tsStr, &run.ReturnValue, &run.OutputContentType, &run.OutputContent, &run.FailureReason); err != nil {
+				if err := rows.Scan(&run.ID, &run.TaskID, &run.Status, &startedMs, &finishedMs, &parentID, &tsStr, &run.ReturnValue, &run.OutputContentType, &run.OutputContent, &run.FailureReason, &run.Group); err != nil {
 					return err
 				}
 				run.TriggerSource = TriggerSource(tsStr)

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -28,12 +28,12 @@ const (
 
 // Run is a single execution record.
 type Run struct {
-	ID            string
-	TaskID        string
-	Status        string
-	StartedAt     time.Time
-	FinishedAt    *time.Time
-	ParentRunID   string
+	ID          string
+	TaskID      string
+	Status      string
+	StartedAt   time.Time
+	FinishedAt  *time.Time
+	ParentRunID string
 	// Group is a free-text label set by the task itself via dicode.set_group().
 	// Used by the WebUI to collapse same-group siblings in the run list (#114).
 	// Column name on disk is `run_group` because GROUP is a SQL keyword.

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -172,6 +172,96 @@ func TestRegistry_ParentRunID(t *testing.T) {
 	}
 }
 
+// ── #116 run grouping ─────────────────────────────────────────────────────────
+
+func TestRegistry_SetRunGroup(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+	ctx := context.Background()
+
+	runID, _ := r.StartRun(ctx, "task-g", "")
+	if err := r.SetRunGroup(ctx, runID, "chat-42"); err != nil {
+		t.Fatalf("SetRunGroup: %v", err)
+	}
+	got, err := r.GetRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if got.Group != "chat-42" {
+		t.Errorf("Group = %q, want %q", got.Group, "chat-42")
+	}
+
+	// Last write wins.
+	if err := r.SetRunGroup(ctx, runID, "chat-99"); err != nil {
+		t.Fatalf("SetRunGroup overwrite: %v", err)
+	}
+	got, _ = r.GetRun(ctx, runID)
+	if got.Group != "chat-99" {
+		t.Errorf("Group after overwrite = %q, want chat-99", got.Group)
+	}
+}
+
+func TestRegistry_ListChildren(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+	ctx := context.Background()
+
+	parentID, _ := r.StartRun(ctx, "parent", "")
+	c1, _ := r.StartRun(ctx, "child-task", parentID)
+	c2, _ := r.StartRun(ctx, "child-task", parentID)
+	// An unrelated run that must NOT appear.
+	_, _ = r.StartRun(ctx, "other", "")
+
+	kids, err := r.ListChildren(ctx, parentID, 10)
+	if err != nil {
+		t.Fatalf("ListChildren: %v", err)
+	}
+	if len(kids) != 2 {
+		t.Fatalf("len(kids) = %d, want 2", len(kids))
+	}
+	got := map[string]bool{kids[0].ID: true, kids[1].ID: true}
+	if !got[c1] || !got[c2] {
+		t.Errorf("missing child IDs in result: %+v", got)
+	}
+}
+
+func TestRegistry_ListByGroup(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+	ctx := context.Background()
+
+	a1, _ := r.StartRun(ctx, "task-a", "")
+	a2, _ := r.StartRun(ctx, "task-a", "")
+	b1, _ := r.StartRun(ctx, "task-b", "")
+	_ = a2
+	// task-a runs share group "g1"; task-b uses the same label but different
+	// task, so it must be excluded.
+	for _, id := range []string{a1, a2} {
+		if err := r.SetRunGroup(ctx, id, "g1"); err != nil {
+			t.Fatalf("SetRunGroup: %v", err)
+		}
+	}
+	if err := r.SetRunGroup(ctx, b1, "g1"); err != nil {
+		t.Fatalf("SetRunGroup b1: %v", err)
+	}
+
+	siblings, err := r.ListByGroup(ctx, "task-a", "g1", 10)
+	if err != nil {
+		t.Fatalf("ListByGroup: %v", err)
+	}
+	if len(siblings) != 2 {
+		t.Fatalf("len(siblings) = %d, want 2", len(siblings))
+	}
+	for _, s := range siblings {
+		if s.TaskID != "task-a" {
+			t.Errorf("got run from task %q in task-a group", s.TaskID)
+		}
+		if s.Group != "g1" {
+			t.Errorf("got group %q, want g1", s.Group)
+		}
+	}
+}
+
 // ── BulkAppendLogs tests ──────────────────────────────────────────────────────
 
 func TestRegistry_BulkAppendLogs_Empty(t *testing.T) {

--- a/pkg/runtime/deno/runtime_test.go
+++ b/pkg/runtime/deno/runtime_test.go
@@ -461,6 +461,31 @@ func TestRuntime_RunRecord(t *testing.T) {
 	}
 }
 
+// #116: dicode.set_group writes the label through IPC and lands on the runs row.
+func TestRuntime_SetGroup_Persists(t *testing.T) {
+	e := newTestEnv(t)
+	r := e.runSpec(t, `export default async function main({ dicode }) {
+		await dicode.set_group("chat-42")
+		return "ok"
+	}`, &task.Spec{
+		ID:      "set-group-task",
+		Name:    "set-group-task",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Timeout: 30 * time.Second,
+	})
+	if r.Error != nil {
+		t.Fatalf("script error: %v", r.Error)
+	}
+	run, err := e.reg.GetRun(context.Background(), r.RunID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if run.Group != "chat-42" {
+		t.Errorf("Group = %q, want chat-42", run.Group)
+	}
+}
+
 func TestRuntime_ScriptError(t *testing.T) {
 	e := newTestEnv(t)
 	r := e.run(t, `throw new Error("boom")`, RunOptions{})

--- a/pkg/runtime/deno/sdk/shim.ts
+++ b/pkg/runtime/deno/sdk/shim.ts
@@ -123,6 +123,10 @@ export interface Dicode {
   run_task:       (taskID: string, params?: Record<string, string>)  => Promise<unknown>;
   list_tasks:     ()                                                   => Promise<unknown>;
   get_runs:       (taskID: string, opts?: { limit?: number })         => Promise<unknown>;
+  // set_group labels the current run with a free-text string used by the
+  // WebUI to collapse same-group siblings (#116). Last write wins; only
+  // affects the current run.
+  set_group:      (label: string)                                      => Promise<void>;
   secrets_set:    (key: string, value: string)                        => Promise<void>;
   secrets_delete: (key: string)                                        => Promise<void>;
   oauth:          DicodeOAuth;
@@ -325,6 +329,7 @@ const dicode: Dicode = {
   run_task:       (taskID, params)  => __call__({ method: "dicode.run_task",       taskID, params: params ?? {} }),
   list_tasks:     ()                => __call__({ method: "dicode.list_tasks" }),
   get_runs:       (taskID, opts)    => __call__({ method: "dicode.get_runs",        taskID, limit: opts?.limit ?? 10 }),
+  set_group:      (label)           => __call__({ method: "dicode.set_group",       group: String(label ?? "") }) as Promise<void>,
   secrets_set:    (key, value)      => __call__({ method: "dicode.secrets_set",     key, stringValue: value }) as Promise<void>,
   secrets_delete: (key)             => __call__({ method: "dicode.secrets_delete",  key }) as Promise<void>,
   oauth: {

--- a/pkg/runtime/python/sdk/dicode_sdk.py
+++ b/pkg/runtime/python/sdk/dicode_sdk.py
@@ -397,6 +397,11 @@ class _Dicode:
         return _call({"method": "dicode.get_runs", "taskID": task_id,
                       "limit": limit}) or []
 
+    def set_group(self, label):
+        # Label the current run with a free-text group string (#116). Used
+        # by the WebUI to collapse same-group siblings. Last write wins.
+        _call({"method": "dicode.set_group", "group": str(label or "")})
+
     async def run_task_async(self, task_id, params=None):
         return await _call_async({"method": "dicode.run_task", "taskID": task_id,
                                   "params": params or {}})
@@ -407,6 +412,9 @@ class _Dicode:
     async def get_runs_async(self, task_id, limit=10):
         return await _call_async({"method": "dicode.get_runs", "taskID": task_id,
                                   "limit": limit}) or []
+
+    async def set_group_async(self, label):
+        await _call_async({"method": "dicode.set_group", "group": str(label or "")})
 
 
 dicode = _Dicode()

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -638,6 +638,23 @@ func (e *Engine) FireManual(ctx context.Context, taskID string, params map[strin
 	return e.fireAsync(context.Background(), spec, pkgruntime.RunOptions{Params: params}, registry.TriggerManual)
 }
 
+// FireFromTask triggers a task as a child of an in-flight run. Used by the
+// dicode.run_task IPC handler so the new run's parent_run_id (#116) points
+// at the caller. Falls back to a plain manual fire when parentRunID is "".
+func (e *Engine) FireFromTask(ctx context.Context, taskID, parentRunID string, params map[string]string) (string, error) {
+	if parentRunID == "" {
+		return e.FireManual(ctx, taskID, params)
+	}
+	spec, ok := e.registry.Get(taskID)
+	if !ok {
+		return "", fmt.Errorf("task %q not found", taskID)
+	}
+	e.log.Info("subtask trigger", zap.String("task", taskID), zap.String("parent", parentRunID))
+	return e.fireAsync(context.Background(), spec,
+		pkgruntime.RunOptions{Params: params, ParentRunID: parentRunID},
+		registry.TriggerManual)
+}
+
 // WaitRun blocks until the run identified by runID reaches a terminal state,
 // then returns a RunResult. Implements ipc.EngineRunner.
 //

--- a/pkg/trigger/run_grouping_e2e_test.go
+++ b/pkg/trigger/run_grouping_e2e_test.go
@@ -1,0 +1,100 @@
+package trigger
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// TestEngine_RunTask_ParentLinkage_E2E covers the third dispatch source from
+// issue #116: when a running task calls dicode.run_task(child), the new run
+// must have parent_run_id pointing back at the caller.
+//
+// This is a true end-to-end integration test — real Deno subprocess, real
+// IPC server, real registry, real engine. It complements the unit-level
+// IPC test (TestServer_Dicode_RunTask_ParentLinkage) which uses a mock
+// EngineRunner and only verifies the IPC handler forwards s.runID; this
+// test verifies fireAsync actually persists the parent ID end-to-end.
+func TestEngine_RunTask_ParentLinkage_E2E(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+	// Wire the engine into the Deno runtime so dicode.run_task works.
+	e.denoRT.SetEngine(e.engine)
+
+	// Child task: trivial, returns its own run id so the parent can record it.
+	child := writeTask(t, dir, "rg-child",
+		`export default async function main({ dicode }) {
+			await dicode.set_group("conversation-7")
+			return dicode.run_id
+		}`,
+		task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(child)
+	e.engine.Register(child)
+
+	// Parent task: uses dicode.run_task to fire the child synchronously,
+	// then returns the child's run id from the call result.
+	parent := writeTask(t, dir, "rg-parent",
+		`export default async function main({ dicode }) {
+			const result = await dicode.run_task("rg-child")
+			return result?.runID ?? null
+		}`,
+		task.TriggerConfig{Manual: true})
+	parent.Permissions.Dicode = &task.DicodePermissions{Tasks: []string{"rg-child"}}
+	_ = e.reg.Register(parent)
+	e.engine.Register(parent)
+
+	parentRunID, err := e.engine.FireManual(context.Background(), "rg-parent", nil)
+	if err != nil {
+		t.Fatalf("FireManual parent: %v", err)
+	}
+
+	// Wait for the parent to finish (this implicitly waits for the child too,
+	// since the parent blocks on dicode.run_task → WaitRun).
+	parentRun := waitForRun(t, e.reg, parentRunID, 60*time.Second)
+	if parentRun.Status != registry.StatusSuccess {
+		t.Fatalf("parent status = %s, want success", parentRun.Status)
+	}
+
+	// The parent's return_value is the child's run ID (JSON-encoded string).
+	// Strip the quotes — JSON-encoded "abc-123" is `"abc-123"` on disk.
+	if len(parentRun.ReturnValue) < 2 {
+		t.Fatalf("parent return_value unexpectedly empty: %q", parentRun.ReturnValue)
+	}
+	childRunID := parentRun.ReturnValue[1 : len(parentRun.ReturnValue)-1]
+
+	childRun, err := e.reg.GetRun(context.Background(), childRunID)
+	if err != nil {
+		t.Fatalf("GetRun child: %v", err)
+	}
+	if childRun.ParentRunID != parentRunID {
+		t.Errorf("child.ParentRunID = %q, want %q (the parent run)", childRun.ParentRunID, parentRunID)
+	}
+	// set_group landed on the child too — proves the SDK call wired through
+	// IPC, lining up the second half of #116 in the same flow.
+	if childRun.Group != "conversation-7" {
+		t.Errorf("child.Group = %q, want conversation-7", childRun.Group)
+	}
+}
+
+// waitForRun polls the registry until the run reaches a terminal state or
+// the deadline expires, then returns the final record. Fails the test if
+// the run is still running at the deadline.
+func waitForRun(t *testing.T, reg *registry.Registry, runID string, timeout time.Duration) *registry.Run {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		run, err := reg.GetRun(context.Background(), runID)
+		if err != nil {
+			t.Fatalf("GetRun %s: %v", runID, err)
+		}
+		if run.Status != registry.StatusRunning {
+			return run
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("run %s did not finish within %s", runID, timeout)
+	return nil
+}

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -482,6 +482,10 @@ func (s *Server) Handler() http.Handler {
 			r.Post("/tasks/{id}/files/{filename}", s.apiSaveFile)
 			r.Post("/tasks/{id}/trigger", s.apiSaveTrigger)
 
+			// /api/runs (collection): supports filtering by parent or by
+			// (group + task), per #116. /api/tasks/{id}/runs above remains
+			// the canonical "list a task's runs" endpoint.
+			r.Get("/runs", s.apiQueryRuns)
 			r.Get("/runs/{runID}", s.apiGetRun)
 			r.Get("/runs/{runID}/logs", s.apiGetLogs)
 			r.Post("/runs/{runID}/kill", s.apiKillRun)
@@ -1550,6 +1554,45 @@ func (s *Server) handleMCP(w http.ResponseWriter, r *http.Request) {
 	}
 	r.URL.Path = "/hooks/mcp"
 	s.gateway.ServeHTTP(w, r)
+}
+
+// apiQueryRuns handles GET /api/runs with one of two filter modes (#116):
+//   - ?parent=<runID>          → list child runs of <runID>
+//   - ?group=<label>&task=<id> → list same-group siblings for a task
+//
+// Either filter is required; group requires task to scope the lookup since
+// labels are task-local.
+func (s *Server) apiQueryRuns(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	limit := 50
+	if v := q.Get("limit"); v != "" {
+		fmt.Sscanf(v, "%d", &limit)
+	}
+	parent := q.Get("parent")
+	group := q.Get("group")
+	taskID := q.Get("task")
+	if parent == "" && group == "" {
+		jsonErr(w, "missing filter: provide ?parent=<id> or ?group=<label>&task=<id>", http.StatusBadRequest)
+		return
+	}
+	if group != "" && taskID == "" {
+		jsonErr(w, "?group requires ?task=<id>", http.StatusBadRequest)
+		return
+	}
+	var (
+		runs []*registry.Run
+		err  error
+	)
+	if parent != "" {
+		runs, err = s.registry.ListChildren(r.Context(), parent, limit)
+	} else {
+		runs, err = s.registry.ListByGroup(r.Context(), taskID, group, limit)
+	}
+	if err != nil {
+		jsonErr(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonOK(w, runs)
 }
 
 func (s *Server) apiListRuns(w http.ResponseWriter, r *http.Request) {

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -1,6 +1,7 @@
 package webui
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -160,6 +161,84 @@ func TestAPI_ListRuns(t *testing.T) {
 	_ = json.NewDecoder(w2.Body).Decode(&runs)
 	if len(runs) == 0 {
 		t.Error("expected at least one run")
+	}
+}
+
+// #116: GET /api/runs?parent=<id> and ?group=<label>&task=<id>.
+func TestAPI_QueryRuns_ByParentAndGroup(t *testing.T) {
+	srv, reg := newTestServer(t)
+	ctx := context.Background()
+
+	parentID, err := reg.StartRun(ctx, "task-a", "")
+	if err != nil {
+		t.Fatalf("StartRun parent: %v", err)
+	}
+	c1, _ := reg.StartRun(ctx, "child-task", parentID)
+	c2, _ := reg.StartRun(ctx, "child-task", parentID)
+	// Unrelated run — must not appear in parent= results.
+	_, _ = reg.StartRun(ctx, "other-task", "")
+
+	// Group label "g1" on two task-a runs and one task-b run; the group
+	// query must scope by task to filter out the cross-task hit.
+	a1, _ := reg.StartRun(ctx, "task-a", "")
+	a2, _ := reg.StartRun(ctx, "task-a", "")
+	b1, _ := reg.StartRun(ctx, "task-b", "")
+	for _, id := range []string{a1, a2, b1} {
+		if err := reg.SetRunGroup(ctx, id, "g1"); err != nil {
+			t.Fatalf("SetRunGroup: %v", err)
+		}
+	}
+
+	// ── parent filter ─────────────────────────────────────────────────────
+	req := httptest.NewRequest(http.MethodGet, "/api/runs?parent="+parentID, nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("parent query: status %d body=%s", w.Code, w.Body.String())
+	}
+	var children []map[string]any
+	_ = json.NewDecoder(w.Body).Decode(&children)
+	if len(children) != 2 {
+		t.Fatalf("expected 2 children, got %d (%v)", len(children), children)
+	}
+	got := map[string]bool{}
+	for _, r := range children {
+		got[r["ID"].(string)] = true
+	}
+	if !got[c1] || !got[c2] {
+		t.Errorf("missing child IDs: %v", got)
+	}
+
+	// ── group + task filter ────────────────────────────────────────────────
+	req = httptest.NewRequest(http.MethodGet, "/api/runs?group=g1&task=task-a", nil)
+	w = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("group query: status %d body=%s", w.Code, w.Body.String())
+	}
+	var siblings []map[string]any
+	_ = json.NewDecoder(w.Body).Decode(&siblings)
+	if len(siblings) != 2 {
+		t.Fatalf("expected 2 siblings, got %d (%v)", len(siblings), siblings)
+	}
+	for _, r := range siblings {
+		if r["TaskID"] != "task-a" {
+			t.Errorf("got task %v in task-a group", r["TaskID"])
+		}
+	}
+
+	// ── error cases ────────────────────────────────────────────────────────
+	req = httptest.NewRequest(http.MethodGet, "/api/runs", nil)
+	w = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("missing-filter: expected 400, got %d", w.Code)
+	}
+	req = httptest.NewRequest(http.MethodGet, "/api/runs?group=g1", nil)
+	w = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("group-without-task: expected 400, got %d", w.Code)
 	}
 }
 


### PR DESCRIPTION
## Summary
Completes the backend foundation for #111 (causal nesting + peer grouping of runs). Unblocks the four downstream webui / ai-agent follow-ups (#112-#115).

- **Migration**: new `run_group` column + indexes (`idx_runs_parent_run_id`, `idx_runs_task_run_group`). `parent_run_id` was already in place from earlier patches.
- **Registry**: `Run.Group` field; new `SetRunGroup`, `ListChildren`, `ListByGroup`.
- **Engine**: `FireFromTask(taskID, parentRunID, params)` so `dicode.run_task` calls automatically link children to their caller (the third dispatch source per the issue spec).
- **IPC**: `dicode.set_group` method + `CapSetGroup` (default-on, self-affecting).
- **SDK**: `dicode.set_group(label)` on Deno + Python (sync + async).
- **REST**: `GET /api/runs?parent=<id>` and `GET /api/runs?group=<label>&task=<id>`.
- **Tests**: registry filters, IPC parent linkage + `set_group` dispatch, webui REST handler, Deno SDK end-to-end.

### Acceptance (from #116)
- [x] Migration applies cleanly on existing databases
- [x] `parent_run_id` populated for chain / `if_missing` / `dicode.run_task` dispatch
- [x] Existing `pkg/task` and `pkg/trigger` tests stay green
- [x] New registry tests cover parent / group filters
- [x] New SDK integration test exercises `set_group` end-to-end (Deno)
- [x] `if_missing` prereq parent linkage was shipped earlier (44ea4f8); no regression

### Design note
The on-disk column is `run_group` rather than `group` because `GROUP` is a SQL keyword and the migration helper (`pkg/db/migrate.go`) rejects quoted identifiers by design. User-facing surfaces (REST query param, JSON field, SDK method) still use `group`.

## Test plan
- [x] `go vet ./...` clean
- [x] `make test` green across the full repo
- [x] New tests: `TestRegistry_SetRunGroup`, `TestRegistry_ListChildren`, `TestRegistry_ListByGroup`, `TestServer_Dicode_RunTask_ParentLinkage`, `TestServer_Dicode_SetGroup_Persists`, `TestAPI_QueryRuns_ByParentAndGroup`, `TestRuntime_SetGroup_Persists`

Closes #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)