### PR TITLE
feat(auth-providers): auto-discover BYO OAuth tasks via template marker

### DIFF
--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -649,11 +649,19 @@ func (s *Server) handleConn(conn net.Conn) {
 				reply(req.ID, nil, "ipc: permission denied (tasks.list)")
 				continue
 			}
+			// Summary intentionally trimmed: id, name, description, params,
+			// template, webhook, enabled. NOT exposed: TaskDir (filesystem
+			// leakage), Permissions (could hint at secret env-var names),
+			// Trigger.WebhookSecret (would defeat HMAC auth). The fields
+			// here are all already visible via the WebUI's /api/tasks JSON.
 			type taskSummary struct {
 				ID          string `json:"id"`
 				Name        string `json:"name"`
 				Description string `json:"description,omitempty"`
 				Params      any    `json:"params,omitempty"`
+				Template    string `json:"template,omitempty"`
+				Webhook     string `json:"webhook,omitempty"`
+				Enabled     bool   `json:"enabled"`
 			}
 			all := s.registry.All()
 			summaries := make([]taskSummary, 0, len(all))
@@ -663,6 +671,9 @@ func (s *Server) handleConn(conn net.Conn) {
 					Name:        sp.Name,
 					Description: sp.Description,
 					Params:      sp.Params,
+					Template:    sp.Template,
+					Webhook:     sp.Trigger.Webhook,
+					Enabled:     sp.Enabled,
 				})
 			}
 			reply(req.ID, summaries, "")

--- a/pkg/ipc/server_test.go
+++ b/pkg/ipc/server_test.go
@@ -650,6 +650,67 @@ func TestServer_Dicode_ListTasks(t *testing.T) {
 	}
 }
 
+// TestServer_Dicode_ListTasks_TemplateAndWebhook confirms that the IPC
+// summary surfaces Spec.Template, Spec.Trigger.Webhook, and Spec.Enabled —
+// the fields buildin/auth-providers needs to auto-detect _oauth-app
+// inheritors without hardcoding a per-task allowlist.
+func TestServer_Dicode_ListTasks_TemplateAndWebhook(t *testing.T) {
+	e := newTestEnv(t)
+	_ = e.reg.Register(&task.Spec{
+		ID:       "auth/google-oauth",
+		Name:     "Google OAuth",
+		Template: "dicode.io/oauth-app",
+		Trigger:  task.TriggerConfig{Webhook: "/hooks/google-oauth"},
+		Enabled:  true,
+	})
+	_ = e.reg.Register(&task.Spec{
+		ID:      "auth/disabled-oauth",
+		Name:    "Disabled OAuth",
+		Enabled: false, // intentionally not template-marked; default false-zero
+	})
+
+	spec := specWithDicode("caller", &task.DicodePermissions{ListTasks: true})
+	conn, _ := e.startWithSpec(t, nil, nil, spec, nil)
+	sendMsg(t, conn, map[string]any{"id": "1", "method": "dicode.list_tasks"})
+	resp := recvMsg(t, conn)
+
+	tasks, ok := resp["result"].([]any)
+	if !ok {
+		t.Fatalf("expected array, got %T", resp["result"])
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(tasks))
+	}
+
+	byID := map[string]map[string]any{}
+	for _, raw := range tasks {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("expected map, got %T", raw)
+		}
+		byID[m["id"].(string)] = m
+	}
+
+	g := byID["auth/google-oauth"]
+	if g["template"] != "dicode.io/oauth-app" {
+		t.Errorf("expected template=dicode.io/oauth-app, got %v", g["template"])
+	}
+	if g["webhook"] != "/hooks/google-oauth" {
+		t.Errorf("expected webhook=/hooks/google-oauth, got %v", g["webhook"])
+	}
+	if g["enabled"] != true {
+		t.Errorf("expected enabled=true, got %v", g["enabled"])
+	}
+
+	d := byID["auth/disabled-oauth"]
+	if _, hasTemplate := d["template"]; hasTemplate {
+		t.Errorf("expected no template field on un-marked task; got %v", d["template"])
+	}
+	if d["enabled"] != false {
+		t.Errorf("expected enabled=false, got %v", d["enabled"])
+	}
+}
+
 func TestServer_Dicode_GetRuns_Denied(t *testing.T) {
 	e := newTestEnv(t)
 	conn, _ := e.start(t, nil, nil)

--- a/pkg/runtime/deno/sdk/sdk.d.ts
+++ b/pkg/runtime/deno/sdk/sdk.d.ts
@@ -57,13 +57,31 @@ declare interface DicodeSecrets {
   has: (key: string) => Promise<boolean>;
 }
 
+/** Summary returned for one task by `dicode.list_tasks()`. The IPC server
+ *  trims the spec to fields already visible in /api/tasks; filesystem paths
+ *  and permission details are deliberately not exposed. */
+declare interface TaskSummary {
+  id:           string;
+  name:         string;
+  description?: string;
+  params?:      unknown;
+  /** Optional namespaced template marker (e.g. "dicode.io/oauth-app").
+   *  Set in the base task.yaml; propagates to every entry that inherits
+   *  via `ref.path`. Use this to discover instances of a template at runtime
+   *  without hardcoding a per-task allowlist. */
+  template?:    string;
+  /** Webhook path for tasks with a webhook trigger (e.g. "/hooks/google-oauth"). */
+  webhook?:     string;
+  enabled:      boolean;
+}
+
 declare interface Dicode {
   /** Fully-namespaced id of the currently-running task (e.g. "buildin/ai-agent"). */
   task_id:        string;
   /** Id of the current run (uuid). */
   run_id:         string;
   run_task:       (taskID: string, params?: Record<string, string>) => Promise<unknown>;
-  list_tasks:     ()                                                 => Promise<unknown>;
+  list_tasks:     ()                                                 => Promise<TaskSummary[]>;
   get_runs:       (taskID: string, opts?: { limit?: number })        => Promise<unknown>;
   secrets_set:    (key: string, value: string) => Promise<void>;
   secrets_delete: (key: string)                => Promise<void>;

--- a/pkg/runtime/deno/sdk/shim.ts
+++ b/pkg/runtime/deno/sdk/shim.ts
@@ -87,6 +87,23 @@ export interface DicodeSecrets {
   has: (key: string) => Promise<boolean>;
 }
 
+// TaskSummary is what dicode.list_tasks() returns per task. The IPC server
+// trims the spec to fields already exposed via /api/tasks; filesystem paths
+// and permission details are deliberately not surfaced.
+export interface TaskSummary {
+  id:           string;
+  name:         string;
+  description?: string;
+  params?:      unknown;
+  // template: optional namespaced marker (e.g. "dicode.io/oauth-app").
+  // Set in the base task.yaml; propagates to every entry that inherits
+  // via ref.path. Use this to discover template instances at runtime.
+  template?:    string;
+  // webhook: webhook path for tasks with a webhook trigger.
+  webhook?:     string;
+  enabled:      boolean;
+}
+
 export interface Dicode {
   // task_id: the fully-namespaced id of the currently-running task (e.g.
   // "buildin/ai-agent"). Populated from the IPC handshake so task code can
@@ -95,7 +112,7 @@ export interface Dicode {
   // run_id: the id of the current run (uuid). Same source as task_id.
   run_id:         string;
   run_task:       (taskID: string, params?: Record<string, string>)  => Promise<unknown>;
-  list_tasks:     ()                                                   => Promise<unknown>;
+  list_tasks:     ()                                                   => Promise<TaskSummary[]>;
   get_runs:       (taskID: string, opts?: { limit?: number })         => Promise<unknown>;
   // set_group labels the current run with a free-text string used by the
   // WebUI to collapse same-group siblings (#116). Last write wins; only
@@ -317,7 +334,7 @@ const dicode: Dicode = {
   task_id:        __hsResp__.task_id ?? "",
   run_id:         __hsResp__.run_id ?? "",
   run_task:       (taskID, params)  => __call__({ method: "dicode.run_task",       taskID, params: params ?? {} }),
-  list_tasks:     ()                => __call__({ method: "dicode.list_tasks" }),
+  list_tasks:     ()                => __call__({ method: "dicode.list_tasks" }) as Promise<TaskSummary[]>,
   get_runs:       (taskID, opts)    => __call__({ method: "dicode.get_runs",        taskID, limit: opts?.limit ?? 10 }),
   set_group:      (label)           => __call__({ method: "dicode.set_group",       group: String(label ?? "") }) as Promise<void>,
   secrets_set:    (key, value)      => __call__({ method: "dicode.secrets_set",     key, stringValue: value }) as Promise<void>,

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -84,11 +84,11 @@ type TriggerConfig struct {
 
 // Param defines a user-configurable input for a task.
 type Param struct {
-	Name        string `yaml:"name"`
-	Type        string `yaml:"type"` // "string" | "number" | "boolean" | "cron"
-	Default     string `yaml:"default"`
-	Description string `yaml:"description"`
-	Required    bool   `yaml:"required"`
+	Name        string `yaml:"name"        json:"name"`
+	Type        string `yaml:"type"        json:"type,omitempty"` // "string" | "number" | "boolean" | "cron"
+	Default     string `yaml:"default"     json:"default,omitempty"`
+	Description string `yaml:"description" json:"description,omitempty"`
+	Required    bool   `yaml:"required"    json:"required,omitempty"`
 }
 
 // Params is a list of Param values that can be written in two equivalent YAML forms:
@@ -366,6 +366,15 @@ type Spec struct {
 	// Default is true; the resolver sets it to true on load and flips it
 	// when an override says false.
 	Enabled bool `yaml:"-" json:"enabled"`
+
+	// Template is an optional, namespaced identifier declaring that this
+	// task is an instance of a generic template. Set in the BASE task.yaml;
+	// the resolver propagates it to every entry that inherits via `ref.path`
+	// because the field is part of the merged spec like any other.
+	// Format: reverse-DNS prefix + slash + slug, e.g. "dicode.io/oauth-app".
+	// Used today by `buildin/auth-providers` to surface BYO OAuth tasks in
+	// the dashboard without hardcoding a per-task allowlist.
+	Template string `yaml:"template,omitempty" json:"template,omitempty"`
 
 	// TaskDir is the directory path of the task in the repo (not stored in YAML).
 	TaskDir string `yaml:"-" json:"-"`

--- a/tasks/auth/_oauth-app/task.yaml
+++ b/tasks/auth/_oauth-app/task.yaml
@@ -1,6 +1,10 @@
 apiVersion: dicode/v1
 kind: Task
 name: OAuth
+# Template marker — propagates to every taskset entry that inherits via
+# ref.path: ./_oauth-app/task.yaml. The dashboard's auth-providers panel
+# uses this to auto-list BYO OAuth tasks (no hardcoded allowlist).
+template: dicode.io/oauth-app
 description: |
   Generic OAuth 2.0 task — the BYO entry point for any provider that the
   dicode-relay broker does not handle for you (e.g. self-hosted GitLab,

--- a/tasks/buildin/auth-providers/task.test.ts
+++ b/tasks/buildin/auth-providers/task.test.ts
@@ -11,10 +11,13 @@ await setupHarness(import.meta.url);
 
 const BROKER_URL = "https://relay.example";
 const BROKER_PROVIDERS = [
-  { key: "github", pkce: true, scopes: ["user", "repo"], secret_required: true,  configured: true },
-  { key: "slack",  pkce: true, scopes: ["channels:read"], secret_required: false, configured: true },
+  { key: "github",  pkce: true,  scopes: ["user", "repo"], secret_required: true,  configured: true },
+  { key: "slack",   pkce: true,  scopes: ["channels:read"], secret_required: false, configured: true },
 ];
 
+// mockBrokerProviders wires the standard /providers response into the fetch
+// interceptor. Tests that don't need a broker omit this and rely on the
+// task's broker-less fallback (returning standalones + inheritors only).
 function mockBrokerProviders(providers: unknown = BROKER_PROVIDERS): void {
   env.set("DICODE_RELAY_BROKER_URL", BROKER_URL);
   http.mock("GET", `${BROKER_URL}/providers`, {
@@ -23,6 +26,8 @@ function mockBrokerProviders(providers: unknown = BROKER_PROVIDERS): void {
   });
 }
 
+// withSecretsHas attaches a stub `dicode.secrets.has` returning `present` for
+// every call. Tests that need per-key behaviour replace it directly.
 function withSecretsHas(present: boolean): void {
   dicode.secrets = { has: async () => present };
 }
@@ -33,7 +38,7 @@ test("list with broker returns the broker catalogue + openrouter standalone", as
 
   const result = await runTask() as Array<Record<string, unknown>>;
 
-  // Broker entries first, then the openrouter standalone.
+  // Order: broker entries first, then standalone (openrouter), then inheritors (none in this test).
   assert.equal(result.length, 3);
   assert.equal(result[0].key, "github");
   assert.equal(result[0].has_token, false);
@@ -51,6 +56,81 @@ test("list without broker returns only standalones (BYO without relay)", async (
   assert.equal(result.length, 1);
   assert.equal(result[0].key, "openrouter");
   assert.ok((result[0].standalone as Record<string, unknown>)?.webhookPath);
+});
+
+test("list auto-discovers _oauth-app inheritors via the template marker", async () => {
+  // No broker; one inheritor task registered.
+  dicode.list_tasks = async () => ([
+    {
+      id: "auth/looker-oauth",
+      name: "Looker OAuth",
+      template: "dicode.io/oauth-app",
+      webhook: "/hooks/looker-oauth",
+      enabled: true,
+      params: [
+        { name: "provider", default: "looker" },
+        { name: "color",    default: "#4285F4" },
+        { name: "client_secret_env", default: "CLIENT_SECRET" },
+      ],
+    },
+    {
+      // Sibling task without the template marker — must be ignored.
+      id: "buildin/something-else",
+      name: "Something Else",
+      enabled: true,
+    },
+  ]);
+  withSecretsHas(false);
+
+  const result = await runTask() as Array<Record<string, unknown>>;
+
+  const looker = result.find(r => r.key === "looker")!;
+  assert.ok(looker, "expected auto-discovered looker entry");
+  assert.equal(looker.label, "Looker OAuth");
+  assert.equal(looker.color, "#4285F4");
+  assert.equal(looker.secret_required, true);
+  assert.equal(looker.has_token, false);
+  assert.ok((looker.standalone as Record<string, unknown>)?.webhookPath === "/hooks/looker-oauth");
+});
+
+test("list inheritor with no provider param is skipped", async () => {
+  dicode.list_tasks = async () => ([{
+    id: "auth/broken-oauth",
+    name: "Broken OAuth",
+    template: "dicode.io/oauth-app",
+    webhook: "/hooks/broken-oauth",
+    enabled: true,
+    params: [], // no `provider` default — misconfigured BYO entry
+  }]);
+  withSecretsHas(false);
+
+  const result = await runTask() as Array<Record<string, unknown>>;
+
+  // Only openrouter standalone remains; the broken inheritor is filtered.
+  assert.equal(result.length, 1);
+  assert.equal(result[0].key, "openrouter");
+});
+
+test("list dedup: broker wins over inheritor with the same key", async () => {
+  // Operator's BYO entry keyed `github` must NOT shadow the broker's github.
+  mockBrokerProviders();
+  dicode.list_tasks = async () => ([{
+    id: "my-stuff/github-oauth",
+    name: "My BYO GitHub",
+    template: "dicode.io/oauth-app",
+    webhook: "/hooks/my-github-oauth",
+    enabled: true,
+    params: [{ name: "provider", default: "github" }],
+  }]);
+  withSecretsHas(false);
+
+  const result = await runTask() as Array<Record<string, unknown>>;
+
+  const github = result.filter(r => r.key === "github");
+  assert.equal(github.length, 1);
+  // The surviving github row is the broker's, not the inheritor's.
+  assert.equal(github[0].label, undefined); // broker entries have no label
+  assert.equal(github[0].standalone, undefined); // broker entries are not standalone
 });
 
 test("list filters by `providers` param when set", async () => {
@@ -95,6 +175,28 @@ test("connect for openrouter (standalone) returns the webhook URL without run_ta
   assert.equal(result.url, "http://localhost:8080/hooks/openrouter-oauth");
 });
 
+test("connect for an _oauth-app inheritor returns the inherited webhook URL", async () => {
+  globalThis.input = { action: "connect", provider: "looker" };
+  env.set("DICODE_BASE_URL", "http://localhost:8080");
+  dicode.list_tasks = async () => ([{
+    id: "auth/looker-oauth",
+    name: "Looker OAuth",
+    template: "dicode.io/oauth-app",
+    webhook: "/hooks/looker-oauth",
+    enabled: true,
+    params: [{ name: "provider", default: "looker" }],
+  }]);
+
+  let runTaskCalls = 0;
+  dicode.run_task = async () => { runTaskCalls += 1; return {}; };
+
+  const result = await runTask() as Record<string, unknown>;
+
+  assert.equal(runTaskCalls, 0); // inheritor connect does NOT delegate to auth-start
+  assert.equal(result.provider, "looker");
+  assert.equal(result.url, "http://localhost:8080/hooks/looker-oauth");
+});
+
 test("connect for a broker provider with relay enabled delegates to auth-start", async () => {
   globalThis.input = { action: "connect", provider: "github" };
   env.set("DICODE_RELAY_BROKER_URL", BROKER_URL);
@@ -115,8 +217,8 @@ test("connect for a broker provider with relay enabled delegates to auth-start",
   assert.equal(result.session_id, "sess-1");
 });
 
-test("connect for a broker provider when relay is off throws", async () => {
-  // No DICODE_RELAY_BROKER_URL set.
+test("connect for a non-standalone, non-inheritor provider when relay is off throws", async () => {
+  // No DICODE_RELAY_BROKER_URL, no inheritor matches `github`.
   globalThis.input = { action: "connect", provider: "github" };
 
   await assert.throws(() => runTask(), /requires the relay broker/);

--- a/tasks/buildin/auth-providers/task.ts
+++ b/tasks/buildin/auth-providers/task.ts
@@ -43,10 +43,11 @@ async function checkConnected(dicode: DicodeSdk["dicode"], providerKey: string):
   }
 }
 
-// STANDALONE maps provider keys that are NOT relay-broker-backed to their
-// webhook path. These providers use PKCE directly without the broker, so they
-// do not appear in the broker's /providers response but must still be listable
-// when the task is invoked with their key in the `providers` param.
+// STANDALONE maps provider keys that are NOT relay-broker-backed AND NOT
+// instantiated from the _oauth-app template. Today this is just openrouter,
+// which has its own bespoke task (no template marker). Anything inherited
+// from _oauth-app is auto-discovered via list_tasks below — no need to
+// hardcode it here.
 const STANDALONE: Record<string, { webhookPath: string; label: string; color: string }> = {
   openrouter: {
     webhookPath: "/hooks/openrouter-oauth",
@@ -54,6 +55,72 @@ const STANDALONE: Record<string, { webhookPath: string; label: string; color: st
     color: "#6467f2",
   },
 };
+
+// OAUTH_APP_TEMPLATE is the marker set in tasks/auth/_oauth-app/task.yaml.
+// Every taskset entry that inherits via `ref.path: ./_oauth-app/task.yaml`
+// gets this propagated onto its merged spec by the resolver. The dashboard
+// uses it to surface BYO OAuth tasks without hardcoding an allowlist —
+// operators with their own taskset entry just appear automatically.
+const OAUTH_APP_TEMPLATE = "dicode.io/oauth-app";
+
+// paramDefault returns the default value of a named param from a list_tasks
+// summary's params field. The IPC server passes through task.Params (a list
+// of Param structs) verbatim; we only need the default value (set via
+// taskset overrides per provider).
+function paramDefault(params: unknown, name: string): string {
+  if (!Array.isArray(params)) return "";
+  for (const p of params) {
+    if (p && typeof p === "object" && (p as { name?: string }).name === name) {
+      return String((p as { default?: unknown }).default ?? "");
+    }
+  }
+  return "";
+}
+
+// scanInheritors enumerates every registered task whose merged spec carries
+// the `dicode.io/oauth-app` template marker, and shapes each as a
+// dashboard-style provider entry. Returns the same canonical shape the
+// STANDALONE branch emits so the panel renders them identically.
+async function scanInheritors(
+  dicode: DicodeSdk["dicode"],
+  requested: Set<string>,
+): Promise<Array<Record<string, unknown>>> {
+  let tasks: Array<{
+    id: string; name: string; template?: string; webhook?: string;
+    enabled: boolean; params?: unknown;
+  }>;
+  try {
+    tasks = await dicode.list_tasks();
+  } catch (err) {
+    console.error(
+      `auth-providers: dicode.list_tasks failed; BYO OAuth tasks will not appear ` +
+      `in the panel. Cause: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return [];
+  }
+
+  const out: Array<Record<string, unknown>> = [];
+  for (const t of tasks) {
+    if (t.template !== OAUTH_APP_TEMPLATE) continue;
+    if (!t.enabled) continue;                     // skip disabled inheritors
+    const key = paramDefault(t.params, "provider");
+    if (!key) continue;                           // misconfigured BYO entry
+    if (requested.size > 0 && !requested.has(key)) continue;
+    if (!t.webhook) continue;                     // need a webhook to Connect
+    out.push({
+      key,
+      pkce: true,
+      scopes: [] as string[],
+      secret_required: paramDefault(t.params, "client_secret_env") !== "",
+      configured: true,
+      has_token: await checkConnected(dicode, key),
+      label: t.name,
+      color: paramDefault(t.params, "color") || "#666",
+      standalone: { webhookPath: t.webhook },
+    });
+  }
+  return out;
+}
 
 export default async function main({ params, input, dicode }: DicodeSdk) {
   const inp = (input ?? null) as Record<string, unknown> | null;
@@ -98,17 +165,53 @@ export default async function main({ params, input, dicode }: DicodeSdk) {
         })),
     );
 
-    return [...withStatus, ...standaloneEntries];
+    // Auto-discovered BYO OAuth tasks (anything inheriting the _oauth-app
+    // template from a taskset entry — built-in office365/looker, plus any
+    // user-supplied entry from their own taskset).
+    const inheritorEntries = await scanInheritors(dicode, requested);
+
+    // Dedup by key. Precedence: broker > standalone > inheritors. The broker
+    // is centrally managed and harder for an operator to misconfigure, so a
+    // user's BYO `github` entry (mistake or intentional) does not shadow the
+    // broker's. Standalone wins over inheritors so an operator who explicitly
+    // ships an `openrouter-oauth` task in their taskset cannot accidentally
+    // double-list it.
+    const seen = new Set<string>();
+    const result: Array<Record<string, unknown>> = [];
+    for (const e of [...withStatus, ...standaloneEntries, ...inheritorEntries]) {
+      const k = (e as { key?: string }).key;
+      if (!k || seen.has(k)) continue;
+      seen.add(k);
+      result.push(e as Record<string, unknown>);
+    }
+    return result;
   }
 
   if (action === "connect") {
     const p = String(inp?.provider ?? "");
+    const baseURL = (Deno.env.get("DICODE_BASE_URL") ?? "http://localhost:8080").replace(/\/$/, "");
 
-    // Standalone provider: return the webhook URL directly.
+    // Standalone provider (e.g. openrouter): return the webhook URL directly.
     const standalone = STANDALONE[p];
     if (standalone) {
-      const baseURL = (Deno.env.get("DICODE_BASE_URL") ?? "http://localhost:8080").replace(/\/$/, "");
       return { provider: p, url: `${baseURL}${standalone.webhookPath}` };
+    }
+
+    // Auto-discovered _oauth-app inheritor (built-in office365/looker, or
+    // any user BYO entry): open the inherited webhook directly.
+    try {
+      const tasks = await dicode.list_tasks();
+      for (const t of tasks) {
+        if (t.template !== OAUTH_APP_TEMPLATE || !t.enabled || !t.webhook) continue;
+        if (paramDefault(t.params, "provider") === p) {
+          return { provider: p, url: `${baseURL}${t.webhook}` };
+        }
+      }
+    } catch (err) {
+      console.error(
+        `auth-providers: dicode.list_tasks failed during connect; falling back to broker. ` +
+        `Cause: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
 
     // Relay-broker provider: delegate to buildin/auth-start. Pre-empt the

--- a/tasks/buildin/auth-providers/task.yaml
+++ b/tasks/buildin/auth-providers/task.yaml
@@ -40,6 +40,7 @@ permissions:
     - "*"  # broker URL is config-driven; wildcard matches relay-client pattern
   dicode:
     secrets_has: true  # dicode.secrets.has — presence check for <PROVIDER>_ACCESS_TOKEN
+    list_tasks:  true  # dicode.list_tasks   — auto-discover _oauth-app inheritors
     tasks:
       # Only auth-start is callable. The per-provider auth/<p>-oauth tasks
       # return HTML (not a JSON {url} contract) so they cannot be invoked

--- a/tests/e2e/auth-providers.spec.ts
+++ b/tests/e2e/auth-providers.spec.ts
@@ -113,6 +113,46 @@ test.describe('Auth Providers dashboard', () => {
     expect(text.toLowerCase()).toContain('relay');
   });
 
+  test('list auto-discovers _oauth-app inheritors via the template marker', async ({ request }) => {
+    // The fixture taskset registers `fixture-oauth`, an instance of
+    // tasks/auth/_oauth-app/task.yaml with `provider: fixture` overrides.
+    // Because _oauth-app is marked `template: dicode.io/oauth-app`, the
+    // dashboard scans `dicode.list_tasks()` and includes it automatically —
+    // no hardcoded entry in the auth-providers task code.
+    await login(request, TEST_PASSPHRASE);
+    const res = await request.post('/hooks/auth-providers', {
+      headers: { 'Content-Type': 'application/json' },
+      data: { action: 'list' },
+    });
+    expect(res.ok()).toBe(true);
+    const body = await res.json() as { result: Array<Record<string, unknown>> } | Array<Record<string, unknown>>;
+    const rows = Array.isArray(body) ? body : body.result;
+    const fixture = rows.find(r => r.key === 'fixture');
+    expect(fixture).toBeDefined();
+    expect(fixture).toMatchObject({
+      key:             'fixture',
+      pkce:            true,
+      configured:      true,
+      has_token:       false,
+      label:           'Fixture OAuth',
+      color:           '#abc123',
+      secret_required: false,
+    });
+    expect(fixture?.standalone).toMatchObject({ webhookPath: '/hooks/fixture-oauth' });
+  });
+
+  test('connect routes _oauth-app inheritors to their webhook', async ({ request }) => {
+    await login(request, TEST_PASSPHRASE);
+    const res = await request.post('/hooks/auth-providers', {
+      headers: { 'Content-Type': 'application/json' },
+      data: { action: 'connect', provider: 'fixture' },
+    });
+    expect(res.ok()).toBe(true);
+    const body = await res.json() as { result: { url?: string } } | { url?: string };
+    const out = (body as { result: { url?: string } }).result ?? body as { url?: string };
+    expect(out.url).toContain('/hooks/fixture-oauth');
+  });
+
   test('connect with standalone openrouter returns the webhook URL', async ({ request }) => {
     await login(request, TEST_PASSPHRASE);
     const res = await request.post('/hooks/auth-providers', {

--- a/tests/e2e/fixtures/tasks/taskset.yaml
+++ b/tests/e2e/fixtures/tasks/taskset.yaml
@@ -43,3 +43,25 @@ spec:
     run-inputs-cleanup:
       ref:
         path: BUILDIN_RUN_INPUTS_CLEANUP_TASK_YAML
+
+    # BYO OAuth fixture: instantiates the generic _oauth-app task with
+    # provider-specific overrides. Used by auth-providers.spec.ts to
+    # confirm the dashboard auto-discovers _oauth-app inheritors via
+    # the `template: dicode.io/oauth-app` marker.
+    fixture-oauth:
+      ref:
+        path: AUTH_OAUTH_APP_TASK_YAML
+      overrides:
+        name: Fixture OAuth
+        trigger:
+          webhook: /hooks/fixture-oauth
+        params:
+          provider:          fixture
+          scope:             "test:read"
+          token_lifetime:    expires
+          color:             "#abc123"
+          client_id_env:     CLIENT_ID
+          access_token_env:  FIXTURE_ACCESS_TOKEN
+        env:
+          - { name: CLIENT_ID,            secret: FIXTURE_CLIENT_ID,    optional: true }
+          - { name: FIXTURE_ACCESS_TOKEN, secret: FIXTURE_ACCESS_TOKEN, optional: true }

--- a/tests/e2e/helpers/dicode-server.ts
+++ b/tests/e2e/helpers/dicode-server.ts
@@ -114,6 +114,7 @@ function writeTaskset(tempDir: string): { tasksetPath: string; tasksDir: string 
   const buildinAuthProvidersTaskYaml = path.join(REPO_ROOT, 'tasks/buildin/auth-providers/task.yaml');
   const buildinLocalStorageTaskYaml = path.join(REPO_ROOT, 'tasks/buildin/local-storage/task.yaml');
   const buildinRunInputsCleanupTaskYaml = path.join(REPO_ROOT, 'tasks/buildin/run-inputs-cleanup/task.yaml');
+  const authOauthAppTaskYaml = path.join(REPO_ROOT, 'tasks/auth/_oauth-app/task.yaml');
   const template = fs.readFileSync(path.join(TASKS_DIR, 'taskset.yaml'), 'utf8');
   const content = template
     .replace(/FIXTURES_TASKS_DIR/g, tasksDir)
@@ -121,7 +122,8 @@ function writeTaskset(tempDir: string): { tasksetPath: string; tasksDir: string 
     .replace(/BUILDIN_MCP_TASK_YAML/g, buildinMcpTaskYaml)
     .replace(/BUILDIN_AUTH_PROVIDERS_TASK_YAML/g, buildinAuthProvidersTaskYaml)
     .replace(/BUILDIN_LOCAL_STORAGE_TASK_YAML/g, buildinLocalStorageTaskYaml)
-    .replace(/BUILDIN_RUN_INPUTS_CLEANUP_TASK_YAML/g, buildinRunInputsCleanupTaskYaml);
+    .replace(/BUILDIN_RUN_INPUTS_CLEANUP_TASK_YAML/g, buildinRunInputsCleanupTaskYaml)
+    .replace(/AUTH_OAUTH_APP_TASK_YAML/g, authOauthAppTaskYaml);
   const tasksetPath = path.join(tempDir, 'taskset.yaml');
   fs.writeFileSync(tasksetPath, content, 'utf8');
   return { tasksetPath, tasksDir };


### PR DESCRIPTION
Follow-up to dicode-core#277 per user direction ("write an agent to see if we can autodetect tasks which inherit the global BYO auth task so we can display them in the ui"). The investigation came back **feasible-with-small-IPC-extension** — only `dicode.list_tasks`'s summary needs three extra fields. No refactor required.

## What this delivers

Operators with a BYO OAuth entry in their own taskset see it appear in the dashboard's auth-providers panel automatically — no hardcoded allowlist, no code change in `auth-providers/task.ts`. Same for any future addition to `tasks/auth/` that inherits from `_oauth-app`.

## Mechanism

| Layer | Change |
|---|---|
| `pkg/task/spec.go` | New `Spec.Template` field (`yaml:"template,omitempty"`). Set in the BASE task.yaml; the resolver propagates it to every entry that inherits via `ref.path` because Template is part of the merged spec the resolver already deep-copies. Override layers cannot clear it (Template is not in the `Overrides` struct). |
| `tasks/auth/_oauth-app/task.yaml` | Declares `template: dicode.io/oauth-app`. Reverse-DNS prefix + slug, namespaced. |
| `pkg/ipc/server.go` | `dicode.list_tasks` summary grows `template`, `webhook`, `enabled`. NOT exposed: `task_dir` (filesystem leakage), `permissions.env` (could hint at secret env-var names), `webhook_secret` (would defeat HMAC auth). The exposed fields are already visible via the WebUI's `/api/tasks` JSON. |
| `pkg/runtime/deno/sdk/{sdk.d.ts,shim.ts}` | New exported `TaskSummary` interface; `list_tasks()` return type narrows from `Promise<unknown>` to `Promise<TaskSummary[]>`. |
| `tasks/buildin/auth-providers/task.ts` | New `scanInheritors()` filters `list_tasks` by `template === "dicode.io/oauth-app"`, extracts `provider`/`color`/`client_secret_env` from params, and emits the panel-shaped row. `list` action union: broker → standalone (openrouter) → inheritors, with broker-wins dedup by key. `connect` action: standalone → inheritor lookup → broker delegation. |
| `tasks/buildin/auth-providers/task.yaml` | Adds `permissions.dicode.list_tasks: true`. |

## Tests

- **Go IPC unit test** (`TestServer_Dicode_ListTasks_TemplateAndWebhook`): registers two specs (one with Template + Webhook + Enabled, one without) and asserts the summary surfaces all three fields correctly, with absent fields omitted via `omitempty`.
- **E2e** (`auth-providers.spec.ts`):
  - `list auto-discovers _oauth-app inheritors via the template marker` — confirms `fixture-oauth` (a fixture taskset entry inheriting `_oauth-app` with `provider=fixture` overrides) appears in the dashboard list with the canonical `PublicProviderInfo + standalone` shape.
  - `connect routes _oauth-app inheritors to their webhook` — confirms Connect for the fixture provider returns the inherited webhook URL.
- New fixture placeholder `AUTH_OAUTH_APP_TASK_YAML` + `fixture-oauth` entry in `tests/e2e/fixtures/tasks/taskset.yaml`.

## Side concerns addressed (per investigation report)

- **Identifying signal stability**: investigation flagged `task_dir.endsWith("/_oauth-app")` string-sniffing as fragile. Switched to the namespaced `template: dicode.io/oauth-app` annotation — durable across renames and re-vendoring.
- **Privacy**: `task_dir` excluded from the IPC summary so a malicious task can't enumerate the daemon's filesystem layout.
- **Fail-open**: `scanInheritors` and the `connect` lookup log+swallow on `list_tasks` failure rather than blanking the panel. Errors visible in run logs (typical cause: forked auth-providers task missing `permissions.dicode.list_tasks`).
- **Hot reload**: existing reconciler re-Registers on diff and the panel runs `list` on every refresh — newly-added BYO entries appear on next click, no extra wiring.
- **TaskID collisions**: namespaced by taskset, no collision between built-in `auth/foo-oauth` and a user's own entry.
- **Broker precedence**: dedup ordering is broker > standalone > inheritors, so a user's accidental BYO `github` entry cannot shadow the broker-managed one.

## Why not the form-webhook fallback

The investigation's fallback option ("Add Provider" task with form-webhook UI) was the user's stated alternative if auto-detect was infeasible. Auto-detect IS feasible, so the form-webhook is **out of scope** for this PR. Could still be a useful guided-setup layer on top of auto-detect — happy to follow up if you want it.

## Stacking

This PR builds on dicode-core#277 (`refactor/auth-consolidation`) but does not depend on it being merged first — the changes are in different files (`#277` only touches `tasks/auth/taskset.yaml`, `_oauth-app/task.yaml` description, `docs/oauth.md`; this PR adds the template marker line + IPC + auth-providers code paths). Either order works; the `_oauth-app/task.yaml` edits will merge cleanly.

## Test plan

- [x] `go test ./... -timeout 120s` — 20 packages PASS
- [x] `make format` clean
- [ ] Reviewer: `make test-e2e-auth` — confirms the new auth-providers tests pass against a real daemon with fixture-oauth registered
- [ ] Reviewer: with relay disabled, run `dicode list` to verify `auth/looker-oauth` appears and `dicode run buildin/auth-providers action=list` returns it as a row with `key: "looker"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)