### PR TITLE
feat(config): AI task-authoring fields + virtual ai-scratch source (epic #288)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -154,6 +154,26 @@ type AIConfig struct {
 	// with the dicode-task-dev skill. Point it at any ai-agent override to
 	// swap providers, skills, or model without changing code.
 	Task string `yaml:"task,omitempty"`
+
+	// CreateTask is the task id invoked for AI-first task authoring sessions
+	// (`dicode task create --ai`, `dicode task edit`, and the dc-task-create
+	// webui component). Defaults to "buildin/task-create" — an ai-agent
+	// override preloaded with the dicode-task-create skill and granted the
+	// sandbox FS + sources_set_dev_mode permissions it needs to scaffold
+	// task files inside a dev-mode clone. Distinct from Task so the
+	// read-only chat surface and the writeable authoring agent can be
+	// swapped independently. Empty-string and absent both resolve to the
+	// default — no explicit-disable state today (matches AI.Task).
+	CreateTask string `yaml:"create_task,omitempty"`
+
+	// CreateSessionTTL bounds how long an open authoring session may sit
+	// idle before the daemon force-cancels it (releasing the dev-mode lock
+	// on its source and cleaning up the sandbox dir). Defaults to 24h.
+	// Empty or zero falls through to the default — no explicit-disable
+	// state today (matches DefaultsConfig.RunInputs.Retention). Operators
+	// who want effectively-never auto-cancel can set a very large value
+	// (e.g. 8760h).
+	CreateSessionTTL time.Duration `yaml:"create_session_ttl,omitempty"`
 }
 
 type Config struct {
@@ -307,6 +327,28 @@ func applyDefaults(cfg *Config, configDir string) {
 
 	cfg.Database.Path = expand(cfg.Database.Path)
 
+	// Synthesise the virtual "ai-scratch" local source if the operator
+	// hasn't already defined one. This is what makes `dicode task create`
+	// zero-config — boilerplate writes land here, the reconciler picks
+	// them up, and the synthesised entry shows up in the Sources webui
+	// page like any other local source. If the operator declares their
+	// own ai-scratch entry, theirs wins.
+	//
+	// Synthesis runs before the entry-expansion loop below so the
+	// synthesised ref goes through the same path-expansion + watch-default
+	// + IsGit-branch normalisation every other entry gets. Anything that
+	// the loop applies (today: ${VAR} expansion, branch/poll defaults for
+	// git, watch=&true for local) will automatically apply to ai-scratch
+	// too — no per-field-on-synthesis maintenance.
+	if cfg.Spec.Entries == nil {
+		cfg.Spec.Entries = map[string]*taskset.Entry{}
+	}
+	if _, exists := cfg.Spec.Entries["ai-scratch"]; !exists {
+		cfg.Spec.Entries["ai-scratch"] = &taskset.Entry{
+			Ref: &taskset.Ref{Path: filepath.Join(cfg.DataDir, "ai-tasks")},
+		}
+	}
+
 	// Expand ${VAR} in ref paths for spec.entries.
 	for _, entry := range cfg.Spec.Entries {
 		if entry == nil || entry.Ref == nil {
@@ -369,6 +411,21 @@ func applyDefaults(cfg *Config, configDir string) {
 	// *string and test for nil instead of empty.
 	if cfg.AI.Task == "" {
 		cfg.AI.Task = "buildin/dicodai"
+	}
+	// AI.CreateTask defaults to the buildin/task-create preset so AI-first
+	// authoring (`dicode task create --ai`, `dicode task edit`, the
+	// dc-task-create webui component) works out of the box. Same
+	// empty-or-default semantics as AI.Task — keep them in lockstep so
+	// operators reason about one rule.
+	if cfg.AI.CreateTask == "" {
+		cfg.AI.CreateTask = "buildin/task-create"
+	}
+	// AI.CreateSessionTTL caps idle authoring-session lifetime so a stale
+	// open session can't hold a source's dev-mode lock indefinitely. 24h
+	// is long enough for "I'll come back to it tomorrow" and short enough
+	// to free shared boxes overnight.
+	if cfg.AI.CreateSessionTTL == 0 {
+		cfg.AI.CreateSessionTTL = 24 * time.Hour
 	}
 	// RunInputs defaults: 30-day retention, local-storage backend.
 	if cfg.Defaults.RunInputs.Retention == 0 {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -328,24 +328,25 @@ func applyDefaults(cfg *Config, configDir string) {
 	cfg.Database.Path = expand(cfg.Database.Path)
 
 	// Synthesise the virtual "ai-scratch" local source if the operator
-	// hasn't already defined one. This is what makes `dicode task create`
-	// zero-config — boilerplate writes land here, the reconciler picks
-	// them up, and the synthesised entry shows up in the Sources webui
-	// page like any other local source. If the operator declares their
-	// own ai-scratch entry, theirs wins.
+	// hasn't already defined one AND the ai-tasks directory already exists.
+	// The directory is created lazily by the first AI authoring session
+	// (`dicode task create --ai`); synthesising a source for a non-existent
+	// path causes the taskset resolver to log spurious WARN on every
+	// fsnotify tick and can race with other sources that share the same
+	// watchRoot (both resolve to filepath.Dir of their ref path).
 	//
 	// Synthesis runs before the entry-expansion loop below so the
 	// synthesised ref goes through the same path-expansion + watch-default
-	// + IsGit-branch normalisation every other entry gets. Anything that
-	// the loop applies (today: ${VAR} expansion, branch/poll defaults for
-	// git, watch=&true for local) will automatically apply to ai-scratch
-	// too — no per-field-on-synthesis maintenance.
+	// + IsGit-branch normalisation every other entry gets.
 	if cfg.Spec.Entries == nil {
 		cfg.Spec.Entries = map[string]*taskset.Entry{}
 	}
+	aiScratchPath := filepath.Join(cfg.DataDir, "ai-tasks")
 	if _, exists := cfg.Spec.Entries["ai-scratch"]; !exists {
-		cfg.Spec.Entries["ai-scratch"] = &taskset.Entry{
-			Ref: &taskset.Ref{Path: filepath.Join(cfg.DataDir, "ai-tasks")},
+		if fi, err := os.Stat(aiScratchPath); err == nil && fi.IsDir() {
+			cfg.Spec.Entries["ai-scratch"] = &taskset.Entry{
+				Ref: &taskset.Ref{Path: aiScratchPath},
+			}
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -647,6 +647,12 @@ func TestLoad_AIScratchSourceSynthesized(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "dicode.yaml")
 
+	// Create the ai-tasks directory — synthesis only triggers when it exists.
+	aiTasksDir := filepath.Join(dir, "ai-tasks")
+	if err := os.MkdirAll(aiTasksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
 	content := fmt.Sprintf(`
 data_dir: %s
 spec:
@@ -684,15 +690,49 @@ spec:
 	}
 }
 
+// TestLoad_AIScratchNotSynthesizedWithoutDir verifies that when the ai-tasks
+// directory does not exist, no ai-scratch source is injected. This prevents
+// a non-existent directory from being watched, which would cause spurious
+// WARN logs and potential race conditions with other sources sharing the
+// same watchRoot.
+func TestLoad_AIScratchNotSynthesizedWithoutDir(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+
+	content := fmt.Sprintf(`
+data_dir: %s
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
+`, dir)
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cfg.Spec.Entries["ai-scratch"]; ok {
+		t.Errorf("Spec.Entries[ai-scratch] present; want absent when ai-tasks dir does not exist")
+	}
+}
+
 // TestLoad_AIScratchSynthesizedFromEmptySpec ensures the synthesis works
 // even when dicode.yaml has no `spec:` block at all (the bare zero-config
-// install). A refactor that drops the `cfg.Spec.Entries == nil` map-init
-// guard would pass every other test in this package because they all
-// pre-populate at least one entry — this is the only test that exercises
-// the nil-map allocation path.
+// install), provided the ai-tasks directory exists. A refactor that drops
+// the `cfg.Spec.Entries == nil` map-init guard would pass every other test
+// in this package because they all pre-populate at least one entry — this
+// is the only test that exercises the nil-map allocation path.
 func TestLoad_AIScratchSynthesizedFromEmptySpec(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "dicode.yaml")
+
+	// Create the ai-tasks directory so synthesis triggers.
+	if err := os.MkdirAll(filepath.Join(dir, "ai-tasks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	content := fmt.Sprintf(`
 data_dir: %s

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestExpandVars(t *testing.T) {
@@ -551,5 +552,228 @@ defaults:
 	}
 	if !strings.Contains(err.Error(), "reserved") {
 		t.Errorf("error = %v; want mention of reserved", err)
+	}
+}
+
+// TestLoad_AICreateTaskDefault ensures an empty ai: block falls back to the
+// buildin/task-create default so zero-config installs get the AI-first task
+// authoring agent wired up without edits to dicode.yaml.
+func TestLoad_AICreateTaskDefault(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+
+	content := `
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AI.CreateTask != "buildin/task-create" {
+		t.Errorf("AI.CreateTask default = %q, want %q", cfg.AI.CreateTask, "buildin/task-create")
+	}
+}
+
+// TestLoad_AICreateTaskOverride ensures a user-supplied ai.create_task survives
+// the YAML round-trip without being clobbered by applyDefaults — operators
+// who point at a custom override (e.g. claude-cli wrapper) must keep their
+// choice across daemon restarts.
+func TestLoad_AICreateTaskOverride(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+
+	content := `
+ai:
+  create_task: examples/task-create-claude
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AI.CreateTask != "examples/task-create-claude" {
+		t.Errorf("AI.CreateTask = %q, want %q", cfg.AI.CreateTask, "examples/task-create-claude")
+	}
+}
+
+// TestLoad_AICreateSessionTTLDefault ensures an empty ai.create_session_ttl
+// falls back to 24h so stale authoring sessions are auto-cancelled without
+// requiring explicit operator config.
+func TestLoad_AICreateSessionTTLDefault(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+
+	content := `
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := 24 * time.Hour
+	if cfg.AI.CreateSessionTTL != want {
+		t.Errorf("AI.CreateSessionTTL default = %v, want %v", cfg.AI.CreateSessionTTL, want)
+	}
+}
+
+// TestLoad_AIScratchSourceSynthesized ensures that when no source named
+// "ai-scratch" is defined in dicode.yaml, applyDefaults synthesizes one
+// pointing at ${DATADIR}/ai-tasks. This is what makes `dicode task create`
+// zero-config: the operator runs it, the boilerplate writes to the
+// synthesized source, and the reconciler picks it up. Without this, every
+// install would need to hand-author an entry in dicode.yaml first.
+func TestLoad_AIScratchSourceSynthesized(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+
+	content := fmt.Sprintf(`
+data_dir: %s
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
+`, dir)
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, ok := cfg.Spec.Entries["ai-scratch"]
+	if !ok || entry == nil {
+		t.Fatalf("Spec.Entries[ai-scratch] missing; want synthesized entry")
+	}
+	if entry.Ref == nil {
+		t.Fatalf("Spec.Entries[ai-scratch].Ref = nil; want non-nil local ref")
+	}
+	wantPath := filepath.Join(dir, "ai-tasks")
+	if entry.Ref.Path != wantPath {
+		t.Errorf("Spec.Entries[ai-scratch].Ref.Path = %q, want %q", entry.Ref.Path, wantPath)
+	}
+	if entry.Ref.URL != "" {
+		t.Errorf("Spec.Entries[ai-scratch].Ref.URL = %q, want empty (local source)", entry.Ref.URL)
+	}
+	// Watch defaults to true for local sources so the agent's writes are
+	// reflected in the registry via fsnotify, matching every other local
+	// source under the same applyDefaults branch.
+	if entry.Ref.Watch == nil || !*entry.Ref.Watch {
+		t.Errorf("Spec.Entries[ai-scratch].Ref.Watch = %v, want explicit true", entry.Ref.Watch)
+	}
+}
+
+// TestLoad_AIScratchSynthesizedFromEmptySpec ensures the synthesis works
+// even when dicode.yaml has no `spec:` block at all (the bare zero-config
+// install). A refactor that drops the `cfg.Spec.Entries == nil` map-init
+// guard would pass every other test in this package because they all
+// pre-populate at least one entry — this is the only test that exercises
+// the nil-map allocation path.
+func TestLoad_AIScratchSynthesizedFromEmptySpec(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+
+	content := fmt.Sprintf(`
+data_dir: %s
+`, dir)
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Spec.Entries == nil {
+		t.Fatal("Spec.Entries = nil after Load; want allocated map containing ai-scratch")
+	}
+	entry, ok := cfg.Spec.Entries["ai-scratch"]
+	if !ok || entry == nil {
+		t.Fatalf("Spec.Entries[ai-scratch] missing; want synthesized entry on empty spec")
+	}
+	wantPath := filepath.Join(dir, "ai-tasks")
+	if entry.Ref == nil || entry.Ref.Path != wantPath {
+		t.Errorf("Spec.Entries[ai-scratch].Ref.Path = %v, want %q", entry.Ref, wantPath)
+	}
+}
+
+// TestLoad_AIScratchUserDefinedWins ensures a user who explicitly defines
+// an `ai-scratch` source in dicode.yaml is not overwritten by the synthesis.
+// The synthesis is a default — like every other applyDefaults branch, a
+// user-supplied value takes precedence.
+func TestLoad_AIScratchUserDefinedWins(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+	userPath := filepath.Join(dir, "my-scratch")
+
+	content := fmt.Sprintf(`
+data_dir: %s
+spec:
+  entries:
+    ai-scratch:
+      ref:
+        path: %s
+`, dir, userPath)
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, ok := cfg.Spec.Entries["ai-scratch"]
+	if !ok || entry == nil {
+		t.Fatalf("Spec.Entries[ai-scratch] missing")
+	}
+	if entry.Ref.Path != userPath {
+		t.Errorf("Spec.Entries[ai-scratch].Ref.Path = %q, want user-supplied %q (synthesis must not overwrite)", entry.Ref.Path, userPath)
+	}
+}
+
+// TestLoad_AICreateSessionTTLOverride ensures a user-supplied duration string
+// parses into time.Duration so operators can tune the auto-cancel window
+// (short TTLs for shared dev boxes, long for personal installs).
+func TestLoad_AICreateSessionTTLOverride(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+
+	content := `
+ai:
+  create_session_ttl: 1h
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AI.CreateSessionTTL != time.Hour {
+		t.Errorf("AI.CreateSessionTTL = %v, want %v", cfg.AI.CreateSessionTTL, time.Hour)
 	}
 }


### PR DESCRIPTION
## Summary

First slice of [epic #288](https://github.com/dicode-ayo/dicode-core/issues/288) — config plumbing for the AI-first task authoring feature. Bounded to `pkg/config/` with no CLI / UI / handler changes; everything downstream will build on this.

- New `AIConfig.CreateTask` (yaml: `ai.create_task`, default `buildin/task-create`) — the writeable agent for AI authoring sessions. Distinct from existing `ai.task` so the read-only dicodai chat and the writeable authoring agent can be swapped independently.
- New `AIConfig.CreateSessionTTL` (yaml: `ai.create_session_ttl`, default `24h`) — caps idle authoring-session lifetime so a stale open session can't hold a source's dev-mode lock indefinitely.
- `applyDefaults` synthesises a virtual `ai-scratch` local source at `${DATADIR}/ai-tasks` when no entry of that name exists. Zero-config first-run UX: `dicode task create` works without operator config. A user-defined `ai-scratch` wins (no overwrite).

## Test plan

- [x] `pkg/config` tests: defaults applied when fields absent, overrides preserved, virtual source synthesised, user-defined entry wins over synthesis.
- [x] `make test` — full suite green (no regressions in any package).
- [x] `make lint` — clean.
- [x] `make format` — re-runs without changes.

## Out of scope (tracked in #288)

- REST handlers `/api/task/{create,edit,save,cancel}` — next slice.
- IPC methods + CLI verbs — follow-up slice.
- `tasks/buildin/task-create/` override + `dicode-task-create.md` skill — separate slice.
- `dc-task-create` web component — separate slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)