### PR TITLE
feat(webui): dc-toast listener wires up the missing toast sink

### DIFF
--- a/tasks/buildin/webui/app/app.js
+++ b/tasks/buildin/webui/app/app.js
@@ -18,6 +18,7 @@ import './components/dc-log-bar.js';
 import './components/dc-notif-panel.js';
 import './components/dc-metrics.js';
 import './components/dc-relay-status.js';
+import './components/dc-toast.js';
 
 // ── Auth overlay ──────────────────────────────────────────────────────────────
 // Inject a single <dc-auth-overlay> into the document body. The API client
@@ -26,6 +27,12 @@ import './components/dc-relay-status.js';
 const authOverlay = document.createElement('dc-auth-overlay');
 document.body.appendChild(authOverlay);
 setAuthOverlay(authOverlay);
+
+// ── Toast container ───────────────────────────────────────────────────────────
+// Single <dc-toast> sink for window-dispatched 'dc-toast' CustomEvents (used
+// by dc-task-list's enable/disable toggle and any future user-actionable
+// notifications).
+document.body.appendChild(document.createElement('dc-toast'));
 
 // ── Router ────────────────────────────────────────────────────────────────────
 const app = document.getElementById('app');

--- a/tasks/buildin/webui/app/components/dc-task-list.js
+++ b/tasks/buildin/webui/app/components/dc-task-list.js
@@ -282,7 +282,7 @@ class DcTaskList extends LitElement {
   }
 
   _toast(msg) {
-    window.dispatchEvent(new CustomEvent('dc-toast', { detail: { message: msg } }));
+    window.dispatchEvent(new CustomEvent('dc-toast', { detail: { message: msg, kind: 'error' } }));
     console.warn('[task-toggle]', msg);
   }
 

--- a/tasks/buildin/webui/app/components/dc-toast.js
+++ b/tasks/buildin/webui/app/components/dc-toast.js
@@ -1,0 +1,108 @@
+import { LitElement, html } from 'https://esm.sh/lit@3';
+
+// dc-toast listens for `dc-toast` window CustomEvents and renders transient
+// notifications stacked at the bottom-right of the viewport. Other components
+// fire toasts by dispatching:
+//
+//   window.dispatchEvent(new CustomEvent('dc-toast', { detail: { message: '...' } }));
+//
+// Optional detail.kind ('error' | 'info', default 'info') tints the bar.
+// Each toast auto-dismisses after 5 seconds and can be dismissed manually.
+
+const TOAST_TTL_MS = 5000;
+const VALID_KINDS = new Set(['info', 'error']);
+
+class DcToast extends LitElement {
+  createRenderRoot() { return this; }
+
+  static properties = {
+    _toasts: { state: true },
+  };
+
+  constructor() {
+    super();
+    this._toasts = [];
+    this._nextID = 0;
+    this._onToast = (e) => this._add(e.detail || {});
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    window.addEventListener('dc-toast', this._onToast);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener('dc-toast', this._onToast);
+  }
+
+  _add({ message, kind }) {
+    if (!message) return;
+    const id = this._nextID++;
+    const safeKind = VALID_KINDS.has(kind) ? kind : 'info';
+    this._toasts = [...this._toasts, { id, message: String(message), kind: safeKind }];
+    setTimeout(() => this._dismiss(id), TOAST_TTL_MS);
+  }
+
+  _dismiss(id) {
+    this._toasts = this._toasts.filter((t) => t.id !== id);
+  }
+
+  render() {
+    return html`
+      <style>
+        dc-toast {
+          position: fixed;
+          right: 1rem;
+          bottom: 1rem;
+          display: flex;
+          flex-direction: column;
+          gap: 0.5rem;
+          z-index: 9999;
+          pointer-events: none;
+        }
+        dc-toast .toast {
+          pointer-events: auto;
+          background: var(--card-bg, #1e1e1e);
+          color: var(--text, #ddd);
+          border: 1px solid var(--border, #333);
+          border-left: 3px solid var(--sky, #4caf50);
+          border-radius: var(--radius-md, 4px);
+          padding: 0.6rem 0.9rem;
+          max-width: 360px;
+          box-shadow: 0 4px 12px rgba(0,0,0,.35);
+          font-size: 0.9rem;
+          display: flex;
+          align-items: flex-start;
+          gap: 0.5rem;
+          animation: dc-toast-in .15s ease-out;
+        }
+        dc-toast .toast.error { border-left-color: #e57373; }
+        dc-toast .toast .msg { flex: 1; word-break: break-word; }
+        dc-toast .toast button {
+          background: none;
+          border: none;
+          color: inherit;
+          cursor: pointer;
+          font-size: 1.1rem;
+          line-height: 1;
+          padding: 0;
+          opacity: 0.6;
+        }
+        dc-toast .toast button:hover { opacity: 1; }
+        @keyframes dc-toast-in {
+          from { transform: translateY(8px); opacity: 0; }
+          to   { transform: translateY(0);   opacity: 1; }
+        }
+      </style>
+      ${this._toasts.map((t) => html`
+        <div class=${`toast ${t.kind}`} role="status">
+          <span class="msg">${t.message}</span>
+          <button type="button" aria-label="Dismiss" @click=${() => this._dismiss(t.id)}>×</button>
+        </div>
+      `)}
+    `;
+  }
+}
+
+customElements.define('dc-toast', DcToast);

--- a/tests/e2e/task-toggle.spec.ts
+++ b/tests/e2e/task-toggle.spec.ts
@@ -80,4 +80,24 @@ test.describe('Task enable/disable toggle', () => {
       headers: { 'Content-Type': 'application/json' },
     });
   });
+
+  test('dc-toast surfaces a visible message when the API rejects a toggle', async ({ page }) => {
+    await gotoWebui(page);
+    // dc-toast is appended to <body> on app boot but renders nothing until a
+    // 'dc-toast' event arrives — the empty element has 0 size, which fails
+    // the default 'visible' state of waitForSelector. Wait for attachment
+    // instead, then dispatch the event and assert the inner toast div renders.
+    await page.waitForSelector('dc-toast', { timeout: 15_000, state: 'attached' });
+
+    await page.evaluate(() => {
+      window.dispatchEvent(new CustomEvent('dc-toast', {
+        detail: { message: 'Toggle failed: simulated', kind: 'error' },
+      }));
+    });
+
+    const toast = page.locator('dc-toast .toast');
+    await expect(toast).toBeVisible({ timeout: 5_000 });
+    await expect(toast).toContainText('Toggle failed: simulated');
+    await expect(toast).toHaveClass(/error/);
+  });
 });


### PR DESCRIPTION
## Summary

Closes the loose end flagged in the PR #265 review: `dc-task-list`'s toggle handler dispatches `dc-toast` window CustomEvents on 409 / 422 / 500 errors, but no listener existed — failures only surfaced in `console.warn`. This PR adds the listener.

- **New `dc-toast` component** ([tasks/buildin/webui/app/components/dc-toast.js](tasks/buildin/webui/app/components/dc-toast.js)) — listens for window `dc-toast` events, stacks notifications bottom-right, 5s auto-dismiss, manual dismiss `×`, error-tinted left border for `{kind: 'error'}` toasts.
- **Single instance** appended to `<body>` from `app.js` alongside `dc-auth-overlay`.
- **`dc-task-list._toast`** now flags toggle-error toasts as `kind: 'error'` so they render with the error tint.
- **E2E test** in `tests/e2e/task-toggle.spec.ts` fires a `dc-toast` CustomEvent and asserts the rendered toast.

Tiny PR — one new component (~95 lines), three single-line wires, one new e2e test.

## Test plan

- [x] `make format && make lint` clean
- [x] New e2e test compiles
- [ ] CI Playwright validates rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)