### PR TITLE
feat(webui): collapse run list + parent/sub-runs in run detail (#114, #115)

### DIFF
--- a/tasks/buildin/webui/app/components/dc-run-detail.js
+++ b/tasks/buildin/webui/app/components/dc-run-detail.js
@@ -16,12 +16,15 @@ class DcRunDetail extends LitElement {
     _error:    { state: true },
     _status:   { state: true },
     _duration: { state: true },
+    _parent:   { state: true }, // Run record for ParentRunID, or null (#115)
+    _children: { state: true }, // child Run[] for the Sub-runs panel (#115)
   };
 
   constructor() {
     super();
     this._run = null; this._logs = []; this._error = null;
     this._status = null; this._duration = null;
+    this._parent = null; this._children = null;
     this._offLog = null; this._offFinished = null;
   }
 
@@ -51,7 +54,12 @@ class DcRunDetail extends LitElement {
     if (!this.runid) return;
     this._run = null; this._logs = []; this._error = null;
     this._status = null; this._duration = null;
+    this._parent = null; this._children = null;
     try {
+      // Children fetch is fire-and-forget — failure here shouldn't block the
+      // main run/logs load (Sub-runs panel just stays empty).
+      const childrenP = get(`/api/runs?parent=${encodeURIComponent(this.runid)}&limit=50`)
+        .catch(() => []);
       const [run, logs] = await Promise.all([
         get(`/api/runs/${this.runid}`),
         get(`/api/runs/${this.runid}/logs`),
@@ -64,6 +72,16 @@ class DcRunDetail extends LitElement {
         time: fmtTime(l.ts),
       }));
       this._status = run.status || run.Status;
+      this._children = await childrenP;
+
+      // #115: if this run has a parent, fetch the parent's record too so the
+      // back-link can show the parent task name instead of just an ID prefix.
+      const parentID = run.ParentRunID || run.parent_run_id;
+      if (parentID) {
+        try { this._parent = await get(`/api/runs/${encodeURIComponent(parentID)}`); }
+        catch (_) { this._parent = { ID: parentID }; }
+      }
+
       if (this._status === 'running') this._wireWS();
 
       await this.updateComplete;
@@ -135,10 +153,25 @@ class DcRunDetail extends LitElement {
     let displayRV = retval;
     if (retval) { try { displayRV = JSON.stringify(JSON.parse(retval), null, 2); } catch(_) {} }
 
+    // #115: parent + children panels — only render when there's something
+    // to show. The data is loaded once in _load(); empty arrays render
+    // nothing so an isolated run looks identical to the pre-#115 view.
+    const parent = this._parent;
+    const parentTask = parent?.task_name || parent?.TaskName || parent?.task_id || parent?.TaskID;
+    const children = this._children || [];
+
     return html`
       <div style="margin-bottom:var(--space-md)">
         <a href="tasks/${encodeURIComponent(taskID)}">← ${taskName}</a>
       </div>
+
+      ${parent ? html`
+        <div class="card" style="margin-bottom:var(--space-md);display:flex;gap:var(--space-md);align-items:center">
+          <span class="meta">Parent run</span>
+          <a href="/runs/${parent.ID || parent.id}">
+            ${parentTask ? `${parentTask} · ` : ''}<code>${(parent.ID || parent.id || '').slice(0,8)}</code>
+          </a>
+        </div>` : ''}
 
       <div class="card">
         <div style="display:flex;gap:var(--space-md);align-items:center;flex-wrap:wrap">
@@ -155,6 +188,21 @@ class DcRunDetail extends LitElement {
             <button class="btn btn-sm" @click=${() => this._replay()} title="Re-fire this run with its persisted input">Replay</button>` : ''}
         </div>
       </div>
+
+      ${children.length ? html`
+        <h2 style="margin-top:var(--space-lg)">Sub-runs <span class="meta">(${children.length})</span></h2>
+        <table>
+          <thead><tr><th>Run</th><th>Status</th><th>Started</th><th>Duration</th></tr></thead>
+          <tbody>
+            ${children.map(c => html`
+              <tr>
+                <td><a href="/runs/${c.ID}">${(c.TaskID || '?')} · <code>${c.ID.slice(0,8)}</code></a></td>
+                <td><span class="badge badge-${c.Status}">${c.Status}</span></td>
+                <td class="meta">${fmtTime(c.StartedAt)}</td>
+                <td class="meta">${fmtDuration(c.StartedAt, c.FinishedAt)}</td>
+              </tr>`)}
+          </tbody>
+        </table>` : ''}
 
       ${otype ? html`
         <div style="margin-bottom:.5rem">

--- a/tasks/buildin/webui/app/components/dc-task-detail.js
+++ b/tasks/buildin/webui/app/components/dc-task-detail.js
@@ -27,6 +27,9 @@ class DcTaskDetail extends LitElement {
     _aiStatus:        { state: true },
     _aiSessionId:     { state: true },
     _currentFile:     { state: true },
+    _showPrereqs:     { state: true },
+    _expanded:        { state: true }, // Set<runID> — top-level rows with children currently expanded
+    _children:        { state: true }, // Map<parentRunID, Run[]> — lazily-fetched child rows
   };
 
   constructor() {
@@ -35,6 +38,9 @@ class DcTaskDetail extends LitElement {
     this._triggerOpen = false; this._triggerType = 'manual';
     this._editorOpen = false; this._editorStatus = ''; this._currentFile = null;
     this._aiOpen = false; this._aiHistory = []; this._aiStatus = ''; this._aiSessionId = '';
+    this._showPrereqs = false;
+    this._expanded = new Set();
+    this._children = new Map();
     this._editor = null;
     this._relayBase = '';
     this._offStarted = null; this._offFinished = null;
@@ -232,6 +238,126 @@ class DcTaskDetail extends LitElement {
     });
   }
 
+  // ── Run-list grouping (#114) ────────────────────────────────────────────
+  // The flat list of runs returned by /api/tasks/{id}/runs is collapsed by
+  // two rules so the user sees one row per logical event:
+  //
+  //   1. Hide rows whose ParentRunID is set — those are sub-runs (a prereq
+  //      run from `if_missing`, or a sub-task fired via dicode.run_task).
+  //      A toggle restores the flat view for debugging.
+  //   2. Collapse consecutive top-level rows with the same non-empty Group
+  //      into one row ("N runs in this session, last 3m ago"). Tasks tag
+  //      themselves via dicode.set_group() — see the ai-agent buildin (#112).
+  //
+  // The result is a list of "items" where each item is either:
+  //   { kind: 'single', run }              — one row
+  //   { kind: 'group',  runs: [...] }      — collapse of consecutive same-group runs
+  _buildRunItems() {
+    const all = this._runs || [];
+    if (this._showPrereqs) return all.map(run => ({ kind: 'single', run }));
+
+    const top = all.filter(r => !(r.ParentRunID || r.parent_run_id));
+    const items = [];
+    for (const run of top) {
+      const group = run.Group || run.group;
+      const last = items[items.length - 1];
+      if (group && last && last.kind === 'group' && (last.runs[0].Group || last.runs[0].group) === group) {
+        last.runs.push(run);
+        continue;
+      }
+      if (group) {
+        items.push({ kind: 'group', runs: [run] });
+      } else {
+        items.push({ kind: 'single', run });
+      }
+    }
+    return items;
+  }
+
+  // _toggleExpand expands or collapses an inline children panel. On first
+  // expand it lazily fetches /api/runs?parent=<id>; subsequent toggles flip
+  // the visibility without re-fetching.
+  async _toggleExpand(runID) {
+    const next = new Set(this._expanded);
+    if (next.has(runID)) {
+      next.delete(runID);
+      this._expanded = next;
+      return;
+    }
+    next.add(runID);
+    this._expanded = next;
+    if (!this._children.has(runID)) {
+      try {
+        const kids = await get(`/api/runs?parent=${encodeURIComponent(runID)}&limit=50`);
+        const cm = new Map(this._children);
+        cm.set(runID, kids || []);
+        this._children = cm;
+      } catch (e) {
+        const cm = new Map(this._children);
+        cm.set(runID, []);
+        this._children = cm;
+      }
+    }
+  }
+
+  _renderRunRow(r, opts) {
+    const indent = opts?.indent || 0;
+    const hint   = opts?.hint;
+    const expandedKid = !!opts?.isChild;
+    const padding = indent ? `padding-left:${indent * 1.5}rem` : '';
+    const expanded = this._expanded.has(r.ID);
+    const kids = this._children.get(r.ID) || [];
+    const showExpand = !expandedKid; // sub-rows don't recurse further by default
+    return html`
+      <tr>
+        <td style=${padding}>
+          ${showExpand ? html`<button class="btn btn-sm secondary"
+            style="padding:0 .35rem;margin-right:.35rem;font-family:monospace"
+            title="Show child runs"
+            @click=${() => this._toggleExpand(r.ID)}>${expanded ? '▾' : '▸'}</button>` : ''}
+          <a href="runs/${r.ID}">${r.ID.slice(0,8)}</a>
+          ${hint ? html`<span class="meta" style="margin-left:.5rem">${hint}</span>` : ''}
+        </td>
+        <td><span class="badge badge-${r.Status}">${r.Status}</span></td>
+        <td class="meta">${fmtTime(r.StartedAt)}</td>
+        <td class="meta">${fmtDuration(r.StartedAt, r.FinishedAt)}</td>
+        <td>${(r.OutputContentType || r.ReturnValue) ? html`
+          <a href="/runs/${r.ID}/result" target="_blank"
+             class="btn btn-sm secondary">Result</a>` : ''}</td>
+      </tr>
+      ${expanded ? (kids.length ? kids.map(kid => this._renderRunRow(kid, { indent: indent + 1, isChild: true })) : html`
+        <tr><td colspan="5" class="meta" style="padding-left:${(indent + 1) * 1.5}rem">No sub-runs.</td></tr>
+      `) : ''}`;
+  }
+
+  _renderGroupRow(item) {
+    const head = item.runs[0];
+    const group = head.Group || head.group;
+    const expanded = this._expanded.has(`group:${group}`);
+    const last = head; // newest first per ListRuns ORDER BY
+    return html`
+      <tr>
+        <td>
+          <button class="btn btn-sm secondary"
+            style="padding:0 .35rem;margin-right:.35rem;font-family:monospace"
+            title="Expand session"
+            @click=${() => {
+              const next = new Set(this._expanded);
+              const key = `group:${group}`;
+              next.has(key) ? next.delete(key) : next.add(key);
+              this._expanded = next;
+            }}>${expanded ? '▾' : '▸'}</button>
+          <strong>${group}</strong>
+          <span class="meta" style="margin-left:.5rem">${item.runs.length} runs</span>
+        </td>
+        <td><span class="badge badge-${last.Status}">${last.Status}</span></td>
+        <td class="meta">last ${fmtTime(last.StartedAt)}</td>
+        <td class="meta">—</td>
+        <td></td>
+      </tr>
+      ${expanded ? item.runs.map(r => this._renderRunRow(r, { indent: 1 })) : ''}`;
+  }
+
   _triggerFields() {
     const t = this._task?.trigger || this._task?.Trigger || {};
     const type = this._triggerType;
@@ -348,22 +474,23 @@ class DcTaskDetail extends LitElement {
           </div>
         </div>` : ''}
 
-      <h2>Recent runs</h2>
+      <div style="display:flex;align-items:baseline;gap:var(--space-md);margin-top:var(--space-lg)">
+        <h2 style="margin:0">Recent runs</h2>
+        <label class="meta" style="margin-left:auto;cursor:pointer">
+          <input type="checkbox"
+            .checked=${this._showPrereqs}
+            @change=${e => { this._showPrereqs = e.target.checked; }}>
+          Show prereq runs
+        </label>
+      </div>
       <table>
         <thead><tr><th>Run ID</th><th>Status</th><th>Started</th><th>Duration</th><th></th></tr></thead>
         <tbody>
           ${!this._runs?.length ? html`
             <tr><td colspan="5" style="text-align:center;color:var(--muted)">No runs yet.</td></tr>
-          ` : this._runs.map(r => html`
-            <tr>
-              <td><a href="runs/${r.ID}">${r.ID.slice(0,8)}</a></td>
-              <td><span class="badge badge-${r.Status}">${r.Status}</span></td>
-              <td class="meta">${fmtTime(r.StartedAt)}</td>
-              <td class="meta">${fmtDuration(r.StartedAt, r.FinishedAt)}</td>
-              <td>${(r.OutputContentType || r.ReturnValue) ? html`
-                <a href="/runs/${r.ID}/result" target="_blank"
-                   class="btn btn-sm secondary">Result</a>` : ''}</td>
-            </tr>`)}
+          ` : this._buildRunItems().map(item => item.kind === 'group'
+              ? this._renderGroupRow(item)
+              : this._renderRunRow(item.run))}
         </tbody>
       </table>`;
   }


### PR DESCRIPTION
## Summary
Closes the WebUI half of epic #111 / #116. Together with PR #251 (ai-agent set_group) this lights up the user-visible side of run grouping: chat conversations collapse, prereq runs hide, and sub-runs are one click away.

### #114 — dc-task-detail.js
- Default view hides rows whose \`parent_run_id\` is set (sub-runs, \`if_missing\` prereqs).
- Consecutive top-level rows with the same non-empty \`Group\` collapse into one expandable row ("N runs", last start time). Click to expand.
- Any single row can also expand inline — fetches \`/api/runs?parent=<id>&limit=50\` once and shows child runs (e.g. an if_missing OAuth prereq).
- "Show prereq runs" checkbox restores the flat view.

### #115 — dc-run-detail.js
- "Parent run" card at the top of the page when \`ParentRunID\` is set; links to the parent run's detail (with parent task name when available).
- "Sub-runs" table when the run has children, populated from \`/api/runs?parent=<this>&limit=50\`. Each row links to the child run's detail.
- Both panels render only when there's data — isolated runs look identical to the pre-#115 view.

Both consume the \`GET /api/runs?parent=<id>\` filter shipped in #116/#250. The Group label is read off \`run.Group\`. Tasks populate it via \`dicode.set_group()\` — see the ai-agent buildin in #112/#251.

## Test plan
- [x] \`make format-check\` clean
- [x] \`make lint\` (gofmt + vet) clean
- [x] \`make test\` — full Go suite green (the new query endpoints already have webui tests from #250)
- [x] \`make test-tasks\` — 56/56 task tests still green
- [x] \`node --check\` passes on both modified component files
- [ ] Manual smoke (recommended after merge): run an ai-agent chat for a few turns, check the task-detail run list collapses to one row; click a chat run, verify Parent + Sub-runs render.

Closes #114. Closes #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)