### PR TITLE
feat(task/docker): add network + hardening fields to docker spec

### DIFF
--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -284,6 +284,30 @@ Use **Edit code** on the task page to edit the Dockerfile directly in the web UI
 | `docker.working_dir` | string | Container working directory |
 | `docker.env_vars` | map | Literal environment variables injected into container |
 | `docker.pull_policy` | string | `missing` (default), `always`, `never`. Ignored when using `build`. |
+| `docker.network_mode` | string | Container network — `bridge` (default for docker), `host`, `none`, or a user-defined network name. `host` collapses isolation; a startup warning is emitted. |
+| `docker.extra_hosts` | list | Extra `/etc/hosts` entries — `"<name>:<ip>"`. Use `host.docker.internal:host-gateway` to reach host services from a bridge-networked container. |
+| `docker.cap_drop` | list | Linux capabilities to drop, e.g. `[ALL]`. |
+| `docker.cap_add` | list | Linux capabilities to re-add after `cap_drop`. Granting `SYS_ADMIN`, `SYS_PTRACE`, `SYS_MODULE`, or `ALL` emits a warning — these can enable container escape. |
+| `docker.security_opt` | list | Container security options, e.g. `["no-new-privileges:true"]`. Disabling sandbox layers (`seccomp=unconfined`, `apparmor=unconfined`, `label=disable`) emits a warning. |
+| `docker.read_only` | bool | Mount the container rootfs read-only. Pair with explicit tmpfs/volumes for any paths that need writes. |
+| `docker.user` | string | Run the container as `<uid>[:<gid>]` or `<name>[:<group>]`. Overrides the image's `USER` directive. |
+
+#### Hardened defaults
+
+For daemon tasks that don't need root or host networking, a defense-in-depth baseline:
+
+```yaml
+docker:
+  image: cloudflare/cloudflared:latest
+  network_mode: bridge
+  extra_hosts: ["host.docker.internal:host-gateway"]
+  cap_drop: [ALL]
+  security_opt: ["no-new-privileges:true"]
+  read_only: true
+  user: "65532:65532"   # nonroot
+```
+
+This keeps services bound to `127.0.0.1` on the host unreachable from the container, drops every capability, blocks setuid escalation, and runs unprivileged.
 
 **Live logs** — container stdout/stderr is streamed line-by-line to the run log as it runs.
 

--- a/docs/podman-runtime.md
+++ b/docs/podman-runtime.md
@@ -116,6 +116,25 @@ Containers are named `dicode-<runID>`. On startup, dicode removes any containers
 
 ---
 
+## Hardening fields
+
+The `docker:` section supports container-isolation fields that map to podman CLI flags:
+
+| Field | Podman flag |
+| --- | --- |
+| `network_mode` | `--network` |
+| `extra_hosts` | `--add-host` (repeated) |
+| `cap_drop` / `cap_add` | `--cap-drop` / `--cap-add` |
+| `security_opt` | `--security-opt` |
+| `read_only` | `--read-only` |
+| `user` | `--user` |
+
+A startup warning is emitted for values that visibly weaken isolation — `network_mode: host`, `cap_add` of `SYS_ADMIN`/`SYS_PTRACE`/`SYS_MODULE`/`ALL`, and `security_opt` disabling seccomp/AppArmor/SELinux. The task still runs; the warning surfaces in the UI so reviewers notice.
+
+See [Task Format → Container fields reference](./concepts/task-format.md#container-fields-reference) for the full schema and a hardened-defaults example.
+
+---
+
 ## Configuration reference
 
 No `dicode.yaml` entry is required. Podman is registered automatically if the binary is found in `PATH` at startup.

--- a/pkg/runtime/docker/docker.go
+++ b/pkg/runtime/docker/docker.go
@@ -116,6 +116,9 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	if cfg.WorkingDir != "" {
 		containerCfg.WorkingDir = cfg.WorkingDir
 	}
+	if cfg.User != "" {
+		containerCfg.User = cfg.User
+	}
 	var envList []string
 	for k, v := range cfg.EnvVars {
 		envList = append(envList, k+"="+v)
@@ -140,9 +143,15 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	containerCfg.ExposedPorts = exposedPorts
 
 	hostCfg := &container.HostConfig{
-		Binds:        cfg.Volumes,
-		PortBindings: portBindings,
-		AutoRemove:   false,
+		Binds:          cfg.Volumes,
+		PortBindings:   portBindings,
+		AutoRemove:     false,
+		NetworkMode:    container.NetworkMode(cfg.NetworkMode),
+		ExtraHosts:     cfg.ExtraHosts,
+		CapAdd:         cfg.CapAdd,
+		CapDrop:        cfg.CapDrop,
+		SecurityOpt:    cfg.SecurityOpt,
+		ReadonlyRootfs: cfg.ReadOnly,
 	}
 
 	created, err := dc.ContainerCreate(ctx, containerCfg, hostCfg, nil, nil, "")

--- a/pkg/runtime/podman/runtime.go
+++ b/pkg/runtime/podman/runtime.go
@@ -267,6 +267,27 @@ func (e *executor) buildArgs(cfg *task.DockerConfig, imageTag, containerName, ru
 	if cfg.WorkingDir != "" {
 		args = append(args, "--workdir", cfg.WorkingDir)
 	}
+	if cfg.NetworkMode != "" {
+		args = append(args, "--network", cfg.NetworkMode)
+	}
+	for _, h := range cfg.ExtraHosts {
+		args = append(args, "--add-host", h)
+	}
+	for _, c := range cfg.CapDrop {
+		args = append(args, "--cap-drop", c)
+	}
+	for _, c := range cfg.CapAdd {
+		args = append(args, "--cap-add", c)
+	}
+	for _, o := range cfg.SecurityOpt {
+		args = append(args, "--security-opt", o)
+	}
+	if cfg.ReadOnly {
+		args = append(args, "--read-only")
+	}
+	if cfg.User != "" {
+		args = append(args, "--user", cfg.User)
+	}
 	// Pull policy only applies when using a pre-built image (not a local build).
 	if cfg.Build == nil {
 		switch cfg.PullPolicy {

--- a/pkg/runtime/podman/runtime_test.go
+++ b/pkg/runtime/podman/runtime_test.go
@@ -1,0 +1,120 @@
+package podman
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// argsContainPair asserts that args contains `flag` immediately followed by `value`.
+func argsContainPair(args []string, flag, value string) bool {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+// argsContainFlag asserts that args contains `flag` as a standalone token (no value).
+func argsContainFlag(args []string, flag string) bool {
+	return slices.Contains(args, flag)
+}
+
+func TestBuildArgs_HardeningFlags(t *testing.T) {
+	cfg := &task.DockerConfig{
+		Image:       "cloudflare/cloudflared:latest",
+		NetworkMode: "bridge",
+		ExtraHosts:  []string{"host.docker.internal:host-gateway", "api.local:10.0.0.5"},
+		CapDrop:     []string{"ALL"},
+		CapAdd:      []string{"NET_BIND_SERVICE"},
+		SecurityOpt: []string{"no-new-privileges:true", "label=disable"},
+		ReadOnly:    true,
+		User:        "65532:65532",
+	}
+	e := &executor{podmanPath: "/usr/bin/podman"}
+	args := e.buildArgs(cfg, "cloudflare/cloudflared:latest", "dicode-run1", "run1", "task1")
+
+	if !argsContainPair(args, "--network", "bridge") {
+		t.Errorf("missing --network bridge in %v", args)
+	}
+	if !argsContainPair(args, "--add-host", "host.docker.internal:host-gateway") {
+		t.Errorf("missing first --add-host in %v", args)
+	}
+	if !argsContainPair(args, "--add-host", "api.local:10.0.0.5") {
+		t.Errorf("missing second --add-host in %v", args)
+	}
+	if !argsContainPair(args, "--cap-drop", "ALL") {
+		t.Errorf("missing --cap-drop ALL in %v", args)
+	}
+	if !argsContainPair(args, "--cap-add", "NET_BIND_SERVICE") {
+		t.Errorf("missing --cap-add NET_BIND_SERVICE in %v", args)
+	}
+	if !argsContainPair(args, "--security-opt", "no-new-privileges:true") {
+		t.Errorf("missing --security-opt no-new-privileges:true in %v", args)
+	}
+	if !argsContainPair(args, "--security-opt", "label=disable") {
+		t.Errorf("missing --security-opt label=disable in %v", args)
+	}
+	if !argsContainFlag(args, "--read-only") {
+		t.Errorf("missing --read-only in %v", args)
+	}
+	if !argsContainPair(args, "--user", "65532:65532") {
+		t.Errorf("missing --user 65532:65532 in %v", args)
+	}
+}
+
+func TestBuildArgs_OmitsHardeningWhenUnset(t *testing.T) {
+	cfg := &task.DockerConfig{Image: "alpine"}
+	e := &executor{podmanPath: "/usr/bin/podman"}
+	args := e.buildArgs(cfg, "alpine", "dicode-run1", "run1", "task1")
+
+	joined := strings.Join(args, " ")
+	for _, forbidden := range []string{"--network", "--add-host", "--cap-drop", "--cap-add", "--security-opt", "--read-only", "--user"} {
+		if strings.Contains(joined, forbidden) {
+			t.Errorf("unexpected %s in %v", forbidden, args)
+		}
+	}
+}
+
+func TestBuildArgs_HardeningPrecedesImage(t *testing.T) {
+	// The image tag must remain the first positional arg after flags, otherwise
+	// podman parses subsequent hardening flags as the container's command args.
+	cfg := &task.DockerConfig{
+		Image:       "alpine",
+		NetworkMode: "host",
+		ReadOnly:    true,
+		Command:     []string{"echo", "hi"},
+	}
+	e := &executor{podmanPath: "/usr/bin/podman"}
+	args := e.buildArgs(cfg, "alpine", "dicode-run1", "run1", "task1")
+
+	imageIdx := -1
+	for i, a := range args {
+		if a == "alpine" {
+			imageIdx = i
+			break
+		}
+	}
+	if imageIdx < 0 {
+		t.Fatalf("image tag not found in args: %v", args)
+	}
+	for _, flag := range []string{"--network", "--read-only"} {
+		idx := -1
+		for i, a := range args {
+			if a == flag {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 || idx >= imageIdx {
+			t.Errorf("%s must appear before image tag (at %d); args=%v", flag, imageIdx, args)
+		}
+	}
+	// Command must come after image.
+	if args[len(args)-2] != "echo" || args[len(args)-1] != "hi" {
+		t.Errorf("command args malformed at tail: %v", args)
+	}
+}

--- a/pkg/runtime/podman/runtime_test.go
+++ b/pkg/runtime/podman/runtime_test.go
@@ -84,32 +84,29 @@ func TestBuildArgs_HardeningPrecedesImage(t *testing.T) {
 	// podman parses subsequent hardening flags as the container's command args.
 	cfg := &task.DockerConfig{
 		Image:       "alpine",
-		NetworkMode: "host",
+		NetworkMode: "bridge",
+		ExtraHosts:  []string{"host.docker.internal:host-gateway"},
+		CapDrop:     []string{"ALL"},
+		CapAdd:      []string{"NET_BIND_SERVICE"},
+		SecurityOpt: []string{"no-new-privileges:true"},
 		ReadOnly:    true,
+		User:        "65532:65532",
 		Command:     []string{"echo", "hi"},
 	}
 	e := &executor{podmanPath: "/usr/bin/podman"}
 	args := e.buildArgs(cfg, "alpine", "dicode-run1", "run1", "task1")
 
-	imageIdx := -1
-	for i, a := range args {
-		if a == "alpine" {
-			imageIdx = i
-			break
-		}
-	}
+	imageIdx := slices.Index(args, "alpine")
 	if imageIdx < 0 {
 		t.Fatalf("image tag not found in args: %v", args)
 	}
-	for _, flag := range []string{"--network", "--read-only"} {
-		idx := -1
-		for i, a := range args {
-			if a == flag {
-				idx = i
-				break
-			}
+	for _, flag := range []string{"--network", "--add-host", "--cap-drop", "--cap-add", "--security-opt", "--read-only", "--user"} {
+		idx := slices.Index(args, flag)
+		if idx < 0 {
+			t.Errorf("%s missing from args: %v", flag, args)
+			continue
 		}
-		if idx < 0 || idx >= imageIdx {
+		if idx >= imageIdx {
 			t.Errorf("%s must appear before image tag (at %d); args=%v", flag, imageIdx, args)
 		}
 	}

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -580,10 +580,37 @@ func (s *Spec) validate() error {
 		default:
 			return fmt.Errorf("docker.pull_policy must be always, missing, or never")
 		}
+		s.Warnings = append(s.Warnings, dockerHardeningWarnings(s.Docker)...)
 	default:
 		// Any other non-empty runtime is accepted; executor presence is checked at run time.
 	}
 	return nil
+}
+
+// dockerHardeningWarnings flags container settings that visibly weaken
+// isolation. These aren't errors — operators can explicitly opt in — but they
+// should surface in the UI so reviewers notice.
+func dockerHardeningWarnings(d *DockerConfig) []string {
+	var warns []string
+	if d.NetworkMode == "host" {
+		warns = append(warns, "docker.network_mode: host shares the host network namespace; the container can reach every loopback service")
+	}
+	for _, c := range d.CapAdd {
+		switch strings.ToUpper(c) {
+		case "SYS_ADMIN", "SYS_PTRACE", "SYS_MODULE", "ALL":
+			warns = append(warns, fmt.Sprintf("docker.cap_add includes %s — this can enable container escape", c))
+		}
+	}
+	for _, o := range d.SecurityOpt {
+		lower := strings.ToLower(o)
+		switch {
+		case strings.HasPrefix(lower, "seccomp=unconfined"),
+			strings.HasPrefix(lower, "apparmor=unconfined"),
+			lower == "label=disable":
+			warns = append(warns, fmt.Sprintf("docker.security_opt %q disables a kernel sandbox layer", o))
+		}
+	}
+	return warns
 }
 
 // ChainOn returns the normalized "on" condition for a chain trigger.

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -61,6 +61,17 @@ type DockerConfig struct {
 	WorkingDir string            `yaml:"working_dir,omitempty"` // container working dir
 	EnvVars    map[string]string `yaml:"env_vars,omitempty"`    // extra env vars (literal)
 	PullPolicy string            `yaml:"pull_policy,omitempty"` // "always" | "missing" (default) | "never"
+
+	// Network / isolation
+	NetworkMode string   `yaml:"network_mode,omitempty"` // "host" | "bridge" | "none" | "<custom-network>"
+	ExtraHosts  []string `yaml:"extra_hosts,omitempty"`  // "<name>:<ip-or-host-gateway>"
+
+	// Hardening
+	CapDrop     []string `yaml:"cap_drop,omitempty"`     // e.g. ["ALL"]
+	CapAdd      []string `yaml:"cap_add,omitempty"`      // e.g. ["NET_BIND_SERVICE"] — re-add after CapDrop
+	SecurityOpt []string `yaml:"security_opt,omitempty"` // e.g. ["no-new-privileges:true"]
+	ReadOnly    bool     `yaml:"read_only,omitempty"`    // mount container rootfs read-only
+	User        string   `yaml:"user,omitempty"`         // "<uid>[:<gid>]" or "<name>[:<group>]"
 }
 
 // ChainTrigger fires a task when another task completes.

--- a/pkg/task/spec_test.go
+++ b/pkg/task/spec_test.go
@@ -146,6 +146,86 @@ docker:
 	}
 }
 
+func TestDockerConfig_HardeningWarnings(t *testing.T) {
+	cases := []struct {
+		name      string
+		yaml      string
+		mustMatch []string // substrings that must appear in s.Warnings
+	}{
+		{
+			name: "network_mode host warns",
+			yaml: `
+name: t
+runtime: docker
+trigger: { manual: true }
+docker:
+  image: alpine
+  network_mode: host
+`,
+			mustMatch: []string{"network_mode: host"},
+		},
+		{
+			name: "cap_add SYS_ADMIN warns",
+			yaml: `
+name: t
+runtime: docker
+trigger: { manual: true }
+docker:
+  image: alpine
+  cap_add: [SYS_ADMIN]
+`,
+			mustMatch: []string{"SYS_ADMIN"},
+		},
+		{
+			name: "seccomp unconfined warns",
+			yaml: `
+name: t
+runtime: docker
+trigger: { manual: true }
+docker:
+  image: alpine
+  security_opt: ["seccomp=unconfined"]
+`,
+			mustMatch: []string{"seccomp=unconfined"},
+		},
+		{
+			name: "hardened config has no warnings",
+			yaml: `
+name: t
+runtime: docker
+trigger: { manual: true }
+docker:
+  image: alpine
+  network_mode: bridge
+  cap_drop: [ALL]
+  security_opt: ["no-new-privileges:true"]
+  read_only: true
+`,
+			mustMatch: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var s Spec
+			if err := yaml.NewDecoder(strings.NewReader(strings.TrimSpace(tc.yaml))).Decode(&s); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if err := s.validate(); err != nil {
+				t.Fatalf("validate: %v", err)
+			}
+			joined := strings.Join(s.Warnings, "|")
+			for _, want := range tc.mustMatch {
+				if !strings.Contains(joined, want) {
+					t.Errorf("missing warning containing %q; got %v", want, s.Warnings)
+				}
+			}
+			if len(tc.mustMatch) == 0 && len(s.Warnings) != 0 {
+				t.Errorf("expected no warnings, got %v", s.Warnings)
+			}
+		})
+	}
+}
+
 func equalSlice(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/pkg/task/spec_test.go
+++ b/pkg/task/spec_test.go
@@ -80,3 +80,80 @@ provider:
 		t.Fatalf("CacheTTL = %v, want 5m", s.Provider.CacheTTL)
 	}
 }
+
+func TestDockerConfig_HardeningFields_Parse(t *testing.T) {
+	src := strings.TrimSpace(`
+name: tunnel
+runtime: docker
+trigger:
+  daemon: true
+docker:
+  image: cloudflare/cloudflared:latest
+  network_mode: bridge
+  extra_hosts:
+    - host.docker.internal:host-gateway
+    - api.local:10.0.0.5
+  cap_drop: [ALL]
+  security_opt:
+    - "no-new-privileges:true"
+  read_only: true
+  user: "65532:65532"
+`)
+	var s Spec
+	if err := yaml.NewDecoder(strings.NewReader(src)).Decode(&s); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if s.Docker == nil {
+		t.Fatalf("Docker was nil")
+	}
+	d := s.Docker
+	if d.NetworkMode != "bridge" {
+		t.Errorf("NetworkMode = %q, want bridge", d.NetworkMode)
+	}
+	if got, want := d.ExtraHosts, []string{"host.docker.internal:host-gateway", "api.local:10.0.0.5"}; !equalSlice(got, want) {
+		t.Errorf("ExtraHosts = %v, want %v", got, want)
+	}
+	if got, want := d.CapDrop, []string{"ALL"}; !equalSlice(got, want) {
+		t.Errorf("CapDrop = %v, want %v", got, want)
+	}
+	if got, want := d.SecurityOpt, []string{"no-new-privileges:true"}; !equalSlice(got, want) {
+		t.Errorf("SecurityOpt = %v, want %v", got, want)
+	}
+	if !d.ReadOnly {
+		t.Errorf("ReadOnly = false, want true")
+	}
+	if d.User != "65532:65532" {
+		t.Errorf("User = %q, want 65532:65532", d.User)
+	}
+}
+
+func TestDockerConfig_HardeningFields_DefaultsZero(t *testing.T) {
+	src := strings.TrimSpace(`
+name: minimal
+runtime: docker
+trigger: { manual: true }
+docker:
+  image: alpine
+`)
+	var s Spec
+	if err := yaml.NewDecoder(strings.NewReader(src)).Decode(&s); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	d := s.Docker
+	if d.NetworkMode != "" || len(d.ExtraHosts) != 0 || len(d.CapDrop) != 0 ||
+		len(d.SecurityOpt) != 0 || d.ReadOnly || d.User != "" {
+		t.Errorf("hardening fields should be zero-valued when omitted, got %+v", d)
+	}
+}
+
+func equalSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Adds six new fields to `DockerConfig` for docker/podman tasks:

| Field | Maps to (docker SDK) | Maps to (podman CLI) |
|---|---|---|
| `network_mode` | `HostConfig.NetworkMode` | `--network` |
| `extra_hosts` | `HostConfig.ExtraHosts` | `--add-host` (repeated) |
| `cap_drop` / `cap_add` | `HostConfig.CapDrop` / `CapAdd` | `--cap-drop` / `--cap-add` |
| `security_opt` | `HostConfig.SecurityOpt` | `--security-opt` |
| `read_only` | `HostConfig.ReadonlyRootfs` | `--read-only` |
| `user` | `container.Config.User` | `--user` |

## Motivation

Needed for hardened docker daemon buildins — e.g. a `cloudflare/cloudflared` tunnel task that:

- Runs in bridge network (not `--network host`) so dicode services bound to `127.0.0.1` stay invisible to the tunnel container.
- Reaches the host only via `extra_hosts: [host.docker.internal:host-gateway]`.
- Drops all caps + `no-new-privileges` + `read_only` + nonroot user.

Without these fields the only way to give a tunnel container access to host services was `network: host`, which collapses the entire isolation boundary.

## Example

```yaml
runtime: docker  # or podman
trigger:
  daemon: true
  restart: always
docker:
  image: cloudflare/cloudflared:latest
  command: [tunnel, --no-autoupdate, --config, /etc/cloudflared/config.yml, run]
  network_mode: bridge
  extra_hosts: ["host.docker.internal:host-gateway"]
  cap_drop: [ALL]
  security_opt: ["no-new-privileges:true"]
  read_only: true
  user: "65532:65532"
  volumes:
    - "${DICODE_DATADIR}/cloudflared:/etc/cloudflared:ro"
```

## Test plan

- [x] `pkg/task` spec parses all new fields (with omitted-defaults assertion)
- [x] `pkg/runtime/podman` `buildArgs` emits each flag, omits when unset, places flags before image tag
- [x] `make format-check` clean
- [x] `make lint` clean
- [x] `go test ./...` all green
- [ ] Manual: run a sample hardened cloudflared task against a real podman/docker daemon (left for follow-up — pure additive change to spec + runtimes, no behavior change for existing tasks)

## Notes

- All fields are zero-value safe — existing task.yaml files unaffected.
- `cap_add` included alongside `cap_drop` so the common pattern `cap_drop:[ALL], cap_add:[NET_BIND_SERVICE]` works.
- Docker SDK runtime has no unit test in this repo (requires a daemon); change is a thin pass-through to `container.HostConfig` and verified by reading the SDK type. Podman runtime has full args coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)