### PR TITLE
fix(buildin/relay-server): pre-create broker signing key on first run

### DIFF
--- a/tasks/buildin/relay-server/task.test.ts
+++ b/tasks/buildin/relay-server/task.test.ts
@@ -1,35 +1,39 @@
 /**
  * task.test.ts — unit tests for buildin/relay-server.
  *
- * Exercises three cases the spec called out:
+ * Exercises four cases:
  *   1. base_url param missing → task body throws before touching the relay.
- *   2. broker signing-key file pinned in relay.yaml but not on disk →
- *      startServer rejects (the published relay's loadBrokerSigningKey()
- *      does an unconditional readFileSync when the YAML pins a path, even
- *      under dryRun, so this is the real "required artefact missing"
- *      failure mode surfaced by 0.1.6).
- *   3. valid base_url + ${DICODE_DATADIR}/relay/broker-signing.key staged
+ *   2. DICODE_DATADIR unset → ensureSigningKey throws with a clear error.
+ *   3. ensureSigningKey on a fresh datadir creates a readable PKCS8 PEM at
+ *      ${DICODE_DATADIR}/relay/broker-signing.key with mode 0o600.
+ *   4. ensureSigningKey is idempotent — when the file already exists it
+ *      neither regenerates nor throws.
+ *   5. valid base_url + ${DICODE_DATADIR}/relay/broker-signing.key staged
  *      on disk + STATUS_PASSWORD set → startServer({dryRun:true}) resolves.
  *
- * Cases 1 and 2 exercise the task body (./task.ts) via a hand-rolled SDK
- * mock — the harness in tasks/sdk-test.ts would dynamically re-import
- * task.ts and lose env determinism between cases. Case 3 calls startServer
- * directly so it stays decoupled from the supervisor's signal-handling
- * scaffolding, which would otherwise leak Deno.addSignalListener handles
- * into the test runner.
+ * Case 1 exercises the task body (./task.ts) via a hand-rolled SDK mock —
+ * the harness in tasks/sdk-test.ts would dynamically re-import task.ts and
+ * lose env determinism between cases. Cases 2-4 call the exported
+ * ensureSigningKey directly. Case 5 calls startServer directly so it stays
+ * decoupled from the supervisor's signal-handling scaffolding, which would
+ * otherwise leak Deno.addSignalListener handles into the test runner.
  *
  * Note (deviation from spec): the spec called for a "STATUS_PASSWORD
  * missing → throws" case. The published 0.1.6 relay's loadConfig() does
  * not throw on unresolved ${VAR} — it logs a warning and collapses to "".
- * The actual hard-failure surface for missing required artefacts is the
- * broker signing-key file, hence case 2 above.
+ * Under 0.1.7+ the relay also throws ENOENT if the signing key file is
+ * missing — but the supervisor now pre-creates it (see ensureSigningKey),
+ * so the "missing required artefact" failure mode is no longer reachable
+ * from the task body's happy path.
  */
 
-import { assertRejects } from "jsr:@std/assert@1";
-import { generateKeyPairSync } from "node:crypto";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { assertEquals, assertRejects, assertThrows } from "jsr:@std/assert@1";
+import { createPrivateKey, generateKeyPairSync } from "node:crypto";
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { startServer } from "npm:dicode-relay@^0.1.6/start";
+
+import { ensureSigningKey } from "./task.ts";
 
 // Doppler-fed env vars that the daemon would otherwise populate. We clear
 // all of them before each test so fixtures are deterministic regardless of
@@ -140,24 +144,52 @@ Deno.test("rejects when base_url param is missing", async () => {
   );
 });
 
+Deno.test("ensureSigningKey throws when DICODE_DATADIR is unset", () => {
+  clearRelayEnv();
+  Deno.env.delete("DICODE_DATADIR");
+  assertThrows(() => ensureSigningKey(), Error, "DICODE_DATADIR");
+});
+
 Deno.test(
-  "rejects when broker signing-key file pinned in relay.yaml is missing",
-  async () => {
+  "ensureSigningKey on fresh datadir creates a loadable PKCS8 PEM at 0o600",
+  () => {
     clearRelayEnv();
-    Deno.env.set("STATUS_PASSWORD", "test-pw");
-    // DICODE_DATADIR points at a tempdir but we intentionally do NOT
-    // seed broker-signing.key — startServer's loadBrokerSigningKey does
-    // a readFileSync against the YAML-pinned path and surfaces ENOENT.
     const datadir = Deno.makeTempDirSync({ prefix: "dicode-relay-test-" });
     Deno.env.set("DICODE_DATADIR", datadir);
 
-    const { default: main } = await import("./task.ts");
-    const sdk = makeSdk({ base_url: "https://relay.example.com" });
+    ensureSigningKey();
 
-    await assertRejects(
-      // deno-lint-ignore no-explicit-any
-      () => main(sdk as any),
-    );
+    const keyPath = join(datadir, "relay", "broker-signing.key");
+    const pem = readFileSync(keyPath, "utf8");
+    // Sanity: PEM is PKCS8 (header reads "PRIVATE KEY", not "EC PRIVATE KEY"
+    // which would be SEC1) and parses as a P-256 key via node:crypto, which
+    // is what relay's loadBrokerSigningKey() does internally.
+    if (!pem.includes("BEGIN PRIVATE KEY")) {
+      throw new Error(
+        `expected PKCS8 PEM header at ${keyPath}, got:\n${pem.slice(0, 80)}`,
+      );
+    }
+    createPrivateKey(pem); // throws if malformed
+
+    // 0o600 = owner rw only. Linux honours this; on macOS the umask may
+    // widen the result but the mode bits we asked for should still be set.
+    const mode = statSync(keyPath).mode & 0o777;
+    assertEquals(mode, 0o600);
+  },
+);
+
+Deno.test(
+  "ensureSigningKey is idempotent — preserves existing key on subsequent calls",
+  () => {
+    clearRelayEnv();
+    const datadir = stageDatadirWithSigningKey();
+    const keyPath = join(datadir, "relay", "broker-signing.key");
+    const before = readFileSync(keyPath, "utf8");
+
+    ensureSigningKey(); // must not throw, must not regenerate.
+
+    const after = readFileSync(keyPath, "utf8");
+    assertEquals(after, before);
   },
 );
 

--- a/tasks/buildin/relay-server/task.ts
+++ b/tasks/buildin/relay-server/task.ts
@@ -10,7 +10,7 @@
 // startup, so this task body just surfaces base_url as BASE_URL and hands
 // off to the relay's library entry point. No subprocess, no shell-out.
 
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { generateKeyPairSync } from "node:crypto";
 import { startServer } from "npm:dicode-relay@^0.1.6/start";
@@ -38,7 +38,13 @@ export function ensureSigningKey(): void {
     );
   }
   const keyPath = join(dataDir, "relay", "broker-signing.key");
-  if (existsSync(keyPath)) return;
+  if (existsSync(keyPath)) {
+    // Tighten perms for keys that may have been written 0o644 by relay
+    // 0.1.6's now-removed auto-generate path before this supervisor took
+    // over the bootstrap responsibility. Idempotent on already-0o600 files.
+    chmodSync(keyPath, 0o600);
+    return;
+  }
   mkdirSync(dirname(keyPath), { recursive: true });
   const { privateKey } = generateKeyPairSync("ec", {
     namedCurve: "prime256v1",
@@ -49,7 +55,19 @@ export function ensureSigningKey(): void {
     privateKeyEncoding: { type: "pkcs8", format: "pem" },
   });
   // With privateKeyEncoding set, `privateKey` is a PKCS8 PEM string.
-  writeFileSync(keyPath, privateKey, { mode: 0o600 });
+  // flag: "wx" fails loudly if another writer raced us — better than
+  // silently clobbering and leaving two daemons disagreeing on the broker
+  // pubkey. The `restart: always` policy means a clean re-dispatch will
+  // short-circuit on existsSync above.
+  try {
+    writeFileSync(keyPath, privateKey, { flag: "wx", mode: 0o600 });
+  } catch (err) {
+    throw new Error(
+      `[relay-server] failed to write broker signing key at ${keyPath}: ` +
+        `${err instanceof Error ? err.message : String(err)}. ` +
+        `Check that DICODE_DATADIR (${dataDir}) is writable and has space.`,
+    );
+  }
   console.warn(
     `[relay-server] generated new broker signing key at ${keyPath} (first-run bootstrap)`,
   );

--- a/tasks/buildin/relay-server/task.ts
+++ b/tasks/buildin/relay-server/task.ts
@@ -10,8 +10,50 @@
 // startup, so this task body just surfaces base_url as BASE_URL and hands
 // off to the relay's library entry point. No subprocess, no shell-out.
 
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { generateKeyPairSync } from "node:crypto";
 import { startServer } from "npm:dicode-relay@^0.1.6/start";
 import type { DicodeSdk } from "../../sdk.ts";
+
+// Pre-create the broker signing key under ${DICODE_DATADIR}/relay/ so the
+// relay's loadBrokerSigningKey() has a file to read on first run.
+//
+// Why this lives in the supervisor (us) rather than the relay: dicode-relay
+// 0.1.7+ (see dicode-ayo/dicode-relay#73) scopes auto-generation back to the
+// legacy <cwd>/broker-signing-key.pem fallback only — when relay.yaml pins
+// `broker.signing_key_file: <path>` (as ours does) and the file is missing,
+// the relay now throws ENOENT instead of generating one at the configured
+// path. Keeping the bootstrap in the supervisor lets the relay stay minimal
+// (it just reads the configured path) while we own first-run setup.
+//
+// Format must match loadBrokerSigningKey(): PKCS8 PEM, P-256 (prime256v1)
+// curve. Public key is derived from the private key at relay load time, so
+// only the private key is persisted.
+export function ensureSigningKey(): void {
+  const dataDir = Deno.env.get("DICODE_DATADIR");
+  if (!dataDir) {
+    throw new Error(
+      "DICODE_DATADIR not set; daemon should always provide this",
+    );
+  }
+  const keyPath = join(dataDir, "relay", "broker-signing.key");
+  if (existsSync(keyPath)) return;
+  mkdirSync(dirname(keyPath), { recursive: true });
+  const { privateKey } = generateKeyPairSync("ec", {
+    namedCurve: "prime256v1",
+    // Both encodings must be supplied together for node:crypto's type
+    // overload to resolve to the "string-returning" variant — we ignore
+    // the public key (relay derives it from the private at load time).
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  // With privateKeyEncoding set, `privateKey` is a PKCS8 PEM string.
+  writeFileSync(keyPath, privateKey, { mode: 0o600 });
+  console.warn(
+    `[relay-server] generated new broker signing key at ${keyPath} (first-run bootstrap)`,
+  );
+}
 
 export default async function main({ params }: DicodeSdk): Promise<void> {
   const baseUrl = await params.get("base_url");
@@ -24,6 +66,10 @@ export default async function main({ params }: DicodeSdk): Promise<void> {
   // Relay's loadConfig() walks YAML strings and replaces ${VAR} from
   // process.env. Deno's node-compat exposes Deno.env as process.env.
   Deno.env.set("BASE_URL", baseUrl);
+
+  // First-run bootstrap: relay 0.1.7+ refuses to auto-generate at a
+  // configured signing_key_file path, so create the key before handoff.
+  ensureSigningKey();
 
   const configPath = new URL("./relay.yaml", import.meta.url).pathname;
   const handle = await startServer({ configPath });


### PR DESCRIPTION
## Why

[dicode-ayo/dicode-relay#73](https://github.com/dicode-ayo/dicode-relay/pull/73) scopes back auto-generation when `signing_key_file: <path>` is configured but the file is missing — the relay now throws `ENOENT` instead of silently generating a fresh key at the configured path. (The legacy `<cwd>/broker-signing-key.pem` fallback still auto-generates; only the explicit-path case is restricted.)

Our shipped `tasks/buildin/relay-server/relay.yaml` pins:

```yaml
broker:
  signing_key_file: ${DICODE_DATADIR}/relay/broker-signing.key
```

So once dicode-relay 0.1.7 ships, `buildin/relay-server` will crash on first run unless the supervisor (us) pre-creates the key. This PR adds that bootstrap step in the existing supervisor — keeping the relay minimal (it just reads the configured path) while we own first-run setup.

Companion to #286 which shipped the `buildin/relay-server` task itself.

## Summary

- New exported helper `ensureSigningKey()` in `tasks/buildin/relay-server/task.ts`:
  - Reads `DICODE_DATADIR` from the env (the daemon always provides it; missing → throw with a clear message).
  - Skips if `${DICODE_DATADIR}/relay/broker-signing.key` already exists.
  - Otherwise `mkdirSync`'s the parent, generates a P-256 (prime256v1) keypair, and writes the private key as PKCS8 PEM at mode `0o600`.
  - Public key is derived at relay load time, so only the private half is persisted.
- Called from `main()` immediately before `await startServer(...)`.
- Format matches the published relay's `loadBrokerSigningKey()` expectations (PKCS8 PEM, P-256), confirmed against `dist/shared/signing.js` in the cached 0.1.6 npm tarball.
- No widening of `permissions.fs`: the existing `${DATADIR}/relay rw` already covers the write.

## Pin

Stayed on `npm:dicode-relay@^0.1.6/start`. As of writing, dicode-relay#73 is still open and `0.1.7` is not yet on npm (latest is `0.1.6`). Bump to `^0.1.7` will land in a follow-up once release-please cuts the new tag — that makes the cross-repo requirement explicit and avoids the TOCTOU between cached `0.1.6` and a `^0.1.7` constraint.

## Test plan

- [x] `make format` clean
- [x] `make format-check` passes
- [x] `go test ./...` passes
- [x] `make test-tasks` passes — 85 task tests, including 5 relay-server cases:
  - `rejects when base_url param is missing`
  - `ensureSigningKey throws when DICODE_DATADIR is unset` (new)
  - `ensureSigningKey on fresh datadir creates a loadable PKCS8 PEM at 0o600` (new — asserts header, parses via `createPrivateKey`, checks mode bits)
  - `ensureSigningKey is idempotent — preserves existing key on subsequent calls` (new — diffs PEM contents before/after a second call)
  - `valid base_url + staged datadir → startServer({dryRun:true}) resolves`
- [ ] After dicode-relay 0.1.7 publishes: follow-up bumps pin to `^0.1.7` and removes the cached-0.1.6 TOCTOU.

The previous "rejects when broker signing-key file pinned in relay.yaml is missing" test was removed — that failure mode is no longer reachable from the task body's happy path because the supervisor now pre-creates the file. The fresh-datadir + idempotency tests cover both halves of the new contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)