### PR TITLE
feat(task): expand template vars in docker.volumes

### DIFF
--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -280,7 +280,7 @@ Use **Edit code** on the task page to edit the Dockerfile directly in the web UI
 | `docker.command` | list | Overrides image CMD |
 | `docker.entrypoint` | list | Overrides image ENTRYPOINT |
 | `docker.ports` | list | Port bindings — `"hostPort:containerPort"` |
-| `docker.volumes` | list | Volume mounts — `"host:container[:ro]"` |
+| `docker.volumes` | list | Volume mounts — `"host:container[:ro]"`. Template vars `${DATADIR}`, `${TASK_DIR}`, `${HOME}` are expanded in the host path; `${UNKNOWN}` is left literal. Daemon env vars are NOT substituted. |
 | `docker.working_dir` | string | Container working directory |
 | `docker.env_vars` | map | Literal environment variables injected into container |
 | `docker.pull_policy` | string | `missing` (default), `always`, `never`. Ignored when using `build`. |
@@ -690,6 +690,7 @@ Template expansion runs over a tight allowlist, not every string field:
 - `permissions.fs[].path`
 - `trigger.webhook_secret`
 - `permissions.env[].from`, `.secret`, `.value` (the indirection keys)
+- `docker.volumes` (host-side mount paths; no env fallback)
 
 Everything else — `name`, `description`, `params.*.default`, `system_prompt` defaults — is taken literally. This is deliberate: expansion in descriptive strings usually hides bugs rather than enabling them.
 

--- a/pkg/task/template.go
+++ b/pkg/task/template.go
@@ -120,6 +120,16 @@ func expandSpec(spec *Spec, vars map[string]string) {
 	for i := range spec.Params {
 		spec.Params[i].Default = expandString(spec.Params[i].Default, vars, false)
 	}
+
+	// docker.volumes: lets tasks reference shared paths (${DATADIR}/foo) as
+	// mount sources. envFallback=false — a task.yaml from an untrusted
+	// source must not be able to mount arbitrary host paths by naming a
+	// daemon env var.
+	if spec.Docker != nil {
+		for i := range spec.Docker.Volumes {
+			spec.Docker.Volumes[i] = expandString(spec.Docker.Volumes[i], vars, false)
+		}
+	}
 }
 
 // builtinVars returns the template var map for a task loaded from dir, with

--- a/pkg/task/template_test.go
+++ b/pkg/task/template_test.go
@@ -252,6 +252,46 @@ func TestVarDataDir_Constant(t *testing.T) {
 	}
 }
 
+func TestExpandSpec_DockerVolumes(t *testing.T) {
+	spec := &Spec{
+		Docker: &DockerConfig{
+			Volumes: []string{
+				"${DATADIR}/cloudflared:/etc/cloudflared:ro",
+				"${TASK_DIR}/local:/work:rw",
+				"${UNKNOWN}/leave-literal:/x",
+			},
+		},
+	}
+	vars := map[string]string{
+		"DATADIR":  "/home/u/.dicode",
+		"TASK_DIR": "/repo/tasks/cf",
+	}
+	expandSpec(spec, vars)
+	want := []string{
+		"/home/u/.dicode/cloudflared:/etc/cloudflared:ro",
+		"/repo/tasks/cf/local:/work:rw",
+		"${UNKNOWN}/leave-literal:/x",
+	}
+	for i, got := range spec.Docker.Volumes {
+		if got != want[i] {
+			t.Errorf("Volumes[%d] = %q, want %q", i, got, want[i])
+		}
+	}
+}
+
+func TestExpandSpec_DockerVolumes_NoEnvFallback(t *testing.T) {
+	// envFallback must be false: a task.yaml from an untrusted source must not be
+	// able to reference a daemon env var as a mount source.
+	t.Setenv("DAEMON_SECRET_PATH", "/etc/dicode/secrets")
+	spec := &Spec{
+		Docker: &DockerConfig{Volumes: []string{"${DAEMON_SECRET_PATH}:/x"}},
+	}
+	expandSpec(spec, map[string]string{})
+	if spec.Docker.Volumes[0] != "${DAEMON_SECRET_PATH}:/x" {
+		t.Errorf("Volumes[0] = %q, want literal preserved (no env fallback)", spec.Docker.Volumes[0])
+	}
+}
+
 func TestLoadDirWithVars_ExpandsTaskSetDir(t *testing.T) {
 	dir := t.TempDir()
 	yaml := `


### PR DESCRIPTION
## Summary

Extends `expandSpec` in `pkg/task/template.go` so `${VAR}` placeholders are expanded inside `spec.Docker.Volumes` entries at task-load time. Mirrors the existing policy for `permissions.fs[].path` / `permissions.env[].value` / `params[].default`: **builtins + caller extras only** — env-fallback is intentionally off.

## Why

This unblocks the daemon-preflight epic (template-resolver-and-preflight). Docker daemon buildins (the cloudflared worked example, dockerized MCP servers, etc.) need to mount a per-task subdirectory of `${DATADIR}` so the daemon and the preflight render task can share files. Without this PR, the literal string `${DATADIR}/foo` ends up in `docker run -v`, which fails.

Why no env fallback? `docker.volumes` is operator-visible host-side config, but the task running inside the container can `ls` the mounted dir. If env fallback were on, a `task.yaml` from an untrusted source could exfiltrate daemon env vars by writing `volumes: ["${DAEMON_SECRET_PATH}:/x"]` and reading `/x` at runtime. Same threat model as `permissions.env[].value`.

## What changed

- `pkg/task/template.go` — adds a `spec.Docker.Volumes` loop inside `expandSpec`, gated on `spec.Docker != nil`, calling `expandString(..., vars, false)` per entry.
- `pkg/task/template_test.go` — two new tests:
  - `TestExpandSpec_DockerVolumes` — covers happy path (`${DATADIR}`, `${TASK_DIR}`) and the "unknown var stays literal" contract.
  - `TestExpandSpec_DockerVolumes_NoEnvFallback` — pins the env-exfiltration guard: `t.Setenv("DAEMON_SECRET_PATH", ...)` and asserts the literal `${DAEMON_SECRET_PATH}` is preserved when only an empty vars map is passed.
- `docs/concepts/task-format.md` — extends the `docker.volumes` row note in the reference table and adds the field to the template-expansion allowlist section.

## Test plan

- [x] `go test ./pkg/task/ -run TestExpandSpec_DockerVolumes -count=1` — both new tests pass.
- [x] `go test ./... -timeout 90s` — full suite green.
- [x] `make format-check` — clean.
- [x] `make lint` (`go vet ./...`) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)