### PR TITLE
fix(buildin): cleanup tasks null-tolerance + relay-client restart backoff

### DIFF
--- a/tasks/buildin/dev-clones-cleanup/task.ts
+++ b/tasks/buildin/dev-clones-cleanup/task.ts
@@ -22,7 +22,8 @@ async function collectActiveRunIDs(dicode: Dicode): Promise<Set<string>> {
   for (const t of tasks) {
     let runs: Array<{ ID: string; Status: string }> = [];
     try {
-      runs = (await dicode.get_runs(t.id, { limit: 100 })) as typeof runs;
+      // get_runs returns null (not []) when the task has no runs.
+      runs = ((await dicode.get_runs(t.id, { limit: 100 })) ?? []) as typeof runs;
     } catch {
       continue; // task may have been deregistered between list_tasks and get_runs
     }

--- a/tasks/buildin/relay-client/task.ts
+++ b/tasks/buildin/relay-client/task.ts
@@ -28,7 +28,37 @@ function b64decode(s: string): Uint8Array {
   return Uint8Array.from(atob(s), (c) => c.charCodeAt(0));
 }
 
+// Initial + max delay for the task-level outer-loop backoff. The npm
+// RelayClient.run() loops internally with WSS-level exp backoff, so this
+// outer loop only fires when something throws OUTSIDE the WSS lifecycle:
+// missing env vars, storage-task failure, decrypt failure during identity
+// load, etc. Such errors are usually persistent (config issue) — fast
+// retries waste cycles. Cap matches the WSS-level cap for symmetry.
+const OUTER_BACKOFF_INITIAL_MS = 5_000;
+const OUTER_BACKOFF_MAX_MS = 60_000;
+
 export default async function main(sdk: DicodeSdk): Promise<void> {
+  let backoff = OUTER_BACKOFF_INITIAL_MS;
+
+  // Outer loop: never exit. task.yaml has restart: never so engine won't
+  // re-spawn this task — instead, transient failures (storage hiccup,
+  // missing config the operator is about to fix, etc.) are absorbed here
+  // with exponential backoff. The only way out is daemon shutdown.
+  while (true) {
+    try {
+      await runOnce(sdk);
+      // runOnce only returns on RelayClient.run() returning, which only
+      // happens on AbortSignal — i.e. clean daemon shutdown. Exit cleanly.
+      return;
+    } catch (err) {
+      console.error(`relay-client: top-level error, retrying in ${Math.round(backoff / 1000)}s:`, err);
+      await new Promise((r) => setTimeout(r, backoff));
+      backoff = Math.min(backoff * 2, OUTER_BACKOFF_MAX_MS);
+    }
+  }
+}
+
+async function runOnce(sdk: DicodeSdk): Promise<void> {
   const url = Deno.env.get("DICODE_RELAY_SERVER_URL");
   const portStr = Deno.env.get("DICODE_RELAY_LOCAL_PORT") ?? "";
   const localPort = Number(portStr);

--- a/tasks/buildin/relay-client/task.yaml
+++ b/tasks/buildin/relay-client/task.yaml
@@ -12,6 +12,12 @@ runtime: deno
 
 trigger:
   daemon: true
+  # Disable engine-level auto-restart. The npm:dicode-relay/client RelayClient
+  # already does exponential backoff for WSS reconnects internally, and the
+  # task's main loop wraps fatal config/storage errors in its own backoff.
+  # Engine-level "always" would tight-loop on a config error (e.g. missing
+  # env var) — the in-task loop avoids the wasted Deno startup + IPC handshake.
+  restart: never
 
 permissions:
   net:

--- a/tasks/buildin/temp-cleanup/task.ts
+++ b/tasks/buildin/temp-cleanup/task.ts
@@ -53,7 +53,10 @@ async function collectRunningRunIDs(dicode: Dicode): Promise<Set<string>> {
   const running = new Set<string>();
   const tasks = (await dicode.list_tasks()) as TaskSummary[];
   for (const t of tasks) {
-    const runs = (await dicode.get_runs(t.id, { limit: 100 })) as Run[];
+    // dicode.get_runs returns null (not an empty array) when a task has no
+    // runs yet, or when the task was deregistered between list_tasks and
+    // get_runs. Coerce to [] so the iteration is always safe.
+    const runs = ((await dicode.get_runs(t.id, { limit: 100 })) ?? []) as Run[];
     for (const r of runs) {
       if (r.Status === "running") running.add(r.ID);
     }


### PR DESCRIPTION
Two production bugs surfaced after the relay TS migration (#254) shipped:

## 1. `runs is not iterable` in cleanup tasks

\`buildin/temp-cleanup\` and \`buildin/dev-clones-cleanup\` crash whenever a registered task has zero runs. Stack trace:

\`\`\`
TypeError: runs is not iterable
    for (const r of runs) {
                    ^
    at collectRunningRunIDs (...task.ts:57:21)
\`\`\`

**Root cause:** \`dicode.get_runs(taskID, opts)\` resolves to \`null\` (not \`[]\`) when \`registry.ListRuns\` returns \`(nil, nil)\`. The TS cast \`as Run[]\` doesn't catch null at runtime.

**Fix:** \`((await dicode.get_runs(...)) ?? []) as Run[]\` in both tasks.

Reported failure log (matches both tasks):

\`\`\`
[error] error: Uncaught (in promise) TypeError: runs is not iterable
[error]     at collectRunningRunIDs (.../tasks/buildin/temp-cleanup/task.ts:57:21)
\`\`\`

## 2. \`relay-client\` tight-restart on config errors

\`buildin/relay-client\` uses \`trigger.daemon: true\` which defaults to \`restart: always\`. A missing env var (\`DICODE_RELAY_SERVER_URL\`, \`DICODE_DATADIR\`, etc.) or a transient storage-task failure throws → engine immediately respawns the task → it throws again. Tight loop, wasted Deno startups.

**Fix:** two layers
- \`task.yaml\`: \`restart: never\` — disable engine-level auto-restart.
- \`task.ts\`: wrap \`main()\` body in an outer \`while (true) { try {...} catch { sleep(backoff); backoff *= 2 }}\` loop. Initial 5s, cap 60s. The npm \`RelayClient.run()\` already does WSS-level exp backoff for transient connection issues; this outer loop catches errors OUTSIDE the WSS lifecycle (config, decrypt, storage).

The task now never exits except on clean daemon shutdown (\`AbortSignal\`).

## Test plan
- [x] \`make build\` clean
- [x] \`go test ./pkg/task/\` green
- [ ] Manual: deploy with relay enabled but \`DICODE_RELAY_SERVER_URL\` unset → expect a single backoff-loop log line every 5s→60s, NOT engine restart spam in the run log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)