### PR TITLE
feat(ai-agent): set_group so chat conversations collapse in the run list (#112, #113)

### DIFF
--- a/tasks/buildin/ai-agent/task.test.ts
+++ b/tasks/buildin/ai-agent/task.test.ts
@@ -79,6 +79,25 @@ test("first turn auto-generates a session_id and returns reply", async () => {
   assert.httpCalled("POST", "http://localhost:11434/v1/chat/completions");
 });
 
+test("tags the run with the chat session group so the WebUI can collapse turns", async () => {
+  // #112: every chat turn calls dicode.set_group(`chat:<sessionId>`) so all
+  // turns of one conversation collapse into one expandable row in the run
+  // list, while a new session_id produces a new group row.
+  useLocal();
+  params.set("prompt", "hello");
+  params.set("session_id", "abc-12345");
+
+  http.mock("POST", "http://localhost:11434/v1/chat/completions", {
+    status: 200,
+    body: completion("hi"),
+  });
+
+  await runTask();
+
+  const calls = (dicode as Record<string, unknown>)._setGroupCalls as string[];
+  assert.equal(calls, ["chat:abc-12345"]);
+});
+
 test("provided session_id is echoed back and history is preserved in kv", async () => {
   useLocal();
   params.set("prompt", "second message");

--- a/tasks/buildin/ai-agent/task.ts
+++ b/tasks/buildin/ai-agent/task.ts
@@ -244,6 +244,12 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
   let sessionId = (await params.get("session_id")) ?? "";
   if (!sessionId) sessionId = crypto.randomUUID();
 
+  // Tag the run so the WebUI collapses every turn of a single chat into
+  // one expandable row in the run list (#112). Tool-call children are
+  // already linked via parent_run_id by the engine (#116), so the run
+  // detail view can render this turn as a timeline of sub-runs (#113).
+  await dicode.set_group(`chat:${sessionId}`);
+
   // Tools: dicode task ids the agent may call. Empty = all except self.
   const toolFilter = ((await params.get("tools")) ?? "")
     .split(",")

--- a/tasks/deno.lock
+++ b/tasks/deno.lock
@@ -1,10 +1,21 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.13",
     "jsr:@std/yaml@1": "1.1.0",
     "npm:openai@4": "4.104.0"
   },
   "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.13": {
+      "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
+    },
     "@std/yaml@1.1.0": {
       "integrity": "fc1c5c63e05c4c5eb6118355f557958035d41940d6c29d35b306ef7155d6edb0"
     }
@@ -221,5 +232,40 @@
         "webidl-conversions"
       ]
     }
+  },
+  "remote": {
+    "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
+    "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
+    "https://deno.land/std@0.224.0/assert/assert_almost_equals.ts": "9e416114322012c9a21fa68e187637ce2d7df25bcbdbfd957cd639e65d3cf293",
+    "https://deno.land/std@0.224.0/assert/assert_array_includes.ts": "14c5094471bc8e4a7895fc6aa5a184300d8a1879606574cb1cd715ef36a4a3c7",
+    "https://deno.land/std@0.224.0/assert/assert_equals.ts": "3bbca947d85b9d374a108687b1a8ba3785a7850436b5a8930d81f34a32cb8c74",
+    "https://deno.land/std@0.224.0/assert/assert_exists.ts": "43420cf7f956748ae6ed1230646567b3593cb7a36c5a5327269279c870c5ddfd",
+    "https://deno.land/std@0.224.0/assert/assert_false.ts": "3e9be8e33275db00d952e9acb0cd29481a44fa0a4af6d37239ff58d79e8edeff",
+    "https://deno.land/std@0.224.0/assert/assert_greater.ts": "5e57b201fd51b64ced36c828e3dfd773412c1a6120c1a5a99066c9b261974e46",
+    "https://deno.land/std@0.224.0/assert/assert_greater_or_equal.ts": "9870030f997a08361b6f63400273c2fb1856f5db86c0c3852aab2a002e425c5b",
+    "https://deno.land/std@0.224.0/assert/assert_instance_of.ts": "e22343c1fdcacfaea8f37784ad782683ec1cf599ae9b1b618954e9c22f376f2c",
+    "https://deno.land/std@0.224.0/assert/assert_is_error.ts": "f856b3bc978a7aa6a601f3fec6603491ab6255118afa6baa84b04426dd3cc491",
+    "https://deno.land/std@0.224.0/assert/assert_less.ts": "60b61e13a1982865a72726a5fa86c24fad7eb27c3c08b13883fb68882b307f68",
+    "https://deno.land/std@0.224.0/assert/assert_less_or_equal.ts": "d2c84e17faba4afe085e6c9123a63395accf4f9e00150db899c46e67420e0ec3",
+    "https://deno.land/std@0.224.0/assert/assert_match.ts": "ace1710dd3b2811c391946954234b5da910c5665aed817943d086d4d4871a8b7",
+    "https://deno.land/std@0.224.0/assert/assert_not_equals.ts": "78d45dd46133d76ce624b2c6c09392f6110f0df9b73f911d20208a68dee2ef29",
+    "https://deno.land/std@0.224.0/assert/assert_not_instance_of.ts": "3434a669b4d20cdcc5359779301a0588f941ffdc2ad68803c31eabdb4890cf7a",
+    "https://deno.land/std@0.224.0/assert/assert_not_match.ts": "df30417240aa2d35b1ea44df7e541991348a063d9ee823430e0b58079a72242a",
+    "https://deno.land/std@0.224.0/assert/assert_not_strict_equals.ts": "37f73880bd672709373d6dc2c5f148691119bed161f3020fff3548a0496f71b8",
+    "https://deno.land/std@0.224.0/assert/assert_object_match.ts": "411450fd194fdaabc0089ae68f916b545a49d7b7e6d0026e84a54c9e7eed2693",
+    "https://deno.land/std@0.224.0/assert/assert_rejects.ts": "4bee1d6d565a5b623146a14668da8f9eb1f026a4f338bbf92b37e43e0aa53c31",
+    "https://deno.land/std@0.224.0/assert/assert_strict_equals.ts": "b4f45f0fd2e54d9029171876bd0b42dd9ed0efd8f853ab92a3f50127acfa54f5",
+    "https://deno.land/std@0.224.0/assert/assert_string_includes.ts": "496b9ecad84deab72c8718735373feb6cdaa071eb91a98206f6f3cb4285e71b8",
+    "https://deno.land/std@0.224.0/assert/assert_throws.ts": "c6508b2879d465898dab2798009299867e67c570d7d34c90a2d235e4553906eb",
+    "https://deno.land/std@0.224.0/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
+    "https://deno.land/std@0.224.0/assert/equal.ts": "bddf07bb5fc718e10bb72d5dc2c36c1ce5a8bdd3b647069b6319e07af181ac47",
+    "https://deno.land/std@0.224.0/assert/fail.ts": "0eba674ffb47dff083f02ced76d5130460bff1a9a68c6514ebe0cdea4abadb68",
+    "https://deno.land/std@0.224.0/assert/mod.ts": "48b8cb8a619ea0b7958ad7ee9376500fe902284bb36f0e32c598c3dc34cbd6f3",
+    "https://deno.land/std@0.224.0/assert/unimplemented.ts": "8c55a5793e9147b4f1ef68cd66496b7d5ba7a9e7ca30c6da070c1a58da723d73",
+    "https://deno.land/std@0.224.0/assert/unreachable.ts": "5ae3dbf63ef988615b93eb08d395dda771c96546565f9e521ed86f6510c29e19",
+    "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
+    "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
+    "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
+    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e"
   }
 }

--- a/tasks/sdk-test.ts
+++ b/tasks/sdk-test.ts
@@ -66,6 +66,7 @@ interface State {
 }
 
 function freshDicode(): MockDicode {
+  const groups: string[] = [];
   return {
     task_id: "test/task",
     run_id: "test-run",
@@ -74,6 +75,13 @@ function freshDicode(): MockDicode {
     get_runs: async () => [],
     secrets_set: async () => {},
     secrets_delete: async () => {},
+    // set_group records each call so tests can assert on the labels written.
+    // Last write wins in production; the array preserves call ordering for
+    // tests that need it.
+    set_group: async (label: string) => {
+      groups.push(String(label ?? ""));
+    },
+    _setGroupCalls: groups,
   };
 }
 


### PR DESCRIPTION
## Summary
Closes the two ai-agent follow-ups from epic #111 / #116:

- **#112** — every chat turn now calls \`dicode.set_group(\`chat:\${sessionId}\`)\` right after the session id is settled. The WebUI run list (#114) will collapse all turns of one conversation into a single expandable row; a new \`session_id\` starts a new group.
- **#113 (stretch)** — tool-call children already link to the agent run via \`parent_run_id\` since #116/#250: \`dicode.run_task\` now goes through \`engine.FireFromTask\`. This PR adds the doc comment so the next person reading the loop knows; the sub-runs timeline becomes visible in the WebUI once #115 lands.

## Changes
- \`tasks/buildin/ai-agent/task.ts\`: one \`await dicode.set_group(...)\` after sessionId resolves, plus a 4-line comment pointing at #112/#113/#116.
- \`tasks/sdk-test.ts\`: \`set_group\` mock added to \`freshDicode()\` — records each call into \`_setGroupCalls\` so tests can assert.
- \`tasks/buildin/ai-agent/task.test.ts\`: new test \"tags the run with the chat session group so the WebUI can collapse turns\".

## Test plan
- [x] \`make test-tasks\` — 57 passing, 0 failing
- [x] \`make test\` — full Go suite green
- [x] \`make format-check\` clean

Closes #112. Closes #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)