### PR TITLE
fix(release): revert draft-mode now that immutable releases is off

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -58,15 +58,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ needs.release-please.outputs.tag_name }}
 
-      # GoReleaser with use_existing_draft: true uploads to the draft but
-      # does NOT promote it to published. Flip the draft flag explicitly so
-      # the release becomes the public latest with binaries attached.
-      - name: Publish GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-          REPO: ${{ github.repository }}
-        run: gh release edit "$TAG_NAME" --draft=false --repo "$REPO"
 
   publish-docker:
     name: Publish Docker image

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,9 +35,13 @@ checksum:
   name_template: "dicode-{{ .Version }}-checksums.txt"
 
 release:
-  # Upload to the GitHub release that release-please already created.
+  # Upload to the GitHub release that release-please already created+published.
+  # release-please runs first and publishes the release immediately (no draft);
+  # GoReleaser then attaches binaries via release-asset uploads. The repo's
+  # immutable-releases setting must be off, otherwise GitHub blocks asset
+  # uploads on already-published releases.
   # GORELEASER_CURRENT_TAG is set by the workflow to the tag release-please created.
-  use_existing_draft: true
+  mode: append
 
 changelog:
   disable: true  # release-please manages the changelog

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,14 +8,37 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,
-  "draft": true,
   "changelog-sections": [
-    { "type": "feat", "section": "Features" },
-    { "type": "fix", "section": "Bug Fixes" },
-    { "type": "perf", "section": "Performance Improvements" },
-    { "type": "revert", "section": "Reverts" },
-    { "type": "docs", "section": "Documentation", "hidden": false },
-    { "type": "chore", "section": "Miscellaneous", "hidden": true },
-    { "type": "refactor", "section": "Miscellaneous", "hidden": true }
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation",
+      "hidden": false
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous",
+      "hidden": true
+    },
+    {
+      "type": "refactor",
+      "section": "Miscellaneous",
+      "hidden": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Repo's immutable-releases policy is now disabled, so we can drop the draft-mode workaround introduced in PR #269 and go back to the pre-immutability flow:

- \`release-please-config.json\`: drop \`\"draft\": true\` → release-please publishes the GitHub Release immediately (mutable + marked latest).
- \`.goreleaser.yaml\`: replace \`use_existing_draft: true\` with \`mode: append\` → GoReleaser attaches binaries to the already-published release.
- \`.github/workflows/release-please.yml\`: drop the now-redundant \"Publish GitHub Release\" step.

## Why simpler

The draft flow interacted badly with \`publish-docker\`'s \`softprops/action-gh-release\` step, which auto-published empty drafts whenever goreleaser failed. Result: four immutable empty releases on the public page (v0.1.0, v0.1.1, v0.1.2, v0.2.0) that can never be retroactively populated.

With this revert + the existing fetch-tags fix from PR #272, the next release (v0.2.1) lands with binaries on the public page on the first try.

## Recovery for the broken releases

Nothing fixable — those four are immutable and locked empty forever. Going forward, v0.2.1+ will be clean.

## Test plan

- [x] Diff inspected; only release flow files modified
- [ ] CI green
- [ ] Once merged, release-please opens a clean v0.2.1 PR (PR #273 will likely auto-close as it points at the same release-please branch — verify)
- [ ] Merge v0.2.1 PR → end-to-end flow produces public binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)