### PR TITLE
feat(trigger): per-edge overrides on trigger.before and trigger.chain

### DIFF
--- a/pkg/task/overrides.go
+++ b/pkg/task/overrides.go
@@ -126,3 +126,70 @@ type Overrides struct {
 	// For task_set entries only — Entries patches specific tasks within the nested set.
 	Entries map[string]*Overrides `yaml:"entries,omitempty"`
 }
+
+// validatePerEdgeOverrides enforces a conservative allowlist on Overrides
+// values used at per-edge dispatch sites — i.e. trigger.before[].overrides
+// and trigger.chain.overrides. Several Overrides fields are meaningful only
+// at the taskset / global level (Defaults, Entries, Enabled, Retry, Name,
+// Description) or are silently ignored by the per-edge dispatch path
+// (Trigger — see PR #303 MED #3). Rejecting them at config-load surfaces
+// operator typos and prevents silent footguns.
+//
+// Allowed at a per-edge site: Params (minus reserved keys), Env, Net, Fs,
+// Timeout, Notify, Dicode, Runtime.
+//
+// The site string names the offending location (e.g.
+// "trigger.before[0].overrides (task \"render\")") so operators can find it
+// in their task.yaml.
+func validatePerEdgeOverrides(site string, o *Overrides) error {
+	if o == nil {
+		return nil
+	}
+	// Enabled — would silently no-op the prereq dispatch. Operators expect
+	// it to "skip this edge"; instead it does nothing. Reject so the wrong
+	// mental model surfaces at load.
+	if o.Enabled != nil {
+		return fmt.Errorf("%s: field %q is not supported at a per-edge site (set on the task itself, not on the edge)", site, "enabled")
+	}
+	// Name / Description — replacing the prereq's identity at the per-edge
+	// dispatch makes no semantic sense; the run is logged under the prereq's
+	// real ID regardless. Reject to avoid misleading task.yaml.
+	if o.Name != "" {
+		return fmt.Errorf("%s: field %q is not supported at a per-edge site", site, "name")
+	}
+	if o.Description != "" {
+		return fmt.Errorf("%s: field %q is not supported at a per-edge site", site, "description")
+	}
+	// Trigger — PR #303 MED #3. The per-edge dispatch path invokes the
+	// prereq directly (registry.TriggerPreflight / chain dispatch) and
+	// ignores any rewired trigger config on the merged spec. Allowing
+	// `trigger:` here misleads operators into thinking they're rewiring the
+	// prereq's trigger graph for this firing.
+	if o.Trigger != nil {
+		return fmt.Errorf("%s: field %q is not supported at a per-edge site (per-edge dispatch ignores the prereq's trigger config)", site, "trigger")
+	}
+	// Retry — would apply per-firing, almost certainly unintended. If
+	// per-edge preflight retries become a real feature request, lift this
+	// rejection and wire applyLayer to copy it.
+	if o.Retry != nil {
+		return fmt.Errorf("%s: field %q is not supported at a per-edge site", site, "retry")
+	}
+	// Defaults / Entries — taskset-level constructs with no per-edge
+	// meaning.
+	if o.Defaults != nil {
+		return fmt.Errorf("%s: field %q is not supported at a per-edge site (taskset-level construct)", site, "defaults")
+	}
+	if o.Entries != nil {
+		return fmt.Errorf("%s: field %q is not supported at a per-edge site (taskset-level construct)", site, "entries")
+	}
+	// Params: same reserved-key check used on trigger.chain.params /
+	// on_failure_chain.params. Reserved engine keys must not appear in
+	// user-supplied per-edge params either — otherwise they'd collide with
+	// the input map the engine populates at firing time.
+	for _, p := range o.Params {
+		if _, reserved := reservedChainParamKeys[p.Name]; reserved {
+			return fmt.Errorf("%s: params %q is a reserved key (used by the engine)", site, p.Name)
+		}
+	}
+	return nil
+}

--- a/pkg/task/overrides.go
+++ b/pkg/task/overrides.go
@@ -1,0 +1,128 @@
+package task
+
+import (
+	"fmt"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Defaults are applied to all entries in a TaskSet before per-entry overrides.
+// They form level 2 in the three-level precedence stack.
+//
+// Defined in pkg/task (rather than pkg/taskset) so the same data type can be
+// referenced from per-edge override sites in this package (BeforeEntry,
+// ChainTrigger.Overrides) without creating an import cycle. pkg/taskset
+// re-exports it via a type alias for source compat.
+type Defaults struct {
+	Timeout time.Duration `yaml:"timeout,omitempty"`
+	Retry   *RetryConfig  `yaml:"retry,omitempty"`
+	// Env accepts full EnvEntry mappings or bare "KEY" / "KEY=value" strings.
+	Env []EnvEntry `yaml:"env,omitempty"`
+	// Trigger sets a fallback trigger for any entry that has none.
+	Trigger *TriggerPatch `yaml:"trigger,omitempty"`
+	Notify  *NotifyConfig `yaml:"notify,omitempty"`
+}
+
+// RetryConfig defines automatic retry behaviour for task runs.
+type RetryConfig struct {
+	Attempts int           `yaml:"attempts"`
+	Backoff  time.Duration `yaml:"backoff,omitempty"`
+}
+
+// TriggerPatch patches individual sub-fields of a TriggerConfig.
+// Pointer fields are nil when not being patched, allowing sub-field
+// merges without clearing unrelated trigger types.
+type TriggerPatch struct {
+	Cron    *string       `yaml:"cron,omitempty"`
+	Webhook *string       `yaml:"webhook,omitempty"`
+	Auth    *bool         `yaml:"auth,omitempty"`
+	Manual  *bool         `yaml:"manual,omitempty"`
+	Chain   *ChainTrigger `yaml:"chain,omitempty"`
+	Daemon  *bool         `yaml:"daemon,omitempty"`
+	Restart *string       `yaml:"restart,omitempty"`
+}
+
+// ParamOverride patches the default (and optionally required) of a named param.
+// It decodes from either a mapping form  {name: x, default: y}  or a scalar
+// "key: value" pair inside a YAML mapping — see ParamOverrides below.
+type ParamOverride struct {
+	Name     string `yaml:"name"`
+	Default  string `yaml:"default"`
+	Required *bool  `yaml:"required,omitempty"`
+}
+
+// ParamOverrides is a list of ParamOverride values that can be written in two
+// equivalent YAML forms:
+//
+//	# concise map (name → default):
+//	params:
+//	  provider: google
+//	  scope: "user,repo"
+//
+//	# explicit list (required: supported):
+//	params:
+//	  - { name: scope, default: "user,repo", required: true }
+type ParamOverrides []ParamOverride
+
+func (p *ParamOverrides) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.MappingNode:
+		// map form: each key/value pair → ParamOverride{Name: key, Default: value}
+		if len(value.Content)%2 != 0 {
+			return fmt.Errorf("params mapping has odd number of nodes")
+		}
+		*p = make(ParamOverrides, 0, len(value.Content)/2)
+		for i := 0; i < len(value.Content); i += 2 {
+			*p = append(*p, ParamOverride{
+				Name:    value.Content[i].Value,
+				Default: value.Content[i+1].Value,
+			})
+		}
+		return nil
+	case yaml.SequenceNode:
+		// list form: decode as []ParamOverride normally
+		type plain []ParamOverride
+		var list plain
+		if err := value.Decode(&list); err != nil {
+			return err
+		}
+		*p = ParamOverrides(list)
+		return nil
+	default:
+		return fmt.Errorf("params must be a mapping or sequence, got %v", value.Tag)
+	}
+}
+
+// Overrides is a patch applied to a resolved task or to a nested TaskSet entry.
+// Fields are applied in the three-level override cascade; later layers win.
+//
+// Defined in pkg/task (rather than pkg/taskset) so the same data type can be
+// referenced from per-edge override sites — BeforeEntry and
+// ChainTrigger.Overrides — without creating an import cycle. The merge
+// implementation continues to live in pkg/taskset (exported as
+// taskset.ApplyOverrides) so per-edge dispatch sites can reuse the exact
+// same semantics as the global `dicode tasks override <id>` path.
+type Overrides struct {
+	Enabled     *bool          `yaml:"enabled,omitempty"`
+	Name        string         `yaml:"name,omitempty"`        // replaces spec.Name
+	Description string         `yaml:"description,omitempty"` // replaces spec.Description
+	Trigger     *TriggerPatch  `yaml:"trigger,omitempty"`
+	Params      ParamOverrides `yaml:"params,omitempty"`
+	// Env accepts full EnvEntry mappings (name/secret/from/value/optional) or bare "KEY" / "KEY=value" strings.
+	Env []EnvEntry `yaml:"env,omitempty"`
+	Net []string   `yaml:"net,omitempty"` // replaces permissions.net
+	// Fs replaces permissions.fs entirely (matches Net's full-replace pattern).
+	Fs      []FSEntry          `yaml:"fs,omitempty"`
+	Timeout time.Duration      `yaml:"timeout,omitempty"`
+	Retry   *RetryConfig       `yaml:"retry,omitempty"`
+	Runtime string             `yaml:"runtime,omitempty"`
+	Notify  *NotifyConfig      `yaml:"notify,omitempty"`
+	Dicode  *DicodePermissions `yaml:"dicode,omitempty"` // replaces permissions.dicode
+
+	// For task_set entries only — Deprecated: Defaults cross-boundary cascade is no longer applied.
+	// Use per-entry overrides.entries[key] to patch nested tasks explicitly.
+	Defaults *Defaults `yaml:"defaults,omitempty"`
+	// For task_set entries only — Entries patches specific tasks within the nested set.
+	Entries map[string]*Overrides `yaml:"entries,omitempty"`
+}

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -86,12 +86,92 @@ type DockerConfig struct {
 // appear in Params at config-load (see Spec.validate), so collisions are
 // impossible at firing time.
 //
+// Overrides, when set, are a per-firing patch applied to the downstream's
+// own spec right before dispatch via this chain edge. Semantically the
+// downstream is declaring the variant of itself it wants to run when fired
+// via this chain — manual fires of the same downstream are unaffected.
+// The merge reuses the same taskset.ApplyOverrides logic that powers the
+// global `dicode tasks override <id>` path. The override is held as a
+// *Overrides pointer so the (already large) override surface stays in one
+// place; a nil pointer means "no per-edge override" (the existing
+// behaviour).
+//
 // Mirror of OnFailureChainSpec.Params (failure-chain side); shares the same
 // reservedChainParamKeys set.
 type ChainTrigger struct {
-	From   string         `yaml:"from"`             // task ID to listen for
-	On     string         `yaml:"on,omitempty"`     // "success" (default) | "failure" | "always"
-	Params map[string]any `yaml:"params,omitempty"` // forwarded into downstream task input
+	From      string         `yaml:"from"`                // task ID to listen for
+	On        string         `yaml:"on,omitempty"`        // "success" (default) | "failure" | "always"
+	Params    map[string]any `yaml:"params,omitempty"`    // forwarded into downstream task input
+	Overrides *Overrides     `yaml:"overrides,omitempty"` // per-firing override applied to the downstream spec
+}
+
+// BeforeEntry is one entry in a daemon task's trigger.before preflight list.
+// It can be written in two YAML forms:
+//
+//	# legacy bare-ID form (single string):
+//	before:
+//	  - render-config
+//	  - fetch-creds
+//
+//	# mapping form with per-edge overrides:
+//	before:
+//	  - task: render-config
+//	    overrides:
+//	      timeout: 5m
+//	      env:
+//	        - name: MODE
+//	          value: preflight
+//
+// Both forms can be mixed within the same list. The bare-ID form is
+// equivalent to `{task: <id>}` with no overrides — preserved verbatim for
+// backwards compat with task.yamls written before the per-edge override
+// extension. The trigger engine applies the per-edge Overrides to a deep
+// copy of the prereq task's spec at dispatch time; the prereq's
+// standalone (manual / cron / chain) fires are unaffected.
+type BeforeEntry struct {
+	Task      string     `yaml:"task"`
+	Overrides *Overrides `yaml:"overrides,omitempty"`
+}
+
+// UnmarshalYAML accepts either a scalar (legacy bare-ID string) or a mapping
+// (task + overrides). Anything else is rejected with an explicit error to
+// surface typos rather than silently dropping the entry.
+func (b *BeforeEntry) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		b.Task = value.Value
+		b.Overrides = nil
+		return nil
+	case yaml.MappingNode:
+		// Decode into an anonymous alias to avoid recursing into this
+		// UnmarshalYAML.
+		type entryShape struct {
+			Task      string     `yaml:"task"`
+			Overrides *Overrides `yaml:"overrides,omitempty"`
+		}
+		var e entryShape
+		if err := value.Decode(&e); err != nil {
+			return fmt.Errorf("trigger.before entry: %w", err)
+		}
+		b.Task = e.Task
+		b.Overrides = e.Overrides
+		return nil
+	default:
+		return fmt.Errorf("trigger.before entry: expected string or mapping, got %v", value.Tag)
+	}
+}
+
+// MarshalYAML emits the bare-ID form when there are no overrides, and the
+// mapping form otherwise. This keeps round-tripping clean for the legacy
+// case (config files don't bloat after a load+rewrite cycle).
+func (b BeforeEntry) MarshalYAML() (interface{}, error) {
+	if b.Overrides == nil {
+		return b.Task, nil
+	}
+	return struct {
+		Task      string     `yaml:"task"`
+		Overrides *Overrides `yaml:"overrides,omitempty"`
+	}{Task: b.Task, Overrides: b.Overrides}, nil
 }
 
 // TriggerConfig defines how a task is triggered.
@@ -112,7 +192,14 @@ type TriggerConfig struct {
 	// only one-shot tasks can be preflights. When a referenced task re-runs
 	// successfully after the daemon is up, the engine restarts the daemon so
 	// it picks up newly-rendered config.
-	Before []string `yaml:"before,omitempty"`
+	//
+	// Each entry can be either a bare task-ID string (legacy form) or a
+	// mapping with `task:` plus optional `overrides:` — see BeforeEntry's
+	// UnmarshalYAML for the dual-form decoder. Per-edge overrides are
+	// applied to a deep copy of the prereq spec at dispatch time, so a
+	// daemon can pin a custom timeout / env / params for the preflight run
+	// without affecting the prereq's standalone (manual / cron) fires.
+	Before []BeforeEntry `yaml:"before,omitempty"`
 }
 
 // Param defines a user-configurable input for a task.
@@ -534,6 +621,13 @@ func (s *Spec) Script() (string, error) {
 	return string(b), nil
 }
 
+// Validate runs the per-spec consistency checks (shape of trigger config,
+// docker section, etc.) and returns the first violation. Exposed publicly
+// so callers that mutate a Spec after LoadDir (e.g. per-edge override
+// dispatch in pkg/trigger) can re-validate the resulting variant before
+// dispatching it.
+func (s *Spec) Validate() error { return s.validate() }
+
 func (s *Spec) validate() error {
 	// Clear stale warnings so re-validation (e.g. on a reloaded spec) starts
 	// from a clean slate; otherwise warnings accumulate across validate
@@ -569,12 +663,12 @@ func (s *Spec) validate() error {
 		if !s.Trigger.Daemon {
 			return fmt.Errorf("trigger.before: requires daemon: true (got non-daemon trigger)")
 		}
-		for _, id := range s.Trigger.Before {
-			if id == "" {
+		for _, entry := range s.Trigger.Before {
+			if entry.Task == "" {
 				return fmt.Errorf("trigger.before: empty task ID")
 			}
-			if id == s.ID {
-				return fmt.Errorf("trigger.before: cannot reference self (task ID %q)", id)
+			if entry.Task == s.ID {
+				return fmt.Errorf("trigger.before: cannot reference self (task ID %q)", entry.Task)
 			}
 		}
 	}

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -663,12 +663,18 @@ func (s *Spec) validate() error {
 		if !s.Trigger.Daemon {
 			return fmt.Errorf("trigger.before: requires daemon: true (got non-daemon trigger)")
 		}
-		for _, entry := range s.Trigger.Before {
+		for i, entry := range s.Trigger.Before {
 			if entry.Task == "" {
 				return fmt.Errorf("trigger.before: empty task ID")
 			}
 			if entry.Task == s.ID {
 				return fmt.Errorf("trigger.before: cannot reference self (task ID %q)", entry.Task)
+			}
+			if entry.Overrides != nil {
+				site := fmt.Sprintf("trigger.before[%d].overrides (task %q)", i, entry.Task)
+				if err := validatePerEdgeOverrides(site, entry.Overrides); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -689,6 +695,11 @@ func (s *Spec) validate() error {
 		for k := range s.Trigger.Chain.Params {
 			if _, reserved := reservedChainParamKeys[k]; reserved {
 				return fmt.Errorf("trigger.chain.params: %q is a reserved key (used by the engine)", k)
+			}
+		}
+		if s.Trigger.Chain.Overrides != nil {
+			if err := validatePerEdgeOverrides("trigger.chain.overrides", s.Trigger.Chain.Overrides); err != nil {
+				return err
 			}
 		}
 	}

--- a/pkg/task/spec_test.go
+++ b/pkg/task/spec_test.go
@@ -282,8 +282,155 @@ docker:
 	if err := yaml.NewDecoder(strings.NewReader(src)).Decode(&s); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if len(s.Trigger.Before) != 2 || s.Trigger.Before[0] != "render-config" || s.Trigger.Before[1] != "fetch-creds" {
+	if len(s.Trigger.Before) != 2 || s.Trigger.Before[0].Task != "render-config" || s.Trigger.Before[1].Task != "fetch-creds" {
 		t.Errorf("Before = %v", s.Trigger.Before)
+	}
+}
+
+// TestTriggerBefore_PerEdgeOverrides verifies the dual-form decoder on the
+// before: list: bare-ID strings, mapping forms with overrides, and a mix
+// of both must all parse correctly. The override blob itself is preserved
+// so the engine can apply it at preflight dispatch time.
+func TestTriggerBefore_PerEdgeOverrides(t *testing.T) {
+	src := strings.TrimSpace(`
+name: tunnel
+runtime: docker
+trigger:
+  daemon: true
+  before:
+    - render-config
+    - task: fetch-creds
+      overrides:
+        timeout: 5m
+        env:
+          - name: MODE
+            value: preflight
+    - task: warm-cache
+docker:
+  image: x
+`)
+	var s Spec
+	if err := yaml.NewDecoder(strings.NewReader(src)).Decode(&s); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(s.Trigger.Before) != 3 {
+		t.Fatalf("Before length = %d, want 3", len(s.Trigger.Before))
+	}
+
+	// Entry 0: bare string form, no overrides.
+	if s.Trigger.Before[0].Task != "render-config" {
+		t.Errorf("entry[0].Task = %q, want render-config", s.Trigger.Before[0].Task)
+	}
+	if s.Trigger.Before[0].Overrides != nil {
+		t.Errorf("entry[0].Overrides should be nil for bare-ID form, got %+v", s.Trigger.Before[0].Overrides)
+	}
+
+	// Entry 1: mapping form WITH overrides.
+	if s.Trigger.Before[1].Task != "fetch-creds" {
+		t.Errorf("entry[1].Task = %q, want fetch-creds", s.Trigger.Before[1].Task)
+	}
+	if s.Trigger.Before[1].Overrides == nil {
+		t.Fatal("entry[1].Overrides should be populated")
+	}
+	if got := s.Trigger.Before[1].Overrides.Timeout; got != 5*time.Minute {
+		t.Errorf("entry[1].Overrides.Timeout = %v, want 5m", got)
+	}
+	if len(s.Trigger.Before[1].Overrides.Env) != 1 ||
+		s.Trigger.Before[1].Overrides.Env[0].Name != "MODE" ||
+		s.Trigger.Before[1].Overrides.Env[0].Value != "preflight" {
+		t.Errorf("entry[1].Overrides.Env = %+v, want one MODE=preflight entry", s.Trigger.Before[1].Overrides.Env)
+	}
+
+	// Entry 2: mapping form WITHOUT overrides — still legal.
+	if s.Trigger.Before[2].Task != "warm-cache" {
+		t.Errorf("entry[2].Task = %q, want warm-cache", s.Trigger.Before[2].Task)
+	}
+	if s.Trigger.Before[2].Overrides != nil {
+		t.Errorf("entry[2].Overrides should be nil (mapping without overrides:), got %+v", s.Trigger.Before[2].Overrides)
+	}
+}
+
+// TestTriggerBefore_BadEntryShapeRejected pins the negative path: a
+// sequence-of-sequences or any other non-scalar / non-mapping node must
+// surface an explicit decode error rather than silently dropping the
+// entry. Catches the failure mode where a stray YAML structure (e.g. a
+// typo'd indentation) gets parsed as a no-op.
+func TestTriggerBefore_BadEntryShapeRejected(t *testing.T) {
+	src := strings.TrimSpace(`
+name: t
+runtime: docker
+trigger:
+  daemon: true
+  before:
+    - [oops, not, scalar]
+docker: { image: x }`)
+	var s Spec
+	err := yaml.NewDecoder(strings.NewReader(src)).Decode(&s)
+	if err == nil {
+		t.Fatalf("expected decode error for nested sequence in before:, got none (got Before=%+v)", s.Trigger.Before)
+	}
+	if !strings.Contains(err.Error(), "trigger.before entry") {
+		t.Errorf("expected error to mention trigger.before entry, got: %v", err)
+	}
+}
+
+// TestTriggerChain_Overrides_Parses verifies that trigger.chain.overrides
+// decodes alongside the existing chain fields. The override blob is held
+// as a *task.Overrides pointer; nil means "no per-edge override" (the
+// pre-existing behaviour preserved for backwards compat).
+func TestTriggerChain_Overrides_Parses(t *testing.T) {
+	src := strings.TrimSpace(`
+name: downstream
+runtime: deno
+trigger:
+  chain:
+    from: upstream
+    on: success
+    overrides:
+      params:
+        mode: prod
+      timeout: 90s
+`)
+	var s Spec
+	if err := yaml.NewDecoder(strings.NewReader(src)).Decode(&s); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if s.Trigger.Chain == nil {
+		t.Fatal("Chain not parsed")
+	}
+	if s.Trigger.Chain.Overrides == nil {
+		t.Fatal("Chain.Overrides not parsed")
+	}
+	if s.Trigger.Chain.Overrides.Timeout != 90*time.Second {
+		t.Errorf("Chain.Overrides.Timeout = %v, want 90s", s.Trigger.Chain.Overrides.Timeout)
+	}
+	if len(s.Trigger.Chain.Overrides.Params) != 1 ||
+		s.Trigger.Chain.Overrides.Params[0].Name != "mode" ||
+		s.Trigger.Chain.Overrides.Params[0].Default != "prod" {
+		t.Errorf("Chain.Overrides.Params = %+v, want one mode=prod entry", s.Trigger.Chain.Overrides.Params)
+	}
+}
+
+// TestTriggerChain_NoOverrides_BackwardsCompat verifies that omitting
+// trigger.chain.overrides leaves the field nil, preserving the existing
+// dispatch path for task.yamls written before the per-edge extension.
+func TestTriggerChain_NoOverrides_BackwardsCompat(t *testing.T) {
+	src := strings.TrimSpace(`
+name: downstream
+runtime: deno
+trigger:
+  chain:
+    from: upstream
+`)
+	var s Spec
+	if err := yaml.NewDecoder(strings.NewReader(src)).Decode(&s); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if s.Trigger.Chain == nil {
+		t.Fatal("Chain not parsed")
+	}
+	if s.Trigger.Chain.Overrides != nil {
+		t.Errorf("Chain.Overrides should be nil when absent, got %+v", s.Trigger.Chain.Overrides)
 	}
 }
 

--- a/pkg/task/spec_test.go
+++ b/pkg/task/spec_test.go
@@ -504,6 +504,248 @@ docker: { image: x }`,
 	}
 }
 
+// TestPerEdgeOverrides_RejectUnsupportedFields pins the validation that runs
+// inside Spec.validate for every per-edge override site (Trigger.Before[].Overrides
+// and Trigger.Chain.Overrides). Fields that don't make sense at a per-edge
+// level — Enabled, Retry, Defaults, Entries, Name, Description, Trigger —
+// must be rejected with an error that names the offending field so operators
+// can find it in their task.yaml. See PR #303 HIGH and MED #3 review threads.
+func TestPerEdgeOverrides_RejectUnsupportedFields(t *testing.T) {
+	cases := []struct {
+		name     string
+		yaml     string
+		wantErr  string // substring that must appear in the error
+		wantSite string // substring naming the site (before/chain.overrides)
+	}{
+		// Trigger.Before[].Overrides — HIGH finding.
+		{
+			name: "before edge: enabled rejected",
+			yaml: `name: d
+runtime: docker
+docker: { image: x }
+trigger:
+  daemon: true
+  before:
+    - task: render
+      overrides:
+        enabled: false`,
+			wantErr:  "enabled",
+			wantSite: "trigger.before",
+		},
+		{
+			name: "before edge: retry rejected",
+			yaml: `name: d
+runtime: docker
+docker: { image: x }
+trigger:
+  daemon: true
+  before:
+    - task: render
+      overrides:
+        retry:
+          attempts: 3`,
+			wantErr:  "retry",
+			wantSite: "trigger.before",
+		},
+		{
+			name: "before edge: trigger rejected (MED #3)",
+			yaml: `name: d
+runtime: docker
+docker: { image: x }
+trigger:
+  daemon: true
+  before:
+    - task: render
+      overrides:
+        trigger:
+          manual: true`,
+			wantErr:  "trigger",
+			wantSite: "trigger.before",
+		},
+		{
+			name: "before edge: defaults rejected",
+			yaml: `name: d
+runtime: docker
+docker: { image: x }
+trigger:
+  daemon: true
+  before:
+    - task: render
+      overrides:
+        defaults:
+          timeout: 5m`,
+			wantErr:  "defaults",
+			wantSite: "trigger.before",
+		},
+		{
+			name: "before edge: entries rejected",
+			yaml: `name: d
+runtime: docker
+docker: { image: x }
+trigger:
+  daemon: true
+  before:
+    - task: render
+      overrides:
+        entries:
+          foo: {}`,
+			wantErr:  "entries",
+			wantSite: "trigger.before",
+		},
+		{
+			name: "before edge: name rejected",
+			yaml: `name: d
+runtime: docker
+docker: { image: x }
+trigger:
+  daemon: true
+  before:
+    - task: render
+      overrides:
+        name: renamed`,
+			wantErr:  "name",
+			wantSite: "trigger.before",
+		},
+		{
+			name: "before edge: description rejected",
+			yaml: `name: d
+runtime: docker
+docker: { image: x }
+trigger:
+  daemon: true
+  before:
+    - task: render
+      overrides:
+        description: nope`,
+			wantErr:  "description",
+			wantSite: "trigger.before",
+		},
+		{
+			name: "before edge: reserved param key rejected (MED #4)",
+			yaml: `name: d
+runtime: docker
+docker: { image: x }
+trigger:
+  daemon: true
+  before:
+    - task: render
+      overrides:
+        params:
+          taskID: x`,
+			wantErr:  "taskID",
+			wantSite: "trigger.before",
+		},
+
+		// Trigger.Chain.Overrides — same rules apply.
+		{
+			name: "chain edge: enabled rejected",
+			yaml: `name: d
+runtime: deno
+trigger:
+  chain:
+    from: upstream
+    overrides:
+      enabled: false`,
+			wantErr:  "enabled",
+			wantSite: "trigger.chain.overrides",
+		},
+		{
+			name: "chain edge: retry rejected",
+			yaml: `name: d
+runtime: deno
+trigger:
+  chain:
+    from: upstream
+    overrides:
+      retry:
+        attempts: 3`,
+			wantErr:  "retry",
+			wantSite: "trigger.chain.overrides",
+		},
+		{
+			name: "chain edge: trigger rejected (MED #3)",
+			yaml: `name: d
+runtime: deno
+trigger:
+  chain:
+    from: upstream
+    overrides:
+      trigger:
+        manual: true`,
+			wantErr:  "trigger",
+			wantSite: "trigger.chain.overrides",
+		},
+		{
+			name: "chain edge: reserved param key rejected (MED #4)",
+			yaml: `name: d
+runtime: deno
+trigger:
+  chain:
+    from: upstream
+    overrides:
+      params:
+        runID: x`,
+			wantErr:  "runID",
+			wantSite: "trigger.chain.overrides",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var s Spec
+			if err := yaml.NewDecoder(strings.NewReader(strings.TrimSpace(tc.yaml))).Decode(&s); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			err := s.validate()
+			if err == nil {
+				t.Fatalf("expected validation error for %s, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not mention offending field %q", err.Error(), tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantSite) {
+				t.Errorf("error %q does not name the site %q", err.Error(), tc.wantSite)
+			}
+		})
+	}
+}
+
+// TestPerEdgeOverrides_LegitimateFieldsAllowed verifies the validator does NOT
+// reject the per-edge override fields that legitimately apply: Params (without
+// reserved keys), Env, Net, FS, Timeout, Notify, Dicode, Runtime. Guards
+// against an over-aggressive validator regression.
+func TestPerEdgeOverrides_LegitimateFieldsAllowed(t *testing.T) {
+	src := strings.TrimSpace(`
+name: d
+runtime: docker
+docker: { image: x }
+trigger:
+  daemon: true
+  before:
+    - task: render
+      overrides:
+        params:
+          mode: prod
+        env:
+          - name: FOO
+            value: bar
+        net: ["api.example.com"]
+        fs:
+          - path: /tmp
+            permission: rw
+        timeout: 30s
+        notify:
+          on_failure: true
+        runtime: deno
+`)
+	var s Spec
+	if err := yaml.NewDecoder(strings.NewReader(src)).Decode(&s); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if err := s.validate(); err != nil {
+		t.Fatalf("expected validate() to accept legitimate per-edge fields, got: %v", err)
+	}
+}
+
 func equalSlice(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/pkg/taskset/override.go
+++ b/pkg/taskset/override.go
@@ -17,6 +17,19 @@ func applyOverrides(base *task.Spec, layers ...*Overrides) *task.Spec {
 	return out
 }
 
+// ApplyOverrides is the exported entry point used by per-edge override
+// dispatch sites (pkg/trigger preflight + chain firing). It returns a
+// deep copy of base with the supplied layers merged on top, reusing the
+// exact same logic that powers `dicode tasks override <id>` and the
+// taskset resolver's three-level cascade.
+//
+// Callers MUST treat the input base as read-only; the returned spec is a
+// fresh deep copy so mutating it does not affect the registry's canonical
+// spec.
+func ApplyOverrides(base *task.Spec, layers ...*Overrides) *task.Spec {
+	return applyOverrides(base, layers...)
+}
+
 func applyLayer(spec *task.Spec, o *Overrides) {
 	if o.Name != "" {
 		spec.Name = o.Name

--- a/pkg/taskset/spec.go
+++ b/pkg/taskset/spec.go
@@ -4,11 +4,9 @@
 package taskset
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/dicode/dicode/pkg/task"
-	"gopkg.in/yaml.v3"
 )
 
 // Ref points to a yaml file (kind: Task or kind: TaskSet).
@@ -51,113 +49,20 @@ func (r *Ref) effectivePoll() time.Duration {
 	return 30 * time.Second
 }
 
-// Defaults are applied to all entries in a TaskSet before per-entry overrides.
-// They form level 2 in the three-level precedence stack.
-type Defaults struct {
-	Timeout time.Duration `yaml:"timeout,omitempty"`
-	Retry   *RetryConfig  `yaml:"retry,omitempty"`
-	// Env accepts full EnvEntry mappings or bare "KEY" / "KEY=value" strings.
-	Env []task.EnvEntry `yaml:"env,omitempty"`
-	// Trigger sets a fallback trigger for any entry that has none.
-	Trigger *TriggerPatch      `yaml:"trigger,omitempty"`
-	Notify  *task.NotifyConfig `yaml:"notify,omitempty"`
-}
-
-// RetryConfig defines automatic retry behaviour for task runs.
-type RetryConfig struct {
-	Attempts int           `yaml:"attempts"`
-	Backoff  time.Duration `yaml:"backoff,omitempty"`
-}
-
-// TriggerPatch patches individual sub-fields of a TriggerConfig.
-// Pointer fields are nil when not being patched, allowing sub-field
-// merges without clearing unrelated trigger types.
-type TriggerPatch struct {
-	Cron    *string            `yaml:"cron,omitempty"`
-	Webhook *string            `yaml:"webhook,omitempty"`
-	Auth    *bool              `yaml:"auth,omitempty"`
-	Manual  *bool              `yaml:"manual,omitempty"`
-	Chain   *task.ChainTrigger `yaml:"chain,omitempty"`
-	Daemon  *bool              `yaml:"daemon,omitempty"`
-	Restart *string            `yaml:"restart,omitempty"`
-}
-
-// ParamOverride patches the default (and optionally required) of a named param.
-// It decodes from either a mapping form  {name: x, default: y}  or a scalar
-// "key: value" pair inside a YAML mapping — see ParamOverrides below.
-type ParamOverride struct {
-	Name     string `yaml:"name"`
-	Default  string `yaml:"default"`
-	Required *bool  `yaml:"required,omitempty"`
-}
-
-// ParamOverrides is a list of ParamOverride values that can be written in two
-// equivalent YAML forms:
-//
-//	# concise map (name → default):
-//	params:
-//	  provider: google
-//	  scope: "user,repo"
-//
-//	# explicit list (required: supported):
-//	params:
-//	  - { name: scope, default: "user,repo", required: true }
-type ParamOverrides []ParamOverride
-
-func (p *ParamOverrides) UnmarshalYAML(value *yaml.Node) error {
-	switch value.Kind {
-	case yaml.MappingNode:
-		// map form: each key/value pair → ParamOverride{Name: key, Default: value}
-		if len(value.Content)%2 != 0 {
-			return fmt.Errorf("params mapping has odd number of nodes")
-		}
-		*p = make(ParamOverrides, 0, len(value.Content)/2)
-		for i := 0; i < len(value.Content); i += 2 {
-			*p = append(*p, ParamOverride{
-				Name:    value.Content[i].Value,
-				Default: value.Content[i+1].Value,
-			})
-		}
-		return nil
-	case yaml.SequenceNode:
-		// list form: decode as []ParamOverride normally
-		type plain []ParamOverride
-		var list plain
-		if err := value.Decode(&list); err != nil {
-			return err
-		}
-		*p = ParamOverrides(list)
-		return nil
-	default:
-		return fmt.Errorf("params must be a mapping or sequence, got %v", value.Tag)
-	}
-}
-
-// Overrides is a patch applied to a resolved task or to a nested TaskSet entry.
-// Fields are applied in the three-level override cascade; later layers win.
-type Overrides struct {
-	Enabled     *bool          `yaml:"enabled,omitempty"`
-	Name        string         `yaml:"name,omitempty"`        // replaces spec.Name
-	Description string         `yaml:"description,omitempty"` // replaces spec.Description
-	Trigger     *TriggerPatch  `yaml:"trigger,omitempty"`
-	Params      ParamOverrides `yaml:"params,omitempty"`
-	// Env accepts full EnvEntry mappings (name/secret/from/value/optional) or bare "KEY" / "KEY=value" strings.
-	Env []task.EnvEntry `yaml:"env,omitempty"`
-	Net []string        `yaml:"net,omitempty"` // replaces permissions.net
-	// Fs replaces permissions.fs entirely (matches Net's full-replace pattern).
-	Fs      []task.FSEntry          `yaml:"fs,omitempty"`
-	Timeout time.Duration           `yaml:"timeout,omitempty"`
-	Retry   *RetryConfig            `yaml:"retry,omitempty"`
-	Runtime string                  `yaml:"runtime,omitempty"`
-	Notify  *task.NotifyConfig      `yaml:"notify,omitempty"`
-	Dicode  *task.DicodePermissions `yaml:"dicode,omitempty"` // replaces permissions.dicode
-
-	// For task_set entries only — Deprecated: Defaults cross-boundary cascade is no longer applied.
-	// Use per-entry overrides.entries[key] to patch nested tasks explicitly.
-	Defaults *Defaults `yaml:"defaults,omitempty"`
-	// For task_set entries only — Entries patches specific tasks within the nested set.
-	Entries map[string]*Overrides `yaml:"entries,omitempty"`
-}
+// Override-related types — Defaults, RetryConfig, TriggerPatch,
+// ParamOverride, ParamOverrides, Overrides — live in pkg/task so the same
+// data type can be referenced from per-edge override sites
+// (TriggerConfig.Before entries, ChainTrigger.Overrides) without creating
+// an import cycle. They are re-exported here as type aliases so existing
+// `taskset.Overrides{}` usage continues to compile unchanged.
+type (
+	Defaults       = task.Defaults
+	RetryConfig    = task.RetryConfig
+	TriggerPatch   = task.TriggerPatch
+	ParamOverride  = task.ParamOverride
+	ParamOverrides = task.ParamOverrides
+	Overrides      = task.Overrides
+)
 
 // Entry is one named item in spec.entries.
 // Exactly one of Ref or Inline must be set.

--- a/pkg/trigger/daemon_state.go
+++ b/pkg/trigger/daemon_state.go
@@ -2,13 +2,24 @@ package trigger
 
 import (
 	"context"
-	"slices"
 	"sync"
 	"time"
 
 	"github.com/dicode/dicode/pkg/task"
 	"go.uber.org/zap"
 )
+
+// beforeContains reports whether any BeforeEntry in entries names taskID.
+// Pulls only the Task field; per-edge overrides are irrelevant for
+// membership checks.
+func beforeContains(entries []task.BeforeEntry, taskID string) bool {
+	for _, e := range entries {
+		if e.Task == taskID {
+			return true
+		}
+	}
+	return false
+}
 
 // DaemonState describes the preflight/lifecycle phase of a daemon task as
 // observed by the trigger engine. Surfaced via Engine.DaemonState so the
@@ -109,7 +120,7 @@ func (e *Engine) notifyPrereqCompletion(completedTaskID string) {
 		if !spec.Trigger.Daemon {
 			continue
 		}
-		if !slices.Contains(spec.Trigger.Before, completedTaskID) {
+		if !beforeContains(spec.Trigger.Before, completedTaskID) {
 			continue
 		}
 		// Only attempt a restart if the daemon was actually up. Restarting

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dicode/dicode/pkg/runtime/envresolve"
 	"github.com/dicode/dicode/pkg/secrets"
 	"github.com/dicode/dicode/pkg/task"
+	"github.com/dicode/dicode/pkg/taskset"
 	"github.com/google/uuid"
 	"github.com/robfig/cron/v3"
 	"go.uber.org/zap"
@@ -383,13 +384,24 @@ func (e *Engine) Register(spec *task.Spec) error {
 // trigger.before back to the daemon, but only daemons may have
 // trigger.before. We therefore do not implement explicit cycle detection.
 func (e *Engine) validateBeforeRefs(spec *task.Spec) error {
-	for _, refID := range spec.Trigger.Before {
-		ref, ok := e.registry.Get(refID)
+	for _, entry := range spec.Trigger.Before {
+		ref, ok := e.registry.Get(entry.Task)
 		if !ok {
-			return fmt.Errorf("trigger.before: task %q not found in registry", refID)
+			return fmt.Errorf("trigger.before: task %q not found in registry", entry.Task)
 		}
 		if ref.Trigger.Daemon {
-			return fmt.Errorf("trigger.before: task %q is a daemon (only one-shot tasks can be preflights)", refID)
+			return fmt.Errorf("trigger.before: task %q is a daemon (only one-shot tasks can be preflights)", entry.Task)
+		}
+		// If this edge carries per-firing overrides, verify they merge
+		// onto the prereq spec without producing an invalid Spec. Doing
+		// this here surfaces malformed overrides at Register time rather
+		// than at the first daemon start — operators see a clean error
+		// path instead of a silently-failing preflight.
+		if entry.Overrides != nil {
+			merged := taskset.ApplyOverrides(ref, entry.Overrides)
+			if err := merged.Validate(); err != nil {
+				return fmt.Errorf("trigger.before: overrides for %q produce invalid spec: %w", entry.Task, err)
+			}
 		}
 	}
 	return nil
@@ -672,8 +684,9 @@ func (e *Engine) runPrereqs(ctx context.Context, spec *task.Spec) error {
 	results := make(chan prereqResult, len(spec.Trigger.Before))
 	var wg sync.WaitGroup
 
-	for _, refID := range spec.Trigger.Before {
-		refID := refID
+	for _, entry := range spec.Trigger.Before {
+		entry := entry
+		refID := entry.Task
 		ref, ok := e.registry.Get(refID)
 		if !ok {
 			// validateBeforeRefs catches this at registration time, but the
@@ -682,10 +695,29 @@ func (e *Engine) runPrereqs(ctx context.Context, spec *task.Spec) error {
 			results <- prereqResult{refID: refID, err: fmt.Errorf("prereq %q vanished from registry", refID)}
 			continue
 		}
+		// Per-edge overrides (#NNN): if this preflight edge declares
+		// `overrides:`, merge them onto a deep copy of the prereq spec
+		// before dispatching. The registry's canonical spec is left
+		// untouched so the prereq's standalone (manual / cron / chain)
+		// fires continue using the spec on disk. The merged spec is
+		// re-validated to surface override-induced invariant violations
+		// (e.g. an override that switches runtime to an unsupported
+		// value) — validateBeforeRefs already runs the same check at
+		// Register time, this is a defensive second pass for cases where
+		// the registry mutated between Register and the preflight fire.
+		dispatchSpec := ref
+		if entry.Overrides != nil {
+			merged := taskset.ApplyOverrides(ref, entry.Overrides)
+			if vErr := merged.Validate(); vErr != nil {
+				results <- prereqResult{refID: refID, err: fmt.Errorf("overrides produce invalid spec: %w", vErr)}
+				continue
+			}
+			dispatchSpec = merged
+		}
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			runID, err := e.fireAsync(ctx, ref, pkgruntime.RunOptions{}, registry.TriggerPreflight)
+			runID, err := e.fireAsync(ctx, dispatchSpec, pkgruntime.RunOptions{}, registry.TriggerPreflight)
 			if err != nil {
 				results <- prereqResult{refID: refID, err: fmt.Errorf("dispatch: %w", err)}
 				return
@@ -999,12 +1031,32 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 		if on != "always" && on != runStatus {
 			continue
 		}
+		// Per-edge overrides (#NNN): when the downstream's trigger.chain
+		// declares `overrides:`, apply them to a deep copy of the
+		// downstream spec before dispatching. The registry's canonical
+		// spec is preserved so manual / cron / non-chain fires of the
+		// same downstream see the on-disk values. The merged spec is
+		// re-validated; on failure we log and skip this edge rather than
+		// dispatching a malformed spec.
+		dispatchSpec := spec
+		if chain.Overrides != nil {
+			merged := taskset.ApplyOverrides(spec, chain.Overrides)
+			if vErr := merged.Validate(); vErr != nil {
+				e.log.Error("chain trigger skipped — overrides produce invalid spec",
+					zap.String("from", completedTaskID),
+					zap.String("to", spec.ID),
+					zap.Error(vErr),
+				)
+				continue
+			}
+			dispatchSpec = merged
+		}
 		e.log.Info("chain trigger",
 			zap.String("from", completedTaskID),
 			zap.String("to", spec.ID),
 			zap.String("on", on),
 		)
-		go e.fireAsync(ctx, spec, pkgruntime.RunOptions{ //nolint:errcheck
+		go e.fireAsync(ctx, dispatchSpec, pkgruntime.RunOptions{ //nolint:errcheck
 			ParentRunID: runID,
 			Input:       buildChainInput(chain.Params, completedTaskID, runID, runStatus, output),
 		}, "chain")

--- a/pkg/trigger/engine_per_edge_overrides_test.go
+++ b/pkg/trigger/engine_per_edge_overrides_test.go
@@ -1,0 +1,371 @@
+package trigger
+
+// Integration tests for per-edge overrides on trigger.before (preflight
+// chains) and trigger.chain (success chains). Both edges reuse
+// taskset.ApplyOverrides — these tests pin the contract that:
+//
+//  1. The override is applied to a deep copy of the prereq/downstream's
+//     spec at dispatch time.
+//  2. The registry's canonical spec is NOT mutated — manual / cron /
+//     unrelated fires of the same task still see the on-disk values.
+//  3. Overrides that produce an invalid Spec are rejected, not dispatched.
+//
+// The preflight test inspects the spec that the executor receives (timeout
+// + env) because those are the cheapest end-to-end-observable side effects.
+// The chain test goes through the real Deno runtime so it can read back
+// the merged Params.Default via the task script.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
+)
+
+// writeTaskFromYAML writes a fully-formed task.yaml + task.ts pair to dir/id
+// and returns nil on success. Unlike writeTask (engine_test.go) which takes
+// a strongly-typed TriggerConfig literal, this helper accepts the raw
+// task.yaml body so tests can exercise YAML-level constructs that the
+// strongly-typed builder doesn't reach (e.g. trigger.chain.overrides — a
+// late-bound *task.Overrides nested under chain).
+func writeTaskFromYAML(t *testing.T, dir, id, yaml, script string) error {
+	t.Helper()
+	td := filepath.Join(dir, id)
+	if err := os.MkdirAll(td, 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(td, "task.yaml"), []byte(yaml), 0o644); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(td, "task.ts"), []byte(script), 0o644)
+}
+
+// captureExec records the spec the executor was handed for every Execute
+// call, keyed by run ID. Lets per-edge override tests assert that the
+// override-merged spec (not the registry's canonical spec) is what reaches
+// the runtime layer. Adapted from preflightExec — kept separate so the
+// captureExec ↔ test contract is obvious from the call sites below.
+type captureExec struct {
+	reg *registry.Registry
+
+	mu       sync.Mutex
+	captured map[string]*task.Spec
+	daemonCh chan struct{}
+}
+
+func newCaptureExec(reg *registry.Registry) *captureExec {
+	return &captureExec{
+		reg:      reg,
+		captured: make(map[string]*task.Spec),
+		daemonCh: make(chan struct{}),
+	}
+}
+
+func (c *captureExec) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
+	c.mu.Lock()
+	// Take a shallow copy: tests assert on Timeout, Env, Params, Runtime —
+	// not on slice identity.
+	specCopy := *spec
+	c.captured[opts.RunID] = &specCopy
+	c.mu.Unlock()
+
+	// Daemons block until ctx cancelled — mirrors preflightExec's daemon path.
+	if spec.Trigger.Daemon {
+		<-ctx.Done()
+		_ = c.reg.FinishRun(context.Background(), opts.RunID, registry.StatusSuccess)
+		return &pkgruntime.RunResult{}, nil
+	}
+	_ = c.reg.FinishRun(context.Background(), opts.RunID, registry.StatusSuccess)
+	return &pkgruntime.RunResult{}, nil
+}
+
+func (c *captureExec) specFor(runID string) *task.Spec {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.captured[runID]
+}
+
+func (c *captureExec) specForTask(reg *registry.Registry, taskID string, triggerSrc registry.TriggerSource) *task.Spec {
+	runs, _ := reg.ListRuns(context.Background(), taskID, 20)
+	for _, r := range runs {
+		if r.TriggerSource == triggerSrc {
+			if s := c.specFor(r.ID); s != nil {
+				return s
+			}
+		}
+	}
+	return nil
+}
+
+func newCaptureEnv(t *testing.T) (*Engine, *registry.Registry, *captureExec) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+	exec := newCaptureExec(reg)
+	eng := New(reg, exec, zap.NewNop())
+	eng.RegisterExecutor(task.RuntimeDocker, exec)
+	return eng, reg, exec
+}
+
+// TestPerEdgeOverrides_BeforeAppliesAtPreflightOnly verifies that a
+// `before: [{task: render, overrides: {timeout: 5m}}]` edge dispatches
+// the prereq with the override-merged timeout, while the prereq's own
+// registry spec (and standalone manual fires) keep the 60s value from
+// task.yaml.
+func TestPerEdgeOverrides_BeforeAppliesAtPreflightOnly(t *testing.T) {
+	eng, reg, exec := newCaptureEnv(t)
+
+	// Prereq: on-disk timeout 60s.
+	prereqOriginalTimeout := 60 * time.Second
+	prereq := &task.Spec{
+		ID:      "render",
+		Name:    "render",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Timeout: prereqOriginalTimeout,
+		Enabled: true,
+	}
+	if err := reg.Register(prereq); err != nil {
+		t.Fatalf("reg.Register prereq: %v", err)
+	}
+
+	// Daemon: declares a per-edge override on the render prereq with
+	// timeout 5m. The override should apply only to the preflight fire.
+	overrideTimeout := 5 * time.Minute
+	daemon := &task.Spec{
+		ID:      "d",
+		Name:    "d",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{
+			Daemon:  true,
+			Restart: "never",
+			Before: []task.BeforeEntry{{
+				Task: "render",
+				Overrides: &task.Overrides{
+					Timeout: overrideTimeout,
+				},
+			}},
+		},
+		Enabled: true,
+	}
+	if err := reg.Register(daemon); err != nil {
+		t.Fatalf("reg.Register daemon: %v", err)
+	}
+	if err := eng.Register(daemon); err != nil {
+		t.Fatalf("eng.Register daemon: %v", err)
+	}
+
+	// Wait for daemon to come up (preflight succeeded).
+	waitUntil(t, 5*time.Second, func() bool {
+		return eng.DaemonState("d") == DaemonRunning
+	}, "daemon never reached Running")
+
+	// The preflight fire of render should have used the override timeout.
+	preflightSpec := exec.specForTask(reg, "render", registry.TriggerPreflight)
+	if preflightSpec == nil {
+		t.Fatal("preflight render run never reached executor")
+	}
+	if preflightSpec.Timeout != overrideTimeout {
+		t.Errorf("preflight render Timeout = %v, want %v (override should apply)",
+			preflightSpec.Timeout, overrideTimeout)
+	}
+
+	// The registry's canonical spec must NOT have been mutated.
+	regSpec, _ := reg.Get("render")
+	if regSpec.Timeout != prereqOriginalTimeout {
+		t.Errorf("registry render spec Timeout = %v, want %v (registry must not be mutated)",
+			regSpec.Timeout, prereqOriginalTimeout)
+	}
+
+	// Standalone manual fire must see the original timeout.
+	manualRunID, err := eng.FireManual(context.Background(), "render", nil)
+	if err != nil {
+		t.Fatalf("FireManual render: %v", err)
+	}
+	waitUntil(t, 5*time.Second, func() bool {
+		s := exec.specFor(manualRunID)
+		return s != nil
+	}, "manual render never reached executor")
+	manualSpec := exec.specFor(manualRunID)
+	if manualSpec.Timeout != prereqOriginalTimeout {
+		t.Errorf("manual render Timeout = %v, want %v (override must not leak to manual fires)",
+			manualSpec.Timeout, prereqOriginalTimeout)
+	}
+}
+
+// TestPerEdgeOverrides_BeforeInvalidOverrideRejectedAtRegister verifies
+// that overrides which would produce an invalid Spec are caught at
+// Engine.Register time. Operators see a clean error path rather than a
+// silently-failing daemon that stays in PrereqFailed forever.
+//
+// We use runtime: "" because Spec.validate accepts any non-empty runtime
+// but the empty case routes through the deno default path — instead
+// trigger an invariant we can actually break: a chain trigger with no
+// `from:`. The override switches the prereq to a chain trigger that
+// fails per-spec validation.
+func TestPerEdgeOverrides_BeforeInvalidOverrideRejectedAtRegister(t *testing.T) {
+	eng, reg, _ := newCaptureEnv(t)
+
+	prereq := &task.Spec{
+		ID:      "render",
+		Name:    "render",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Timeout: 60 * time.Second,
+		Enabled: true,
+	}
+	if err := reg.Register(prereq); err != nil {
+		t.Fatal(err)
+	}
+
+	emptyFrom := ""
+	daemon := &task.Spec{
+		ID:      "d",
+		Name:    "d",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{
+			Daemon: true,
+			Before: []task.BeforeEntry{{
+				Task: "render",
+				Overrides: &task.Overrides{
+					Trigger: &task.TriggerPatch{
+						Chain: &task.ChainTrigger{From: emptyFrom},
+					},
+				},
+			}},
+		},
+		Enabled: true,
+	}
+	if err := reg.Register(daemon); err != nil {
+		t.Fatal(err)
+	}
+
+	err := eng.Register(daemon)
+	if err == nil {
+		t.Fatal("expected Register to fail with invalid override, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid spec") {
+		t.Errorf("expected error mentioning invalid spec, got: %v", err)
+	}
+}
+
+// TestPerEdgeOverrides_ChainAppliesAtChainOnly is the end-to-end chain
+// dispatch test. It uses the real Deno runtime path (writeTask + newTestEnv
+// from engine_test.go's helpers) so we can read back the merged spec
+// values via the task script's return value.
+//
+// Upstream completes; downstream's trigger.chain.overrides patches
+// params.mode to "prod". The downstream task reads params.mode at runtime
+// and returns it; the test asserts the value is the override-merged
+// "prod", not the on-disk default "review".
+func TestPerEdgeOverrides_ChainAppliesAtChainOnly(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	// Downstream task: declares trigger.chain on "upstream-edge" with an
+	// override that changes the `mode` param default from "review" to
+	// "prod". The script echoes the param so the test can compare.
+	defaultMode := "review"
+	overrideMode := "prod"
+
+	downstreamYAML := `
+name: downstream-edge
+runtime: deno
+trigger:
+  chain:
+    from: upstream-edge
+    on: success
+    overrides:
+      params:
+        mode: ` + overrideMode + `
+params:
+  mode:
+    default: ` + defaultMode + `
+`
+	// writeTask doesn't support trigger.chain.overrides directly because
+	// the helper takes a strongly-typed TriggerConfig literal. Build the
+	// spec via WriteFile + LoadDir instead so we exercise the real YAML
+	// path the engine sees in production.
+	if err := writeTaskFromYAML(t, dir, "downstream-edge", downstreamYAML,
+		`export default async function main({ params }) { return await params.get("mode") }`); err != nil {
+		t.Fatalf("write downstream: %v", err)
+	}
+	downstream, err := task.LoadDir(dir + "/downstream-edge")
+	if err != nil {
+		t.Fatalf("load downstream: %v", err)
+	}
+	if err := e.reg.Register(downstream); err != nil {
+		t.Fatalf("reg.Register downstream: %v", err)
+	}
+	if err := e.engine.Register(downstream); err != nil {
+		t.Fatalf("eng.Register downstream: %v", err)
+	}
+
+	// Upstream: just returns; the engine fires downstream on success.
+	upstream := writeTask(t, dir, "upstream-edge",
+		`export default async function main() { return "go" }`,
+		task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(upstream)
+	if err := e.engine.Register(upstream); err != nil {
+		t.Fatalf("eng.Register upstream: %v", err)
+	}
+
+	// Fire upstream.
+	upstreamRunID, err := e.engine.FireManual(context.Background(), "upstream-edge", nil)
+	if err != nil {
+		t.Fatalf("FireManual upstream: %v", err)
+	}
+	primary := waitForTerminal(t, e.engine, upstreamRunID, 30*time.Second)
+	if primary.Status != registry.StatusSuccess {
+		t.Fatalf("upstream status = %q, want success", primary.Status)
+	}
+
+	// Wait for the chain-fired downstream run and inspect its return.
+	got := waitForRunOfTask(t, e.engine, "downstream-edge", 30*time.Second)
+	if got == nil {
+		t.Fatal("downstream-edge was never fired via chain")
+	}
+	if got.Status != registry.StatusSuccess {
+		t.Errorf("downstream status = %q, want success", got.Status)
+	}
+	returnValue := pollReturnValue(t, e.engine, got.ID, 5*time.Second)
+	var mode string
+	if err := json.Unmarshal([]byte(returnValue), &mode); err != nil {
+		t.Fatalf("unmarshal return %q: %v", returnValue, err)
+	}
+	if mode != overrideMode {
+		t.Errorf("chain-fired downstream params.mode = %q, want %q (override should apply)",
+			mode, overrideMode)
+	}
+
+	// Now fire the downstream manually — wait, downstream's trigger is
+	// chain-only, so manual fire would be rejected by the engine. The
+	// "doesn't leak to manual" half of this assertion is covered by the
+	// before-edge test above (where a manual fire is legal because the
+	// prereq's trigger is Manual). Instead assert the registry's
+	// canonical downstream spec was NOT mutated.
+	regDownstream, _ := e.reg.Get("downstream-edge")
+	if len(regDownstream.Params) != 1 || regDownstream.Params[0].Name != "mode" {
+		t.Fatalf("registry downstream params = %+v, want [mode]", regDownstream.Params)
+	}
+	if regDownstream.Params[0].Default != defaultMode {
+		t.Errorf("registry downstream params.mode.default = %q, want %q (registry must not be mutated)",
+			regDownstream.Params[0].Default, defaultMode)
+	}
+}

--- a/pkg/trigger/engine_preflight_test.go
+++ b/pkg/trigger/engine_preflight_test.go
@@ -30,7 +30,7 @@ func TestRegister_BeforeUnknownTaskRejected(t *testing.T) {
 		Name:    "d",
 		Runtime: task.RuntimeDocker,
 		Docker:  &task.DockerConfig{Image: "alpine"},
-		Trigger: task.TriggerConfig{Daemon: true, Before: []string{"missing"}},
+		Trigger: task.TriggerConfig{Daemon: true, Before: []task.BeforeEntry{{Task: "missing"}}},
 		Enabled: true,
 	}
 	err := e.engine.Register(daemon)
@@ -57,7 +57,7 @@ func TestRegister_BeforeDaemonRejected(t *testing.T) {
 		Name:    "d",
 		Runtime: task.RuntimeDocker,
 		Docker:  &task.DockerConfig{Image: "alpine"},
-		Trigger: task.TriggerConfig{Daemon: true, Before: []string{"other-daemon"}},
+		Trigger: task.TriggerConfig{Daemon: true, Before: []task.BeforeEntry{{Task: "other-daemon"}}},
 		Enabled: true,
 	}
 	err := e.engine.Register(target)
@@ -120,7 +120,7 @@ func TestRegister_BeforeValid_NonDaemonTarget(t *testing.T) {
 		Name:    "d",
 		Runtime: task.RuntimeDocker,
 		Docker:  &task.DockerConfig{Image: "alpine"},
-		Trigger: task.TriggerConfig{Daemon: true, Before: []string{"render"}},
+		Trigger: task.TriggerConfig{Daemon: true, Before: []task.BeforeEntry{{Task: "render"}}},
 		Enabled: true,
 	}
 	if err := e.engine.Register(daemon); err != nil {
@@ -267,7 +267,7 @@ func TestPreflight_DaemonWaitsForPrereqSuccess(t *testing.T) {
 		Name:    "d",
 		Runtime: task.RuntimeDocker,
 		Docker:  &task.DockerConfig{Image: "alpine"},
-		Trigger: task.TriggerConfig{Daemon: true, Before: []string{"render"}, Restart: "never"},
+		Trigger: task.TriggerConfig{Daemon: true, Before: []task.BeforeEntry{{Task: "render"}}, Restart: "never"},
 		Enabled: true,
 	}
 	if err := reg.Register(daemon); err != nil {
@@ -319,6 +319,10 @@ func TestPreflight_NoBefore_StartsImmediately(t *testing.T) {
 // makeDaemonSpec is a tiny convenience to keep the table-style tests below
 // from drowning in struct literals. Kept local to this file.
 func makeDaemonSpec(id string, before []string) *task.Spec {
+	entries := make([]task.BeforeEntry, len(before))
+	for i, t := range before {
+		entries[i] = task.BeforeEntry{Task: t}
+	}
 	return &task.Spec{
 		ID:      id,
 		Name:    id,
@@ -328,7 +332,7 @@ func makeDaemonSpec(id string, before []string) *task.Spec {
 		// existing "always restart" hook AND the prereq-driven restart
 		// path together (would double-count daemon runs in the
 		// coalescing test).
-		Trigger: task.TriggerConfig{Daemon: true, Before: before, Restart: "never"},
+		Trigger: task.TriggerConfig{Daemon: true, Before: entries, Restart: "never"},
 		Enabled: true,
 	}
 }


### PR DESCRIPTION
## Summary

Extends the task-trigger graph so individual edges can optionally carry
inline overrides that are merged onto the dispatched task's spec for
that one firing. The override surface reuses the existing
`taskset.ApplyOverrides` logic that powers the global
`dicode tasks override <id>` path, so per-edge overrides behave
identically to every other override layer.

**Stacked on `feat/daemon-preflight-before` (PR #300)**, which is itself
stacked on the chain-params PR (#299). The base-branch points at #300
so the diff shows only this PR's changes; once the stack lands this
auto-rebases.

## Schema (before/after)

### `trigger.before`

```yaml
# before — legacy, still works:
trigger:
  daemon: true
  before:
    - render-config
    - fetch-creds

# after — bare-ID, mapping-with-overrides, and mapping-without-overrides
#         can be freely mixed:
trigger:
  daemon: true
  before:
    - render-config                       # bare-ID (legacy)
    - task: fetch-creds                   # mapping, no overrides
    - task: warm-cache                    # mapping, with overrides
      overrides:
        timeout: 5m
        env:
          - name: MODE
            value: preflight
```

### `trigger.chain`

```yaml
# before (chain.params from #299, no overrides):
trigger:
  chain:
    from: upstream
    on: success
    params:
      shard: "3"

# after (overrides apply to the downstream's own spec on this edge):
trigger:
  chain:
    from: upstream
    on: success
    params:
      shard: "3"
    overrides:
      params:
        mode: prod
      timeout: 90s
```

## Implementation notes

- `BeforeEntry.UnmarshalYAML` accepts both scalar (legacy bare-ID) and
  mapping forms; non-scalar/non-mapping nodes (e.g. nested sequences
  from typo'd indentation) surface an explicit decode error rather than
  being silently dropped.
- `BeforeEntry.MarshalYAML` emits the bare form when overrides are nil,
  keeping round-trips clean for existing configs.
- The override types (`Overrides`, `TriggerPatch`, `ParamOverride/s`,
  `RetryConfig`, `Defaults`) move from `pkg/taskset` to `pkg/task` to
  break the cycle that would otherwise block
  `task.BeforeEntry.Overrides *Overrides` and
  `task.ChainTrigger.Overrides *Overrides`. `pkg/taskset` re-exports
  each via a type alias, so existing `taskset.Overrides{}` literals
  keep working unchanged.
- Engine merge sites (`runPrereqs`, `FireChain`) clone the prereq /
  downstream spec, apply the edge's overrides, re-validate, then
  dispatch. The registry's canonical spec is never mutated.
- `validateBeforeRefs` runs the same merge+validate at `Register` time
  so malformed overrides surface as a clean Register error instead of a
  silently-failing daemon stuck in `PrereqFailed`.

## Test plan

- [x] **Schema — `before:`**: `TestTriggerBefore_PerEdgeOverrides`
      parses a mixed list (bare-ID + mapping-with-overrides +
      mapping-without-overrides). Each entry's `Task` and `Overrides`
      fields hit expected values.
- [x] **Schema — `before:` negative**:
      `TestTriggerBefore_BadEntryShapeRejected` confirms a nested
      sequence inside `before:` surfaces an explicit decode error.
- [x] **Schema — `chain.overrides`**:
      `TestTriggerChain_Overrides_Parses` plus
      `TestTriggerChain_NoOverrides_BackwardsCompat` for the nil-case.
- [x] **Backwards compat — `before: [a, b]`**:
      `TestTriggerBefore_Parses` (existing, updated to read
      `.Task`) confirms the legacy form still decodes.
- [x] **Dispatch — preflight**:
      `TestPerEdgeOverrides_BeforeAppliesAtPreflightOnly` asserts the
      preflight fire runs the prereq with the override timeout, AND
      that the registry's canonical spec + a follow-up manual fire
      both keep the on-disk timeout (no mutation, no leak).
- [x] **Dispatch — chain**:
      `TestPerEdgeOverrides_ChainAppliesAtChainOnly` uses the real
      Deno runtime: upstream completes, downstream's chain edge
      patches `params.mode` from "review" to "prod"; the script reads
      `params.get("mode")` and returns it. Test also re-checks the
      registry's downstream spec still holds the on-disk default.
- [x] **Validation — invalid overrides rejected at Register**:
      `TestPerEdgeOverrides_BeforeInvalidOverrideRejectedAtRegister`
      patches the prereq's trigger to a chain with no `from:`; the
      merged spec fails `Validate()`, surfaced via `Register` error.
- [x] `make format && make format-check && make lint` — clean.
- [x] `go test ./... -timeout 120s` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)