### PR TITLE
fix(webui): protect Server.cfg with sync.RWMutex (closes #264)

### DIFF
--- a/pkg/webui/ai_chat.go
+++ b/pkg/webui/ai_chat.go
@@ -50,10 +50,12 @@ func (s *Server) apiAIChat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.cfgMu.RLock()
 	taskID := ""
 	if s.cfg != nil {
 		taskID = s.cfg.AI.Task
 	}
+	s.cfgMu.RUnlock()
 	if taskID == "" {
 		jsonErr(w, "ai task not configured or not registered", http.StatusServiceUnavailable)
 		return

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -176,8 +176,14 @@ var Version = "dev"
 
 // Server is the HTTP server for the web UI and REST API.
 type Server struct {
-	registry           *registry.Registry
-	engine             *trigger.Engine
+	registry *registry.Registry
+	engine   *trigger.Engine
+	// cfg is mutated by apiSaveConfigRaw, apiSaveAISettings, apiSaveServerSettings,
+	// apiAddSource, apiRemoveSource, apiSaveRuntime, apiPatchTaskOverrides, and
+	// concurrently read by every handler that touches configuration. Guard all
+	// access with cfgMu — RLock for reads, Lock for writes. cfgPath is set once
+	// at construction and is read without locking.
+	cfgMu              sync.RWMutex
 	cfg                *config.Config
 	cfgPath            string               // path to dicode.yaml; empty in tests
 	secretsMgr         SecretsManager       // nil if local provider not configured
@@ -380,6 +386,13 @@ func New(port int, r *registry.Registry, eng *trigger.Engine, cfg *config.Config
 		s.ws.recentLogs = logs.Recent
 	}
 
+	// Bind the cfg mutex into the SourceManager so its cfg reads serialise
+	// with our writers. SourceManager is constructed in daemon initialisation
+	// before the Server, hence the late-bind setter.
+	if sourceMgr != nil {
+		sourceMgr.BindCfgMutex(&s.cfgMu)
+	}
+
 	return s, nil
 }
 
@@ -403,7 +416,9 @@ func (s *Server) Handler() http.Handler {
 	// /api/auth/login is exempted in csrfGuard below because it follows a
 	// different threat model (same-origin fetch with credentials; no cookie
 	// to forge in a cross-origin form).
+	s.cfgMu.RLock()
 	tlsConfigured := s.cfg.Server.TLSCertFile != ""
+	s.cfgMu.RUnlock()
 	csrfProtect := csrf.Protect(
 		s.csrfKey,
 		csrf.CookieName("dicode_csrf"),
@@ -588,7 +603,10 @@ func (s *Server) Handler() http.Handler {
 		// the request body to /hooks/mcp through the trigger engine's
 		// webhook handler. MCP is a *bool pointer; nil = default enabled
 		// once applyDefaults has filled it in.
-		if s.cfg == nil || s.cfg.Server.MCP == nil || *s.cfg.Server.MCP {
+		s.cfgMu.RLock()
+		mcpEnabled := s.cfg == nil || s.cfg.Server.MCP == nil || *s.cfg.Server.MCP
+		s.cfgMu.RUnlock()
+		if mcpEnabled {
 			r.With(s.requireAPIKey).HandleFunc("/mcp", s.handleMCP)
 		}
 
@@ -639,8 +657,10 @@ func (s *Server) Start(ctx context.Context) error {
 		defer cancel()
 		_ = s.srv.Shutdown(shutCtx)
 	}()
+	s.cfgMu.RLock()
 	certFile := s.cfg.Server.TLSCertFile
 	keyFile := s.cfg.Server.TLSKeyFile
+	s.cfgMu.RUnlock()
 	if certFile != "" && keyFile != "" {
 		s.log.Info("webui listening (HTTPS)", zap.Int("port", s.port),
 			zap.String("hint", fmt.Sprintf("set DICODE_BASE_URL secret to https://YOUR_HOST:%d", s.port)))
@@ -757,7 +777,9 @@ func (s *Server) apiSaveConfigRaw(w http.ResponseWriter, r *http.Request) {
 
 	// Hot-reload config into memory (best-effort; server restart needed for port changes).
 	if newCfg, err := config.Load(s.cfgPath); err == nil {
+		s.cfgMu.Lock()
 		s.cfg = newCfg
+		s.cfgMu.Unlock()
 	} else {
 		s.log.Warn("config reload after raw save failed", zap.Error(err))
 	}
@@ -965,7 +987,10 @@ const sessionCookie = "dicode_secrets_sess"
 // receive a JSON response; when next is present and safe it is echoed back so
 // the SPA can navigate to it.
 func (s *Server) apiSecretsUnlock(w http.ResponseWriter, r *http.Request) {
-	ip := clientIP(r, s.cfg.Server.TrustProxy)
+	s.cfgMu.RLock()
+	trustProxy := s.cfg.Server.TrustProxy
+	s.cfgMu.RUnlock()
+	ip := clientIP(r, trustProxy)
 	if !s.limiter.allow(ip) {
 		jsonErr(w, "too many unlock attempts — try again in a minute", http.StatusTooManyRequests)
 		return
@@ -1287,15 +1312,23 @@ func (s *Server) apiGetConfig(w http.ResponseWriter, r *http.Request) {
 		*config.Config
 		RelayHookBaseURL string `json:"relay_hook_base_url,omitempty"`
 	}
-	resp := configResponse{Config: s.cfg}
+	// Read relay hook URL from the KV store before acquiring cfgMu — the
+	// query doesn't touch s.cfg, so keeping it outside the read lock avoids
+	// blocking writers across a SQLite round-trip.
+	var relayHookBaseURL string
 	if raw, _ := readKvJSON(r.Context(), s.db, "buildin/relay-client:status"); raw != nil {
 		var st struct {
 			HookBaseURL string `json:"hook_base_url"`
 		}
 		_ = json.Unmarshal(raw, &st)
-		resp.RelayHookBaseURL = st.HookBaseURL
+		relayHookBaseURL = st.HookBaseURL
 	}
-	jsonOK(w, resp)
+	// Hold the read lock across JSON marshalling — jsonOK encodes synchronously
+	// and configResponse embeds *config.Config, which means the encoder walks
+	// the live cfg's nested maps/slices.
+	s.cfgMu.RLock()
+	defer s.cfgMu.RUnlock()
+	jsonOK(w, configResponse{Config: s.cfg, RelayHookBaseURL: relayHookBaseURL})
 }
 
 // TaskListItem is the shape returned by GET /api/tasks.
@@ -1468,8 +1501,14 @@ func (s *Server) apiPatchTaskOverrides(w http.ResponseWriter, r *http.Request) {
 			// LiftEntryEnabled (called by config.applyDefaults during Load)
 			// has already moved any top-level entry.Enabled shortcut into
 			// entry.Overrides.Enabled, so that's the only field to check.
+			s.cfgMu.RLock()
+			ancestorDisabled := false
 			if entry := s.cfg.Spec.Entries[source]; entry != nil &&
 				entry.Overrides != nil && entry.Overrides.Enabled != nil && !*entry.Overrides.Enabled {
+				ancestorDisabled = true
+			}
+			s.cfgMu.RUnlock()
+			if ancestorDisabled {
 				jsonErr(w, "source "+source+" is disabled — enable the source first",
 					http.StatusUnprocessableEntity)
 				return
@@ -1493,19 +1532,16 @@ func (s *Server) apiPatchTaskOverrides(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Reload dicode.yaml into memory so the running daemon reflects the
-	// change without a restart.
-	//
-	// NOTE: s.cfg is not currently mutex-protected — apiSaveConfigRaw,
-	// apiAddSource, and others mutate it without synchronisation, so
-	// concurrent reads (e.g. apiGetConfig) can race with this assignment.
-	// Pre-existing systemic gap, tracked in issue #264. Adding a mutex
-	// here without sweeping the other handlers would only paper over it.
+	// change without a restart. cfgMu serialises this with concurrent
+	// readers (apiGetConfig, etc.) and other writers.
 	updated, loadErr := config.Load(s.cfgPath)
 	if loadErr != nil {
 		s.log.Warn("config reload after override patch failed",
 			zap.String("task", id), zap.Error(loadErr))
 	} else {
+		s.cfgMu.Lock()
 		s.cfg.Spec = updated.Spec
+		s.cfgMu.Unlock()
 		if s.sourceMgr != nil {
 			if src, ok := s.sourceMgr.Get(source); ok {
 				if entry := updated.Spec.Entries[source]; entry != nil {
@@ -1945,8 +1981,11 @@ func (s *Server) apiSaveAISettings(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, "task must have a webhook trigger under "+webhookPathPrefix, http.StatusBadRequest)
 		return
 	}
+	s.cfgMu.Lock()
 	s.cfg.AI.Task = task
-	if err := s.persistConfig(); err != nil {
+	err := s.persistConfigLocked()
+	s.cfgMu.Unlock()
+	if err != nil {
 		s.log.Warn("settings persist failed", zap.Error(err))
 		jsonErr(w, "saved in memory but could not write file: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -1964,13 +2003,16 @@ func (s *Server) apiSaveServerSettings(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, "bad request", http.StatusBadRequest)
 		return
 	}
+	s.cfgMu.Lock()
 	if body.LogLevel != "" {
 		s.cfg.LogLevel = body.LogLevel
 	}
 	if body.Secret != "" {
 		s.cfg.Server.Secret = body.Secret
 	}
-	if err := s.persistConfig(); err != nil {
+	err := s.persistConfigLocked()
+	s.cfgMu.Unlock()
+	if err != nil {
 		s.log.Warn("settings persist failed", zap.Error(err))
 		jsonErr(w, "saved in memory but could not write file: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -2044,12 +2086,15 @@ func (s *Server) apiAddSource(w http.ResponseWriter, r *http.Request) {
 		s.sourceMgr.Register(name, ts)
 	}
 
+	s.cfgMu.Lock()
 	if s.cfg.Spec.Entries == nil {
 		s.cfg.Spec.Entries = make(map[string]*taskset.Entry)
 	}
 	s.cfg.Spec.Entries[name] = entry
-	if err := s.persistConfig(); err != nil {
-		s.log.Warn("source persist failed", zap.Error(err))
+	persistErr := s.persistConfigLocked()
+	s.cfgMu.Unlock()
+	if persistErr != nil {
+		s.log.Warn("source persist failed", zap.Error(persistErr))
 	}
 	s.log.Info("source added", zap.String("name", name))
 	jsonOK(w, map[string]string{"status": "ok"})
@@ -2076,11 +2121,17 @@ func (s *Server) apiRemoveSource(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, "source name is required", http.StatusBadRequest)
 		return
 	}
+	s.cfgMu.Lock()
 	entry := s.cfg.Spec.Entries[name]
 	if entry == nil {
+		s.cfgMu.Unlock()
 		jsonErr(w, "source not found", http.StatusNotFound)
 		return
 	}
+	delete(s.cfg.Spec.Entries, name)
+	persistErr := s.persistConfigLocked()
+	s.cfgMu.Unlock()
+
 	if s.reconciler != nil && entry.Ref != nil {
 		id := entry.Ref.URL
 		if id == "" {
@@ -2088,9 +2139,8 @@ func (s *Server) apiRemoveSource(w http.ResponseWriter, r *http.Request) {
 		}
 		s.reconciler.RemoveSource(id)
 	}
-	delete(s.cfg.Spec.Entries, name)
-	if err := s.persistConfig(); err != nil {
-		s.log.Warn("source persist failed", zap.Error(err))
+	if persistErr != nil {
+		s.log.Warn("source persist failed", zap.Error(persistErr))
 	}
 	s.log.Info("source removed", zap.String("name", name))
 	jsonOK(w, map[string]string{"status": "ok"})
@@ -2108,12 +2158,16 @@ type RuntimeInfo struct {
 }
 
 func (s *Server) apiListRuntimes(w http.ResponseWriter, r *http.Request) {
+	s.cfgMu.RLock()
+	pinnedVersions := make(map[string]string, len(s.cfg.Runtimes))
+	for name, rc := range s.cfg.Runtimes {
+		pinnedVersions[name] = rc.Version
+	}
+	s.cfgMu.RUnlock()
+
 	var out []RuntimeInfo
 	for _, mgr := range s.managedRuntimes {
-		version := ""
-		if rc, ok := s.cfg.Runtimes[mgr.Name()]; ok {
-			version = rc.Version
-		}
+		version := pinnedVersions[mgr.Name()]
 		effectiveVersion := version
 		if effectiveVersion == "" {
 			effectiveVersion = mgr.DefaultVersion()
@@ -2150,7 +2204,10 @@ func (s *Server) apiInstallRuntime(w http.ResponseWriter, r *http.Request) {
 	}
 	version := strings.TrimSpace(r.FormValue("version"))
 	if version == "" {
-		if rc, ok := s.cfg.Runtimes[name]; ok && rc.Version != "" {
+		s.cfgMu.RLock()
+		rc, ok := s.cfg.Runtimes[name]
+		s.cfgMu.RUnlock()
+		if ok && rc.Version != "" {
 			version = rc.Version
 		} else {
 			version = mgr.DefaultVersion()
@@ -2164,14 +2221,17 @@ func (s *Server) apiInstallRuntime(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.cfgMu.Lock()
 	if s.cfg.Runtimes == nil {
 		s.cfg.Runtimes = make(map[string]config.RuntimeConfig)
 	}
-	rc := s.cfg.Runtimes[name]
-	rc.Version = version
-	s.cfg.Runtimes[name] = rc
-	if err := s.persistConfig(); err != nil {
-		s.log.Warn("runtime config persist failed", zap.Error(err))
+	rcUpdate := s.cfg.Runtimes[name]
+	rcUpdate.Version = version
+	s.cfg.Runtimes[name] = rcUpdate
+	persistErr := s.persistConfigLocked()
+	s.cfgMu.Unlock()
+	if persistErr != nil {
+		s.log.Warn("runtime config persist failed", zap.Error(persistErr))
 	}
 
 	if path, err := mgr.BinaryPath(version); err == nil {
@@ -2188,17 +2248,23 @@ func (s *Server) apiRemoveRuntime(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, "deno is required and cannot be removed", http.StatusBadRequest)
 		return
 	}
+	s.cfgMu.Lock()
 	if s.cfg.Runtimes != nil {
 		delete(s.cfg.Runtimes, name)
 	}
-	if err := s.persistConfig(); err != nil {
-		s.log.Warn("runtime config persist failed", zap.Error(err))
+	persistErr := s.persistConfigLocked()
+	s.cfgMu.Unlock()
+	if persistErr != nil {
+		s.log.Warn("runtime config persist failed", zap.Error(persistErr))
 	}
 	jsonOK(w, map[string]string{"status": "ok"})
 }
 
 // persistConfig writes the current in-memory config back to dicode.yaml.
-func (s *Server) persistConfig() error {
+// persistConfigLocked serialises the in-memory cfg back to dicode.yaml.
+// CALLER MUST HOLD s.cfgMu.Lock — this function reads every cfg field
+// without re-acquiring the mutex.
+func (s *Server) persistConfigLocked() error {
 	if s.cfgPath == "" {
 		return nil
 	}

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -1132,8 +1132,11 @@ func TestPersistConfig_OverridesAndTagsSurviveRoundTrip(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	if err := srv.persistConfig(); err != nil {
-		t.Fatalf("persistConfig: %v", err)
+	srv.cfgMu.Lock()
+	persistErr := srv.persistConfigLocked()
+	srv.cfgMu.Unlock()
+	if persistErr != nil {
+		t.Fatalf("persistConfigLocked: %v", persistErr)
 	}
 
 	// Re-load the written YAML and verify overrides + tags are present.
@@ -1346,4 +1349,46 @@ func TestPatchTaskOverrides_WrongSuffix(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body = %s", w.Code, w.Body.String())
 	}
+}
+
+// TestServer_CfgConcurrentReadWrite hammers the cfg with parallel readers
+// (GET /api/config) and writers (PATCH /api/tasks/{id}/overrides) to verify
+// cfgMu correctly serialises them. Run with -race to catch unsynchronised
+// access. Without the mutex this test would flag a data race on s.cfg.Spec.
+func TestServer_CfgConcurrentReadWrite(t *testing.T) {
+	srv, _ := newTestServerWithConfigPath(t)
+	srv.registry.Register(&task.Spec{ID: "buildin/x", Enabled: true})
+	h := srv.Handler()
+
+	const iterations = 50
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Reader: GET /api/config in a tight loop.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+		}
+	}()
+
+	// Writer: alternate PATCH enabled=false / enabled=true.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			body := `{"enabled":false}`
+			if i%2 == 1 {
+				body = `{"enabled":true}`
+			}
+			req := httptest.NewRequest(http.MethodPatch, "/api/tasks/buildin/x/overrides",
+				bytes.NewBufferString(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+		}
+	}()
+
+	wg.Wait()
 }

--- a/pkg/webui/sources.go
+++ b/pkg/webui/sources.go
@@ -36,8 +36,13 @@ type SourceInfo struct {
 
 // SourceManager tracks taskset sources by name and provides dev mode control.
 // It is the single point of truth for source state visible to the REST API.
+//
+// cfgMu protects reads of cfg fields (Spec.Entries) — it is shared with the
+// Server so writers there serialise correctly with readers here. Pass nil
+// only in tests that don't exercise concurrent cfg mutations.
 type SourceManager struct {
 	mu       sync.RWMutex
+	cfgMu    *sync.RWMutex
 	cfg      *config.Config
 	tasksets map[string]*taskset.Source // source name → live taskset.Source
 	dataDir  string
@@ -46,6 +51,8 @@ type SourceManager struct {
 
 // NewSourceManager creates a SourceManager.
 // tasksetSources maps source name to the live *taskset.Source (may be nil map for non-taskset setups).
+// The cfg mutex is bound separately via BindCfgMutex once the Server is built;
+// chicken-and-egg between daemon initialisation order is why we don't take it here.
 func NewSourceManager(cfg *config.Config, tasksetSources map[string]*taskset.Source, dataDir string, log *zap.Logger) *SourceManager {
 	if tasksetSources == nil {
 		tasksetSources = make(map[string]*taskset.Source)
@@ -55,6 +62,26 @@ func NewSourceManager(cfg *config.Config, tasksetSources map[string]*taskset.Sou
 		tasksets: tasksetSources,
 		dataDir:  dataDir,
 		log:      log,
+	}
+}
+
+// BindCfgMutex wires the Server's cfg mutex into this SourceManager so reads
+// of m.cfg.Spec.Entries serialise with concurrent writers. Call once, after
+// the Server has been constructed and before the HTTP handler is exposed.
+func (m *SourceManager) BindCfgMutex(mu *sync.RWMutex) {
+	m.cfgMu = mu
+}
+
+// rLockCfg / rUnlockCfg let SourceManager methods uniformly acquire the
+// shared cfg lock; they're no-ops if cfgMu is nil (test setups).
+func (m *SourceManager) rLockCfg() {
+	if m.cfgMu != nil {
+		m.cfgMu.RLock()
+	}
+}
+func (m *SourceManager) rUnlockCfg() {
+	if m.cfgMu != nil {
+		m.cfgMu.RUnlock()
 	}
 }
 
@@ -80,6 +107,8 @@ func (m *SourceManager) List() []SourceInfo {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	m.rLockCfg()
+	defer m.rUnlockCfg()
 	entries := m.cfg.Spec.Entries
 	out := make([]SourceInfo, 0, len(entries))
 	for name, entry := range entries {
@@ -152,11 +181,16 @@ func (m *SourceManager) ResolveRepoPath(name string) (string, error) {
 
 // ListBranches returns remote branches for the named git source.
 func (m *SourceManager) ListBranches(ctx context.Context, name string) ([]string, error) {
+	m.rLockCfg()
 	entry := m.cfg.Spec.Entries[name]
 	if entry == nil || entry.Ref == nil || !entry.Ref.IsGit() {
+		m.rUnlockCfg()
 		return nil, fmt.Errorf("source %q not found or not a git source", name)
 	}
-	return gitSource.ListBranches(ctx, entry.Ref.URL, entry.Ref.Auth.TokenEnv)
+	url := entry.Ref.URL
+	tokenEnv := entry.Ref.Auth.TokenEnv
+	m.rUnlockCfg()
+	return gitSource.ListBranches(ctx, url, tokenEnv)
 }
 
 // --- HTTP handlers ---


### PR DESCRIPTION
## Summary

Closes [#264](https://github.com/dicode-ayo/dicode-core/issues/264). Pre-existing systemic gap: every webui handler that read or mutated dicode.yaml in-memory state (`Server.cfg`) did so without synchronisation. Under `-race`, concurrent \`GET /api/config\` + \`PATCH /api/tasks/{id}/overrides\` is a data race. Sweep:

- **`Server.cfgMu sync.RWMutex`** added. `cfgPath` is set once at construction and remains lock-free.
- **All reads** wrapped with \`RLock\` (handlers, middleware, route setup, ai_chat.go).
- **All writes** wrapped with \`Lock\`: \`apiSaveConfigRaw\`, \`apiSaveAISettings\`, \`apiSaveServerSettings\`, \`apiAddSource\`, \`apiRemoveSource\`, \`apiInstallRuntime\`, \`apiRemoveRuntime\`, \`apiPatchTaskOverrides\`.
- **`persistConfig` renamed to `persistConfigLocked`** with a doc comment stating the caller must hold the write lock — the function reads every cfg field unsynchronised.
- **`SourceManager.cfg` reads** (\`List\`, \`ListBranches\`) now serialise via a shared mutex installed by \`Server.New\` through \`BindCfgMutex\`. Chicken-and-egg between \`daemon.buildSources\` and \`webui.New\` rules out passing it via the constructor.
- **`TestServer_CfgConcurrentReadWrite`** new race-detector test that fires 50 parallel reader iterations against \`GET /api/config\` and 50 writer iterations against \`PATCH /api/tasks/{id}/overrides\`. Passes cleanly under \`-race\` (40s); would flag the race without this PR.

## Test plan

- [x] \`go test ./... -timeout 120s\` — all 20 packages PASS
- [x] \`go test ./pkg/webui/ -count=1 -race\` — PASS (40s, including the new concurrent test)
- [x] \`make format && make lint\` — clean
- [ ] CI Playwright validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)