### PR TITLE
feat: dicode.yaml as inline-root TaskSet (hard cut from sources array)

### DIFF
--- a/dicode.yaml
+++ b/dicode.yaml
@@ -30,13 +30,17 @@ server:
   port: 8080
   secret: ""
   tray: true
-sources:
-  - name: buildin
-    path: ${CONFIGDIR}/tasks/buildin/taskset.yaml
-    type: local
-  - name: auth
-    path: ${CONFIGDIR}/tasks/auth/taskset.yaml
-    type: local
-  - name: examples
-    path: ${CONFIGDIR}/tasks/examples/taskset.yaml
-    type: local
+spec:
+  entries:
+    buildin:
+      ref:
+        path: ${CONFIGDIR}/tasks/buildin/taskset.yaml
+        watch: true
+    auth:
+      ref:
+        path: ${CONFIGDIR}/tasks/auth/taskset.yaml
+        watch: true
+    examples:
+      ref:
+        path: ${CONFIGDIR}/tasks/examples/taskset.yaml
+        watch: true

--- a/docs/concepts/sources.md
+++ b/docs/concepts/sources.md
@@ -4,21 +4,55 @@ Dicode watches one or more **sources** for task files and reconciles them automa
 
 ---
 
+## dicode.yaml as a root TaskSet
+
+`dicode.yaml` is now treated as a **root TaskSet**. Its `spec.entries` block declares every source the daemon loads. Each entry key is the namespace for the tasks it contains; the `ref` block points at a `taskset.yaml` file (local or git).
+
+This is a pure structural unification: the same `parent.overrides.entries` mechanism that operators use inside a `taskset.yaml` now works at the top level too, so you can disable or patch buildin tasks directly in `dicode.yaml` without forking the taskset.
+
+```yaml
+# dicode.yaml
+spec:
+  entries:
+    buildin:
+      ref:
+        path: ${CONFIGDIR}/tasks/buildin/taskset.yaml
+      overrides:
+        entries:
+          relay-client:
+            enabled: false       # disable one buildin task without forking the set
+    examples:
+      ref:
+        url: https://github.com/dicode-ayo/dicode-core
+        branch: main
+        path: tasks/examples/taskset.yaml
+        poll_interval: 5m
+        auth:
+          token_env: GITHUB_TOKEN
+```
+
+### Field reference for `spec.entries.<name>.ref`
+
+| Field | Default | Description |
+|---|---|---|
+| `path` | required (local) | Absolute path to `taskset.yaml`; `${CONFIGDIR}` and `${HOME}` expanded |
+| `url` | required (git) | HTTPS or SSH git URL |
+| `branch` | `main` | Branch to track (git only) |
+| `poll_interval` | `30s` | How often to fetch (git only) |
+| `auth.token_env` | | Env var holding a personal access token |
+| `auth.ssh_key` | | Path to an SSH private key |
+| `watch` | `true` | Enable fsnotify live reload (local refs) |
+| `dev_ref` | | Substitute ref when dev mode is active |
+
+---
+
 ## Source types
 
 ### TaskSet source (recommended)
 
 A **TaskSet source** uses a `taskset.yaml` file as its entry point. Tasks are composed hierarchically — a TaskSet can reference other TaskSets, allowing large task trees to be built from smaller ones (like ArgoCD App-of-Apps).
 
-```yaml
-# dicode.yaml
-sources:
-  - name: infra
-    path: /home/user/tasks/taskset.yaml
-    type: local
-```
-
-**`taskset.yaml`** — the root entry point:
+**`taskset.yaml`** — the entry point for one source:
 
 ```yaml
 apiVersion: dicode/v1
@@ -50,18 +84,18 @@ trigger:
 ```
 
 **Namespace-scoped task IDs** — task IDs are built from the path of TaskSet names:
-- Root TaskSet `infra` + entry `deploy-backend` → ID `infra/deploy-backend`
-- Nested TaskSet `infra` > `platform` + entry `nginx-start` → ID `infra/platform/nginx-start`
+- Root entry `buildin` + inner entry `relay-client` → ID `buildin/relay-client`
+- Nested entry `buildin` > `platform` + inner entry `nginx-start` → ID `buildin/platform/nginx-start`
 
 **3-level precedence stack** (lowest → highest):
 
 1. `task.yaml` base values
-2. Root TaskSet `spec.defaults`
+2. TaskSet `spec.defaults`
 3. Per-entry `overrides` (parent entry patch merged with local entry overrides; leaf wins)
 
 > **Deprecated:** `kind:Config spec.defaults` and `overrides.defaults` from parent TaskSets are no longer applied to the override stack. Migrate shared defaults to `dicode.yaml defaults:` instead.
 
-**Disabling an entry** — set `enabled: false` to skip a task without deleting its definition. Useful for temporarily turning off a buildin or bisecting a misbehaving task:
+**Disabling an entry** — set `enabled: false` to disable a task without deleting its definition. Disabled tasks remain visible in the API (with `enabled: false`) and the registry, but are not scheduled (no cron), not spawned (no daemon), and not routed (no webhook).
 
 ```yaml
 spec:
@@ -74,26 +108,13 @@ spec:
 
 The longer nested form (`overrides.enabled: false`) is equivalent and still supported; setting both is a parse error.
 
-A parent TaskSet can also flip an entry's enabled state via its own `overrides.entries.<key>.enabled` (parent wins over child). This lets a higher-level TaskSet disable a buildin task in a child without forking the child.
-
-**`kind:Config`** — optional shared defaults file:
-
-```yaml
-apiVersion: dicode/v1
-kind: Config
-metadata:
-  name: infra-config
-spec:
-  defaults:
-    timeout: 1h
-    runtime: deno
-```
+A parent TaskSet (or `dicode.yaml`) can also flip an entry's enabled state via its own `overrides.entries.<key>.enabled`. This lets a higher-level operator disable a buildin task without forking the taskset. Parent-level override wins over child-level.
 
 **Dev mode** — swap the TaskSet root to a local path for live development without editing `dicode.yaml`:
 
 ```bash
 # via REST API
-curl -X PATCH http://localhost:8080/api/sources/infra/dev \
+curl -X PATCH http://localhost:8080/api/sources/buildin/dev \
   -H 'Content-Type: application/json' \
   -d '{"enabled": true, "local_path": "/tmp/my-dev-tasks/taskset.yaml"}'
 ```
@@ -104,91 +125,24 @@ Disabling dev mode immediately reverts to the original root ref.
 
 ---
 
-### Git source
-
-Watches a git repository. Tasks are committed into the repo — dicode polls or receives a push webhook, pulls changes, and updates the running task set accordingly.
-
-```yaml
-sources:
-  - type: git
-    id: team-tasks
-    url: https://github.com/acme/tasks
-    branch: main
-    poll_interval: 60s
-    auth:
-      type: token
-      token_env: GITHUB_TOKEN
-```
-
-**Options:**
-
-| Field | Default | Description |
-|---|---|---|
-| `id` | (derived from URL) | Unique source identifier |
-| `url` | required | Repository HTTPS or SSH URL |
-| `branch` | `main` | Branch to track |
-| `poll_interval` | `30s` | How often to check for changes |
-| `auth.type` | `none` | `token`, `ssh`, `none` |
-| `auth.token_env` | | Env var name containing the token |
-| `tags` | | Task tag filter (future: source selectors) |
-
-**How it works:**
-1. On startup: clone repo to `~/.dicode/repos/{source-id}/`
-2. Periodic poll: `git fetch` + diff to identify changed task folders
-3. Push webhook (optional): HTTP endpoint at `/hooks/git/{source-id}` triggers immediate sync
-4. Tasks in subdirectories deeper than one level are ignored
-
-**Auth:** token auth sends the token as the HTTP password (standard GitHub/GitLab personal access token flow). SSH key auth (future) will use a configured key file.
-
----
-
-### Local source
-
-Watches a local directory using `fsnotify`. File saves trigger near-instant reload (~100ms). No git required.
-
-```yaml
-sources:
-  - type: local
-    id: dev
-    path: ~/dicode-tasks
-    watch: true
-```
-
-**Options:**
-
-| Field | Default | Description |
-|---|---|---|
-| `id` | (derived from path) | Unique source identifier |
-| `path` | required | Absolute or `~`-prefixed path to tasks directory |
-| `watch` | `true` | Enable fsnotify live reload |
-
-**How it works:**
-1. On startup: scan directory, emit Added events for all valid task folders
-2. If `watch: true`: start fsnotify watcher on the directory
-3. On file change: debounce 100ms, re-scan the affected task folder, emit Updated event
-4. On folder delete: emit Removed event
-
-**Debouncing:** writes are debounced by 100ms to avoid partial-file events when editors do atomic saves (write to temp file → rename).
-
----
-
 ## Multiple sources
 
-You can configure multiple sources simultaneously. A common pattern is a git source for stable/shared tasks and a local source for active development:
+Configure multiple sources by adding entries to `spec.entries`. Each entry key is the namespace:
 
 ```yaml
-sources:
-  - type: git
-    id: shared
-    url: https://github.com/acme/tasks
-    branch: main
-  - type: local
-    id: dev
-    path: ~/tasks-dev
-    watch: true
+spec:
+  entries:
+    shared:
+      ref:
+        url: https://github.com/acme/tasks
+        branch: main
+    dev:
+      ref:
+        path: ~/tasks-dev
+        watch: true
 ```
 
-Both sources contribute tasks to the same registry. Task IDs must be unique across all sources. If two sources declare a task with the same folder name, the conflict is logged as an error and the second task is skipped.
+Both sources contribute tasks to the same registry. Task IDs must be unique across all sources.
 
 ---
 
@@ -216,22 +170,62 @@ The reconciler is the component that consumes events from all sources and keeps 
 
 Each task belongs to exactly one source. When a task is registered, the source ID is recorded. This matters for `dicode task commit` — it knows which source to commit to.
 
-If you move a task from a local source to a git source using `dicode task commit`, the local source emits a Removed event (file deleted) and the git source eventually emits an Added event (after push + pull). The task briefly disappears from the registry during this transition.
-
 ---
 
-## Source selector tags (future)
+## Migration from old `sources:` array
 
-Future feature: each task can declare tags in `task.yaml`, and each source can filter which tags it loads. This lets one dicode instance load production tasks from a prod source and dev tasks from a dev source without collision.
+The old `sources:` array was removed in v0.1+. The format change is mechanical:
 
+**Before:**
 ```yaml
-# task.yaml
-tags:
-  - env:prod
-
-# dicode.yaml
 sources:
-  - type: git
-    url: https://github.com/acme/tasks
-    tags: [env:prod]     # only load tasks tagged env:prod
+  - name: buildin
+    type: local
+    path: ${CONFIGDIR}/tasks/buildin/taskset.yaml
+    watch: true
+  - name: examples
+    type: git
+    url: https://github.com/dicode-ayo/dicode-core
+    branch: main
+    entry_path: tasks/examples/taskset.yaml
+    poll_interval: 5m
+    auth:
+      type: token
+      token_env: GITHUB_TOKEN
 ```
+
+**After:**
+```yaml
+spec:
+  entries:
+    buildin:
+      ref:
+        path: ${CONFIGDIR}/tasks/buildin/taskset.yaml
+        watch: true
+    examples:
+      ref:
+        url: https://github.com/dicode-ayo/dicode-core
+        branch: main
+        path: tasks/examples/taskset.yaml
+        poll_interval: 5m
+        auth:
+          token_env: GITHUB_TOKEN
+```
+
+**Field mapping:**
+
+| Old `sources[]` field | New location |
+|---|---|
+| `name` | entry key (e.g. `buildin:`) |
+| `type` | inferred: `url` present → git; `path` present → local |
+| `path` | `ref.path` |
+| `url` | `ref.url` |
+| `branch` | `ref.branch` |
+| `poll_interval` | `ref.poll_interval` |
+| `auth.token_env` | `ref.auth.token_env` |
+| `auth.ssh_key` | `ref.auth.ssh_key` |
+| `watch` | `ref.watch` |
+| `dev_ref` | `ref.dev_ref` |
+| `tags` | `entry.tags` |
+
+If you have a `sources:` array in your `dicode.yaml`, the daemon will refuse to start and print an error pointing at this migration guide. The error message includes the issue tracker URL: see [#261](https://github.com/dicode-ayo/dicode-core/issues/261).

--- a/docs/concepts/sources.md
+++ b/docs/concepts/sources.md
@@ -61,6 +61,21 @@ trigger:
 
 > **Deprecated:** `kind:Config spec.defaults` and `overrides.defaults` from parent TaskSets are no longer applied to the override stack. Migrate shared defaults to `dicode.yaml defaults:` instead.
 
+**Disabling an entry** — set `enabled: false` to skip a task without deleting its definition. Useful for temporarily turning off a buildin or bisecting a misbehaving task:
+
+```yaml
+spec:
+  entries:
+    relay-client:
+      enabled: false        # one-liner shortcut; default is true when omitted
+      ref:
+        path: ./relay-client/task.yaml
+```
+
+The longer nested form (`overrides.enabled: false`) is equivalent and still supported; setting both is a parse error.
+
+A parent TaskSet can also flip an entry's enabled state via its own `overrides.entries.<key>.enabled` (parent wins over child). This lets a higher-level TaskSet disable a buildin task in a child without forking the child.
+
 **`kind:Config`** — optional shared defaults file:
 
 ```yaml

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -399,7 +399,10 @@ func (cfg *Config) validate() error {
 		}
 		if entry.Ref != nil {
 			if entry.Ref.IsGit() {
-				// URL is present (checked by IsGit) — nothing more to validate here.
+				// URL is present (checked by IsGit); validate its scheme.
+				if err := taskset.ValidateRefURL("dicode.yaml", name, entry.Ref.URL); err != nil {
+					return err
+				}
 			} else if entry.Ref.Path == "" {
 				return fmt.Errorf("spec.entries[%q]: ref.path is required for local entries", name)
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -405,6 +405,13 @@ func (cfg *Config) validate() error {
 			}
 		}
 	}
+	// Lift the top-level `enabled` shortcut into overrides.enabled so that all
+	// downstream code (resolver, override merging) sees one canonical path.
+	// The same lift is applied by validateTaskSet for TaskSet files — both call
+	// the shared helper to stay DRY.
+	if err := taskset.LiftEntryEnabled(cfg.Spec.Entries); err != nil {
+		return fmt.Errorf("spec.entries: %w", err)
+	}
 	if cfg.Relay.BrokerURL != "" {
 		u, err := url.Parse(cfg.Relay.BrokerURL)
 		if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -9,7 +10,21 @@ import (
 	"time"
 
 	"github.com/dicode/dicode/pkg/task"
+	"github.com/dicode/dicode/pkg/taskset"
 	"gopkg.in/yaml.v3"
+)
+
+// ErrLegacySourcesFormat is returned by Load when the config file contains the
+// legacy `sources:` array. Operators must migrate to the new `spec.entries`
+// shape — see https://github.com/dicode-ayo/dicode-core/issues/261 and
+// docs/concepts/sources.md for a side-by-side migration guide.
+var ErrLegacySourcesFormat = errors.New(
+	"dicode.yaml: legacy `sources` array detected. The format changed: declare\n" +
+		"sources as `spec.entries` instead. See\n" +
+		"https://github.com/dicode-ayo/dicode-core/issues/261\n" +
+		"or docs/concepts/sources.md for the migration. The translation is\n" +
+		"mechanical — each `sources[]` entry becomes a `spec.entries.<name>`\n" +
+		"with the source's fields nested under `ref`.",
 )
 
 // RuntimeConfig configures a managed runtime executor.
@@ -127,7 +142,24 @@ type AIConfig struct {
 }
 
 type Config struct {
-	Sources       []SourceConfig           `yaml:"sources"`
+	// Spec is the root TaskSet defined inline in dicode.yaml. Its entries
+	// declare every source the daemon loads. Overrides on these entries
+	// propagate down to the referenced TaskSet using the standard
+	// parent.overrides.entries mechanism — see pkg/taskset/resolver.go.
+	//
+	// Example:
+	//   spec:
+	//     entries:
+	//       buildin:
+	//         ref:
+	//           path: ${CONFIGDIR}/tasks/buildin/taskset.yaml
+	//       examples:
+	//         ref:
+	//           url: https://github.com/org/examples
+	//           branch: main
+	//           poll_interval: 5m
+	//           auth: { token_env: GITHUB_TOKEN }
+	Spec          taskset.TaskSetBody      `yaml:"spec"`
 	Database      DatabaseConfig           `yaml:"database"`
 	Secrets       SecretsConfig            `yaml:"secrets"`
 	Notifications NotificationsConfig      `yaml:"notifications"`
@@ -190,55 +222,6 @@ type NotifyProviderConfig struct {
 	TokenEnv string `yaml:"token_env"` // env var holding auth token
 }
 
-// SourceType identifies the kind of task source.
-type SourceType string
-
-const (
-	SourceTypeGit   SourceType = "git"
-	SourceTypeLocal SourceType = "local"
-)
-
-// SourceConfig describes one task source — either a remote git repo or a
-// local path pointing to a taskset.yaml (or kind: Task yaml).
-type SourceConfig struct {
-	Type SourceType `yaml:"type"` // "git" | "local"
-
-	// Git source fields
-	URL          string        `yaml:"url,omitempty"`
-	Branch       string        `yaml:"branch,omitempty"`
-	PollInterval time.Duration `yaml:"poll_interval,omitempty"`
-	Auth         SourceAuth    `yaml:"auth,omitempty"`
-
-	// Local source fields
-	Path string `yaml:"path,omitempty"` // absolute path to taskset.yaml (local) or tasks dir (legacy)
-	// Watch enables fsnotify on the local source. Nil means "unset — apply
-	// default"; an explicit `watch: false` in YAML preserves false so the
-	// user can opt out. Default (nil → true) is applied in applyDefaults.
-	Watch *bool `yaml:"watch,omitempty"`
-
-	// TaskSet fields (new model)
-	// Name is the root namespace segment for all tasks from this source.
-	// Defaults to the last segment of URL or Path.
-	Name string `yaml:"name,omitempty"`
-	// EntryPath is the path within the git repo (or absolute path for local)
-	// to the entry yaml file. Defaults to "taskset.yaml".
-	EntryPath string `yaml:"entry_path,omitempty"`
-	// ConfigPath is the path to an optional kind:Config yaml file.
-	// For git sources: path within the repo. For local: absolute path.
-	// Defaults to "dicode-config.yaml" alongside the entry file.
-	ConfigPath string `yaml:"config_path,omitempty"`
-
-	// Shared / future
-	Tags []string `yaml:"tags,omitempty"`
-}
-
-// SourceAuth holds credentials for a git source.
-type SourceAuth struct {
-	Type     string `yaml:"type"`      // "token" | "ssh"
-	TokenEnv string `yaml:"token_env"` // env var name holding the token
-	SSHKey   string `yaml:"ssh_key"`   // path to SSH private key file
-}
-
 type ServerConfig struct {
 	Port           int      `yaml:"port"`
 	Secret         string   `yaml:"secret" json:"-"`           // optional passphrase; excluded from JSON API
@@ -259,14 +242,22 @@ type ServerConfig struct {
 
 // Load reads and parses the config file at path, then applies defaults.
 func Load(path string) (*Config, error) {
-	f, err := os.Open(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("open config: %w", err)
 	}
-	defer f.Close()
+
+	// Probe for the old `sources:` array before decoding into Config.
+	// Fail fast with a clear migration error instead of silently dropping sources.
+	var probe struct {
+		Sources any `yaml:"sources"`
+	}
+	if err := yaml.Unmarshal(data, &probe); err == nil && probe.Sources != nil {
+		return nil, ErrLegacySourcesFormat
+	}
 
 	var cfg Config
-	if err := yaml.NewDecoder(f).Decode(&cfg); err != nil {
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
 
@@ -324,29 +315,26 @@ func applyDefaults(cfg *Config, configDir string) {
 	vars["DATADIR"] = cfg.DataDir
 
 	cfg.Database.Path = expand(cfg.Database.Path)
-	for i := range cfg.Sources {
-		cfg.Sources[i].Path = expand(cfg.Sources[i].Path)
-	}
 
-	for i := range cfg.Sources {
-		s := &cfg.Sources[i]
-		if s.Type == SourceTypeGit {
-			if s.Branch == "" {
-				s.Branch = "main"
+	// Expand ${VAR} in ref paths for spec.entries.
+	for _, entry := range cfg.Spec.Entries {
+		if entry == nil || entry.Ref == nil {
+			continue
+		}
+		entry.Ref.Path = expand(entry.Ref.Path)
+		// Apply defaults for git refs.
+		if entry.Ref.IsGit() {
+			if entry.Ref.Branch == "" {
+				entry.Ref.Branch = "main"
 			}
-			if s.PollInterval == 0 {
-				s.PollInterval = 30 * time.Second
+			if entry.Ref.PollInterval == 0 {
+				entry.Ref.PollInterval = 30 * time.Second
 			}
 		}
-		if s.Type == SourceTypeLocal {
-			// Watch defaults to true for local sources. A pointer lets us
-			// distinguish "unset" (nil → apply default true) from "explicitly
-			// false" (user opted out) — the previous non-pointer form made
-			// `watch: false` a no-op.
-			if s.Watch == nil {
-				t := true
-				s.Watch = &t
-			}
+		// Watch defaults to true for local refs.
+		if !entry.Ref.IsGit() && entry.Ref.Watch == nil {
+			t := true
+			entry.Ref.Watch = &t
 		}
 	}
 	if cfg.Server.Port == 0 {
@@ -402,20 +390,19 @@ func applyDefaults(cfg *Config, configDir string) {
 }
 
 func (cfg *Config) validate() error {
-	for i, s := range cfg.Sources {
-		switch s.Type {
-		case SourceTypeGit:
-			if s.URL == "" {
-				return fmt.Errorf("sources[%d]: url is required for git source", i)
+	for name, entry := range cfg.Spec.Entries {
+		if entry == nil {
+			return fmt.Errorf("spec.entries[%q]: entry must not be null", name)
+		}
+		if entry.Ref == nil && entry.Inline == nil {
+			return fmt.Errorf("spec.entries[%q]: either ref or inline must be set", name)
+		}
+		if entry.Ref != nil {
+			if entry.Ref.IsGit() {
+				// URL is present (checked by IsGit) — nothing more to validate here.
+			} else if entry.Ref.Path == "" {
+				return fmt.Errorf("spec.entries[%q]: ref.path is required for local entries", name)
 			}
-		case SourceTypeLocal:
-			if s.Path == "" {
-				return fmt.Errorf("sources[%d]: path is required for local source", i)
-			}
-		case "":
-			return fmt.Errorf("sources[%d]: type is required (git or local)", i)
-		default:
-			return fmt.Errorf("sources[%d]: unknown type %q (valid: git, local)", i, s.Type)
 		}
 	}
 	if cfg.Relay.BrokerURL != "" {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -41,11 +41,14 @@ func TestLoadWithVars(t *testing.T) {
 	cfgPath := filepath.Join(dir, "dicode.yaml")
 
 	content := `
-sources:
-  - type: local
-    path: ${HOME}/my-tasks
-  - type: local
-    path: ${CONFIGDIR}/tasks
+spec:
+  entries:
+    my-tasks:
+      ref:
+        path: ${HOME}/my-tasks
+    tasks:
+      ref:
+        path: ${CONFIGDIR}/tasks
 database:
   type: sqlite
   path: ${DATADIR}/test.db
@@ -61,15 +64,48 @@ database:
 
 	home, _ := os.UserHomeDir()
 
-	if cfg.Sources[0].Path != home+"/my-tasks" {
-		t.Errorf("sources[0].path = %q, want %q", cfg.Sources[0].Path, home+"/my-tasks")
+	myTasksEntry := cfg.Spec.Entries["my-tasks"]
+	if myTasksEntry == nil || myTasksEntry.Ref == nil {
+		t.Fatal("spec.entries[my-tasks] not found")
 	}
-	if cfg.Sources[1].Path != dir+"/tasks" {
-		t.Errorf("sources[1].path = %q, want %q", cfg.Sources[1].Path, dir+"/tasks")
+	if myTasksEntry.Ref.Path != home+"/my-tasks" {
+		t.Errorf("spec.entries[my-tasks].ref.path = %q, want %q", myTasksEntry.Ref.Path, home+"/my-tasks")
 	}
+
+	tasksEntry := cfg.Spec.Entries["tasks"]
+	if tasksEntry == nil || tasksEntry.Ref == nil {
+		t.Fatal("spec.entries[tasks] not found")
+	}
+	if tasksEntry.Ref.Path != dir+"/tasks" {
+		t.Errorf("spec.entries[tasks].ref.path = %q, want %q", tasksEntry.Ref.Path, dir+"/tasks")
+	}
+
 	wantDB := home + "/.dicode/test.db"
 	if cfg.Database.Path != wantDB {
 		t.Errorf("database.path = %q, want %q", cfg.Database.Path, wantDB)
+	}
+}
+
+// TestLoad_RejectsLegacySources ensures the old `sources:` array is rejected
+// at load time with a clear error pointing at the migration guide.
+func TestLoad_RejectsLegacySources(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+
+	content := `
+sources:
+  - type: local
+    path: /tmp/tasks
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(cfgPath)
+	if err == nil {
+		t.Fatal("Load accepted legacy sources array; want error")
+	}
+	if !strings.Contains(err.Error(), "spec.entries") {
+		t.Errorf("error = %v; want mention of spec.entries", err)
 	}
 }
 
@@ -86,9 +122,11 @@ ai:
   api_key_env: OPENAI_API_KEY
   base_url: ""
   model: gpt-4o
-sources:
-  - type: local
-    path: ${CONFIGDIR}/tasks
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
 `
 	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
@@ -106,9 +144,11 @@ func TestLoad_AITaskDefault(t *testing.T) {
 	cfgPath := filepath.Join(dir, "dicode.yaml")
 
 	content := `
-sources:
-  - type: local
-    path: ${CONFIGDIR}/tasks
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
 `
 	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
@@ -131,9 +171,11 @@ func TestLoad_AITaskOverride(t *testing.T) {
 	content := `
 ai:
   task: examples/ai-agent-ollama
-sources:
-  - type: local
-    path: ${CONFIGDIR}/tasks
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
 `
 	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
@@ -211,9 +253,11 @@ func TestLoad_RelayBrokerURL_Roundtrip(t *testing.T) {
 	cfgPath := filepath.Join(dir, "dicode.yaml")
 
 	content := `
-sources:
-  - type: local
-    path: ${CONFIGDIR}/tasks
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
 relay:
   enabled: true
   server_url: wss://relay.example.com
@@ -249,9 +293,11 @@ func TestLoad_RelayBrokerURL_RejectsMalformed(t *testing.T) {
 			dir := t.TempDir()
 			cfgPath := filepath.Join(dir, "dicode.yaml")
 			content := fmt.Sprintf(`
-sources:
-  - type: local
-    path: ${CONFIGDIR}/tasks
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
 relay:
   enabled: true
   broker_url: %q
@@ -271,9 +317,11 @@ func TestLoadExecutionMaxConcurrentTasks(t *testing.T) {
 	cfgPath := filepath.Join(dir, "dicode.yaml")
 
 	content := `
-sources:
-  - type: local
-    path: ${CONFIGDIR}/tasks
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
 execution:
   max_concurrent_tasks: 8
 `
@@ -292,6 +340,7 @@ execution:
 // Regression for #177: `watch: false` and `mcp: false` in YAML must survive
 // applyDefaults. Previously both fields were `bool` with a default-flip
 // (`if !x { x = true }`) that made explicit false a no-op.
+// With the new spec.entries shape, watch lives on spec.entries.<name>.ref.watch.
 func TestLoadWatchAndMCPRespectExplicitFalse(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "dicode.yaml")
@@ -300,10 +349,12 @@ func TestLoadWatchAndMCPRespectExplicitFalse(t *testing.T) {
 server:
   port: 8080
   mcp: false
-sources:
-  - type: local
-    path: ${CONFIGDIR}/tasks
-    watch: false
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
+        watch: false
 `
 	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
@@ -315,11 +366,12 @@ sources:
 	if cfg.Server.MCP == nil || *cfg.Server.MCP {
 		t.Errorf("Server.MCP = %v, want explicit false", cfg.Server.MCP)
 	}
-	if len(cfg.Sources) != 1 {
-		t.Fatalf("want 1 source, got %d", len(cfg.Sources))
+	localEntry := cfg.Spec.Entries["local"]
+	if localEntry == nil || localEntry.Ref == nil {
+		t.Fatal("spec.entries[local] not found")
 	}
-	if cfg.Sources[0].Watch == nil || *cfg.Sources[0].Watch {
-		t.Errorf("Sources[0].Watch = %v, want explicit false", cfg.Sources[0].Watch)
+	if localEntry.Ref.Watch == nil || *localEntry.Ref.Watch {
+		t.Errorf("Spec.Entries[local].Ref.Watch = %v, want explicit false", localEntry.Ref.Watch)
 	}
 }
 
@@ -328,9 +380,11 @@ func TestLoadWatchAndMCPDefaultsToTrueWhenUnset(t *testing.T) {
 	cfgPath := filepath.Join(dir, "dicode.yaml")
 
 	content := `
-sources:
-  - type: local
-    path: ${CONFIGDIR}/tasks
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
 `
 	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
@@ -342,11 +396,12 @@ sources:
 	if cfg.Server.MCP == nil || !*cfg.Server.MCP {
 		t.Errorf("Server.MCP = %v, want default true when unset", cfg.Server.MCP)
 	}
-	if len(cfg.Sources) != 1 {
-		t.Fatalf("want 1 source, got %d", len(cfg.Sources))
+	localEntry := cfg.Spec.Entries["local"]
+	if localEntry == nil || localEntry.Ref == nil {
+		t.Fatal("spec.entries[local] not found")
 	}
-	if cfg.Sources[0].Watch == nil || !*cfg.Sources[0].Watch {
-		t.Errorf("Sources[0].Watch = %v, want default true when unset", cfg.Sources[0].Watch)
+	if localEntry.Ref.Watch == nil || !*localEntry.Ref.Watch {
+		t.Errorf("Spec.Entries[local].Ref.Watch = %v, want default true when unset", localEntry.Ref.Watch)
 	}
 }
 
@@ -359,9 +414,11 @@ func TestLoad_BcryptCost_DefaultIs12WhenUnset(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "dicode.yaml")
 	content := `
-sources:
-  - type: local
-    path: ${CONFIGDIR}/tasks
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
 `
 	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
@@ -379,9 +436,11 @@ func TestLoad_BcryptCost_AcceptsValidOverride(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "dicode.yaml")
 	content := `
-sources:
-  - type: local
-    path: ${CONFIGDIR}/tasks
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
 server:
   bcrypt_cost: 10
 `
@@ -399,17 +458,18 @@ server:
 
 // Out-of-range values must be rejected at Load time so the operator finds out
 // at startup rather than discovering at first login that bcrypt is rejecting
-// the cost. We cap at 14 to prevent pathological values like 20 (~minutes
-// per login) that would functionally lock a user out.
+// the cost. We cap at 14 to prevent operators from accidentally locking themselves out.
 func TestLoad_BcryptCost_RejectsOutOfRange(t *testing.T) {
 	for _, bad := range []int{1, 2, 3, 15, 20, 31} {
 		t.Run(fmt.Sprintf("cost=%d", bad), func(t *testing.T) {
 			dir := t.TempDir()
 			cfgPath := filepath.Join(dir, "dicode.yaml")
 			content := fmt.Sprintf(`
-sources:
-  - type: local
-    path: ${CONFIGDIR}/tasks
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
 server:
   bcrypt_cost: %d
 `, bad)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
-	"strings"
 	"sync"
 	"syscall"
 
@@ -29,8 +28,6 @@ import (
 	pythonruntime "github.com/dicode/dicode/pkg/runtime/python"
 	"github.com/dicode/dicode/pkg/secrets"
 	"github.com/dicode/dicode/pkg/source"
-	gitSource "github.com/dicode/dicode/pkg/source/git"
-	"github.com/dicode/dicode/pkg/source/local"
 	"github.com/dicode/dicode/pkg/task"
 	"github.com/dicode/dicode/pkg/taskset"
 	"github.com/dicode/dicode/pkg/trigger"
@@ -554,97 +551,35 @@ func buildSources(cfg *config.Config, dataDir string, log *zap.Logger) ([]source
 	tasksetSources := make(map[string]*taskset.Source)
 	var sources []source.Source
 
-	for _, sc := range cfg.Sources {
-		if sc.Name != "" || sc.EntryPath != "" {
-			ts, err := buildTaskSetSource(sc, dataDir, log)
-			if err != nil {
-				return nil, nil, err
-			}
-			sources = append(sources, ts)
-			tasksetSources[sourceNameFor(sc)] = ts
+	// Each entry in cfg.Spec.Entries is a named source. The entry key is the
+	// namespace; entry.Ref is the source descriptor (local path or git URL).
+	for name, entry := range cfg.Spec.Entries {
+		if entry == nil || entry.Ref == nil {
 			continue
 		}
-		switch sc.Type {
-		case config.SourceTypeLocal:
-			// Watch is a *bool pointer after #177; applyDefaults guarantees
-			// it's non-nil here, but treat nil as "watch enabled" defensively.
-			watchEnabled := sc.Watch == nil || *sc.Watch
-			s, err := local.New(sc.Path, sc.Path, watchEnabled, log)
-			if err != nil {
-				return nil, nil, fmt.Errorf("local source %q: %w", sc.Path, err)
-			}
-			sources = append(sources, s)
-		case config.SourceTypeGit:
-			gs, err := gitSource.New(dataDir, sc.URL, sc.Branch, sc.PollInterval, sc.Auth.TokenEnv, sc.Auth.SSHKey, log)
-			if err != nil {
-				return nil, nil, fmt.Errorf("git source %q: %w", sc.URL, err)
-			}
-			sources = append(sources, gs)
-		default:
-			return nil, nil, fmt.Errorf("unknown source type %q", sc.Type)
+		ref := entry.Ref
+		var overrides *taskset.Overrides
+		if entry.Overrides != nil {
+			overrides = entry.Overrides
 		}
+		ts := buildTaskSetSourceFromEntry(name, ref, overrides, dataDir, log)
+		sources = append(sources, ts)
+		tasksetSources[name] = ts
 	}
 
 	sourceMgr := webui.NewSourceManager(cfg, tasksetSources, dataDir, log)
 	return sources, sourceMgr, nil
 }
 
-func sourceNameFor(sc config.SourceConfig) string {
-	if sc.Name != "" {
-		return sc.Name
-	}
-	base := sc.URL
-	if base == "" {
-		base = sc.Path
-	}
-	base = strings.TrimRight(base, "/")
-	name := filepath.Base(base)
-	if ext := filepath.Ext(name); ext == ".yaml" || ext == ".yml" {
-		name = strings.TrimSuffix(name, ext)
-	}
-	return name
-}
-
-func buildTaskSetSource(sc config.SourceConfig, dataDir string, log *zap.Logger) (*taskset.Source, error) {
-	namespace := sc.Name
-	if namespace == "" {
-		base := sc.URL
-		if base == "" {
-			base = sc.Path
-		}
-		base = strings.TrimRight(base, "/")
-		namespace = filepath.Base(base)
-		if ext := filepath.Ext(namespace); ext == ".yaml" || ext == ".yml" {
-			namespace = strings.TrimSuffix(namespace, ext)
-		}
-	}
-
-	var rootRef *taskset.Ref
-	if sc.URL != "" {
-		entryPath := sc.EntryPath
-		if entryPath == "" {
-			entryPath = "taskset.yaml"
-		}
-		rootRef = &taskset.Ref{
-			URL:          sc.URL,
-			Branch:       sc.Branch,
-			Path:         entryPath,
-			PollInterval: sc.PollInterval,
-			Auth:         taskset.RefAuth{TokenEnv: sc.Auth.TokenEnv, SSHKey: sc.Auth.SSHKey},
-		}
-	} else {
-		entryPath := sc.Path
-		if sc.EntryPath != "" {
-			entryPath = sc.EntryPath
-		}
-		rootRef = &taskset.Ref{Path: entryPath}
-	}
-
-	id := sc.URL
+func buildTaskSetSourceFromEntry(name string, ref *taskset.Ref, _ *taskset.Overrides, dataDir string, log *zap.Logger) *taskset.Source {
+	// The entry key is the namespace. The ref points at the taskset.yaml.
+	// applyDefaults has already expanded ${VAR} and set branch/poll defaults.
+	id := ref.URL
 	if id == "" {
-		id = sc.Path
+		id = ref.Path
 	}
-	return taskset.NewSource(id, namespace, rootRef, sc.ConfigPath, dataDir, false, sc.PollInterval, log), nil
+	var pollInterval = ref.PollInterval
+	return taskset.NewSource(id, name, ref, "", dataDir, false, pollInterval, log)
 }
 
 func buildLogger(level string, broadcast *webui.LogBroadcaster) (*zap.Logger, error) {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -558,11 +558,7 @@ func buildSources(cfg *config.Config, dataDir string, log *zap.Logger) ([]source
 			continue
 		}
 		ref := entry.Ref
-		var overrides *taskset.Overrides
-		if entry.Overrides != nil {
-			overrides = entry.Overrides
-		}
-		ts := buildTaskSetSourceFromEntry(name, ref, overrides, dataDir, log)
+		ts := buildTaskSetSourceFromEntry(name, ref, dataDir, log)
 		sources = append(sources, ts)
 		tasksetSources[name] = ts
 	}
@@ -571,7 +567,7 @@ func buildSources(cfg *config.Config, dataDir string, log *zap.Logger) ([]source
 	return sources, sourceMgr, nil
 }
 
-func buildTaskSetSourceFromEntry(name string, ref *taskset.Ref, _ *taskset.Overrides, dataDir string, log *zap.Logger) *taskset.Source {
+func buildTaskSetSourceFromEntry(name string, ref *taskset.Ref, dataDir string, log *zap.Logger) *taskset.Source {
 	// The entry key is the namespace. The ref points at the taskset.yaml.
 	// applyDefaults has already expanded ${VAR} and set branch/poll defaults.
 	id := ref.URL

--- a/pkg/onboarding/onboarding.go
+++ b/pkg/onboarding/onboarding.go
@@ -71,18 +71,60 @@ func Run(ctx context.Context, configPath string, opts RunOptions) error {
 		}
 	}
 
-	// Make sure the local tasks directory exists; without this the
-	// daemon's source layer refuses to start on the generated config
-	// ("no such file or directory"). No-op when the user picked
+	// Scaffold the local tasks directory so the source loader can resolve
+	// the generated `local` entry on first boot. No-op when the user picked
 	// "skip" — an empty LocalTasksDir means no local source entry, so
 	// there's nothing to create.
 	if res.LocalTasksDir != "" {
-		if err := os.MkdirAll(res.LocalTasksDir, 0o755); err != nil {
-			return fmt.Errorf("create local tasks dir: %w", err)
+		if err := scaffoldLocalTaskSet(res.LocalTasksDir); err != nil {
+			return err
 		}
 	}
 
 	PrintSuccess(opts.Out, res, configPath)
+	return nil
+}
+
+// starterTaskSetYAML is dropped into a freshly-created local tasks dir on
+// first run. The empty entries map is intentional: the source resolver
+// requires `spec.entries` to be present (even if empty) and rejects a
+// missing file with a startup-blocking error. Users add their own entries
+// here as they create tasks.
+const starterTaskSetYAML = `apiVersion: dicode/v1
+kind: TaskSet
+metadata:
+  name: local
+spec:
+  # Add your tasks here. Each entry is keyed by the namespace segment
+  # under which the referenced task or taskset is registered.
+  # Example:
+  #   hello:
+  #     ref:
+  #       path: ./hello/task.yaml
+  entries: {}
+`
+
+// scaffoldLocalTaskSet creates dir (if missing) and writes a starter
+// taskset.yaml inside it (if missing). Without the starter file the
+// daemon's source loader would fail on "open <dir>/taskset.yaml: no such
+// file or directory" the first time it tries to resolve the local source,
+// blocking startup before the wizard's success banner has any meaning.
+//
+// Existing taskset.yaml files are left untouched so a returning user who
+// wiped only dicode.yaml does not lose their work.
+func scaffoldLocalTaskSet(dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create local tasks dir: %w", err)
+	}
+	tsPath := filepath.Join(dir, "taskset.yaml")
+	if _, err := os.Stat(tsPath); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat %s: %w", tsPath, err)
+	}
+	if err := os.WriteFile(tsPath, []byte(starterTaskSetYAML), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", tsPath, err)
+	}
 	return nil
 }
 

--- a/pkg/onboarding/onboarding_test.go
+++ b/pkg/onboarding/onboarding_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/dicode/dicode/pkg/config"
+	"github.com/dicode/dicode/pkg/taskset"
 )
 
 // TestRenderConfig_LoadsCleanly writes the first-run output through the
@@ -75,6 +76,61 @@ func TestDefaultResult_HonorsDataDirEnv(t *testing.T) {
 			t.Errorf("DataDir = %q, want %q (home fallback)", r.DataDir, want)
 		}
 	})
+}
+
+// TestScaffoldLocalTaskSet_CreatesParseableStarter writes the starter
+// taskset.yaml into a fresh dir and verifies it loads through the real
+// taskset.LoadTaskSet path. Without this guard, drift between the starter
+// template and the loader's validation rules would show up as a startup
+// failure on every fresh install.
+func TestScaffoldLocalTaskSet_CreatesParseableStarter(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tasks")
+	if err := scaffoldLocalTaskSet(dir); err != nil {
+		t.Fatalf("scaffoldLocalTaskSet: %v", err)
+	}
+
+	tsPath := filepath.Join(dir, "taskset.yaml")
+	if _, err := os.Stat(tsPath); err != nil {
+		t.Fatalf("starter taskset.yaml not created: %v", err)
+	}
+
+	ts, err := taskset.LoadTaskSet(tsPath)
+	if err != nil {
+		t.Fatalf("LoadTaskSet on starter: %v", err)
+	}
+	if ts.Spec.Entries == nil {
+		t.Error("starter spec.entries should be a non-nil empty map")
+	}
+	if len(ts.Spec.Entries) != 0 {
+		t.Errorf("starter spec.entries should be empty, got %d", len(ts.Spec.Entries))
+	}
+}
+
+// TestScaffoldLocalTaskSet_DoesNotClobberExisting protects user data on a
+// re-run: if a returning user wipes dicode.yaml but keeps their tasks dir,
+// re-running onboarding must NOT overwrite their existing taskset.yaml.
+func TestScaffoldLocalTaskSet_DoesNotClobberExisting(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tasks")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	tsPath := filepath.Join(dir, "taskset.yaml")
+	const userContent = "kind: TaskSet\napiVersion: dicode/v1\nmetadata:\n  name: mine\nspec:\n  entries:\n    foo:\n      ref:\n        path: ./foo/task.yaml\n"
+	if err := os.WriteFile(tsPath, []byte(userContent), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := scaffoldLocalTaskSet(dir); err != nil {
+		t.Fatalf("scaffoldLocalTaskSet: %v", err)
+	}
+
+	got, err := os.ReadFile(tsPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != userContent {
+		t.Errorf("starter overwrote user content; got:\n%s\nwant:\n%s", got, userContent)
+	}
 }
 
 // TestWriteConfig_FileAndParentArePrivate guards the dashboard

--- a/pkg/onboarding/onboarding_test.go
+++ b/pkg/onboarding/onboarding_test.go
@@ -36,8 +36,8 @@ func TestRenderConfig_LoadsCleanly(t *testing.T) {
 		t.Errorf("AI.Task = %q, want %q (default should land)", cfg.AI.Task, "buildin/dicodai")
 	}
 
-	if len(cfg.Sources) == 0 {
-		t.Error("sources should not be empty")
+	if len(cfg.Spec.Entries) == 0 {
+		t.Error("spec.entries should not be empty")
 	}
 	if cfg.Database.Type != "sqlite" {
 		t.Errorf("Database.Type = %q, want sqlite", cfg.Database.Type)

--- a/pkg/onboarding/presets.go
+++ b/pkg/onboarding/presets.go
@@ -1,8 +1,8 @@
 package onboarding
 
 // TaskSetPreset describes one curated git-backed taskset that the first-run
-// wizard offers. Each preset maps to a single entry under `sources:` in the
-// generated dicode.yaml.
+// wizard offers. Each preset maps to a single entry under `spec.entries` in
+// the generated dicode.yaml.
 type TaskSetPreset struct {
 	Name      string // unique namespace segment; used as the source's `name`
 	Label     string // shown in the UI

--- a/pkg/onboarding/render.go
+++ b/pkg/onboarding/render.go
@@ -17,9 +17,9 @@ type Result struct {
 }
 
 // RenderConfig generates a dicode.yaml document from the wizard's Result.
-// The output includes a commented header, the selected git sources, an
-// optional local source, and server.auth + server.secret filled from the
-// generated passphrase.
+// The output uses the new spec.entries shape: each source is an entry under
+// spec.entries keyed by its name. The local tasks dir (if set) appears as a
+// "local" entry pointing at the user's tasks directory.
 func RenderConfig(r Result) string {
 	var b strings.Builder
 
@@ -32,28 +32,31 @@ func RenderConfig(r Result) string {
 #   ${DATADIR}   — resolved data_dir (default: ~/.dicode)
 
 # ---------------------------------------------------------------------------
-# Task sources — where dicode looks for tasks.
+# Task sources — declared as spec.entries. Each entry key is the namespace
+# for the tasks it contains. The ref block points at a taskset.yaml.
 # ---------------------------------------------------------------------------
-sources:
+spec:
+  entries:
 `)
 
 	for _, p := range TaskSetPresets {
 		if !r.TaskSetsEnabled[p.Name] {
 			continue
 		}
-		fmt.Fprintf(&b, `  - type: git
-    name: %s
-    url: %s
-    branch: %s
-    entry_path: %s
-    poll_interval: 30s
+		fmt.Fprintf(&b, `    %s:
+      ref:
+        url: %s
+        branch: %s
+        path: %s
+        poll_interval: 30s
 `, p.Name, p.URL, p.Branch, p.EntryPath)
 	}
 
 	if r.LocalTasksDir != "" {
-		fmt.Fprintf(&b, `  - type: local
-    path: %s
-    watch: true
+		fmt.Fprintf(&b, `    local:
+      ref:
+        path: %s
+        watch: true
 `, r.LocalTasksDir)
 	}
 

--- a/pkg/onboarding/render_test.go
+++ b/pkg/onboarding/render_test.go
@@ -6,16 +6,22 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// renderedEntry captures one spec.entries entry from the generated YAML.
+type renderedEntry struct {
+	Ref struct {
+		URL    string `yaml:"url"`
+		Branch string `yaml:"branch"`
+		Path   string `yaml:"path"`
+	} `yaml:"ref"`
+}
+
 // renderedConfig captures just the pieces of the generated YAML we assert on.
+// The new shape uses spec.entries (a map keyed by source name) instead of the
+// old sources[] array.
 type renderedConfig struct {
-	Sources []struct {
-		Type      string `yaml:"type"`
-		Name      string `yaml:"name"`
-		URL       string `yaml:"url"`
-		Branch    string `yaml:"branch"`
-		EntryPath string `yaml:"entry_path"`
-		Path      string `yaml:"path"`
-	} `yaml:"sources"`
+	Spec struct {
+		Entries map[string]renderedEntry `yaml:"entries"`
+	} `yaml:"spec"`
 	Server struct {
 		Auth   bool   `yaml:"auth"`
 		Secret string `yaml:"secret"`
@@ -51,13 +57,13 @@ func TestRenderConfig_AllTasksetsEnabled_ThreeGitSources(t *testing.T) {
 	rc := parseRendered(t, RenderConfig(r))
 
 	gitCount := 0
-	for _, s := range rc.Sources {
-		if s.Type == "git" {
+	for _, e := range rc.Spec.Entries {
+		if e.Ref.URL != "" {
 			gitCount++
 		}
 	}
 	if gitCount != 3 {
-		t.Errorf("git sources = %d; want 3", gitCount)
+		t.Errorf("git entries = %d; want 3", gitCount)
 	}
 }
 
@@ -72,16 +78,16 @@ func TestRenderConfig_AllTasksetsEnabled_IncludesLocalSource(t *testing.T) {
 	rc := parseRendered(t, RenderConfig(r))
 
 	localCount := 0
-	for _, s := range rc.Sources {
-		if s.Type == "local" {
+	for _, e := range rc.Spec.Entries {
+		if e.Ref.URL == "" && e.Ref.Path != "" {
 			localCount++
-			if s.Path != "/home/user/dicode-tasks" {
-				t.Errorf("local path = %q; want /home/user/dicode-tasks", s.Path)
+			if e.Ref.Path != "/home/user/dicode-tasks" {
+				t.Errorf("local path = %q; want /home/user/dicode-tasks", e.Ref.Path)
 			}
 		}
 	}
 	if localCount != 1 {
-		t.Errorf("local sources = %d; want 1", localCount)
+		t.Errorf("local entries = %d; want 1", localCount)
 	}
 }
 
@@ -116,13 +122,13 @@ func TestRenderConfig_PartialSelection_DropsUnselected(t *testing.T) {
 	rc := parseRendered(t, RenderConfig(r))
 
 	var gitNames []string
-	for _, s := range rc.Sources {
-		if s.Type == "git" {
-			gitNames = append(gitNames, s.Name)
+	for name, e := range rc.Spec.Entries {
+		if e.Ref.URL != "" {
+			gitNames = append(gitNames, name)
 		}
 	}
 	if len(gitNames) != 1 || gitNames[0] != "buildin" {
-		t.Errorf("git source names = %v; want [buildin]", gitNames)
+		t.Errorf("git entry names = %v; want [buildin]", gitNames)
 	}
 }
 
@@ -136,9 +142,9 @@ func TestRenderConfig_EmptyLocalTasksDir_OmitsLocalSource(t *testing.T) {
 	}
 	rc := parseRendered(t, RenderConfig(r))
 
-	for _, s := range rc.Sources {
-		if s.Type == "local" {
-			t.Errorf("unexpected local source %+v when LocalTasksDir is empty", s)
+	for name, e := range rc.Spec.Entries {
+		if e.Ref.URL == "" && e.Ref.Path != "" {
+			t.Errorf("unexpected local entry %q when LocalTasksDir is empty", name)
 		}
 	}
 }
@@ -152,33 +158,24 @@ func TestRenderConfig_GitSourceFieldsMatchPreset(t *testing.T) {
 	}
 	rc := parseRendered(t, RenderConfig(r))
 
-	var found bool
-	for _, s := range rc.Sources {
-		if s.Type != "git" {
-			continue
-		}
-		found = true
-		var preset TaskSetPreset
-		for _, p := range TaskSetPresets {
-			if p.Name == "buildin" {
-				preset = p
-				break
-			}
-		}
-		if s.Name != preset.Name {
-			t.Errorf("name = %q; want %q", s.Name, preset.Name)
-		}
-		if s.URL != preset.URL {
-			t.Errorf("url = %q; want %q", s.URL, preset.URL)
-		}
-		if s.Branch != preset.Branch {
-			t.Errorf("branch = %q; want %q", s.Branch, preset.Branch)
-		}
-		if s.EntryPath != preset.EntryPath {
-			t.Errorf("entry_path = %q; want %q", s.EntryPath, preset.EntryPath)
+	e, found := rc.Spec.Entries["buildin"]
+	if !found {
+		t.Fatal("buildin entry not found in spec.entries")
+	}
+	var preset TaskSetPreset
+	for _, p := range TaskSetPresets {
+		if p.Name == "buildin" {
+			preset = p
+			break
 		}
 	}
-	if !found {
-		t.Error("no git source found in output")
+	if e.Ref.URL != preset.URL {
+		t.Errorf("url = %q; want %q", e.Ref.URL, preset.URL)
+	}
+	if e.Ref.Branch != preset.Branch {
+		t.Errorf("branch = %q; want %q", e.Ref.Branch, preset.Branch)
+	}
+	if e.Ref.Path != preset.EntryPath {
+		t.Errorf("path = %q; want %q", e.Ref.Path, preset.EntryPath)
 	}
 }

--- a/pkg/onboarding/run_test.go
+++ b/pkg/onboarding/run_test.go
@@ -33,10 +33,13 @@ func TestRun_Silent_WritesParseableYAML(t *testing.T) {
 	}
 
 	var parsed struct {
-		Sources []struct {
-			Type string `yaml:"type"`
-			Name string `yaml:"name"`
-		} `yaml:"sources"`
+		Spec struct {
+			Entries map[string]struct {
+				Ref struct {
+					URL string `yaml:"url"`
+				} `yaml:"ref"`
+			} `yaml:"entries"`
+		} `yaml:"spec"`
 		Server struct {
 			Auth   bool   `yaml:"auth"`
 			Secret string `yaml:"secret"`
@@ -47,15 +50,15 @@ func TestRun_Silent_WritesParseableYAML(t *testing.T) {
 	}
 
 	// Silent default enables all three presets.
-	gitNames := map[string]bool{}
-	for _, s := range parsed.Sources {
-		if s.Type == "git" {
-			gitNames[s.Name] = true
-		}
-	}
+	// Each preset becomes a git entry (URL non-empty) keyed by its name.
 	for _, p := range TaskSetPresets {
-		if !gitNames[p.Name] {
-			t.Errorf("silent default missing preset %q", p.Name)
+		e, ok := parsed.Spec.Entries[p.Name]
+		if !ok {
+			t.Errorf("silent default missing preset entry %q", p.Name)
+			continue
+		}
+		if e.Ref.URL == "" {
+			t.Errorf("silent default entry %q has empty ref.url", p.Name)
 		}
 	}
 	if !parsed.Server.Auth {

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -355,6 +355,14 @@ type Spec struct {
 	// Independent of RunInputs (which controls persistence). Used by #238.
 	AutoFix *AutoFixConfig `yaml:"auto_fix,omitempty" json:"auto_fix,omitempty"`
 
+	// Enabled is false when this task has been disabled via an override or
+	// entry-level `enabled: false`. Disabled tasks remain in the registry and
+	// appear in the API (with enabled:false) but are not scheduled, spawned,
+	// or registered as webhooks by the trigger engine.
+	// Default is true; the resolver sets it to true on load and flips it
+	// when an override says false.
+	Enabled bool `yaml:"-" json:"enabled"`
+
 	// TaskDir is the directory path of the task in the repo (not stored in YAML).
 	TaskDir string `yaml:"-" json:"-"`
 	// ID is derived from the directory name (not stored in YAML).
@@ -424,6 +432,9 @@ func LoadDirWithVars(dir string, extras map[string]string) (*Spec, error) {
 
 	spec.TaskDir = dir
 	spec.ID = filepath.Base(dir)
+	// Default Enabled to true; the taskset resolver may flip it to false if
+	// an override or entry-level `enabled: false` is in effect.
+	spec.Enabled = true
 
 	// Expand ${VAR} template references in paths, secrets, and env indirection
 	// keys. Kept intentionally narrow — see expandSpec for the allowlist and

--- a/pkg/taskset/loader.go
+++ b/pkg/taskset/loader.go
@@ -83,6 +83,30 @@ func LoadConfig(path string) (*ConfigSpec, error) {
 	return &cs, nil
 }
 
+// LiftEntryEnabled normalises the top-level `enabled` shortcut on every entry
+// in the provided map. After the call each entry.Enabled is nil and the value
+// lives exclusively in entry.Overrides.Enabled. If both are set on the same
+// entry an error is returned so callers never silently pick a winner.
+//
+// This is extracted as a package-level helper so that both validateTaskSet and
+// pkg/config's validate() can call it without duplicating the logic.
+func LiftEntryEnabled(entries map[string]*Entry) error {
+	for key, entry := range entries {
+		if entry == nil || entry.Enabled == nil {
+			continue
+		}
+		if entry.Overrides != nil && entry.Overrides.Enabled != nil {
+			return fmt.Errorf("entry %q: top-level `enabled` conflicts with `overrides.enabled` — set one or the other", key)
+		}
+		if entry.Overrides == nil {
+			entry.Overrides = &Overrides{}
+		}
+		entry.Overrides.Enabled = entry.Enabled
+		entry.Enabled = nil
+	}
+	return nil
+}
+
 func validateTaskSet(ts *TaskSetSpec, path string) error {
 	if ts.Spec.Entries == nil {
 		return fmt.Errorf("%s: spec.entries is required", path)
@@ -100,20 +124,11 @@ func validateTaskSet(ts *TaskSetSpec, path string) error {
 		if entry.Ref != nil && entry.Ref.Path == "" {
 			return fmt.Errorf("%s: entry %q: ref.path is required", path, key)
 		}
-
-		// Lift the top-level `enabled` shortcut into overrides.enabled so all
-		// downstream code (resolver, override merging) sees one canonical
-		// path. Reject conflicts rather than picking a silent winner.
-		if entry.Enabled != nil {
-			if entry.Overrides != nil && entry.Overrides.Enabled != nil {
-				return fmt.Errorf("%s: entry %q: top-level `enabled` conflicts with `overrides.enabled` — set one or the other", path, key)
-			}
-			if entry.Overrides == nil {
-				entry.Overrides = &Overrides{}
-			}
-			entry.Overrides.Enabled = entry.Enabled
-			entry.Enabled = nil
-		}
+	}
+	// Lift the top-level `enabled` shortcut into overrides.enabled so all
+	// downstream code (resolver, override merging) sees one canonical path.
+	if err := LiftEntryEnabled(ts.Spec.Entries); err != nil {
+		return fmt.Errorf("%s: %w", path, err)
 	}
 	return nil
 }

--- a/pkg/taskset/loader.go
+++ b/pkg/taskset/loader.go
@@ -2,7 +2,9 @@ package taskset
 
 import (
 	"fmt"
+	"net/url"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -107,6 +109,43 @@ func LiftEntryEnabled(entries map[string]*Entry) error {
 	return nil
 }
 
+// ValidateRefURL validates the scheme of a git ref URL.
+// It accepts http, https, ssh, and git schemes, plus the SSH shorthand
+// form (git@host:path) which url.Parse would misparse as a relative URL
+// with scheme "". The SSH shorthand is detected by the SCP-style
+// user@host:path pattern: the URL must contain no "://" (which would mean
+// it already has an explicit scheme), and the colon separating host from
+// path must follow the "@".
+func ValidateRefURL(filePath, key, rawURL string) error {
+	// Detect the SCP-style SSH shorthand: user@host:path (e.g. git@github.com:org/repo.git).
+	// These look like relative paths to url.Parse (Scheme=""), so we handle them
+	// explicitly before calling url.Parse.
+	// Guard: skip if the URL already has an explicit scheme (contains "://").
+	if !strings.Contains(rawURL, "://") {
+		if at := strings.Index(rawURL, "@"); at > 0 {
+			afterAt := rawURL[at+1:]
+			if colon := strings.Index(afterAt, ":"); colon > 0 {
+				// Ensure no "/" before the ":" — a slash means it's a path
+				// separator, not the SCP host:path separator.
+				hostPart := afterAt[:colon]
+				if !strings.Contains(hostPart, "/") {
+					return nil // valid SSH shorthand
+				}
+			}
+		}
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("%s: entry %q: invalid ref.url: %w", filePath, key, err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https", "ssh", "git":
+		return nil
+	default:
+		return fmt.Errorf("%s: entry %q: ref.url must use scheme http, https, ssh, or git (got %q)", filePath, key, u.Scheme)
+	}
+}
+
 func validateTaskSet(ts *TaskSetSpec, path string) error {
 	if ts.Spec.Entries == nil {
 		return fmt.Errorf("%s: spec.entries is required", path)
@@ -121,8 +160,13 @@ func validateTaskSet(ts *TaskSetSpec, path string) error {
 		if entry.Ref != nil && entry.Inline != nil {
 			return fmt.Errorf("%s: entry %q: ref and inline are mutually exclusive", path, key)
 		}
-		if entry.Ref != nil && entry.Ref.Path == "" {
-			return fmt.Errorf("%s: entry %q: ref.path is required", path, key)
+		if entry.Ref != nil && entry.Ref.URL == "" && entry.Ref.Path == "" {
+			return fmt.Errorf("%s: entry %q: ref.path is required for local refs", path, key)
+		}
+		if entry.Ref != nil && entry.Ref.URL != "" {
+			if err := ValidateRefURL(path, key, entry.Ref.URL); err != nil {
+				return err
+			}
 		}
 	}
 	// Lift the top-level `enabled` shortcut into overrides.enabled so all

--- a/pkg/taskset/loader.go
+++ b/pkg/taskset/loader.go
@@ -100,6 +100,20 @@ func validateTaskSet(ts *TaskSetSpec, path string) error {
 		if entry.Ref != nil && entry.Ref.Path == "" {
 			return fmt.Errorf("%s: entry %q: ref.path is required", path, key)
 		}
+
+		// Lift the top-level `enabled` shortcut into overrides.enabled so all
+		// downstream code (resolver, override merging) sees one canonical
+		// path. Reject conflicts rather than picking a silent winner.
+		if entry.Enabled != nil {
+			if entry.Overrides != nil && entry.Overrides.Enabled != nil {
+				return fmt.Errorf("%s: entry %q: top-level `enabled` conflicts with `overrides.enabled` — set one or the other", path, key)
+			}
+			if entry.Overrides == nil {
+				entry.Overrides = &Overrides{}
+			}
+			entry.Overrides.Enabled = entry.Enabled
+			entry.Enabled = nil
+		}
 	}
 	return nil
 }

--- a/pkg/taskset/loader_test.go
+++ b/pkg/taskset/loader_test.go
@@ -187,9 +187,32 @@ spec:
 	}
 }
 
+// TestLoadTaskSet_EntryRefMissingPath checks that:
+//   - a git ref (URL non-empty) with no path is valid — the source manager
+//     treats an empty path as "taskset.yaml at the repo root".
+//   - a local ref (URL empty) with no path is still rejected.
 func TestLoadTaskSet_EntryRefMissingPath(t *testing.T) {
 	dir := t.TempDir()
-	content := `
+
+	// Git ref with empty path — must succeed.
+	gitContent := `
+kind: TaskSet
+apiVersion: dicode/v1
+metadata:
+  name: x
+spec:
+  entries:
+    root-ref:
+      ref:
+        url: https://github.com/org/repo
+`
+	p := writeFile(t, dir, "ts_git.yaml", gitContent)
+	if _, err := LoadTaskSet(p); err != nil {
+		t.Errorf("git ref with empty path should be valid, got: %v", err)
+	}
+
+	// Local ref with empty path — must be rejected.
+	localContent := `
 kind: TaskSet
 apiVersion: dicode/v1
 metadata:
@@ -197,13 +220,15 @@ metadata:
 spec:
   entries:
     bad:
-      ref:
-        url: https://github.com/org/repo
+      ref: {}
 `
-	p := writeFile(t, dir, "ts.yaml", content)
-	_, err := LoadTaskSet(p)
+	p2 := writeFile(t, dir, "ts_local.yaml", localContent)
+	_, err := LoadTaskSet(p2)
 	if err == nil {
-		t.Fatal("expected error for ref missing path")
+		t.Fatal("expected error for local ref missing path")
+	}
+	if !strings.Contains(err.Error(), "ref.path is required for local refs") {
+		t.Errorf("expected 'ref.path is required for local refs' in error, got: %v", err)
 	}
 }
 
@@ -275,6 +300,56 @@ spec:
 	}
 	if !strings.Contains(err.Error(), "conflicts with `overrides.enabled`") {
 		t.Errorf("expected conflict error, got: %v", err)
+	}
+}
+
+func TestLoadTaskSet_RefURLSchemes(t *testing.T) {
+	dir := t.TempDir()
+
+	mkYAML := func(u string) string {
+		return `
+kind: TaskSet
+apiVersion: dicode/v1
+metadata:
+  name: x
+spec:
+  entries:
+    entry:
+      ref:
+        url: ` + u + `
+`
+	}
+
+	allowed := []string{
+		"https://github.com/org/repo",
+		"http://internal.corp/tasks",
+		"ssh://git@github.com/org/repo.git",
+		"git://github.com/org/repo.git",
+		"git@github.com:org/repo.git",       // SSH shorthand
+		"git@gitlab.com:group/subgroup.git", // SSH shorthand with subgroup
+	}
+	for _, u := range allowed {
+		t.Run("allowed:"+u, func(t *testing.T) {
+			p := writeFile(t, dir, "ts_allowed.yaml", mkYAML(u))
+			if _, err := LoadTaskSet(p); err != nil {
+				t.Errorf("expected %q to be allowed, got error: %v", u, err)
+			}
+		})
+	}
+
+	rejected := []string{
+		"file:///etc/passwd",
+		"file://localhost/tmp/tasks",
+		"/tmp/local-path",
+	}
+	for _, u := range rejected {
+		t.Run("rejected:"+u, func(t *testing.T) {
+			p := writeFile(t, dir, "ts_rejected.yaml", mkYAML(u))
+			_, err := LoadTaskSet(p)
+			if err == nil {
+				t.Errorf("expected %q to be rejected, got nil error", u)
+			}
+		})
 	}
 }
 

--- a/pkg/taskset/loader_test.go
+++ b/pkg/taskset/loader_test.go
@@ -3,6 +3,7 @@ package taskset
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -203,6 +204,77 @@ spec:
 	_, err := LoadTaskSet(p)
 	if err == nil {
 		t.Fatal("expected error for ref missing path")
+	}
+}
+
+func TestLoadTaskSet_EntryEnabledShortcut(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+kind: TaskSet
+apiVersion: dicode/v1
+metadata:
+  name: x
+spec:
+  entries:
+    on-task:
+      enabled: true
+      inline:
+        name: a
+        runtime: deno
+        trigger: { manual: true }
+        timeout: 5s
+    off-task:
+      enabled: false
+      inline:
+        name: b
+        runtime: deno
+        trigger: { manual: true }
+        timeout: 5s
+`
+	p := writeFile(t, dir, "ts.yaml", content)
+	ts, err := LoadTaskSet(p)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	on := ts.Spec.Entries["on-task"]
+	if on.Enabled != nil {
+		t.Errorf("on-task: Enabled should be lifted to Overrides.Enabled, got top-level set")
+	}
+	if on.Overrides == nil || on.Overrides.Enabled == nil || *on.Overrides.Enabled != true {
+		t.Errorf("on-task: expected overrides.enabled=true after lift, got %+v", on.Overrides)
+	}
+	off := ts.Spec.Entries["off-task"]
+	if off.Overrides == nil || off.Overrides.Enabled == nil || *off.Overrides.Enabled != false {
+		t.Errorf("off-task: expected overrides.enabled=false after lift, got %+v", off.Overrides)
+	}
+}
+
+func TestLoadTaskSet_EntryEnabledConflict(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+kind: TaskSet
+apiVersion: dicode/v1
+metadata:
+  name: x
+spec:
+  entries:
+    bad:
+      enabled: false
+      overrides:
+        enabled: true
+      inline:
+        name: a
+        runtime: deno
+        trigger: { manual: true }
+        timeout: 5s
+`
+	p := writeFile(t, dir, "ts.yaml", content)
+	_, err := LoadTaskSet(p)
+	if err == nil {
+		t.Fatal("expected conflict error when both top-level enabled and overrides.enabled are set")
+	}
+	if !strings.Contains(err.Error(), "conflicts with `overrides.enabled`") {
+		t.Errorf("expected conflict error, got: %v", err)
 	}
 }
 

--- a/pkg/taskset/resolver.go
+++ b/pkg/taskset/resolver.go
@@ -148,8 +148,13 @@ func (r *Resolver) resolveBody(
 			parentEntryOverride = parentOverrides.Entries[key]
 		}
 
-		// Determine enabled state; entry override wins over parent.
+		// Determine enabled state.
+		// Precedence (highest wins): parentEntryOverride.Enabled >
+		// entry.Overrides.Enabled > entry.Enabled shortcut > default true.
 		enabled := true
+		if entry.Enabled != nil {
+			enabled = *entry.Enabled
+		}
 		if entry.Overrides != nil && entry.Overrides.Enabled != nil {
 			enabled = *entry.Overrides.Enabled
 		}
@@ -158,13 +163,11 @@ func (r *Resolver) resolveBody(
 		}
 
 		if entry.Inline != nil {
-			if !enabled {
-				continue
-			}
 			layers := buildOverrideLayers(ts.Spec.Defaults, parentEntryOverride, entry.Overrides)
 			resolved := applyOverrides(entry.Inline, layers...)
 			resolved.ID = fullID
 			resolved.TaskDir = filepath.Dir(tsPath)
+			resolved.Enabled = enabled
 			results = append(results, &ResolvedTask{
 				Spec:    resolved,
 				ID:      fullID,
@@ -195,9 +198,6 @@ func (r *Resolver) resolveBody(
 
 		switch kind {
 		case KindTask:
-			if !enabled {
-				continue
-			}
 			taskDir := filepath.Dir(localPath)
 			extras := extraVars
 			if extras == nil {
@@ -228,6 +228,7 @@ func (r *Resolver) resolveBody(
 			layers := buildOverrideLayers(ts.Spec.Defaults, parentEntryOverride, entry.Overrides)
 			resolved := applyOverrides(spec, layers...)
 			resolved.ID = fullID
+			resolved.Enabled = enabled
 			results = append(results, &ResolvedTask{
 				Spec:    resolved,
 				ID:      fullID,
@@ -235,9 +236,9 @@ func (r *Resolver) resolveBody(
 			})
 
 		case KindTaskSet:
-			// Build the overrides context for the nested set.
-			// entry.Overrides carries per-entry patches for children; parentEntryOverride
-			// is the parent's patch for this entry — merge them (entry wins on conflict).
+			// A disabled TaskSet entry propagates disabled to all its children.
+			// Resolve the sub-tree so tasks remain visible in the API; the
+			// engine skips scheduling for any task where Enabled == false.
 			nestedOverrides := entry.Overrides
 			if parentEntryOverride != nil {
 				nestedOverrides = mergeOverrides(parentEntryOverride, nestedOverrides)
@@ -247,6 +248,13 @@ func (r *Resolver) resolveBody(
 				r.log.Warn("taskset: failed to resolve nested taskset",
 					zap.String("entry", fullID), zap.Error(err))
 				continue
+			}
+			// If this entry is disabled, propagate disabled to all its children
+			// so the whole sub-tree stays visible in the API but is not scheduled.
+			if !enabled {
+				for _, rt := range nested {
+					rt.Spec.Enabled = false
+				}
 			}
 			results = append(results, nested...)
 

--- a/pkg/taskset/resolver.go
+++ b/pkg/taskset/resolver.go
@@ -150,11 +150,11 @@ func (r *Resolver) resolveBody(
 
 		// Determine enabled state.
 		// Precedence (highest wins): parentEntryOverride.Enabled >
-		// entry.Overrides.Enabled > entry.Enabled shortcut > default true.
+		// entry.Overrides.Enabled > default true.
+		// Note: the top-level `entry.Enabled` shortcut is always lifted into
+		// entry.Overrides.Enabled by LiftEntryEnabled during load/validate, so
+		// there is no need to check entry.Enabled here.
 		enabled := true
-		if entry.Enabled != nil {
-			enabled = *entry.Enabled
-		}
 		if entry.Overrides != nil && entry.Overrides.Enabled != nil {
 			enabled = *entry.Overrides.Enabled
 		}

--- a/pkg/taskset/resolver_test.go
+++ b/pkg/taskset/resolver_test.go
@@ -224,6 +224,8 @@ spec:
 }
 
 func TestResolver_DisabledEntrySkipped(t *testing.T) {
+	// Disabled tasks now remain in results (Enabled=false) for API visibility.
+	// The trigger engine skips scheduling them; the registry keeps them visible.
 	repoDir := t.TempDir()
 	taskDir := writeTaskDir(t, repoDir, "deploy")
 
@@ -246,13 +248,17 @@ spec:
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
-	if len(results) != 0 {
-		t.Errorf("disabled task should not appear: %v", results)
+	if len(results) != 1 {
+		t.Fatalf("disabled task should appear with Enabled=false: got %d results", len(results))
+	}
+	if results[0].Spec.Enabled {
+		t.Errorf("disabled task should have Enabled=false, got Enabled=true")
 	}
 }
 
 func TestResolver_ParentEntryPatchDisables(t *testing.T) {
 	// Task is enabled in taskset.yaml but parent patches it to disabled.
+	// The task remains in results with Enabled=false for API visibility.
 	repoDir := t.TempDir()
 	taskDir := writeTaskDir(t, repoDir, "deploy")
 
@@ -280,8 +286,11 @@ spec:
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
-	if len(results) != 0 {
-		t.Errorf("parent disabled task should not appear: got %d results", len(results))
+	if len(results) != 1 {
+		t.Fatalf("parent-disabled task should appear with Enabled=false: got %d results", len(results))
+	}
+	if results[0].Spec.Enabled {
+		t.Errorf("parent-disabled task should have Enabled=false, got Enabled=true")
 	}
 }
 
@@ -770,5 +779,125 @@ spec:
 	}
 	if got, want := results[0].Spec.Permissions.FS[0].Path, "/caller/wins/pool"; got != want {
 		t.Errorf("fs.path: got %q, want %q — caller extraVars should override resolver derivation", got, want)
+	}
+}
+
+// ── Item 6: root-level spec.entries override cascade ─────────────────────────
+
+// TestResolver_RootSpecEntryOverrideCascades verifies that an override applied
+// at the dicode.yaml spec.entries level (simulated via parentOverrides) propagates
+// into the inner TaskSet at the highest precedence. This mirrors the real
+// dicode.yaml spec.entries.<name>.overrides.entries.<inner> mechanism.
+//
+// Setup: inner TaskSet has entry "deploy" with timeout 30s. A parent override
+// sets timeout 5m. The resolved task should have timeout 5m.
+func TestResolver_RootSpecEntryOverrideCascades(t *testing.T) {
+	repoDir := t.TempDir()
+	taskDir := writeTaskDir(t, repoDir, "deploy")
+
+	// Inner taskset with a short default timeout for the entry.
+	tsContent := `
+apiVersion: dicode/v1
+kind: TaskSet
+metadata:
+  name: buildin
+spec:
+  entries:
+    deploy:
+      ref:
+        path: ` + filepath.Join(taskDir, "task.yaml") + `
+`
+	tsPath := writeTaskSetFile(t, repoDir, "taskset.yaml", tsContent)
+
+	r := newResolver(t)
+	// Parent override: spec.entries["buildin"].overrides.entries["deploy"].timeout = 5m
+	// This is the highest-precedence layer — it should win over anything in the taskset.
+	parentOverrides := &Overrides{
+		Entries: map[string]*Overrides{
+			"deploy": {
+				Timeout: 5 * time.Minute,
+			},
+		},
+	}
+	results, err := r.Resolve(context.Background(), "buildin", &Ref{Path: tsPath}, nil, parentOverrides, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	if results[0].Spec.Timeout != 5*time.Minute {
+		t.Errorf("timeout = %v, want 5m (root spec.entries override should cascade)", results[0].Spec.Timeout)
+	}
+}
+
+// TestResolver_RootSpecEntryDisablesInnerTask verifies that
+// spec.entries.<name>.overrides.entries.<inner>.enabled=false applied at the
+// dicode.yaml level (via parentOverrides) marks the inner task Enabled=false.
+func TestResolver_RootSpecEntryDisablesInnerTask(t *testing.T) {
+	repoDir := t.TempDir()
+	taskDir := writeTaskDir(t, repoDir, "relay-client")
+
+	tsContent := `
+apiVersion: dicode/v1
+kind: TaskSet
+metadata:
+  name: buildin
+spec:
+  entries:
+    relay-client:
+      ref:
+        path: ` + filepath.Join(taskDir, "task.yaml") + `
+`
+	tsPath := writeTaskSetFile(t, repoDir, "taskset.yaml", tsContent)
+
+	r := newResolver(t)
+	// Operator disables relay-client at the dicode.yaml level:
+	//   spec.entries.buildin.overrides.entries.relay-client.enabled: false
+	parentOverrides := &Overrides{
+		Entries: map[string]*Overrides{
+			"relay-client": {Enabled: boolPtr(false)},
+		},
+	}
+	results, err := r.Resolve(context.Background(), "buildin", &Ref{Path: tsPath}, nil, parentOverrides, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result (Enabled=false), got %d", len(results))
+	}
+	if results[0].Spec.Enabled {
+		t.Errorf("relay-client should be Enabled=false via root spec.entries override")
+	}
+}
+
+// TestResolver_EnabledDefaultsTrue confirms that tasks without any enabled
+// override have Spec.Enabled == true after resolution.
+func TestResolver_EnabledDefaultsTrue(t *testing.T) {
+	repoDir := t.TempDir()
+	taskDir := writeTaskDir(t, repoDir, "hello")
+
+	tsContent := `
+apiVersion: dicode/v1
+kind: TaskSet
+metadata:
+  name: examples
+spec:
+  entries:
+    hello:
+      ref:
+        path: ` + filepath.Join(taskDir, "task.yaml") + `
+`
+	tsPath := writeTaskSetFile(t, repoDir, "taskset.yaml", tsContent)
+	r := newResolver(t)
+	results, err := r.Resolve(context.Background(), "examples", &Ref{Path: tsPath}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	if !results[0].Spec.Enabled {
+		t.Errorf("task without enabled override should default to Enabled=true")
 	}
 }

--- a/pkg/taskset/spec.go
+++ b/pkg/taskset/spec.go
@@ -21,6 +21,9 @@ type Ref struct {
 	Auth         RefAuth       `yaml:"auth,omitempty"`
 	// DevRef is substituted in place of this ref when dev mode is active.
 	DevRef *Ref `yaml:"dev_ref,omitempty"`
+	// Watch enables fsnotify on local refs. Nil means "unset — apply default true".
+	// Explicit `watch: false` opts out of live reload for this entry.
+	Watch *bool `yaml:"watch,omitempty"`
 }
 
 // RefAuth holds optional credentials for a git ref.
@@ -167,6 +170,9 @@ type Entry struct {
 	// Conflicts with `overrides.enabled` if both are set — the loader rejects
 	// that ambiguity rather than picking a winner. Default (omitted) is true.
 	Enabled *bool `yaml:"enabled,omitempty"`
+	// Tags are UI grouping labels for this entry. Used by the API and web UI to
+	// filter or group tasks by source membership.
+	Tags []string `yaml:"tags,omitempty"`
 }
 
 // TaskSetSpec is parsed from a yaml file with kind: TaskSet.

--- a/pkg/taskset/spec.go
+++ b/pkg/taskset/spec.go
@@ -162,6 +162,11 @@ type Entry struct {
 	Ref       *Ref       `yaml:"ref,omitempty"`
 	Inline    *task.Spec `yaml:"inline,omitempty"`
 	Overrides *Overrides `yaml:"overrides,omitempty"`
+	// Enabled is a top-level shortcut for `overrides.enabled`. Useful for
+	// one-liner toggling (`enabled: false`) without nesting under overrides.
+	// Conflicts with `overrides.enabled` if both are set — the loader rejects
+	// that ambiguity rather than picking a winner. Default (omitted) is true.
+	Enabled *bool `yaml:"enabled,omitempty"`
 }
 
 // TaskSetSpec is parsed from a yaml file with kind: TaskSet.

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -323,6 +323,16 @@ func (e *Engine) Start(ctx context.Context) error {
 func (e *Engine) Register(spec *task.Spec) {
 	e.Unregister(spec.ID)
 
+	// Disabled tasks are kept in the registry for API visibility but must not
+	// be scheduled, spawned as daemons, or registered as webhook endpoints.
+	if !spec.Enabled {
+		e.log.Info("task registered (disabled — no triggers scheduled)",
+			zap.String("task", spec.ID),
+			zap.String("runtime", string(spec.Runtime)),
+		)
+		return
+	}
+
 	if spec.Trigger.Cron != "" {
 		e.registerCron(spec)
 	}

--- a/pkg/trigger/engine_test.go
+++ b/pkg/trigger/engine_test.go
@@ -58,6 +58,7 @@ func writeTask(t *testing.T, dir, id, script string, trigger task.TriggerConfig)
 		Trigger: trigger,
 		Timeout: 30 * time.Second,
 		TaskDir: td,
+		Enabled: true,
 	}
 	return spec
 }
@@ -321,6 +322,7 @@ func writeUITask(t *testing.T, dir, id string, trigger task.TriggerConfig, extra
 		Runtime: task.RuntimeDeno,
 		Trigger: trigger,
 		TaskDir: td,
+		Enabled: true,
 	}
 }
 
@@ -1307,4 +1309,75 @@ func (f *fakeExecutor) Execute(_ context.Context, _ *task.Spec, opts pkgruntime.
 		f.fn()
 	}
 	return &pkgruntime.RunResult{}, nil
+}
+
+// ── Item 7: disabled-task semantics ──────────────────────────────────────────
+
+// TestEngine_DisabledTask_NoCronScheduled verifies that a task with Enabled=false
+// does NOT get a cron entry registered when passed to engine.Register.
+func TestEngine_DisabledTask_NoCronScheduled(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	spec := writeTask(t, dir, "disabled-cron", `return 1`, task.TriggerConfig{Cron: "* * * * *"})
+	spec.Enabled = false
+	_ = e.reg.Register(spec)
+	e.engine.Register(spec)
+
+	e.engine.mu.Lock()
+	_, hasCron := e.engine.cronEntries[spec.ID]
+	e.engine.mu.Unlock()
+
+	if hasCron {
+		t.Errorf("disabled task should NOT have a cron entry scheduled")
+	}
+}
+
+// TestEngine_DisabledTask_NoWebhookRegistered verifies that a task with Enabled=false
+// does NOT get a webhook route registered.
+func TestEngine_DisabledTask_NoWebhookRegistered(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	spec := writeTask(t, dir, "disabled-webhook", `return 1`, task.TriggerConfig{Webhook: "/hooks/disabled-hook"})
+	spec.Enabled = false
+	_ = e.reg.Register(spec)
+	e.engine.Register(spec)
+
+	e.engine.mu.Lock()
+	_, hasWebhook := e.engine.webhooks["/hooks/disabled-hook"]
+	e.engine.mu.Unlock()
+
+	if hasWebhook {
+		t.Errorf("disabled task should NOT have a webhook route registered")
+	}
+
+	// Also confirm the webhook returns 404.
+	handler := e.engine.WebhookHandler()
+	req := httptest.NewRequest(http.MethodPost, "/hooks/disabled-hook", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("disabled webhook should return 404, got %d", w.Code)
+	}
+}
+
+// TestEngine_DisabledTask_NoDaemonSpawned verifies that a task with Enabled=false
+// does NOT get registered as a daemon (no daemonSpecs entry).
+func TestEngine_DisabledTask_NoDaemonSpawned(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	spec := writeTask(t, dir, "disabled-daemon", `export default async function main() { while(true) { await new Promise(r=>setTimeout(r,1000)) } }`, task.TriggerConfig{Daemon: true})
+	spec.Enabled = false
+	_ = e.reg.Register(spec)
+	e.engine.Register(spec)
+
+	e.engine.daemonMu.Lock()
+	_, hasDaemon := e.engine.daemonSpecs[spec.ID]
+	e.engine.daemonMu.Unlock()
+
+	if hasDaemon {
+		t.Errorf("disabled task should NOT be registered as a daemon")
+	}
 }

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -531,7 +532,7 @@ func (s *Server) Handler() http.Handler {
 			r.Post("/settings/server", s.apiSaveServerSettings)
 			r.Post("/settings/ai", s.apiSaveAISettings)
 			r.Post("/settings/sources", s.apiAddSource)
-			r.Delete("/settings/sources/{idx}", s.apiRemoveSource)
+			r.Delete("/settings/sources/{name}", s.apiRemoveSource)
 			r.Get("/settings/sources/git/branches", s.apiListGitBranches)
 
 			// Relay status (#87) — returns {"enabled":false} when disabled.
@@ -1903,8 +1904,7 @@ func (s *Server) apiListGitBranches(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) apiRemoveSource(w http.ResponseWriter, r *http.Request) {
-	// The route parameter is now the source name (was previously a numeric index).
-	name := chi.URLParam(r, "idx") // reuse the :idx slot — value is now a name
+	name := chi.URLParam(r, "name")
 	if name == "" {
 		jsonErr(w, "source name is required", http.StatusBadRequest)
 		return
@@ -2101,32 +2101,35 @@ func (s *Server) persistConfig() error {
 	}
 
 	// Persist spec.entries as the new `spec:` block in the YAML document.
+	// Entries are marshalled via yaml.Marshal so that all fields (ref, overrides,
+	// tags, inline) round-trip without the serialiser needing to know about every
+	// field individually. Keys are sorted for deterministic output — non-sorted
+	// map iteration produces noisy git diffs on every save.
 	if len(s.cfg.Spec.Entries) > 0 {
+		entryKeys := make([]string, 0, len(s.cfg.Spec.Entries))
+		for k := range s.cfg.Spec.Entries {
+			entryKeys = append(entryKeys, k)
+		}
+		sort.Strings(entryKeys)
+
 		specEntries := make(map[string]any, len(s.cfg.Spec.Entries))
-		for name, entry := range s.cfg.Spec.Entries {
-			if entry == nil || entry.Ref == nil {
+		for _, name := range entryKeys {
+			entry := s.cfg.Spec.Entries[name]
+			if entry == nil {
 				continue
 			}
-			ref := entry.Ref
-			refMap := map[string]any{}
-			if ref.URL != "" {
-				refMap["url"] = ref.URL
+			// Round-trip via yaml.Marshal → yaml.Unmarshal into map[string]any so
+			// that all Entry fields (ref, overrides, tags, inline) are preserved
+			// without enumerating them here.
+			entryYAML, err := yaml.Marshal(entry)
+			if err != nil {
+				return fmt.Errorf("marshal entry %q: %w", name, err)
 			}
-			if ref.Path != "" {
-				refMap["path"] = ref.Path
+			var entryMap map[string]any
+			if err := yaml.Unmarshal(entryYAML, &entryMap); err != nil {
+				return fmt.Errorf("unmarshal entry %q: %w", name, err)
 			}
-			if ref.Branch != "" {
-				refMap["branch"] = ref.Branch
-			}
-			if ref.PollInterval > 0 {
-				refMap["poll_interval"] = ref.PollInterval.String()
-			}
-			if ref.Auth.TokenEnv != "" {
-				refMap["auth"] = map[string]any{"token_env": ref.Auth.TokenEnv}
-			} else if ref.Auth.SSHKey != "" {
-				refMap["auth"] = map[string]any{"ssh_key": ref.Auth.SSHKey}
-			}
-			specEntries[name] = map[string]any{"ref": refMap}
+			specEntries[name] = entryMap
 		}
 		specBlock, _ := doc["spec"].(map[string]any)
 		if specBlock == nil {

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -27,8 +27,8 @@ import (
 	denoruntime "github.com/dicode/dicode/pkg/runtime/deno"
 	"github.com/dicode/dicode/pkg/secrets"
 	gitSource "github.com/dicode/dicode/pkg/source/git"
-	"github.com/dicode/dicode/pkg/source/local"
 	"github.com/dicode/dicode/pkg/task"
+	"github.com/dicode/dicode/pkg/taskset"
 	"github.com/dicode/dicode/pkg/tasktest"
 	"github.com/dicode/dicode/pkg/trigger"
 	"github.com/go-chi/chi/v5"
@@ -1822,7 +1822,7 @@ func (s *Server) apiSaveServerSettings(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) apiAddSource(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		Type     string `json:"type"`
+		Name     string `json:"name"`
 		Path     string `json:"path"`
 		URL      string `json:"url"`
 		Branch   string `json:"branch"`
@@ -1832,69 +1832,58 @@ func (s *Server) apiAddSource(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, "bad request", http.StatusBadRequest)
 		return
 	}
-	var sc config.SourceConfig
-	switch config.SourceType(body.Type) {
-	case config.SourceTypeLocal:
-		path := strings.TrimSpace(body.Path)
-		if path == "" {
-			jsonErr(w, "path is required for local source", http.StatusBadRequest)
-			return
-		}
-		watchTrue := true
-		sc = config.SourceConfig{Type: config.SourceTypeLocal, Path: path, Watch: &watchTrue}
-	case config.SourceTypeGit:
-		url := strings.TrimSpace(body.URL)
-		if url == "" {
-			jsonErr(w, "url is required for git source", http.StatusBadRequest)
-			return
-		}
+
+	name := strings.TrimSpace(body.Name)
+	if name == "" {
+		jsonErr(w, "name is required", http.StatusBadRequest)
+		return
+	}
+
+	var ref taskset.Ref
+	if url := strings.TrimSpace(body.URL); url != "" {
 		branch := body.Branch
 		if branch == "" {
 			branch = "main"
 		}
-		sc = config.SourceConfig{
-			Type:         config.SourceTypeGit,
+		ref = taskset.Ref{
 			URL:          url,
 			Branch:       branch,
 			PollInterval: 30 * 1e9,
-			Auth:         config.SourceAuth{TokenEnv: body.TokenEnv},
+			Auth:         taskset.RefAuth{TokenEnv: body.TokenEnv},
 		}
-	default:
-		jsonErr(w, "type must be 'local' or 'git'", http.StatusBadRequest)
+	} else if path := strings.TrimSpace(body.Path); path != "" {
+		watchTrue := true
+		ref = taskset.Ref{Path: path, Watch: &watchTrue}
+	} else {
+		jsonErr(w, "either url or path is required", http.StatusBadRequest)
 		return
 	}
 
+	entry := &taskset.Entry{Ref: &ref}
+
+	id := ref.URL
+	if id == "" {
+		id = ref.Path
+	}
+	ts := taskset.NewSource(id, name, &ref, "", s.dataDir, false, ref.PollInterval, s.log)
 	if s.reconciler != nil {
-		switch sc.Type {
-		case config.SourceTypeLocal:
-			watchEnabled := sc.Watch == nil || *sc.Watch
-			ls, err := local.New(sc.Path, sc.Path, watchEnabled, s.log)
-			if err != nil {
-				jsonErr(w, "create local source: "+err.Error(), http.StatusInternalServerError)
-				return
-			}
-			if err := s.reconciler.AddSource(ls); err != nil {
-				jsonErr(w, "start source: "+err.Error(), http.StatusInternalServerError)
-				return
-			}
-		case config.SourceTypeGit:
-			gs, err := gitSource.New(s.dataDir, sc.URL, sc.Branch, sc.PollInterval, sc.Auth.TokenEnv, sc.Auth.SSHKey, s.log)
-			if err != nil {
-				jsonErr(w, "create git source: "+err.Error(), http.StatusInternalServerError)
-				return
-			}
-			if err := s.reconciler.AddSource(gs); err != nil {
-				jsonErr(w, "start source: "+err.Error(), http.StatusInternalServerError)
-				return
-			}
+		if err := s.reconciler.AddSource(ts); err != nil {
+			jsonErr(w, "start source: "+err.Error(), http.StatusInternalServerError)
+			return
 		}
 	}
+	if s.sourceMgr != nil {
+		s.sourceMgr.Register(name, ts)
+	}
 
-	s.cfg.Sources = append(s.cfg.Sources, sc)
+	if s.cfg.Spec.Entries == nil {
+		s.cfg.Spec.Entries = make(map[string]*taskset.Entry)
+	}
+	s.cfg.Spec.Entries[name] = entry
 	if err := s.persistConfig(); err != nil {
 		s.log.Warn("source persist failed", zap.Error(err))
 	}
-	s.log.Info("source added", zap.String("type", body.Type))
+	s.log.Info("source added", zap.String("name", name))
 	jsonOK(w, map[string]string{"status": "ok"})
 }
 
@@ -1914,26 +1903,29 @@ func (s *Server) apiListGitBranches(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) apiRemoveSource(w http.ResponseWriter, r *http.Request) {
-	idxStr := chi.URLParam(r, "idx")
-	idx := 0
-	if _, err := fmt.Sscanf(idxStr, "%d", &idx); err != nil || idx < 0 || idx >= len(s.cfg.Sources) {
-		jsonErr(w, "invalid index", http.StatusBadRequest)
+	// The route parameter is now the source name (was previously a numeric index).
+	name := chi.URLParam(r, "idx") // reuse the :idx slot — value is now a name
+	if name == "" {
+		jsonErr(w, "source name is required", http.StatusBadRequest)
 		return
 	}
-	sc := s.cfg.Sources[idx]
-	if s.reconciler != nil {
-		switch sc.Type {
-		case config.SourceTypeLocal:
-			s.reconciler.RemoveSource(sc.Path)
-		case config.SourceTypeGit:
-			s.reconciler.RemoveSource(sc.URL)
-		}
+	entry := s.cfg.Spec.Entries[name]
+	if entry == nil {
+		jsonErr(w, "source not found", http.StatusNotFound)
+		return
 	}
-	s.cfg.Sources = append(s.cfg.Sources[:idx], s.cfg.Sources[idx+1:]...)
+	if s.reconciler != nil && entry.Ref != nil {
+		id := entry.Ref.URL
+		if id == "" {
+			id = entry.Ref.Path
+		}
+		s.reconciler.RemoveSource(id)
+	}
+	delete(s.cfg.Spec.Entries, name)
 	if err := s.persistConfig(); err != nil {
 		s.log.Warn("source persist failed", zap.Error(err))
 	}
-	s.log.Info("source removed", zap.Int("idx", idx))
+	s.log.Info("source removed", zap.String("name", name))
 	jsonOK(w, map[string]string{"status": "ok"})
 }
 
@@ -2108,32 +2100,47 @@ func (s *Server) persistConfig() error {
 		delete(doc, "runtimes")
 	}
 
-	if len(s.cfg.Sources) > 0 {
-		var srcs []map[string]any
-		for _, sc := range s.cfg.Sources {
-			m := map[string]any{"type": string(sc.Type)}
-			switch sc.Type {
-			case config.SourceTypeLocal:
-				m["path"] = sc.Path
-			case config.SourceTypeGit:
-				m["url"] = sc.URL
-				if sc.Branch != "" {
-					m["branch"] = sc.Branch
-				}
-				if sc.PollInterval > 0 {
-					m["poll_interval"] = sc.PollInterval.String()
-				}
-				if sc.Auth.TokenEnv != "" {
-					m["auth"] = map[string]any{"type": "token", "token_env": sc.Auth.TokenEnv}
-				} else if sc.Auth.SSHKey != "" {
-					m["auth"] = map[string]any{"type": "ssh", "ssh_key": sc.Auth.SSHKey}
-				}
+	// Persist spec.entries as the new `spec:` block in the YAML document.
+	if len(s.cfg.Spec.Entries) > 0 {
+		specEntries := make(map[string]any, len(s.cfg.Spec.Entries))
+		for name, entry := range s.cfg.Spec.Entries {
+			if entry == nil || entry.Ref == nil {
+				continue
 			}
-			srcs = append(srcs, m)
+			ref := entry.Ref
+			refMap := map[string]any{}
+			if ref.URL != "" {
+				refMap["url"] = ref.URL
+			}
+			if ref.Path != "" {
+				refMap["path"] = ref.Path
+			}
+			if ref.Branch != "" {
+				refMap["branch"] = ref.Branch
+			}
+			if ref.PollInterval > 0 {
+				refMap["poll_interval"] = ref.PollInterval.String()
+			}
+			if ref.Auth.TokenEnv != "" {
+				refMap["auth"] = map[string]any{"token_env": ref.Auth.TokenEnv}
+			} else if ref.Auth.SSHKey != "" {
+				refMap["auth"] = map[string]any{"ssh_key": ref.Auth.SSHKey}
+			}
+			specEntries[name] = map[string]any{"ref": refMap}
 		}
-		doc["sources"] = srcs
+		specBlock, _ := doc["spec"].(map[string]any)
+		if specBlock == nil {
+			specBlock = map[string]any{}
+		}
+		specBlock["entries"] = specEntries
+		doc["spec"] = specBlock
 	} else {
-		doc["sources"] = []any{}
+		if specBlock, ok := doc["spec"].(map[string]any); ok {
+			delete(specBlock, "entries")
+			if len(specBlock) == 0 {
+				delete(doc, "spec")
+			}
+		}
 	}
 
 	out, err := yaml.Marshal(doc)

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -21,6 +21,7 @@ import (
 	denoruntime "github.com/dicode/dicode/pkg/runtime/deno"
 	"github.com/dicode/dicode/pkg/secrets"
 	"github.com/dicode/dicode/pkg/task"
+	"github.com/dicode/dicode/pkg/taskset"
 	"github.com/dicode/dicode/pkg/trigger"
 	"go.uber.org/zap"
 )
@@ -1081,5 +1082,78 @@ func TestAPI_GetTask_DisabledTaskVisible(t *testing.T) {
 		t.Error("'enabled' field missing from /api/tasks/{id} response")
 	} else if enabledBool, _ := enabled.(bool); enabledBool {
 		t.Errorf("expected enabled=false for disabled task, got enabled=true")
+	}
+}
+
+// TestPersistConfig_OverridesAndTagsSurviveRoundTrip is a regression guard for
+// Fix 2 of PR #262: persistConfig previously serialised only the `ref` block,
+// silently dropping `overrides` and `tags` on every web-UI save.
+func TestPersistConfig_OverridesAndTagsSurviveRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+
+	// Write a minimal dicode.yaml to disk so persistConfig has a file to round-trip.
+	initial := "log_level: info\nspec:\n  entries: {}\n"
+	if err := os.WriteFile(cfgPath, []byte(initial), 0600); err != nil {
+		t.Fatalf("write initial cfg: %v", err)
+	}
+
+	enabled := false
+	cfg := &config.Config{
+		LogLevel: "info",
+	}
+	cfg.Spec.Entries = map[string]*taskset.Entry{
+		"myrepo": {
+			Ref: &taskset.Ref{Path: "/tmp/myrepo"},
+			Overrides: &taskset.Overrides{
+				Enabled: &enabled,
+				Name:    "My Repo Override",
+			},
+			Tags: []string{"team-a", "backend"},
+		},
+	}
+
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	defer d.Close()
+
+	rt, err := denoruntime.New(registry.New(d), secrets.Chain{}, d, zap.NewNop())
+	if err != nil {
+		t.Skipf("deno not available: %v", err)
+	}
+	reg := registry.New(d)
+	eng := trigger.New(reg, rt, zap.NewNop())
+
+	srv, err := New(8080, reg, eng, cfg, cfgPath, nil, nil, nil, dir, NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if err := srv.persistConfig(); err != nil {
+		t.Fatalf("persistConfig: %v", err)
+	}
+
+	// Re-load the written YAML and verify overrides + tags are present.
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	content := string(raw)
+	if !strings.Contains(content, "overrides:") {
+		t.Errorf("persisted YAML missing 'overrides:' block; got:\n%s", content)
+	}
+	if !strings.Contains(content, "My Repo Override") {
+		t.Errorf("persisted YAML missing override name value; got:\n%s", content)
+	}
+	if !strings.Contains(content, "tags:") {
+		t.Errorf("persisted YAML missing 'tags:' block; got:\n%s", content)
+	}
+	if !strings.Contains(content, "team-a") {
+		t.Errorf("persisted YAML missing tag 'team-a'; got:\n%s", content)
+	}
+	if !strings.Contains(content, "backend") {
+		t.Errorf("persisted YAML missing tag 'backend'; got:\n%s", content)
 	}
 }

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -61,6 +61,7 @@ func registerTask(t *testing.T, reg *registry.Registry, id, script string) *task
 		Trigger: task.TriggerConfig{Manual: true},
 		Timeout: 5 * time.Second,
 		TaskDir: td,
+		Enabled: true,
 	}
 	_ = reg.Register(spec)
 	return spec
@@ -1005,4 +1006,80 @@ func containsStr(s, sub string) bool {
 		}
 	}
 	return false
+}
+
+// ── Item 8: API visibility of disabled tasks ──────────────────────────────────
+
+// TestAPI_ListTasks_DisabledTaskVisible verifies that a task with Enabled=false
+// appears in the GET /api/tasks response with "enabled":false. Disabled tasks
+// must remain visible in the API so operators can see what they've turned off.
+func TestAPI_ListTasks_DisabledTaskVisible(t *testing.T) {
+	srv, reg := newTestServer(t)
+
+	// Register one enabled and one disabled task.
+	_ = registerTask(t, reg, "enabled-task", `return 1`)
+	disabledSpec := registerTask(t, reg, "disabled-task", `return 1`)
+	disabledSpec.Enabled = false
+	// Re-register with Enabled=false so the registry holds the updated spec.
+	_ = reg.Register(disabledSpec)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var tasks []map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&tasks); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Errorf("expected 2 tasks (enabled + disabled), got %d", len(tasks))
+	}
+
+	// Find the disabled task and assert enabled=false in the JSON.
+	var foundDisabled bool
+	for _, task := range tasks {
+		if task["id"] == "disabled-task" {
+			foundDisabled = true
+			enabled, ok := task["enabled"]
+			if !ok {
+				t.Error("disabled task: 'enabled' field missing from JSON")
+			} else if enabledBool, _ := enabled.(bool); enabledBool {
+				t.Errorf("disabled task: expected enabled=false, got enabled=true")
+			}
+		}
+	}
+	if !foundDisabled {
+		t.Error("disabled-task not found in /api/tasks response")
+	}
+}
+
+// TestAPI_GetTask_DisabledTaskVisible verifies that GET /api/tasks/{id} returns
+// a disabled task with "enabled":false in the response.
+func TestAPI_GetTask_DisabledTaskVisible(t *testing.T) {
+	srv, reg := newTestServer(t)
+
+	spec := registerTask(t, reg, "off-task", `return 1`)
+	spec.Enabled = false
+	_ = reg.Register(spec)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks/off-task", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+	var detail map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	enabled, ok := detail["enabled"]
+	if !ok {
+		t.Error("'enabled' field missing from /api/tasks/{id} response")
+	} else if enabledBool, _ := enabled.(bool); enabledBool {
+		t.Errorf("expected enabled=false for disabled task, got enabled=true")
+	}
 }

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -1156,4 +1156,39 @@ func TestPersistConfig_OverridesAndTagsSurviveRoundTrip(t *testing.T) {
 	if !strings.Contains(content, "backend") {
 		t.Errorf("persisted YAML missing tag 'backend'; got:\n%s", content)
 	}
+
+	// Full re-parse: load the persisted file via config.Load() and assert that
+	// the parsed struct carries the original overrides and tags — not just raw
+	// bytes. This exercises the persist → YAML → parse round-trip end to end.
+	reloaded, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("config.Load after persist: %v", err)
+	}
+	reloadedEntry := reloaded.Spec.Entries["myrepo"]
+	if reloadedEntry == nil {
+		t.Fatal("reloaded config: spec.entries[myrepo] missing")
+	}
+	if reloadedEntry.Overrides == nil {
+		t.Fatal("reloaded config: spec.entries[myrepo].overrides is nil")
+	}
+	if reloadedEntry.Overrides.Enabled == nil || *reloadedEntry.Overrides.Enabled != false {
+		t.Errorf("reloaded config: overrides.enabled: got %v, want false", reloadedEntry.Overrides.Enabled)
+	}
+	if reloadedEntry.Overrides.Name != "My Repo Override" {
+		t.Errorf("reloaded config: overrides.name: got %q, want %q", reloadedEntry.Overrides.Name, "My Repo Override")
+	}
+	wantTags := []string{"team-a", "backend"}
+	if len(reloadedEntry.Tags) != len(wantTags) {
+		t.Errorf("reloaded config: tags: got %v, want %v", reloadedEntry.Tags, wantTags)
+	} else {
+		tagSet := make(map[string]bool, len(reloadedEntry.Tags))
+		for _, tag := range reloadedEntry.Tags {
+			tagSet[tag] = true
+		}
+		for _, want := range wantTags {
+			if !tagSet[want] {
+				t.Errorf("reloaded config: tags: missing %q in %v", want, reloadedEntry.Tags)
+			}
+		}
+	}
 }

--- a/pkg/webui/sources.go
+++ b/pkg/webui/sources.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -72,14 +70,18 @@ func (m *SourceManager) List() []SourceInfo {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	out := make([]SourceInfo, 0, len(m.cfg.Sources))
-	for _, sc := range m.cfg.Sources {
-		name := sourceName(sc)
+	entries := m.cfg.Spec.Entries
+	out := make([]SourceInfo, 0, len(entries))
+	for name, entry := range entries {
+		if entry == nil || entry.Ref == nil {
+			continue
+		}
+		ref := entry.Ref
 		info := SourceInfo{
 			Name:   name,
-			URL:    sc.URL,
-			Path:   sc.Path,
-			Branch: sc.Branch,
+			URL:    ref.URL,
+			Path:   ref.Path,
+			Branch: ref.Branch,
 		}
 		if src, ok := m.tasksets[name]; ok {
 			info.Type = "taskset"
@@ -95,7 +97,7 @@ func (m *SourceManager) List() []SourceInfo {
 				info.LastPullOK = ps.OK
 				info.LastPullError = ps.Error
 			}
-		} else if sc.URL != "" {
+		} else if ref.IsGit() {
 			info.Type = "git"
 		} else {
 			info.Type = "local"
@@ -140,29 +142,11 @@ func (m *SourceManager) ResolveRepoPath(name string) (string, error) {
 
 // ListBranches returns remote branches for the named git source.
 func (m *SourceManager) ListBranches(ctx context.Context, name string) ([]string, error) {
-	for _, sc := range m.cfg.Sources {
-		if sourceName(sc) == name && sc.URL != "" {
-			return gitSource.ListBranches(ctx, sc.URL, sc.Auth.TokenEnv)
-		}
+	entry := m.cfg.Spec.Entries[name]
+	if entry == nil || entry.Ref == nil || !entry.Ref.IsGit() {
+		return nil, fmt.Errorf("source %q not found or not a git source", name)
 	}
-	return nil, fmt.Errorf("source %q not found or not a git source", name)
-}
-
-// sourceName derives the canonical name for a SourceConfig (same logic as buildTaskSetSource).
-func sourceName(sc config.SourceConfig) string {
-	if sc.Name != "" {
-		return sc.Name
-	}
-	base := sc.URL
-	if base == "" {
-		base = sc.Path
-	}
-	base = strings.TrimRight(base, "/")
-	name := filepath.Base(base)
-	if ext := filepath.Ext(name); ext == ".yaml" || ext == ".yml" {
-		name = strings.TrimSuffix(name, ext)
-	}
-	return name
+	return gitSource.ListBranches(ctx, entry.Ref.URL, entry.Ref.Auth.TokenEnv)
 }
 
 // --- HTTP handlers ---

--- a/pkg/webui/sources_test.go
+++ b/pkg/webui/sources_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/dicode/dicode/pkg/config"
+	"github.com/dicode/dicode/pkg/taskset"
 	"go.uber.org/zap"
 )
 
@@ -20,10 +21,10 @@ import (
 // `omitempty` emits `"0001-01-01T00:00:00Z"`, which is truthy in JS.
 // Using a *time.Time pointer fixes it.
 func TestSourceManager_List_LocalSource_NoPullFieldsInJSON(t *testing.T) {
-	cfg := &config.Config{
-		Sources: []config.SourceConfig{
-			{Type: config.SourceTypeLocal, Path: "/tmp/tasks"},
-		},
+	watchTrue := true
+	cfg := &config.Config{}
+	cfg.Spec.Entries = map[string]*taskset.Entry{
+		"tasks": {Ref: &taskset.Ref{Path: "/tmp/tasks", Watch: &watchTrue}},
 	}
 	m := NewSourceManager(cfg, nil, t.TempDir(), zap.NewNop())
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
   reporter: [['html', { open: 'never' }], ['list']],
   use: {
     baseURL: BASE_URL,
+    headless: true,
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
   },

--- a/tasks/buildin/webui/app/components/dc-config.js
+++ b/tasks/buildin/webui/app/components/dc-config.js
@@ -86,9 +86,9 @@ class DcConfig extends LitElement {
     } catch(e) { this._srvStatus = 'Error: ' + e.message; }
   }
 
-  async _removeSource(idx) {
+  async _removeSource(name) {
     if (!confirm('Remove this source?')) return;
-    try { await del(`/api/settings/sources/${idx}`); this._load(); }
+    try { await del(`/api/settings/sources/${name}`); this._load(); }
     catch(e) { this._srcStatus = 'Error: ' + e.message; }
   }
 
@@ -207,7 +207,7 @@ class DcConfig extends LitElement {
                 <td><span class="badge badge-manual">${s.Type || s.type || ''}</span></td>
                 <td style="word-break:break-all">${s.Path || s.path || s.URL || s.url || ''}</td>
                 <td class="meta">${(s.Type || s.type) === 'git' ? `branch: ${s.Branch || s.branch || ''}` : `watch: ${s.Watch || s.watch || false}`}</td>
-                <td><button class="btn btn-sm" style="background:var(--red)" @click=${() => this._removeSource(i)}>Remove</button></td>
+                <td><button class="btn btn-sm" style="background:var(--red)" @click=${() => this._removeSource(s.name)}>Remove</button></td>
               </tr>`)}
           </tbody>
         </table>

--- a/tests/e2e/config.spec.ts
+++ b/tests/e2e/config.spec.ts
@@ -32,15 +32,29 @@ test.describe('Config API', () => {
     expect(server).not.toHaveProperty('secret');
   });
 
-  test('GET /api/config returns sources array including e2e-tests', async ({ request }) => {
+  test('GET /api/config exposes spec.entries including e2e-tests', async ({ request }) => {
     const res = await request.get('/api/config');
     expect(res.ok()).toBe(true);
     const cfg = await res.json() as Record<string, unknown>;
-    const sources = (cfg.Sources || cfg.sources) as Array<Record<string, unknown>>;
-    expect(Array.isArray(sources)).toBe(true);
-    const e2e = sources.find((s) => (s.Name || s.name) === 'e2e-tests');
+    const spec = (cfg.Spec || cfg.spec) as Record<string, unknown>;
+    expect(spec).toBeTruthy();
+    const entries = (spec.Entries || spec.entries) as Record<string, Record<string, unknown>>;
+    expect(entries).toBeTruthy();
+    const e2e = entries['e2e-tests'];
     expect(e2e).toBeTruthy();
-    expect(e2e!.Type || e2e!.type).toBe('local');
+    const ref = (e2e.Ref || e2e.ref) as Record<string, unknown>;
+    expect(ref).toBeTruthy();
+    expect(typeof (ref.Path || ref.path)).toBe('string');
+  });
+
+  test('GET /api/sources lists e2e-tests as a taskset source', async ({ request }) => {
+    const res = await request.get('/api/sources');
+    expect(res.ok()).toBe(true);
+    const sources = await res.json() as Array<Record<string, unknown>>;
+    expect(Array.isArray(sources)).toBe(true);
+    const e2e = sources.find((s) => (s.name || s.Name) === 'e2e-tests');
+    expect(e2e).toBeTruthy();
+    expect(e2e!.type || e2e!.Type).toBe('taskset');
   });
 
   test('GET /api/config/raw returns YAML content', async ({ request }) => {

--- a/tests/e2e/fixtures/dicode-auth.yaml
+++ b/tests/e2e/fixtures/dicode-auth.yaml
@@ -14,8 +14,9 @@ server:
   auth: true
   secret: test-passphrase-12345
   mcp: false
-sources:
-  - name: e2e-tests
-    type: local
-    path: TEMP_TASKSET_PATH
-    watch: true
+spec:
+  entries:
+    e2e-tests:
+      ref:
+        path: TEMP_TASKSET_PATH
+        watch: true

--- a/tests/e2e/fixtures/dicode-unauth.yaml
+++ b/tests/e2e/fixtures/dicode-unauth.yaml
@@ -15,8 +15,9 @@ server:
   port: 8765
   auth: false
   mcp: true
-sources:
-  - name: e2e-tests
-    type: local
-    path: TEMP_TASKSET_PATH
-    watch: true
+spec:
+  entries:
+    e2e-tests:
+      ref:
+        path: TEMP_TASKSET_PATH
+        watch: true


### PR DESCRIPTION
## Summary

- **Breaking schema change**: `sources:` array removed from `dicode.yaml`. It is now treated as a root `TaskSet` — sources are declared under `spec.entries` where each key is the namespace and `ref` is the source descriptor (local path or git URL). Daemon refuses to start with the old format and prints an actionable error pointing at docs + issue #261.
- **Disabled-task visibility**: `task.Spec.Enabled bool` added (not YAML-parsed, serialised to JSON). Resolver sets `Enabled=false` instead of skipping disabled entries, so the API and registry still expose them. Trigger engine skips scheduling/spawning/routing for disabled tasks.
- **New fields**: `taskset.Ref.Watch *bool` (opt-out of fsnotify per-entry) and `taskset.Entry.Tags []string` (UI grouping labels).

## What changed

| Area | Change |
|---|---|
| `pkg/config` | `Config.Sources []SourceConfig` → `Config.Spec taskset.TaskSetBody`; `ErrLegacySourcesFormat` sentinel |
| `pkg/taskset/spec.go` | `Ref.Watch *bool`, `Entry.Tags []string` |
| `pkg/task/spec.go` | `Spec.Enabled bool` (`yaml:"-"`, `json:"enabled"`); defaults to `true` in `LoadDirWithVars` |
| `pkg/taskset/resolver.go` | Sets `resolved.Enabled=false` instead of skipping; propagates to TaskSet children |
| `pkg/trigger/engine.go` | Early-return guard: `if !spec.Enabled { log + return }` |
| `pkg/daemon`, `pkg/webui`, `pkg/onboarding` | Iterate `cfg.Spec.Entries` map instead of old slice |
| `tests/e2e/fixtures`, `dicode.yaml` | Migrated to `spec.entries` format |
| `docs/concepts/sources.md` | Full rewrite with migration guide and field reference table |

## Migration (operators)

```yaml
# Before
sources:
  - name: buildin
    type: local
    path: ${CONFIGDIR}/tasks/buildin/taskset.yaml
    watch: true

# After
spec:
  entries:
    buildin:
      ref:
        path: ${CONFIGDIR}/tasks/buildin/taskset.yaml
        watch: true
```

See `docs/concepts/sources.md` for the full field mapping table.

## Test plan

- [x] `go test ./...` — all 20 packages pass
- [x] `make lint` / `make format` — clean
- [x] `TestLoad_RejectsLegacySources` — daemon rejects old format
- [x] `TestResolver_RootSpecEntryOverrideCascades` / `_DisablesInnerTask` / `_EnabledDefaultsTrue`
- [x] `TestEngine_DisabledTask_NoCronScheduled` / `_NoWebhookRegistered` / `_NoDaemonSpawned`
- [x] `TestAPI_ListTasks_DisabledTaskVisible` / `TestAPI_GetTask_DisabledTaskVisible`
- [x] `TestSourceManager_List_LocalSource_NoPullFieldsInJSON`

Closes part of #261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)