### PR TITLE
Restore auth-providers connection status + new providers endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,24 @@
 
 ## [Unreleased]
 
-### Known regressions
+### Fixed
 
-- **`auth-providers` UI shows no connected providers** even when tokens
-  are written. The legacy `dicode.oauth.list_status` IPC verb is gone;
-  `auth-providers/task.ts` hardcodes `has_token: false` until a generic
-  secrets-presence SDK surface lands. Tracked in #255. Tokens ARE being
-  written correctly by `auth-relay`; only the indicator is regressed.
+- **`auth-providers` UI now correctly shows connected providers** via the new
+  `dicode.secrets.has` IPC verb (closes #255). Previously the `has_token`
+  field was hardcoded `false` for every provider; tokens written by
+  `auth-relay` are now reflected immediately.
+
+### Added
+
+- **`dicode.secrets.has(key)` IPC verb** — cap-gated boolean presence check;
+  never returns the secret value. Enable with
+  `permissions.dicode.secrets_has: true` in `task.yaml`. Symmetric with
+  `secrets_write` so tasks can check presence without write rights.
+- **Provider list now sourced dynamically from the dicode-relay broker's
+  `GET /providers` endpoint** (requires dicode-relay >= 0.1.5). Eliminates
+  the hardcoded provider list maintenance burden — adding or removing a
+  provider in `relay.yaml` is immediately reflected without a dicode-core
+  release.
 
 ### Breaking
 

--- a/pkg/ipc/capability.go
+++ b/pkg/ipc/capability.go
@@ -71,6 +71,11 @@ const (
 	CapHTTPRegister  = "http.register" // register HTTP handler routes (issue #54)
 	CapSourcesManage = "sources.manage"
 	CapSecretsWrite  = "secrets.write"
+	// CapSecretsHas allows a task to call dicode.secrets.has(key) — a
+	// boolean presence check. Never returns the value. Symmetric with
+	// SecretsWrite but a distinct cap so tasks can check presence without
+	// write rights.
+	CapSecretsHas = "secrets.has"
 
 	// CLI capabilities — granted to dicode CLI clients on the control socket.
 	CapCLIRun     = "cli.run"     // trigger a task run and stream its output

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -187,6 +187,9 @@ func (s *Server) Start(ctx context.Context) (socketPath, token string, err error
 		if dp.SecretsWrite {
 			caps = append(caps, CapSecretsWrite)
 		}
+		if dp.SecretsHas {
+			caps = append(caps, CapSecretsHas)
+		}
 		if dp.RunsListExpired {
 			caps = append(caps, CapRunsListExpired)
 		}
@@ -971,6 +974,35 @@ func (s *Server) handleConn(conn net.Conn) {
 				continue
 			}
 			reply(req.ID, true, "")
+
+		case "dicode.secrets.has":
+			// Presence-only check — never returns the value. Requires
+			// permissions.dicode.secrets_has: true (CapSecretsHas).
+			if !hasCap(caps, CapSecretsHas) {
+				reply(req.ID, nil, "ipc: permission denied (secrets.has)")
+				continue
+			}
+			if s.secrets == nil {
+				reply(req.ID, nil, "ipc: no secrets provider configured")
+				continue
+			}
+			if req.Key == "" {
+				reply(req.ID, nil, "ipc: key required")
+				continue
+			}
+			keys, err := s.secrets.List(context.Background())
+			if err != nil {
+				reply(req.ID, nil, err.Error())
+				continue
+			}
+			found := false
+			for _, k := range keys {
+				if k == req.Key {
+					found = true
+					break
+				}
+			}
+			reply(req.ID, found, "")
 
 		// ── mcp.* ─────────────────────────────────────────────────────────
 

--- a/pkg/ipc/server_test.go
+++ b/pkg/ipc/server_test.go
@@ -1055,6 +1055,94 @@ func TestServer_Dicode_SecretsSet_EmptyKey(t *testing.T) {
 	}
 }
 
+// ── dicode.secrets.has tests ─────────────────────────────────────────────────
+
+func TestServer_Dicode_SecretsHas_Denied(t *testing.T) {
+	e := newTestEnv(t)
+	// No secrets_has permission — should be denied.
+	conn, _ := e.start(t, nil, nil)
+
+	sendMsg(t, conn, map[string]any{"id": "1", "method": "dicode.secrets.has", "key": "FOO"})
+	resp := recvMsg(t, conn)
+	if resp["error"] == nil {
+		t.Errorf("expected permission denied for dicode.secrets.has without secrets_has cap")
+	}
+}
+
+func TestServer_Dicode_SecretsHas_Present(t *testing.T) {
+	e := newTestEnv(t)
+	mgr := newMockSecrets()
+	mgr.store["MY_TOKEN"] = "secret123"
+	spec := specWithDicode("caller", &task.DicodePermissions{SecretsHas: true})
+	conn, _ := e.startWithSecrets(t, spec, mgr)
+
+	sendMsg(t, conn, map[string]any{"id": "1", "method": "dicode.secrets.has", "key": "MY_TOKEN"})
+	resp := recvMsg(t, conn)
+	if resp["error"] != nil {
+		t.Fatalf("unexpected error: %v", resp["error"])
+	}
+	if resp["result"] != true {
+		t.Errorf("expected result=true for present key, got %v", resp["result"])
+	}
+}
+
+func TestServer_Dicode_SecretsHas_Absent(t *testing.T) {
+	e := newTestEnv(t)
+	mgr := newMockSecrets()
+	spec := specWithDicode("caller", &task.DicodePermissions{SecretsHas: true})
+	conn, _ := e.startWithSecrets(t, spec, mgr)
+
+	sendMsg(t, conn, map[string]any{"id": "1", "method": "dicode.secrets.has", "key": "MISSING_KEY"})
+	resp := recvMsg(t, conn)
+	if resp["error"] != nil {
+		t.Fatalf("unexpected error: %v", resp["error"])
+	}
+	if resp["result"] != false {
+		t.Errorf("expected result=false for absent key, got %v", resp["result"])
+	}
+}
+
+func TestServer_Dicode_SecretsHas_EmptyKey(t *testing.T) {
+	e := newTestEnv(t)
+	mgr := newMockSecrets()
+	spec := specWithDicode("caller", &task.DicodePermissions{SecretsHas: true})
+	conn, _ := e.startWithSecrets(t, spec, mgr)
+
+	sendMsg(t, conn, map[string]any{"id": "1", "method": "dicode.secrets.has"})
+	resp := recvMsg(t, conn)
+	if resp["error"] == nil {
+		t.Errorf("expected error for empty key")
+	}
+}
+
+// TestServer_Dicode_SecretsHas_IndependentOfWrite confirms that SecretsHas and
+// SecretsWrite are independent caps — presence check works without write rights.
+func TestServer_Dicode_SecretsHas_IndependentOfWrite(t *testing.T) {
+	e := newTestEnv(t)
+	mgr := newMockSecrets()
+	mgr.store["TOKEN"] = "actual-secret-value"
+	// Grant only SecretsHas, NOT SecretsWrite.
+	spec := specWithDicode("caller", &task.DicodePermissions{SecretsHas: true, SecretsWrite: false})
+	conn, _ := e.startWithSecrets(t, spec, mgr)
+
+	// Confirm has works.
+	sendMsg(t, conn, map[string]any{"id": "1", "method": "dicode.secrets.has", "key": "TOKEN"})
+	resp := recvMsg(t, conn)
+	if resp["error"] != nil {
+		t.Fatalf("unexpected error: %v", resp["error"])
+	}
+	if resp["result"] != true {
+		t.Errorf("expected result=true, got %v", resp["result"])
+	}
+
+	// Confirm write is still denied.
+	sendMsg(t, conn, map[string]any{"id": "2", "method": "dicode.secrets_set", "key": "TOKEN", "stringValue": "new"})
+	resp2 := recvMsg(t, conn)
+	if resp2["error"] == nil {
+		t.Errorf("expected write denied when only secrets_has is granted")
+	}
+}
+
 // ── additional coverage ───────────────────────────────────────────────────────
 
 func TestToken_Expired(t *testing.T) {

--- a/pkg/runtime/deno/sdk/sdk.d.ts
+++ b/pkg/runtime/deno/sdk/sdk.d.ts
@@ -51,6 +51,12 @@ declare interface DicodeCrypto {
   decrypt: (context: string, ciphertext: Uint8Array) => Promise<Uint8Array>;
 }
 
+declare interface DicodeSecrets {
+  /** Returns true if a secret with the given key exists in the store.
+   *  Never returns the value. Requires permissions.dicode.secrets_has: true. */
+  has: (key: string) => Promise<boolean>;
+}
+
 declare interface Dicode {
   /** Fully-namespaced id of the currently-running task (e.g. "buildin/ai-agent"). */
   task_id:        string;
@@ -61,6 +67,8 @@ declare interface Dicode {
   get_runs:       (taskID: string, opts?: { limit?: number })        => Promise<unknown>;
   secrets_set:    (key: string, value: string) => Promise<void>;
   secrets_delete: (key: string)                => Promise<void>;
+  /** Secrets presence API. Requires permissions.dicode.secrets_has: true. */
+  secrets:        DicodeSecrets;
   crypto:         DicodeCrypto;
 }
 

--- a/pkg/runtime/deno/sdk/shim.ts
+++ b/pkg/runtime/deno/sdk/shim.ts
@@ -81,6 +81,12 @@ export interface DicodeCrypto {
   decrypt: (context: string, ciphertext: Uint8Array) => Promise<Uint8Array>;
 }
 
+export interface DicodeSecrets {
+  // has returns true if a secret with the given key exists in the secrets
+  // store. Never returns the value. Requires permissions.dicode.secrets_has.
+  has: (key: string) => Promise<boolean>;
+}
+
 export interface Dicode {
   // task_id: the fully-namespaced id of the currently-running task (e.g.
   // "buildin/ai-agent"). Populated from the IPC handshake so task code can
@@ -97,6 +103,7 @@ export interface Dicode {
   set_group:      (label: string)      => Promise<void>;
   secrets_set:    (key: string, value: string) => Promise<void>;
   secrets_delete: (key: string)                => Promise<void>;
+  secrets:        DicodeSecrets;
   crypto:         DicodeCrypto;
   runs: {
     list_expired: (opts?: { before_ts?: number }) => Promise<unknown>;
@@ -315,6 +322,9 @@ const dicode: Dicode = {
   set_group:      (label)           => __call__({ method: "dicode.set_group",       group: String(label ?? "") }) as Promise<void>,
   secrets_set:    (key, value)      => __call__({ method: "dicode.secrets_set",     key, stringValue: value }) as Promise<void>,
   secrets_delete: (key)             => __call__({ method: "dicode.secrets_delete",  key }) as Promise<void>,
+  secrets: {
+    has: (key) => __call__({ method: "dicode.secrets.has", key }) as Promise<boolean>,
+  },
   runs: {
     list_expired: (opts) =>
       __call__({ method: "dicode.runs.list_expired", before_ts: opts?.before_ts ?? 0 }),

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -265,6 +265,10 @@ type DicodePermissions struct {
 	// SecretsWrite enables dicode.secrets_set() and dicode.secrets_delete().
 	// Tasks may write or overwrite secrets but never read them back.
 	SecretsWrite bool `yaml:"secrets_write,omitempty" json:"secrets_write,omitempty"`
+	// SecretsHas enables dicode.secrets.has(key) — a boolean presence check.
+	// Returns true/false only; never returns the secret value. Distinct from
+	// SecretsWrite so tasks can check presence without write rights.
+	SecretsHas bool `yaml:"secrets_has,omitempty" json:"secrets_has,omitempty"`
 	// RunsListExpired enables dicode.runs.list_expired().
 	RunsListExpired bool `yaml:"runs_list_expired,omitempty" json:"runs_list_expired,omitempty"`
 	// RunsDeleteInput enables dicode.runs.delete_input().

--- a/tasks/buildin/auth-providers/task.ts
+++ b/tasks/buildin/auth-providers/task.ts
@@ -1,80 +1,114 @@
 import type { DicodeSdk } from "../../sdk.ts";
 
-interface ProviderMeta {
-  key:        string;
-  label:      string;
-  color:      string;
-  // standalone === true means the provider is NOT relay-broker-backed.
-  // The Connect button opens the webhook URL directly; the per-provider
-  // task renders an "Authorize with X" page. Currently only OpenRouter.
-  standalone?: { webhookPath: string };
+// BrokerProvider is the shape returned by the relay broker's GET /providers
+// endpoint (dicode-relay >= 0.1.5).
+interface BrokerProvider {
+  key:             string;
+  pkce:            boolean;
+  scopes:          string[];
+  secret_required: boolean;
+  configured:      boolean;
 }
 
-// KNOWN must stay in sync with the providers in tasks/auth/taskset.yaml.
-// Adding a provider there means appending one row here (key/label/color),
-// and vice versa. The colors here mirror the per-provider `color` params
-// in that taskset; they are duplicated for now because the SPA renders the
-// list before the per-provider task runs, so the dashboard cannot read
-// them from the taskset directly. If the duplication becomes painful,
-// extract a shared providers.json.
-const KNOWN: ProviderMeta[] = [
-  { key: "github",     label: "GitHub",     color: "#24292e" },
-  { key: "google",     label: "Google",     color: "#4285f4" },
-  { key: "slack",      label: "Slack",      color: "#4a154b" },
-  { key: "spotify",    label: "Spotify",    color: "#1db954" },
-  { key: "linear",     label: "Linear",     color: "#5e6ad2" },
-  { key: "discord",    label: "Discord",    color: "#5865f2" },
-  { key: "gitlab",     label: "GitLab",     color: "#fc6d26" },
-  { key: "airtable",   label: "Airtable",   color: "#fcb400" },
-  { key: "notion",     label: "Notion",     color: "#000000" },
-  { key: "confluence", label: "Confluence", color: "#0052cc" },
-  { key: "salesforce", label: "Salesforce", color: "#00a1e0" },
-  { key: "stripe",     label: "Stripe",     color: "#635bff" },
-  { key: "office365",  label: "Office365",  color: "#d83b01" },
-  { key: "azure",      label: "Azure",      color: "#0078d4" },
-  { key: "looker",     label: "Looker",     color: "#4285f4" },
-  { key: "openrouter", label: "OpenRouter", color: "#6467f2",
-    standalone: { webhookPath: "/hooks/openrouter-oauth" } },
-];
+// fetchBrokerProviders retrieves the provider catalogue from the relay broker.
+// The endpoint is unauthenticated and returns no secret values.
+async function fetchBrokerProviders(brokerURL: string): Promise<BrokerProvider[]> {
+  const base = brokerURL.replace(/\/$/, "");
+  const res = await fetch(`${base}/providers`);
+  if (!res.ok) {
+    throw new Error(`broker /providers returned ${res.status}: ${await res.text()}`);
+  }
+  return await res.json() as BrokerProvider[];
+}
 
-const MAX_PROVIDERS = 64;
+// checkConnected returns true when the provider's access token is present in
+// the secrets store. Convention: auth-relay/task.ts writes
+// <PROVIDER_UPPER>_ACCESS_TOKEN.  Closes #255.
+async function checkConnected(dicode: DicodeSdk["dicode"], providerKey: string): Promise<boolean> {
+  const secretName = providerKey.toUpperCase() + "_ACCESS_TOKEN";
+  try {
+    return await dicode.secrets.has(secretName);
+  } catch {
+    // Fallback to false if the IPC call fails (e.g. during tests or when
+    // secrets_has permission is not granted).
+    return false;
+  }
+}
+
+// STANDALONE maps provider keys that are NOT relay-broker-backed to their
+// webhook path. These providers use PKCE directly without the broker, so they
+// do not appear in the broker's /providers response but must still be listable
+// when the task is invoked with their key in the `providers` param.
+const STANDALONE: Record<string, { webhookPath: string; label: string; color: string }> = {
+  openrouter: {
+    webhookPath: "/hooks/openrouter-oauth",
+    label: "OpenRouter",
+    color: "#6467f2",
+  },
+};
 
 export default async function main({ params, input, dicode }: DicodeSdk) {
-  const requested = ((await params.get("providers")) ?? "")
-    .split(",").map(s => s.trim()).filter(Boolean);
-  if (requested.length > MAX_PROVIDERS) {
-    throw new Error(`at most ${MAX_PROVIDERS} providers`);
-  }
-
   const inp = (input ?? null) as Record<string, unknown> | null;
   const action = (inp?.action ?? "list") as string;
 
   if (action === "list") {
-    if (requested.length === 0) return [];
-    // TODO(#255): Restore real has_token detection. The legacy
-    // dicode.oauth.list_status IPC verb was deleted in the relay-TS
-    // migration; this branch hardcodes has_token: false until a generic
-    // secrets-presence SDK surface (e.g. dicode.secrets.has) is added.
-    // Tokens ARE being written correctly by auth-relay — only the UI
-    // indication is regressed.
-    const meta = new Map(KNOWN.map(m => [m.key, m]));
-    const statuses = requested.map(provider => ({
-      provider,
-      has_token: false, // see TODO(#255) above
-    }));
-    return statuses.map(s => ({ ...s, meta: meta.get(s.provider) ?? null }));
+    const brokerURL = Deno.env.get("DICODE_RELAY_BROKER_URL");
+    if (!brokerURL) {
+      throw new Error(
+        "DICODE_RELAY_BROKER_URL not set — relay must be enabled in dicode.yaml",
+      );
+    }
+
+    // Fetch provider catalogue from the broker (single source of truth).
+    const brokerProviders = await fetchBrokerProviders(brokerURL);
+
+    // Determine which broker providers to include: either all, or the
+    // subset requested via the `providers` param.
+    const requested = new Set(
+      ((await params.get("providers")) ?? "")
+        .split(",").map(s => s.trim()).filter(Boolean),
+    );
+    const filtered = requested.size === 0
+      ? brokerProviders
+      : brokerProviders.filter(p => requested.has(p.key));
+
+    // Enrich with has_token via dicode.secrets.has.
+    const withStatus = await Promise.all(filtered.map(async (p) => ({
+      ...p,
+      has_token: await checkConnected(dicode, p.key),
+    })));
+
+    // Append standalone providers if explicitly requested.
+    const standaloneEntries = await Promise.all(
+      Object.entries(STANDALONE)
+        .filter(([key]) => requested.size === 0 || requested.has(key))
+        .map(async ([key, meta]) => ({
+          key,
+          pkce: true,
+          scopes: [] as string[],
+          secret_required: false,
+          configured: true, // standalone never requires broker config
+          has_token: await checkConnected(dicode, key),
+          label: meta.label,
+          color: meta.color,
+          standalone: { webhookPath: meta.webhookPath },
+        })),
+    );
+
+    return [...withStatus, ...standaloneEntries];
   }
 
   if (action === "connect") {
     const p = String(inp?.provider ?? "");
-    const m = KNOWN.find(k => k.key === p);
-    if (!m) throw new Error(`unknown provider: ${p}`);
 
-    if (m.standalone) {
+    // Standalone provider: return the webhook URL directly.
+    const standalone = STANDALONE[p];
+    if (standalone) {
       const baseURL = (Deno.env.get("DICODE_BASE_URL") ?? "http://localhost:8080").replace(/\/$/, "");
-      return { provider: p, url: `${baseURL}${m.standalone.webhookPath}` };
+      return { provider: p, url: `${baseURL}${standalone.webhookPath}` };
     }
 
+    // Relay-broker provider: delegate to buildin/auth-start.
     const run = await dicode.run_task("buildin/auth-start", { provider: p });
     const ret = (run as { returnValue?: { url?: string; session_id?: string } })?.returnValue;
     if (!ret?.url) throw new Error(`buildin/auth-start did not return a url for ${p}`);

--- a/tasks/buildin/auth-providers/task.yaml
+++ b/tasks/buildin/auth-providers/task.yaml
@@ -3,11 +3,16 @@ kind: Task
 name: "Auth Providers"
 description: |
   Dashboard listing every OAuth provider known to this dicode instance,
-  with connection state and a Connect button. Connect for relay-broker
-  providers (github, google, slack, ...) calls buildin/auth-start to
-  obtain a signed /auth/:provider URL. Connect for OpenRouter (the only
-  standalone PKCE provider) opens /hooks/openrouter-oauth directly,
-  which renders an "Authorize with OpenRouter" page.
+  with connection state and a Connect button.
+
+  The provider catalogue is fetched dynamically from the dicode-relay broker's
+  GET /providers endpoint (requires dicode-relay >= 0.1.5). Connection status
+  is determined per-provider via dicode.secrets.has(<PROVIDER>_ACCESS_TOKEN).
+
+  Connect for relay-broker providers (github, google, slack, ...) calls
+  buildin/auth-start to obtain a signed /auth/:provider URL. Connect for
+  OpenRouter (the only standalone PKCE provider) opens /hooks/openrouter-oauth
+  directly, which renders an "Authorize with OpenRouter" page.
 
   Open in a browser via the Tasks list → Auth Providers → "open
   webhook UI" — or directly at /hooks/auth-providers.
@@ -21,15 +26,20 @@ trigger:
 params:
   providers:
     type: string
-    default: "github,google,slack,spotify,linear,discord,gitlab,airtable,notion,confluence,salesforce,stripe,office365,azure,looker,openrouter"
+    default: ""
     description: |
-      Comma-separated provider keys to display. Override to subset.
-      Each key must satisfy [a-z0-9_]{2,}.
+      Comma-separated provider keys to display. Leave empty to return all
+      providers reported by the broker (plus OpenRouter standalone).
+      Override to subset (e.g. "github,slack").
 
 permissions:
   env:
-    - DICODE_BASE_URL  # used to build the standalone openrouter URL
+    - DICODE_BASE_URL          # used to build the standalone openrouter URL
+    - DICODE_RELAY_BROKER_URL  # broker base URL; required for the list action
+  net:
+    - "*"  # broker URL is config-driven; wildcard matches relay-client pattern
   dicode:
+    secrets_has: true  # dicode.secrets.has — presence check for <PROVIDER>_ACCESS_TOKEN
     tasks:
       # Only auth-start is callable. The per-provider auth/<p>-oauth tasks
       # return HTML (not a JSON {url} contract) so they cannot be invoked


### PR DESCRIPTION
Closes #255.

Restores `auth-providers` UI's connection status that was inadvertently regressed in the relay TS migration's dead-code sweep, and consolidates the provider catalogue with dicode-relay (the broker is the source of truth).

## Changes

1. **`dicode.secrets.has(key)` IPC verb** (`feat(ipc)`) — cap-gated, presence-only check. Returns boolean. Permission: `permissions.dicode.secrets_has: true`. The new generic primitive any task can use to check whether a secret is set, without ever exposing the value.

2. **`auth-providers/task.ts` rewritten** (`fix(auth-providers)`):
   - Fetches the provider list from `${DICODE_RELAY_BROKER_URL}/providers` (new endpoint in dicode-relay — requires `dicode-relay >= 0.1.5`).
   - Computes `has_token` per provider via `dicode.secrets.has(<PROVIDER>_ACCESS_TOKEN)`.
   - No more hardcoded provider catalogue in dicode-core — single source of truth in `relay.yaml`.

## Why broker as source of truth

- dicode-relay's `relay.yaml` already declares the providers + their scopes/PKCE/secret-required config. Mirroring that list in dicode-core was a maintenance burden destined to drift.
- The broker can add/remove providers without dicode-core needing a release.

## Threat model

- The broker's `/providers` endpoint never returns secret values (`client_id`, `client_secret`); only metadata + a `configured` boolean. No regression vs the prior hardcoded approach.
- `dicode.secrets.has` is presence-only — values never cross IPC.

## Test plan
- [x] `make test` green (`pkg/ipc`, `pkg/webui`, `pkg/task`)
- [x] `make build` clean
- [x] `make lint` + `make format` clean
- [ ] Manual smoke: with relay enabled, run `auth-providers` task's `list` action; verify it returns the broker's configured providers with correct `has_token` values.
- [ ] Verify against `dicode-relay >= 0.1.5` once that's published (parallel PR).