### PR TITLE
feat(task): run_result flag to suppress return-value persistence

### DIFF
--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -90,6 +90,8 @@ permissions:
 | `params[].description` | string | | Human-readable description |
 | `params[].default` | string | | Default value (all params are strings) |
 | `tags` | list of strings | | Tags for filtering (future: source selectors) |
+| `run_result` | object | | Per-task return-value persistence config — see [Suppressing return-value persistence](#suppressing-return-value-persistence) |
+| `run_result.enabled` | bool | | When `false`, the JSON return value is not written to `runs.return_value`; in-memory delivery (`dicode.run_task`, chain `input.output`) is unaffected. Default `true`. |
 
 ### Trigger types
 
@@ -666,6 +668,37 @@ return output.html(htmlContent, { data: { count: 5 } })
 ```
 
 See [JS Runtime — output global](./js-runtime.md#output--rich-return-values) for the full API.
+
+## Suppressing return-value persistence
+
+By default every successful task's return value is JSON-marshalled and written to the `runs.return_value` column. The WebUI, run-history API, WebSocket stream, and replay tooling all read from that column. For tasks that return secret-bearing material — a rendered config with embedded tokens, a freshly minted credential, a Doppler-resolved bundle — that persisted copy is a confidentiality leak.
+
+Opt out at the task level:
+
+```yaml
+name: render-config
+runtime: deno
+trigger: { manual: true }
+permissions:
+  dicode: { secrets_has: true }
+run_result:
+  enabled: false      # do not persist return value to runs.return_value
+```
+
+What changes:
+
+- The `runs.return_value` column is left empty for this task's runs.
+- WebUI, REST `/api/runs`, and WebSocket payloads show no return value.
+- Replay can re-fire the task (the input is still persisted unless `run_inputs.enabled: false` is also set) but won't have the previous return value to display.
+
+What does **not** change:
+
+- Synchronous callers of `dicode.run_task("render-config")` still receive the return value in-memory — the engine holds it briefly outside the DB until the waiting caller picks it up.
+- Chain triggers (`trigger.chain.from: render-config`) still see the value as `input.output` in the downstream task — chain delivery never touches the persisted column.
+- Structured rich-output payloads (`output.html(...)`, `output.image(...)`, `output.file(...)`) continue to persist normally, since they live in the `output_content` columns and aren't part of the return-value confidentiality concern. If those carry secrets too, route them through a different task or scrub before returning.
+- `stdout`/`stderr` log lines persist normally. Combine with [`silent: true`](#) on the task spec when the script may print plaintext credentials.
+
+**Security note:** this flag suppresses the persisted *return value* only. A task that wants to handle plaintext credentials end-to-end should typically combine `run_result.enabled: false`, `run_inputs.enabled: false`, `silent: true`, and the tightest possible `permissions.{net,fs,env}` allowlists to remove every exfiltration channel.
 
 ## Task ID
 

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -366,6 +366,19 @@ type Spec struct {
 	// defaults.run_inputs from dicode.yaml for this task only.
 	RunInputs *RunInputsTaskOverride `yaml:"run_inputs,omitempty" json:"run_inputs,omitempty"`
 
+	// RunResult configures per-task return-value persistence. When
+	// `enabled: false` the JSON-marshalled return value is NOT written to
+	// `runs.return_value` in the database. The value still flows in-memory:
+	// synchronous callers of `dicode.run_task` receive it through WaitRun,
+	// and chain triggers receive it via `input.output`. Only the persisted
+	// (replayable / WebUI-visible) copy is suppressed.
+	//
+	// Use this for tasks that legitimately return secret material
+	// (e.g. a template renderer that emits a rendered config with embedded
+	// tokens). Structured `dicode.output(content, contentType)` data, stdout,
+	// stderr, and `fail_reason` are unaffected — those persist as usual.
+	RunResult *RunResultConfig `yaml:"run_result,omitempty" json:"run_result,omitempty"`
+
 	// AutoFix configures how the auto-fix loop sees this task's input.
 	// Independent of RunInputs (which controls persistence). Used by #238.
 	AutoFix *AutoFixConfig `yaml:"auto_fix,omitempty" json:"auto_fix,omitempty"`
@@ -402,6 +415,30 @@ type RunInputsTaskOverride struct {
 	Enabled         *bool         `yaml:"enabled,omitempty"          json:"enabled,omitempty"`
 	Retention       time.Duration `yaml:"retention,omitempty"        json:"retention,omitempty"`
 	BodyFullTextual *bool         `yaml:"body_full_textual,omitempty" json:"body_full_textual,omitempty"`
+}
+
+// RunResultConfig configures per-task return-value persistence. See the
+// Spec.RunResult doc comment for the full contract; the short version is
+// that `enabled: false` suppresses the JSON-marshalled return value from
+// being written to `runs.return_value`, while still letting it flow to
+// in-memory consumers (synchronous `dicode.run_task` callers via WaitRun,
+// chain triggers via `input.output`). Structured `dicode.output()` data,
+// stdout, and stderr are unaffected.
+type RunResultConfig struct {
+	// Enabled (default true) controls return-value persistence. When set
+	// to false, the engine skips the `SetRunResult` write for the
+	// return_value column. A nil pointer is treated as the default (true).
+	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+}
+
+// PersistReturnValue reports whether this RunResultConfig allows the
+// return value to be persisted to `runs.return_value`. Treats a nil
+// receiver or a nil Enabled pointer as the default (true).
+func (c *RunResultConfig) PersistReturnValue() bool {
+	if c == nil || c.Enabled == nil {
+		return true
+	}
+	return *c.Enabled
 }
 
 // AutoFixConfig configures how the auto-fix loop sees this task's input.

--- a/pkg/task/spec_test.go
+++ b/pkg/task/spec_test.go
@@ -60,6 +60,41 @@ run_inputs:
 	}
 }
 
+func TestSpec_RunResultOverride_Parses(t *testing.T) {
+	yamlSrc := []byte(`
+name: test
+runtime: deno
+trigger: { manual: true }
+run_result:
+  enabled: false
+`)
+	var s Spec
+	if err := yaml.Unmarshal(yamlSrc, &s); err != nil {
+		t.Fatal(err)
+	}
+	if s.RunResult == nil {
+		t.Fatal("RunResult not parsed")
+	}
+	if s.RunResult.Enabled == nil || *s.RunResult.Enabled != false {
+		t.Errorf("RunResult.Enabled = %v, want false ptr", s.RunResult.Enabled)
+	}
+}
+
+func TestSpec_RunResultOverride_Omitted(t *testing.T) {
+	yamlSrc := []byte(`
+name: test
+runtime: deno
+trigger: { manual: true }
+`)
+	var s Spec
+	if err := yaml.Unmarshal(yamlSrc, &s); err != nil {
+		t.Fatal(err)
+	}
+	if s.RunResult != nil {
+		t.Errorf("RunResult should be nil when omitted, got %+v", s.RunResult)
+	}
+}
+
 func TestSpec_ProviderBlockRoundTrip(t *testing.T) {
 	src := strings.TrimSpace(`
 name: doppler

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -40,6 +40,14 @@ import (
 // ErrRunNotFound is returned by WaitRun when no run record exists for the given ID.
 var ErrRunNotFound = errors.New("run not found")
 
+// runReturnValueTTL is how long a suppressed-persistence return value
+// stays in the in-memory runReturnValue map after the run reaches a
+// terminal state. Long enough for a WaitRun caller woken by the runDone
+// close to scan the map; short enough that orphaned entries (no waiter)
+// don't accumulate. Only `run_result.enabled: false` tasks populate the
+// map, so this is a small footprint either way.
+const runReturnValueTTL = 30 * time.Second
+
 // Engine coordinates all trigger types and fires task runs.
 type Engine struct {
 	registry  *registry.Registry
@@ -55,6 +63,24 @@ type Engine struct {
 	runDone          sync.Map // runID (string) → chan struct{}, closed when the run reaches a terminal state
 	runTriggerSource sync.Map // runID (string) → triggerSource (registry.TriggerSource)
 	runChainDepth    sync.Map // runID (string) → int; _chain_depth from the run's input
+
+	// runReturnValue holds JSON-marshalled return values for runs whose task
+	// spec set `run_result.enabled: false`. The value is NOT written to the
+	// `runs.return_value` column in those cases, so WaitRun would otherwise
+	// see an empty value and break the synchronous dicode.run_task contract.
+	//
+	// Entries are added by dispatch right after marshalling and deleted by
+	// startRun's cleanup func via a time.AfterFunc that fires several
+	// seconds after the run reaches a terminal state — long enough for any
+	// WaitRun caller woken by the runDone close to scan the map before
+	// the entry disappears.
+	//
+	// Common case (persistence enabled) leaves this map untouched — the
+	// DB row carries the value as before, so there is no memory cost for
+	// regular tasks.
+	//
+	// Keys: runID (string). Values: string (JSON-marshalled return value).
+	runReturnValue sync.Map
 
 	shutdownMu  sync.RWMutex
 	shutdownCtx context.Context
@@ -696,9 +722,21 @@ func (e *Engine) WaitRun(ctx context.Context, runID string) (ipc.RunResult, erro
 		}
 		return ipc.RunResult{}, err
 	}
+	// Prefer the persisted return_value when present. Fall back to the
+	// in-memory runReturnValue cache for tasks that opted out of
+	// persistence via `run_result.enabled: false` — without this fallback,
+	// `dicode.run_task` callers would receive nil for those tasks even
+	// though the value is available in process. The cache entry survives
+	// for runReturnValueTTL after run completion (see startRun cleanup).
+	returnJSON := run.ReturnValue
+	if returnJSON == "" {
+		if v, ok := e.runReturnValue.Load(runID); ok {
+			returnJSON, _ = v.(string)
+		}
+	}
 	var returnValue interface{}
-	if run.ReturnValue != "" {
-		_ = json.Unmarshal([]byte(run.ReturnValue), &returnValue)
+	if returnJSON != "" {
+		_ = json.Unmarshal([]byte(returnJSON), &returnValue)
 	}
 	return ipc.RunResult{
 		RunID:       runID,
@@ -1551,6 +1589,16 @@ func (e *Engine) startRun(spec *task.Spec, opts *pkgruntime.RunOptions, source r
 		if v, ok := e.runDone.LoadAndDelete(opts.RunID); ok {
 			close(v.(chan struct{}))
 		}
+		// Defer deletion of the suppressed-persistence return-value cache:
+		// WaitRun goroutines woken by the runDone close above need time to
+		// scan runReturnValue before the entry is removed. The map is only
+		// populated for `run_result.enabled: false` tasks, so this AfterFunc
+		// is a no-op for the common case. Bounded by runReturnValueTTL so
+		// orphaned entries (no waiter ever calls WaitRun) don't leak.
+		runID := opts.RunID
+		time.AfterFunc(runReturnValueTTL, func() {
+			e.runReturnValue.Delete(runID)
+		})
 	}
 	return runCtx, cleanup, nil
 }
@@ -1957,6 +2005,17 @@ func (e *Engine) dispatch(ctx context.Context, spec *task.Spec, opts pkgruntime.
 	}
 
 	// Store return value and structured output if present.
+	//
+	// `run_result.enabled: false` opts out of persisting the JSON-marshalled
+	// return value to `runs.return_value`. Structured output_content and
+	// output_content_type are unaffected — those carry rich-output payloads
+	// (images, HTML) that are addressed separately by the WebUI's content
+	// type negotiation and aren't part of the confidentiality concern.
+	//
+	// In-memory delivery: regardless of persistence, the marshalled JSON is
+	// stashed in runReturnValue so WaitRun can serve it to synchronous
+	// callers (dicode.run_task -> IPC reply). The entry is cleared by the
+	// startRun cleanup func once the run reaches a terminal state.
 	if result != nil && (result.ReturnValue != nil || result.OutputContent != "") {
 		retJSON := ""
 		if result.ReturnValue != nil {
@@ -1964,7 +2023,32 @@ func (e *Engine) dispatch(ctx context.Context, spec *task.Spec, opts pkgruntime.
 				retJSON = string(b)
 			}
 		}
-		_ = e.registry.SetRunResult(context.Background(), opts.RunID, retJSON, result.OutputContentType, result.OutputContent)
+		persistReturnValue := spec.RunResult.PersistReturnValue()
+		// When persistence is suppressed, stash the in-memory copy so
+		// WaitRun can still serve it to synchronous callers
+		// (dicode.run_task -> IPC reply). Done BEFORE the DB write
+		// (skipped below) so a WaitRun caller racing against the runDone
+		// close never observes an empty value: dispatch is called from
+		// runTask synchronously, the runDone channel is closed only by
+		// startRun's cleanup func which runs after runTask returns, and
+		// the cleanup defers the runReturnValue deletion to give
+		// post-close WaitRun goroutines time to scan the map.
+		//
+		// Common case (persistence enabled) takes no in-memory slot — the
+		// DB row carries the value as before.
+		persistedReturnJSON := retJSON
+		if !persistReturnValue {
+			persistedReturnJSON = ""
+			if retJSON != "" {
+				e.runReturnValue.Store(opts.RunID, retJSON)
+			}
+		}
+		// Skip the SetRunResult call entirely when nothing would be
+		// written (e.g. return-value persistence disabled AND no
+		// structured output) to avoid a needless UPDATE statement.
+		if persistedReturnJSON != "" || result.OutputContent != "" {
+			_ = e.registry.SetRunResult(context.Background(), opts.RunID, persistedReturnJSON, result.OutputContentType, result.OutputContent)
+		}
 	}
 
 	status := registry.StatusSuccess

--- a/pkg/trigger/engine_result_persist_test.go
+++ b/pkg/trigger/engine_result_persist_test.go
@@ -1,0 +1,173 @@
+package trigger
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// TestEngine_RunResult_Disabled_SuppressesPersistence verifies the new
+// `run_result: { enabled: false }` flag suppresses the JSON-marshalled
+// return value from being persisted to `runs.return_value`, while still
+// allowing structured output_content to be persisted.
+func TestEngine_RunResult_Disabled_SuppressesPersistence(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+	disabled := false
+	spec := writeTask(t, dir, "secret-emitter",
+		`export default async function main() { return { token: "ya29.sensitive" } }`,
+		task.TriggerConfig{Manual: true})
+	spec.RunResult = &task.RunResultConfig{Enabled: &disabled}
+	_ = e.reg.Register(spec)
+
+	runID, err := e.engine.FireManual(context.Background(), "secret-emitter", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	run := waitForTerminal(t, e.engine, runID, 30*time.Second)
+	if run.Status != registry.StatusSuccess {
+		t.Fatalf("status = %q, want success", run.Status)
+	}
+	if run.ReturnValue != "" {
+		t.Errorf("ReturnValue should be empty when run_result.enabled=false, got %q", run.ReturnValue)
+	}
+}
+
+// TestEngine_RunResult_Default_PersistsValue is the baseline: without the
+// flag set the same task body produces a populated return_value column.
+// This guards against accidentally suppressing persistence for everyone.
+func TestEngine_RunResult_Default_PersistsValue(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+	spec := writeTask(t, dir, "plain-emitter",
+		`export default async function main() { return { token: "ya29.sensitive" } }`,
+		task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(spec)
+
+	runID, err := e.engine.FireManual(context.Background(), "plain-emitter", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	run := waitForTerminal(t, e.engine, runID, 30*time.Second)
+	if run.Status != registry.StatusSuccess {
+		t.Fatalf("status = %q, want success", run.Status)
+	}
+	if run.ReturnValue == "" {
+		t.Errorf("ReturnValue should be populated by default; got empty")
+	}
+}
+
+// TestEngine_RunResult_Disabled_WaitRunStillDelivers verifies the in-memory
+// delivery contract: even when persistence is suppressed, synchronous
+// callers (dicode.run_task -> WaitRun) still see the return value. This is
+// the load-bearing invariant — without it, dicode.run_task would silently
+// return nil for any non-persisted task.
+func TestEngine_RunResult_Disabled_WaitRunStillDelivers(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+	disabled := false
+	spec := writeTask(t, dir, "wait-secret",
+		`export default async function main() { return { token: "ya29.in-memory" } }`,
+		task.TriggerConfig{Manual: true})
+	spec.RunResult = &task.RunResultConfig{Enabled: &disabled}
+	_ = e.reg.Register(spec)
+
+	runID, err := e.engine.FireManual(context.Background(), "wait-secret", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	res, err := e.engine.WaitRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("WaitRun: %v", err)
+	}
+	if res.Status != registry.StatusSuccess {
+		t.Fatalf("status = %q, want success", res.Status)
+	}
+	m, ok := res.ReturnValue.(map[string]interface{})
+	if !ok {
+		t.Fatalf("WaitRun ReturnValue is %T, want map; value=%v", res.ReturnValue, res.ReturnValue)
+	}
+	if m["token"] != "ya29.in-memory" {
+		t.Errorf("WaitRun lost the token: got %v", m["token"])
+	}
+
+	// And confirm the DB row still shows it was suppressed (defence in depth).
+	run, err := e.reg.GetRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if run.ReturnValue != "" {
+		t.Errorf("DB ReturnValue should be empty; got %q", run.ReturnValue)
+	}
+}
+
+// TestEngine_RunResult_Disabled_ChainStillReceivesOutput verifies that
+// chained downstream tasks still receive the upstream task's return value
+// through `input.output`, even when persistence is suppressed. FireChain
+// already routes through the in-memory ChainInput on the RunResult, so this
+// test guards against future refactors accidentally tying chain delivery
+// to the persisted column.
+func TestEngine_RunResult_Disabled_ChainStillReceivesOutput(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+	disabled := false
+
+	upstream := writeTask(t, dir, "chain-up",
+		`export default async function main() { return { msg: "from-up" } }`,
+		task.TriggerConfig{Manual: true})
+	upstream.RunResult = &task.RunResultConfig{Enabled: &disabled}
+
+	downstream := writeTask(t, dir, "chain-down",
+		`export default async function main({ input }) { return "got:" + input.msg }`,
+		task.TriggerConfig{Chain: &task.ChainTrigger{From: "chain-up", On: "success"}})
+
+	_ = e.reg.Register(upstream)
+	_ = e.reg.Register(downstream)
+
+	upRunID, err := e.engine.FireManual(context.Background(), "chain-up", nil)
+	if err != nil {
+		t.Fatalf("FireManual upstream: %v", err)
+	}
+	waitForTerminal(t, e.engine, upRunID, 30*time.Second)
+
+	// Wait for the chained downstream run to appear and complete. Poll
+	// until a downstream run with our parent_run_id finishes successfully
+	// — chain firing is goroutine-driven so it lands shortly after the
+	// upstream cleanup runs.
+	deadline := time.Now().Add(60 * time.Second)
+	var downRun *registry.Run
+	for time.Now().Before(deadline) {
+		runs, err := e.reg.ListRuns(context.Background(), "chain-down", 5)
+		if err != nil {
+			t.Fatalf("ListRuns: %v", err)
+		}
+		for _, r := range runs {
+			if r.Status == registry.StatusSuccess {
+				downRun = r
+				break
+			}
+		}
+		if downRun != nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if downRun == nil {
+		t.Fatal("downstream chain run never reached success")
+	}
+	// Downstream's ReturnValue should embed the upstream payload.
+	if downRun.ReturnValue == "" {
+		t.Fatal("downstream ReturnValue empty — chain input never made it through")
+	}
+	// JSON-encoded string: "\"got:from-up\""
+	want := `"got:from-up"`
+	if downRun.ReturnValue != want {
+		t.Errorf("downstream ReturnValue = %q, want %q", downRun.ReturnValue, want)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `run_result: { enabled: false }` to `task.yaml`, suppressing JSON
persistence of a task's return value to `runs.return_value` for tasks
that legitimately return secret material.

### What's suppressed

- **Only** the JSON-marshalled return value column (`runs.return_value`).
- WebUI run-detail panel, REST `/api/runs`, WebSocket payloads, replay tooling all see an empty return value for those runs.

### What still flows (in-memory)

- `dicode.run_task("secret-task")` synchronous callers — `WaitRun` falls back to an in-memory cache populated by `dispatch` before the DB write is skipped.
- Chain triggers (`trigger.chain.from`) — `input.output` is delivered via the in-memory `RunResult.ChainInput` field; chain plumbing never touched the persisted column.
- Structured `output.html(...)`, `output.image(...)`, `output.file(...)` payloads keep persisting via `output_content` / `output_content_type` (separate columns, separate concern).
- `stdout`, `stderr`, `fail_reason` persist as usual — pair with [`silent: true`](https://github.com/dicode-ayo/dicode-core/blob/main/docs/concepts/task-format.md) when stdio may carry credentials.

### Downstream impact

- **Replay**: replaying a `run_result.enabled: false` task won't have the previous return value to display — acceptable since the whole point is that the value is sensitive and shouldn't be re-served from disk. The input remains replayable (unless also opted out via `run_inputs.enabled: false`).
- **Auto-fix loop**: agents looking at history of secret-bearing tasks won't see the return value either — desirable.
- **Memory**: in-memory cache is only populated when `enabled: false`; entries are deleted via `time.AfterFunc(30s)` after run completion (long enough for blocked `WaitRun` callers to scan the map; short enough to bound orphaned-entry footprint).

### Naming choice

Picked `run_result: { enabled: false }` to mirror the existing
`run_inputs: { enabled: false }` block. Both are per-task overrides for
"should this half of the run record get persisted?", so symmetric naming
keeps cognitive load minimal. Boolean (not an enum like `result_persist: never`) avoids string-validation logic and leaves room to grow the
block with sub-fields later if needed (e.g. retention overrides,
redaction selectors).

### Files changed

- `pkg/task/spec.go` — new `RunResultConfig` type + `Spec.RunResult` field + `PersistReturnValue()` helper that treats nil/nil-Enabled as default-true.
- `pkg/task/spec_test.go` — `TestSpec_RunResultOverride_Parses` (positive) + `TestSpec_RunResultOverride_Omitted` (default nil).
- `pkg/trigger/engine.go` — `runReturnValue sync.Map` + `runReturnValueTTL` constant; `dispatch` stashes to map when persistence is off; `WaitRun` falls back to the map; `startRun` cleanup deletes via `time.AfterFunc`.
- `pkg/trigger/engine_result_persist_test.go` — four new tests covering: suppression actually suppresses, default still persists, `WaitRun` still delivers in-memory, and chain downstream still receives `input.output`.
- `docs/concepts/task-format.md` — new "Suppressing return-value persistence" section + field-table entries.

## Test plan

- [x] `go test ./... -timeout 180s` green
- [x] `make format && make format-check && make lint` clean
- [x] `TestSpec_RunResultOverride_Parses` / `_Omitted` cover spec parsing
- [x] `TestEngine_RunResult_Disabled_SuppressesPersistence` verifies DB column is empty
- [x] `TestEngine_RunResult_Default_PersistsValue` guards against accidentally suppressing for everyone
- [x] `TestEngine_RunResult_Disabled_WaitRunStillDelivers` verifies the load-bearing in-memory contract
- [x] `TestEngine_RunResult_Disabled_ChainStillReceivesOutput` verifies chain delivery is unaffected
- [ ] Manual: add `run_result.enabled: false` to a real task, fire via `dicode.run_task` from a parent, confirm parent sees the value but WebUI shows empty