### PR TITLE
feat(trigger): chain trigger params (symmetry with failure chain)

### DIFF
--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -75,9 +75,23 @@ type DockerConfig struct {
 }
 
 // ChainTrigger fires a task when another task completes.
+//
+// Params are user-supplied values forwarded into the downstream task's input
+// map alongside engine-reserved keys (taskID, runID, status, output,
+// _chain_depth). When Params is empty, the engine passes the upstream task's
+// raw output through as input — preserving the historical contract where
+// downstream tasks consume `input` as the upstream's return value directly.
+// When Params is non-empty, input becomes a map[string]any merging user
+// params with the reserved engine keys; reserved keys are validated to not
+// appear in Params at config-load (see Spec.validate), so collisions are
+// impossible at firing time.
+//
+// Mirror of OnFailureChainSpec.Params (failure-chain side); shares the same
+// reservedChainParamKeys set.
 type ChainTrigger struct {
-	From string `yaml:"from"`         // task ID to listen for
-	On   string `yaml:"on,omitempty"` // "success" (default) | "failure" | "always"
+	From   string         `yaml:"from"`             // task ID to listen for
+	On     string         `yaml:"on,omitempty"`     // "success" (default) | "failure" | "always"
+	Params map[string]any `yaml:"params,omitempty"` // forwarded into downstream task input
 }
 
 // TriggerConfig defines how a task is triggered.
@@ -549,6 +563,14 @@ func (s *Spec) validate() error {
 			// ok
 		default:
 			return fmt.Errorf("trigger.chain.on must be success, failure, or always")
+		}
+		// Reject reserved keys at config load so the engine never has to
+		// disambiguate user vs. engine values at firing time. Mirrors the
+		// check on OnFailureChainSpec.Params (see onfailurechain.go).
+		for k := range s.Trigger.Chain.Params {
+			if _, reserved := reservedChainParamKeys[k]; reserved {
+				return fmt.Errorf("trigger.chain.params: %q is a reserved key (used by the engine)", k)
+			}
 		}
 	}
 	if triggers == 0 {

--- a/pkg/task/spec_test.go
+++ b/pkg/task/spec_test.go
@@ -226,6 +226,48 @@ docker:
 	}
 }
 
+func TestChainTrigger_Params_Parses(t *testing.T) {
+	src := strings.TrimSpace(`
+name: downstream
+runtime: deno
+trigger:
+  chain:
+    from: upstream
+    on: success
+    params:
+      mode: production
+      shard: "3"
+`)
+	var s Spec
+	if err := yaml.NewDecoder(strings.NewReader(src)).Decode(&s); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if s.Trigger.Chain == nil {
+		t.Fatal("Chain nil")
+	}
+	if got := s.Trigger.Chain.Params["mode"]; got != "production" {
+		t.Errorf("Params[mode] = %v, want production", got)
+	}
+	if got := s.Trigger.Chain.Params["shard"]; got != "3" {
+		t.Errorf("Params[shard] = %v, want 3", got)
+	}
+}
+
+func TestChainTrigger_Params_ReservedKeyRejected(t *testing.T) {
+	for _, reserved := range []string{"taskID", "runID", "status", "output", "_chain_depth"} {
+		t.Run(reserved, func(t *testing.T) {
+			src := "name: t\nruntime: deno\ntrigger:\n  chain:\n    from: x\n    params:\n      " + reserved + ": v\n"
+			var s Spec
+			if err := yaml.NewDecoder(strings.NewReader(src)).Decode(&s); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if err := s.validate(); err == nil || !strings.Contains(err.Error(), reserved) {
+				t.Errorf("expected error mentioning %q, got: %v", reserved, err)
+			}
+		})
+	}
+}
+
 func equalSlice(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -844,7 +844,7 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 		)
 		go e.fireAsync(ctx, spec, pkgruntime.RunOptions{ //nolint:errcheck
 			ParentRunID: runID,
-			Input:       output,
+			Input:       buildChainInput(chain.Params, completedTaskID, runID, runStatus, output),
 		}, "chain")
 	}
 
@@ -993,6 +993,43 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 			}
 		}
 	}
+}
+
+// buildChainInput shapes the `Input` value handed to a downstream task that
+// was fired by a success-path trigger.chain (NOT on_failure_chain — that
+// path runs through fireFailureChain and always wraps).
+//
+// Contract:
+//
+//   - When userParams is empty (the historical case), returns the upstream's
+//     raw output unchanged. This preserves the existing contract for tasks
+//     that consume `input` as the upstream's return value directly. Adding
+//     a wrapping unconditionally would silently break every downstream task
+//     in the wild that reads input as e.g. a string or a typed object.
+//
+//   - When userParams is non-empty, returns a map merging user params with
+//     engine-reserved keys (taskID, runID, status, output, _chain_depth).
+//     Reserved keys cannot collide with user params: Spec.validate rejects
+//     reserved keys in trigger.chain.params at config load.
+//
+// _chain_depth is set to 0 for success chains. Depth tracking only matters
+// on the failure path today (cap loops via OnFailureChainSpec.MaxDepth);
+// success chains are intentionally not depth-capped because users build
+// fan-out pipelines (render → start daemon, etc.) where depth > 1 is normal.
+func buildChainInput(userParams map[string]any, completedTaskID, runID, status string, output any) any {
+	if len(userParams) == 0 {
+		return output
+	}
+	m := make(map[string]any, len(userParams)+5)
+	for k, v := range userParams {
+		m[k] = v
+	}
+	m["taskID"] = completedTaskID
+	m["runID"] = runID
+	m["status"] = status
+	m["output"] = output
+	m["_chain_depth"] = 0
+	return m
 }
 
 const (

--- a/pkg/trigger/engine_success_chain_params_test.go
+++ b/pkg/trigger/engine_success_chain_params_test.go
@@ -1,0 +1,152 @@
+package trigger
+
+// Integration tests for FireChain's success-path Params merge. Mirrors
+// engine_chain_params_test.go (failure-chain side) but exercises the
+// declared trigger.chain → spec.Trigger.Chain.Params path instead of
+// on_failure_chain.
+//
+// Two cases:
+//
+//  1. No params on trigger.chain: downstream sees the raw upstream output as
+//     its `input` argument (existing contract — backwards compat).
+//
+//  2. Params set on trigger.chain: downstream sees a wrapped map with
+//     engine-reserved keys (taskID, runID, status, output) merged on top of
+//     user-supplied params.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+func TestFireChain_Success_ParamsMergedIntoInput(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	// Downstream task: declares trigger.chain on "upstream-params" + user
+	// params. Echoes the full `input` back as its return value so the test
+	// can inspect every key the engine injected.
+	downstream := writeTask(t, dir, "downstream-params",
+		`export default async function main({ input }) { return input }`,
+		task.TriggerConfig{
+			Chain: &task.ChainTrigger{
+				From:   "upstream-params",
+				On:     "success",
+				Params: map[string]any{"mode": "prod", "shard": "3"},
+			},
+		})
+	_ = e.reg.Register(downstream)
+
+	// Upstream task: returns a string. With Params set the engine should
+	// wrap this in the downstream's input map under the "output" key.
+	upstream := writeTask(t, dir, "upstream-params",
+		`export default async function main() { return "rendered-yaml-content" }`,
+		task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(upstream)
+
+	// Fire upstream and wait for it to reach terminal state.
+	upstreamRunID, err := e.engine.FireManual(context.Background(), "upstream-params", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	primary := waitForTerminal(t, e.engine, upstreamRunID, 30*time.Second)
+	if primary.Status != registry.StatusSuccess {
+		t.Fatalf("upstream status = %q, want success", primary.Status)
+	}
+
+	// Wait for the downstream chain target to complete.
+	got := waitForRunOfTask(t, e.engine, "downstream-params", 30*time.Second)
+	if got == nil {
+		t.Fatal("downstream-params was not fired within the timeout")
+	}
+	if got.Status != registry.StatusSuccess {
+		t.Errorf("downstream status = %q, want success", got.Status)
+	}
+
+	returnValue := pollReturnValue(t, e.engine, got.ID, 5*time.Second)
+	var input map[string]any
+	if err := json.Unmarshal([]byte(returnValue), &input); err != nil {
+		t.Fatalf("unmarshal return value %q: %v", returnValue, err)
+	}
+
+	// Reserved keys must be present.
+	if input["taskID"] != "upstream-params" {
+		t.Errorf("taskID = %v, want upstream-params", input["taskID"])
+	}
+	if input["runID"] != upstreamRunID {
+		t.Errorf("runID = %v, want %s", input["runID"], upstreamRunID)
+	}
+	if input["status"] != "success" {
+		t.Errorf("status = %v, want success", input["status"])
+	}
+	if input["output"] != "rendered-yaml-content" {
+		t.Errorf("output = %v, want rendered-yaml-content", input["output"])
+	}
+
+	// User params must be merged in.
+	if input["mode"] != "prod" {
+		t.Errorf("mode = %v, want prod", input["mode"])
+	}
+	if input["shard"] != "3" {
+		t.Errorf("shard = %v, want 3", input["shard"])
+	}
+}
+
+// TestFireChain_Success_NoParams_PreservesRawOutput verifies the
+// backwards-compat path: when trigger.chain has no Params, downstream
+// receives the upstream's raw return value as `input` — same as today's
+// behavior. This protects tasks that consume `input` as the upstream's
+// output directly rather than as a map.
+func TestFireChain_Success_NoParams_PreservesRawOutput(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	// Downstream: no Params; echoes input back so we can inspect it.
+	downstream := writeTask(t, dir, "downstream-noparams",
+		`export default async function main({ input }) { return input }`,
+		task.TriggerConfig{
+			Chain: &task.ChainTrigger{
+				From: "upstream-noparams",
+				On:   "success",
+			},
+		})
+	_ = e.reg.Register(downstream)
+
+	// Upstream emits a string. Engine must forward it as-is.
+	upstream := writeTask(t, dir, "upstream-noparams",
+		`export default async function main() { return "raw-value" }`,
+		task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(upstream)
+
+	runID, err := e.engine.FireManual(context.Background(), "upstream-noparams", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	primary := waitForTerminal(t, e.engine, runID, 30*time.Second)
+	if primary.Status != registry.StatusSuccess {
+		t.Fatalf("upstream status = %q, want success", primary.Status)
+	}
+
+	got := waitForRunOfTask(t, e.engine, "downstream-noparams", 30*time.Second)
+	if got == nil {
+		t.Fatal("downstream-noparams was not fired within the timeout")
+	}
+	if got.Status != registry.StatusSuccess {
+		t.Errorf("downstream status = %q, want success", got.Status)
+	}
+
+	returnValue := pollReturnValue(t, e.engine, got.ID, 5*time.Second)
+	// No wrapping: downstream sees the raw upstream output as a JSON string.
+	var input any
+	if err := json.Unmarshal([]byte(returnValue), &input); err != nil {
+		t.Fatalf("unmarshal return value %q: %v", returnValue, err)
+	}
+	if input != "raw-value" {
+		t.Errorf("input = %v (%T), want raw-value (no wrapping when params empty)", input, input)
+	}
+}


### PR DESCRIPTION
## Summary

Mirrors the failure-chain `OnFailureChainSpec.Params` pattern on the success path. Adds `ChainTrigger.Params` (`map[string]any`) so a `trigger.chain` block can forward user params into the downstream task's input alongside engine-reserved keys.

- **Backwards-compat:** when `params` is empty / omitted, downstream sees the upstream's raw output as `input` — same as today. Existing tasks that read `input` as the upstream's return value directly are unaffected.
- **Wrapped-map contract:** when `params` is set, `input` becomes a map merging user params with engine-reserved keys (`taskID`, `runID`, `status`, `output`, `_chain_depth`).
- **Reserved-key validation at config load:** `Spec.validate` rejects reserved keys in `trigger.chain.params`, mirroring `OnFailureChainSpec.Validate`. Same `reservedChainParamKeys` set is reused.
- `_chain_depth` is set to `0` for success chains (no depth-cap loop concern — success chains are intentionally not capped).

## Why this shape

The input-contract change is the load-bearing decision: a less compatible alternative would always wrap upstream output in a map, but that would silently break every existing chain consumer that reads `input` as a string / typed object. Gating the wrap on `len(params) > 0` lets new tasks opt into the structured shape while leaving the existing contract intact for tasks that haven't set params.

## Files

- `pkg/task/spec.go` — `ChainTrigger.Params` field + reserved-key validation
- `pkg/task/spec_test.go` — parsing + reserved-key tests
- `pkg/trigger/engine.go` — `buildChainInput` helper, used at the `FireChain` success-path firing site
- `pkg/trigger/engine_success_chain_params_test.go` — integration tests for both code paths (params set, params empty)

## Test plan

- [x] `go test ./pkg/task/ -run TestChainTrigger_Params -count=1` — green
- [x] `go test ./pkg/trigger/ -run TestFireChain_Success -count=1` — green
- [x] `go test ./... -timeout 120s` — full suite green
- [x] `go vet ./...` clean
- [x] `make format-check` clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>