### PR TITLE
fix(release): fetch tags in goreleaser checkout

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,6 +39,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # Required: release-please created the v0.X.Y tag earlier in this
+          # workflow run; checkout v4+ does NOT fetch tags even with
+          # fetch-depth: 0 unless this is set, which makes GoReleaser fail
+          # with "git tag <X> was not made against commit <Y>".
+          fetch-tags: true
 
       - uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
## Summary

PR #269 fixed release-please-as-draft + the goreleaser publish step, but v0.1.2's release-please workflow then failed with:

\`\`\`
release failed after 0s   error=git tag v0.1.2 was not made against commit b48c15b...
\`\`\`

Root cause: \`actions/checkout@v6\` defaults to \`fetch-tags: false\`, even with \`fetch-depth: 0\`. release-please creates the v0.X.Y tag during the workflow run (release-please job runs before goreleaser job). Goreleaser's checkout fetched no tags, so when it looked up v0.1.2 the local ref was missing, the HEAD/tag-commit comparison failed, and the release was aborted before any binary was built.

Fix: add \`fetch-tags: true\` to the goreleaser job's checkout. Five lines + a comment.

## Recovering v0.1.2

Once this PR merges, re-trigger the \`Release Please\` workflow on main (Actions UI → re-run failed jobs). Goreleaser will then find v0.1.2, upload binaries, and the publish step flips draft → published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)