### PR TITLE
chore: land daemon preflight + per-edge overrides on main

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -250,7 +250,20 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 				}
 			}
 		}
-		eng.Register(spec)
+		if err := eng.Register(spec); err != nil {
+			// Cross-spec validation (trigger.before pointing at an unknown
+			// task or at another daemon) is the only error Register currently
+			// returns. The reconciler will retry on the next reload, so a
+			// transient registry mismatch heals itself; a persistent config
+			// error surfaces here every cycle. Log at WARN — matches how the
+			// reconciler/engine surface other config-validation failures —
+			// and skip the downstream webhook/footgun checks so a half-
+			// registered task doesn't claim its gateway path.
+			log.Warn("task registration rejected by engine — fix the spec to re-enable",
+				zap.String("task", spec.ID),
+				zap.Error(err))
+			return
+		}
 		if spec.Trigger.Webhook != "" {
 			gateway.Register(spec.Trigger.Webhook, webhookH)
 			webhookMu.Lock()

--- a/pkg/registry/trigger_source.go
+++ b/pkg/registry/trigger_source.go
@@ -18,4 +18,9 @@ const (
 	TriggerCronCatchup TriggerSource = "cron-catchup"
 	TriggerProvider    TriggerSource = "provider"
 	TriggerIfMissing   TriggerSource = "if_missing"
+	// TriggerPreflight tags a run fired by the daemon-preflight gating
+	// mechanism (`trigger.before`). Distinct from TriggerChain so the
+	// WebUI can group preflight runs under the daemon they're gating
+	// rather than under their own chain-trigger history.
+	TriggerPreflight TriggerSource = "preflight"
 )

--- a/pkg/task/overrides.go
+++ b/pkg/task/overrides.go
@@ -1,0 +1,195 @@
+package task
+
+import (
+	"fmt"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Defaults are applied to all entries in a TaskSet before per-entry overrides.
+// They form level 2 in the three-level precedence stack.
+//
+// Defined in pkg/task (rather than pkg/taskset) so the same data type can be
+// referenced from per-edge override sites in this package (BeforeEntry,
+// ChainTrigger.Overrides) without creating an import cycle. pkg/taskset
+// re-exports it via a type alias for source compat.
+type Defaults struct {
+	Timeout time.Duration `yaml:"timeout,omitempty"`
+	Retry   *RetryConfig  `yaml:"retry,omitempty"`
+	// Env accepts full EnvEntry mappings or bare "KEY" / "KEY=value" strings.
+	Env []EnvEntry `yaml:"env,omitempty"`
+	// Trigger sets a fallback trigger for any entry that has none.
+	Trigger *TriggerPatch `yaml:"trigger,omitempty"`
+	Notify  *NotifyConfig `yaml:"notify,omitempty"`
+}
+
+// RetryConfig defines automatic retry behaviour for task runs.
+type RetryConfig struct {
+	Attempts int           `yaml:"attempts"`
+	Backoff  time.Duration `yaml:"backoff,omitempty"`
+}
+
+// TriggerPatch patches individual sub-fields of a TriggerConfig.
+// Pointer fields are nil when not being patched, allowing sub-field
+// merges without clearing unrelated trigger types.
+type TriggerPatch struct {
+	Cron    *string       `yaml:"cron,omitempty"`
+	Webhook *string       `yaml:"webhook,omitempty"`
+	Auth    *bool         `yaml:"auth,omitempty"`
+	Manual  *bool         `yaml:"manual,omitempty"`
+	Chain   *ChainTrigger `yaml:"chain,omitempty"`
+	Daemon  *bool         `yaml:"daemon,omitempty"`
+	Restart *string       `yaml:"restart,omitempty"`
+}
+
+// ParamOverride patches the default (and optionally required) of a named param.
+// It decodes from either a mapping form  {name: x, default: y}  or a scalar
+// "key: value" pair inside a YAML mapping — see ParamOverrides below.
+type ParamOverride struct {
+	Name     string `yaml:"name"`
+	Default  string `yaml:"default"`
+	Required *bool  `yaml:"required,omitempty"`
+}
+
+// ParamOverrides is a list of ParamOverride values that can be written in two
+// equivalent YAML forms:
+//
+//	# concise map (name → default):
+//	params:
+//	  provider: google
+//	  scope: "user,repo"
+//
+//	# explicit list (required: supported):
+//	params:
+//	  - { name: scope, default: "user,repo", required: true }
+type ParamOverrides []ParamOverride
+
+func (p *ParamOverrides) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.MappingNode:
+		// map form: each key/value pair → ParamOverride{Name: key, Default: value}
+		if len(value.Content)%2 != 0 {
+			return fmt.Errorf("params mapping has odd number of nodes")
+		}
+		*p = make(ParamOverrides, 0, len(value.Content)/2)
+		for i := 0; i < len(value.Content); i += 2 {
+			*p = append(*p, ParamOverride{
+				Name:    value.Content[i].Value,
+				Default: value.Content[i+1].Value,
+			})
+		}
+		return nil
+	case yaml.SequenceNode:
+		// list form: decode as []ParamOverride normally
+		type plain []ParamOverride
+		var list plain
+		if err := value.Decode(&list); err != nil {
+			return err
+		}
+		*p = ParamOverrides(list)
+		return nil
+	default:
+		return fmt.Errorf("params must be a mapping or sequence, got %v", value.Tag)
+	}
+}
+
+// Overrides is a patch applied to a resolved task or to a nested TaskSet entry.
+// Fields are applied in the three-level override cascade; later layers win.
+//
+// Defined in pkg/task (rather than pkg/taskset) so the same data type can be
+// referenced from per-edge override sites — BeforeEntry and
+// ChainTrigger.Overrides — without creating an import cycle. The merge
+// implementation continues to live in pkg/taskset (exported as
+// taskset.ApplyOverrides) so per-edge dispatch sites can reuse the exact
+// same semantics as the global `dicode tasks override <id>` path.
+type Overrides struct {
+	Enabled     *bool          `yaml:"enabled,omitempty"`
+	Name        string         `yaml:"name,omitempty"`        // replaces spec.Name
+	Description string         `yaml:"description,omitempty"` // replaces spec.Description
+	Trigger     *TriggerPatch  `yaml:"trigger,omitempty"`
+	Params      ParamOverrides `yaml:"params,omitempty"`
+	// Env accepts full EnvEntry mappings (name/secret/from/value/optional) or bare "KEY" / "KEY=value" strings.
+	Env []EnvEntry `yaml:"env,omitempty"`
+	Net []string   `yaml:"net,omitempty"` // replaces permissions.net
+	// Fs replaces permissions.fs entirely (matches Net's full-replace pattern).
+	Fs      []FSEntry          `yaml:"fs,omitempty"`
+	Timeout time.Duration      `yaml:"timeout,omitempty"`
+	Retry   *RetryConfig       `yaml:"retry,omitempty"`
+	Runtime string             `yaml:"runtime,omitempty"`
+	Notify  *NotifyConfig      `yaml:"notify,omitempty"`
+	Dicode  *DicodePermissions `yaml:"dicode,omitempty"` // replaces permissions.dicode
+
+	// For task_set entries only — Deprecated: Defaults cross-boundary cascade is no longer applied.
+	// Use per-entry overrides.entries[key] to patch nested tasks explicitly.
+	Defaults *Defaults `yaml:"defaults,omitempty"`
+	// For task_set entries only — Entries patches specific tasks within the nested set.
+	Entries map[string]*Overrides `yaml:"entries,omitempty"`
+}
+
+// validatePerEdgeOverrides enforces a conservative allowlist on Overrides
+// values used at per-edge dispatch sites — i.e. trigger.before[].overrides
+// and trigger.chain.overrides. Several Overrides fields are meaningful only
+// at the taskset / global level (Defaults, Entries, Enabled, Retry, Name,
+// Description) or are silently ignored by the per-edge dispatch path
+// (Trigger — see PR #303 MED #3). Rejecting them at config-load surfaces
+// operator typos and prevents silent footguns.
+//
+// Allowed at a per-edge site: Params (minus reserved keys), Env, Net, Fs,
+// Timeout, Notify, Dicode, Runtime.
+//
+// The site string names the offending location (e.g.
+// "trigger.before[0].overrides (task \"render\")") so operators can find it
+// in their task.yaml.
+func validatePerEdgeOverrides(site string, o *Overrides) error {
+	if o == nil {
+		return nil
+	}
+	// Enabled — would silently no-op the prereq dispatch. Operators expect
+	// it to "skip this edge"; instead it does nothing. Reject so the wrong
+	// mental model surfaces at load.
+	if o.Enabled != nil {
+		return fmt.Errorf("%s: field %q is not supported at a per-edge site (set on the task itself, not on the edge)", site, "enabled")
+	}
+	// Name / Description — replacing the prereq's identity at the per-edge
+	// dispatch makes no semantic sense; the run is logged under the prereq's
+	// real ID regardless. Reject to avoid misleading task.yaml.
+	if o.Name != "" {
+		return fmt.Errorf("%s: field %q is not supported at a per-edge site", site, "name")
+	}
+	if o.Description != "" {
+		return fmt.Errorf("%s: field %q is not supported at a per-edge site", site, "description")
+	}
+	// Trigger — PR #303 MED #3. The per-edge dispatch path invokes the
+	// prereq directly (registry.TriggerPreflight / chain dispatch) and
+	// ignores any rewired trigger config on the merged spec. Allowing
+	// `trigger:` here misleads operators into thinking they're rewiring the
+	// prereq's trigger graph for this firing.
+	if o.Trigger != nil {
+		return fmt.Errorf("%s: field %q is not supported at a per-edge site (per-edge dispatch ignores the prereq's trigger config)", site, "trigger")
+	}
+	// Retry — would apply per-firing, almost certainly unintended. If
+	// per-edge preflight retries become a real feature request, lift this
+	// rejection and wire applyLayer to copy it.
+	if o.Retry != nil {
+		return fmt.Errorf("%s: field %q is not supported at a per-edge site", site, "retry")
+	}
+	// Defaults / Entries — taskset-level constructs with no per-edge
+	// meaning.
+	if o.Defaults != nil {
+		return fmt.Errorf("%s: field %q is not supported at a per-edge site (taskset-level construct)", site, "defaults")
+	}
+	if o.Entries != nil {
+		return fmt.Errorf("%s: field %q is not supported at a per-edge site (taskset-level construct)", site, "entries")
+	}
+	// Params: same reserved-key check used on trigger.chain.params /
+	// on_failure_chain.params. Reserved engine keys must not appear in
+	// user-supplied per-edge params either — otherwise they'd collide with
+	// the input map the engine populates at firing time.
+	for _, p := range o.Params {
+		if _, reserved := reservedChainParamKeys[p.Name]; reserved {
+			return fmt.Errorf("%s: params %q is a reserved key (used by the engine)", site, p.Name)
+		}
+	}
+	return nil
+}

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -86,12 +86,92 @@ type DockerConfig struct {
 // appear in Params at config-load (see Spec.validate), so collisions are
 // impossible at firing time.
 //
+// Overrides, when set, are a per-firing patch applied to the downstream's
+// own spec right before dispatch via this chain edge. Semantically the
+// downstream is declaring the variant of itself it wants to run when fired
+// via this chain — manual fires of the same downstream are unaffected.
+// The merge reuses the same taskset.ApplyOverrides logic that powers the
+// global `dicode tasks override <id>` path. The override is held as a
+// *Overrides pointer so the (already large) override surface stays in one
+// place; a nil pointer means "no per-edge override" (the existing
+// behaviour).
+//
 // Mirror of OnFailureChainSpec.Params (failure-chain side); shares the same
 // reservedChainParamKeys set.
 type ChainTrigger struct {
-	From   string         `yaml:"from"`             // task ID to listen for
-	On     string         `yaml:"on,omitempty"`     // "success" (default) | "failure" | "always"
-	Params map[string]any `yaml:"params,omitempty"` // forwarded into downstream task input
+	From      string         `yaml:"from"`                // task ID to listen for
+	On        string         `yaml:"on,omitempty"`        // "success" (default) | "failure" | "always"
+	Params    map[string]any `yaml:"params,omitempty"`    // forwarded into downstream task input
+	Overrides *Overrides     `yaml:"overrides,omitempty"` // per-firing override applied to the downstream spec
+}
+
+// BeforeEntry is one entry in a daemon task's trigger.before preflight list.
+// It can be written in two YAML forms:
+//
+//	# legacy bare-ID form (single string):
+//	before:
+//	  - render-config
+//	  - fetch-creds
+//
+//	# mapping form with per-edge overrides:
+//	before:
+//	  - task: render-config
+//	    overrides:
+//	      timeout: 5m
+//	      env:
+//	        - name: MODE
+//	          value: preflight
+//
+// Both forms can be mixed within the same list. The bare-ID form is
+// equivalent to `{task: <id>}` with no overrides — preserved verbatim for
+// backwards compat with task.yamls written before the per-edge override
+// extension. The trigger engine applies the per-edge Overrides to a deep
+// copy of the prereq task's spec at dispatch time; the prereq's
+// standalone (manual / cron / chain) fires are unaffected.
+type BeforeEntry struct {
+	Task      string     `yaml:"task"`
+	Overrides *Overrides `yaml:"overrides,omitempty"`
+}
+
+// UnmarshalYAML accepts either a scalar (legacy bare-ID string) or a mapping
+// (task + overrides). Anything else is rejected with an explicit error to
+// surface typos rather than silently dropping the entry.
+func (b *BeforeEntry) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		b.Task = value.Value
+		b.Overrides = nil
+		return nil
+	case yaml.MappingNode:
+		// Decode into an anonymous alias to avoid recursing into this
+		// UnmarshalYAML.
+		type entryShape struct {
+			Task      string     `yaml:"task"`
+			Overrides *Overrides `yaml:"overrides,omitempty"`
+		}
+		var e entryShape
+		if err := value.Decode(&e); err != nil {
+			return fmt.Errorf("trigger.before entry: %w", err)
+		}
+		b.Task = e.Task
+		b.Overrides = e.Overrides
+		return nil
+	default:
+		return fmt.Errorf("trigger.before entry: expected string or mapping, got %v", value.Tag)
+	}
+}
+
+// MarshalYAML emits the bare-ID form when there are no overrides, and the
+// mapping form otherwise. This keeps round-tripping clean for the legacy
+// case (config files don't bloat after a load+rewrite cycle).
+func (b BeforeEntry) MarshalYAML() (interface{}, error) {
+	if b.Overrides == nil {
+		return b.Task, nil
+	}
+	return struct {
+		Task      string     `yaml:"task"`
+		Overrides *Overrides `yaml:"overrides,omitempty"`
+	}{Task: b.Task, Overrides: b.Overrides}, nil
 }
 
 // TriggerConfig defines how a task is triggered.
@@ -112,7 +192,14 @@ type TriggerConfig struct {
 	// only one-shot tasks can be preflights. When a referenced task re-runs
 	// successfully after the daemon is up, the engine restarts the daemon so
 	// it picks up newly-rendered config.
-	Before []string `yaml:"before,omitempty"`
+	//
+	// Each entry can be either a bare task-ID string (legacy form) or a
+	// mapping with `task:` plus optional `overrides:` — see BeforeEntry's
+	// UnmarshalYAML for the dual-form decoder. Per-edge overrides are
+	// applied to a deep copy of the prereq spec at dispatch time, so a
+	// daemon can pin a custom timeout / env / params for the preflight run
+	// without affecting the prereq's standalone (manual / cron) fires.
+	Before []BeforeEntry `yaml:"before,omitempty"`
 }
 
 // Param defines a user-configurable input for a task.
@@ -571,6 +658,13 @@ func (s *Spec) Script() (string, error) {
 	return string(b), nil
 }
 
+// Validate runs the per-spec consistency checks (shape of trigger config,
+// docker section, etc.) and returns the first violation. Exposed publicly
+// so callers that mutate a Spec after LoadDir (e.g. per-edge override
+// dispatch in pkg/trigger) can re-validate the resulting variant before
+// dispatching it.
+func (s *Spec) Validate() error { return s.validate() }
+
 func (s *Spec) validate() error {
 	// Clear stale warnings so re-validation (e.g. on a reloaded spec) starts
 	// from a clean slate; otherwise warnings accumulate across validate
@@ -606,12 +700,18 @@ func (s *Spec) validate() error {
 		if !s.Trigger.Daemon {
 			return fmt.Errorf("trigger.before: requires daemon: true (got non-daemon trigger)")
 		}
-		for _, id := range s.Trigger.Before {
-			if id == "" {
+		for i, entry := range s.Trigger.Before {
+			if entry.Task == "" {
 				return fmt.Errorf("trigger.before: empty task ID")
 			}
-			if id == s.ID {
-				return fmt.Errorf("trigger.before: cannot reference self (task ID %q)", id)
+			if entry.Task == s.ID {
+				return fmt.Errorf("trigger.before: cannot reference self (task ID %q)", entry.Task)
+			}
+			if entry.Overrides != nil {
+				site := fmt.Sprintf("trigger.before[%d].overrides (task %q)", i, entry.Task)
+				if err := validatePerEdgeOverrides(site, entry.Overrides); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -632,6 +732,11 @@ func (s *Spec) validate() error {
 		for k := range s.Trigger.Chain.Params {
 			if _, reserved := reservedChainParamKeys[k]; reserved {
 				return fmt.Errorf("trigger.chain.params: %q is a reserved key (used by the engine)", k)
+			}
+		}
+		if s.Trigger.Chain.Overrides != nil {
+			if err := validatePerEdgeOverrides("trigger.chain.overrides", s.Trigger.Chain.Overrides); err != nil {
+				return err
 			}
 		}
 	}

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -105,6 +105,14 @@ type TriggerConfig struct {
 	Chain         *ChainTrigger `yaml:"chain,omitempty"`          // fire when another task completes
 	Daemon        bool          `yaml:"daemon,omitempty"`         // start on app start, restart on exit
 	Restart       string        `yaml:"restart,omitempty"`        // daemon only: "always"(default)|"on-failure"|"never"
+	// Before lists task IDs that must run to success before this daemon starts.
+	// Only valid alongside `daemon: true`; per-spec validation rejects it on
+	// non-daemon triggers. Cross-spec validation (in pkg/trigger.Engine.Register)
+	// additionally rejects references to unknown tasks and to other daemons —
+	// only one-shot tasks can be preflights. When a referenced task re-runs
+	// successfully after the daemon is up, the engine restarts the daemon so
+	// it picks up newly-rendered config.
+	Before []string `yaml:"before,omitempty"`
 }
 
 // Param defines a user-configurable input for a task.
@@ -588,6 +596,23 @@ func (s *Spec) validate() error {
 			// ok
 		default:
 			return fmt.Errorf("trigger.restart must be always, on-failure, or never")
+		}
+	}
+	// trigger.before: declarative preflight dependency for daemon tasks. Only
+	// validated locally here; cross-spec checks (does the referenced task
+	// exist? is it a daemon?) live in pkg/trigger.Engine.Register because they
+	// need the full registry snapshot.
+	if len(s.Trigger.Before) > 0 {
+		if !s.Trigger.Daemon {
+			return fmt.Errorf("trigger.before: requires daemon: true (got non-daemon trigger)")
+		}
+		for _, id := range s.Trigger.Before {
+			if id == "" {
+				return fmt.Errorf("trigger.before: empty task ID")
+			}
+			if id == s.ID {
+				return fmt.Errorf("trigger.before: cannot reference self (task ID %q)", id)
+			}
 		}
 	}
 	if s.Trigger.Chain != nil {

--- a/pkg/task/spec_test.go
+++ b/pkg/task/spec_test.go
@@ -303,6 +303,95 @@ func TestChainTrigger_Params_ReservedKeyRejected(t *testing.T) {
 	}
 }
 
+func TestTriggerBefore_Parses(t *testing.T) {
+	src := strings.TrimSpace(`
+name: tunnel
+runtime: docker
+trigger:
+  daemon: true
+  before: [render-config, fetch-creds]
+docker:
+  image: x
+`)
+	var s Spec
+	if err := yaml.NewDecoder(strings.NewReader(src)).Decode(&s); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(s.Trigger.Before) != 2 || s.Trigger.Before[0] != "render-config" || s.Trigger.Before[1] != "fetch-creds" {
+		t.Errorf("Before = %v", s.Trigger.Before)
+	}
+}
+
+func TestTriggerBefore_Validation(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "before without daemon",
+			yaml: `name: t
+runtime: deno
+trigger: { manual: true, before: [x] }`,
+			wantErr: "before: requires daemon: true",
+		},
+		{
+			name: "self-reference",
+			yaml: `name: selfref
+runtime: docker
+trigger: { daemon: true, before: [selfref] }
+docker: { image: x }`,
+			wantErr: "before: cannot reference self",
+		},
+		{
+			name: "empty task ID",
+			yaml: `name: t
+runtime: docker
+trigger: { daemon: true, before: [""] }
+docker: { image: x }`,
+			wantErr: "before: empty task ID",
+		},
+		{
+			name: "valid empty before",
+			yaml: `name: ok
+runtime: docker
+trigger: { daemon: true, before: [] }
+docker: { image: x }`,
+			wantErr: "",
+		},
+		{
+			name: "valid populated before",
+			yaml: `name: ok2
+runtime: docker
+trigger: { daemon: true, before: [render-config] }
+docker: { image: x }`,
+			wantErr: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var s Spec
+			if err := yaml.NewDecoder(strings.NewReader(strings.TrimSpace(tc.yaml))).Decode(&s); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			// Mimic LoadDirWithVars' post-decode initialisation: the ID is set
+			// from the directory base name. The self-reference test requires
+			// it to match the YAML name.
+			s.ID = s.Name
+			err := s.validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("expected error containing %q, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
 func equalSlice(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/pkg/task/spec_test.go
+++ b/pkg/task/spec_test.go
@@ -317,8 +317,155 @@ docker:
 	if err := yaml.NewDecoder(strings.NewReader(src)).Decode(&s); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if len(s.Trigger.Before) != 2 || s.Trigger.Before[0] != "render-config" || s.Trigger.Before[1] != "fetch-creds" {
+	if len(s.Trigger.Before) != 2 || s.Trigger.Before[0].Task != "render-config" || s.Trigger.Before[1].Task != "fetch-creds" {
 		t.Errorf("Before = %v", s.Trigger.Before)
+	}
+}
+
+// TestTriggerBefore_PerEdgeOverrides verifies the dual-form decoder on the
+// before: list: bare-ID strings, mapping forms with overrides, and a mix
+// of both must all parse correctly. The override blob itself is preserved
+// so the engine can apply it at preflight dispatch time.
+func TestTriggerBefore_PerEdgeOverrides(t *testing.T) {
+	src := strings.TrimSpace(`
+name: tunnel
+runtime: docker
+trigger:
+  daemon: true
+  before:
+    - render-config
+    - task: fetch-creds
+      overrides:
+        timeout: 5m
+        env:
+          - name: MODE
+            value: preflight
+    - task: warm-cache
+docker:
+  image: x
+`)
+	var s Spec
+	if err := yaml.NewDecoder(strings.NewReader(src)).Decode(&s); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(s.Trigger.Before) != 3 {
+		t.Fatalf("Before length = %d, want 3", len(s.Trigger.Before))
+	}
+
+	// Entry 0: bare string form, no overrides.
+	if s.Trigger.Before[0].Task != "render-config" {
+		t.Errorf("entry[0].Task = %q, want render-config", s.Trigger.Before[0].Task)
+	}
+	if s.Trigger.Before[0].Overrides != nil {
+		t.Errorf("entry[0].Overrides should be nil for bare-ID form, got %+v", s.Trigger.Before[0].Overrides)
+	}
+
+	// Entry 1: mapping form WITH overrides.
+	if s.Trigger.Before[1].Task != "fetch-creds" {
+		t.Errorf("entry[1].Task = %q, want fetch-creds", s.Trigger.Before[1].Task)
+	}
+	if s.Trigger.Before[1].Overrides == nil {
+		t.Fatal("entry[1].Overrides should be populated")
+	}
+	if got := s.Trigger.Before[1].Overrides.Timeout; got != 5*time.Minute {
+		t.Errorf("entry[1].Overrides.Timeout = %v, want 5m", got)
+	}
+	if len(s.Trigger.Before[1].Overrides.Env) != 1 ||
+		s.Trigger.Before[1].Overrides.Env[0].Name != "MODE" ||
+		s.Trigger.Before[1].Overrides.Env[0].Value != "preflight" {
+		t.Errorf("entry[1].Overrides.Env = %+v, want one MODE=preflight entry", s.Trigger.Before[1].Overrides.Env)
+	}
+
+	// Entry 2: mapping form WITHOUT overrides — still legal.
+	if s.Trigger.Before[2].Task != "warm-cache" {
+		t.Errorf("entry[2].Task = %q, want warm-cache", s.Trigger.Before[2].Task)
+	}
+	if s.Trigger.Before[2].Overrides != nil {
+		t.Errorf("entry[2].Overrides should be nil (mapping without overrides:), got %+v", s.Trigger.Before[2].Overrides)
+	}
+}
+
+// TestTriggerBefore_BadEntryShapeRejected pins the negative path: a
+// sequence-of-sequences or any other non-scalar / non-mapping node must
+// surface an explicit decode error rather than silently dropping the
+// entry. Catches the failure mode where a stray YAML structure (e.g. a
+// typo'd indentation) gets parsed as a no-op.
+func TestTriggerBefore_BadEntryShapeRejected(t *testing.T) {
+	src := strings.TrimSpace(`
+name: t
+runtime: docker
+trigger:
+  daemon: true
+  before:
+    - [oops, not, scalar]
+docker: { image: x }`)
+	var s Spec
+	err := yaml.NewDecoder(strings.NewReader(src)).Decode(&s)
+	if err == nil {
+		t.Fatalf("expected decode error for nested sequence in before:, got none (got Before=%+v)", s.Trigger.Before)
+	}
+	if !strings.Contains(err.Error(), "trigger.before entry") {
+		t.Errorf("expected error to mention trigger.before entry, got: %v", err)
+	}
+}
+
+// TestTriggerChain_Overrides_Parses verifies that trigger.chain.overrides
+// decodes alongside the existing chain fields. The override blob is held
+// as a *task.Overrides pointer; nil means "no per-edge override" (the
+// pre-existing behaviour preserved for backwards compat).
+func TestTriggerChain_Overrides_Parses(t *testing.T) {
+	src := strings.TrimSpace(`
+name: downstream
+runtime: deno
+trigger:
+  chain:
+    from: upstream
+    on: success
+    overrides:
+      params:
+        mode: prod
+      timeout: 90s
+`)
+	var s Spec
+	if err := yaml.NewDecoder(strings.NewReader(src)).Decode(&s); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if s.Trigger.Chain == nil {
+		t.Fatal("Chain not parsed")
+	}
+	if s.Trigger.Chain.Overrides == nil {
+		t.Fatal("Chain.Overrides not parsed")
+	}
+	if s.Trigger.Chain.Overrides.Timeout != 90*time.Second {
+		t.Errorf("Chain.Overrides.Timeout = %v, want 90s", s.Trigger.Chain.Overrides.Timeout)
+	}
+	if len(s.Trigger.Chain.Overrides.Params) != 1 ||
+		s.Trigger.Chain.Overrides.Params[0].Name != "mode" ||
+		s.Trigger.Chain.Overrides.Params[0].Default != "prod" {
+		t.Errorf("Chain.Overrides.Params = %+v, want one mode=prod entry", s.Trigger.Chain.Overrides.Params)
+	}
+}
+
+// TestTriggerChain_NoOverrides_BackwardsCompat verifies that omitting
+// trigger.chain.overrides leaves the field nil, preserving the existing
+// dispatch path for task.yamls written before the per-edge extension.
+func TestTriggerChain_NoOverrides_BackwardsCompat(t *testing.T) {
+	src := strings.TrimSpace(`
+name: downstream
+runtime: deno
+trigger:
+  chain:
+    from: upstream
+`)
+	var s Spec
+	if err := yaml.NewDecoder(strings.NewReader(src)).Decode(&s); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if s.Trigger.Chain == nil {
+		t.Fatal("Chain not parsed")
+	}
+	if s.Trigger.Chain.Overrides != nil {
+		t.Errorf("Chain.Overrides should be nil when absent, got %+v", s.Trigger.Chain.Overrides)
 	}
 }
 
@@ -389,6 +536,248 @@ docker: { image: x }`,
 				t.Errorf("expected error containing %q, got: %v", tc.wantErr, err)
 			}
 		})
+	}
+}
+
+// TestPerEdgeOverrides_RejectUnsupportedFields pins the validation that runs
+// inside Spec.validate for every per-edge override site (Trigger.Before[].Overrides
+// and Trigger.Chain.Overrides). Fields that don't make sense at a per-edge
+// level — Enabled, Retry, Defaults, Entries, Name, Description, Trigger —
+// must be rejected with an error that names the offending field so operators
+// can find it in their task.yaml. See PR #303 HIGH and MED #3 review threads.
+func TestPerEdgeOverrides_RejectUnsupportedFields(t *testing.T) {
+	cases := []struct {
+		name     string
+		yaml     string
+		wantErr  string // substring that must appear in the error
+		wantSite string // substring naming the site (before/chain.overrides)
+	}{
+		// Trigger.Before[].Overrides — HIGH finding.
+		{
+			name: "before edge: enabled rejected",
+			yaml: `name: d
+runtime: docker
+docker: { image: x }
+trigger:
+  daemon: true
+  before:
+    - task: render
+      overrides:
+        enabled: false`,
+			wantErr:  "enabled",
+			wantSite: "trigger.before",
+		},
+		{
+			name: "before edge: retry rejected",
+			yaml: `name: d
+runtime: docker
+docker: { image: x }
+trigger:
+  daemon: true
+  before:
+    - task: render
+      overrides:
+        retry:
+          attempts: 3`,
+			wantErr:  "retry",
+			wantSite: "trigger.before",
+		},
+		{
+			name: "before edge: trigger rejected (MED #3)",
+			yaml: `name: d
+runtime: docker
+docker: { image: x }
+trigger:
+  daemon: true
+  before:
+    - task: render
+      overrides:
+        trigger:
+          manual: true`,
+			wantErr:  "trigger",
+			wantSite: "trigger.before",
+		},
+		{
+			name: "before edge: defaults rejected",
+			yaml: `name: d
+runtime: docker
+docker: { image: x }
+trigger:
+  daemon: true
+  before:
+    - task: render
+      overrides:
+        defaults:
+          timeout: 5m`,
+			wantErr:  "defaults",
+			wantSite: "trigger.before",
+		},
+		{
+			name: "before edge: entries rejected",
+			yaml: `name: d
+runtime: docker
+docker: { image: x }
+trigger:
+  daemon: true
+  before:
+    - task: render
+      overrides:
+        entries:
+          foo: {}`,
+			wantErr:  "entries",
+			wantSite: "trigger.before",
+		},
+		{
+			name: "before edge: name rejected",
+			yaml: `name: d
+runtime: docker
+docker: { image: x }
+trigger:
+  daemon: true
+  before:
+    - task: render
+      overrides:
+        name: renamed`,
+			wantErr:  "name",
+			wantSite: "trigger.before",
+		},
+		{
+			name: "before edge: description rejected",
+			yaml: `name: d
+runtime: docker
+docker: { image: x }
+trigger:
+  daemon: true
+  before:
+    - task: render
+      overrides:
+        description: nope`,
+			wantErr:  "description",
+			wantSite: "trigger.before",
+		},
+		{
+			name: "before edge: reserved param key rejected (MED #4)",
+			yaml: `name: d
+runtime: docker
+docker: { image: x }
+trigger:
+  daemon: true
+  before:
+    - task: render
+      overrides:
+        params:
+          taskID: x`,
+			wantErr:  "taskID",
+			wantSite: "trigger.before",
+		},
+
+		// Trigger.Chain.Overrides — same rules apply.
+		{
+			name: "chain edge: enabled rejected",
+			yaml: `name: d
+runtime: deno
+trigger:
+  chain:
+    from: upstream
+    overrides:
+      enabled: false`,
+			wantErr:  "enabled",
+			wantSite: "trigger.chain.overrides",
+		},
+		{
+			name: "chain edge: retry rejected",
+			yaml: `name: d
+runtime: deno
+trigger:
+  chain:
+    from: upstream
+    overrides:
+      retry:
+        attempts: 3`,
+			wantErr:  "retry",
+			wantSite: "trigger.chain.overrides",
+		},
+		{
+			name: "chain edge: trigger rejected (MED #3)",
+			yaml: `name: d
+runtime: deno
+trigger:
+  chain:
+    from: upstream
+    overrides:
+      trigger:
+        manual: true`,
+			wantErr:  "trigger",
+			wantSite: "trigger.chain.overrides",
+		},
+		{
+			name: "chain edge: reserved param key rejected (MED #4)",
+			yaml: `name: d
+runtime: deno
+trigger:
+  chain:
+    from: upstream
+    overrides:
+      params:
+        runID: x`,
+			wantErr:  "runID",
+			wantSite: "trigger.chain.overrides",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var s Spec
+			if err := yaml.NewDecoder(strings.NewReader(strings.TrimSpace(tc.yaml))).Decode(&s); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			err := s.validate()
+			if err == nil {
+				t.Fatalf("expected validation error for %s, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not mention offending field %q", err.Error(), tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantSite) {
+				t.Errorf("error %q does not name the site %q", err.Error(), tc.wantSite)
+			}
+		})
+	}
+}
+
+// TestPerEdgeOverrides_LegitimateFieldsAllowed verifies the validator does NOT
+// reject the per-edge override fields that legitimately apply: Params (without
+// reserved keys), Env, Net, FS, Timeout, Notify, Dicode, Runtime. Guards
+// against an over-aggressive validator regression.
+func TestPerEdgeOverrides_LegitimateFieldsAllowed(t *testing.T) {
+	src := strings.TrimSpace(`
+name: d
+runtime: docker
+docker: { image: x }
+trigger:
+  daemon: true
+  before:
+    - task: render
+      overrides:
+        params:
+          mode: prod
+        env:
+          - name: FOO
+            value: bar
+        net: ["api.example.com"]
+        fs:
+          - path: /tmp
+            permission: rw
+        timeout: 30s
+        notify:
+          on_failure: true
+        runtime: deno
+`)
+	var s Spec
+	if err := yaml.NewDecoder(strings.NewReader(src)).Decode(&s); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if err := s.validate(); err != nil {
+		t.Fatalf("expected validate() to accept legitimate per-edge fields, got: %v", err)
 	}
 }
 

--- a/pkg/taskset/override.go
+++ b/pkg/taskset/override.go
@@ -17,6 +17,19 @@ func applyOverrides(base *task.Spec, layers ...*Overrides) *task.Spec {
 	return out
 }
 
+// ApplyOverrides is the exported entry point used by per-edge override
+// dispatch sites (pkg/trigger preflight + chain firing). It returns a
+// deep copy of base with the supplied layers merged on top, reusing the
+// exact same logic that powers `dicode tasks override <id>` and the
+// taskset resolver's three-level cascade.
+//
+// Callers MUST treat the input base as read-only; the returned spec is a
+// fresh deep copy so mutating it does not affect the registry's canonical
+// spec.
+func ApplyOverrides(base *task.Spec, layers ...*Overrides) *task.Spec {
+	return applyOverrides(base, layers...)
+}
+
 func applyLayer(spec *task.Spec, o *Overrides) {
 	if o.Name != "" {
 		spec.Name = o.Name

--- a/pkg/taskset/spec.go
+++ b/pkg/taskset/spec.go
@@ -4,11 +4,9 @@
 package taskset
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/dicode/dicode/pkg/task"
-	"gopkg.in/yaml.v3"
 )
 
 // Ref points to a yaml file (kind: Task or kind: TaskSet).
@@ -51,113 +49,20 @@ func (r *Ref) effectivePoll() time.Duration {
 	return 30 * time.Second
 }
 
-// Defaults are applied to all entries in a TaskSet before per-entry overrides.
-// They form level 2 in the three-level precedence stack.
-type Defaults struct {
-	Timeout time.Duration `yaml:"timeout,omitempty"`
-	Retry   *RetryConfig  `yaml:"retry,omitempty"`
-	// Env accepts full EnvEntry mappings or bare "KEY" / "KEY=value" strings.
-	Env []task.EnvEntry `yaml:"env,omitempty"`
-	// Trigger sets a fallback trigger for any entry that has none.
-	Trigger *TriggerPatch      `yaml:"trigger,omitempty"`
-	Notify  *task.NotifyConfig `yaml:"notify,omitempty"`
-}
-
-// RetryConfig defines automatic retry behaviour for task runs.
-type RetryConfig struct {
-	Attempts int           `yaml:"attempts"`
-	Backoff  time.Duration `yaml:"backoff,omitempty"`
-}
-
-// TriggerPatch patches individual sub-fields of a TriggerConfig.
-// Pointer fields are nil when not being patched, allowing sub-field
-// merges without clearing unrelated trigger types.
-type TriggerPatch struct {
-	Cron    *string            `yaml:"cron,omitempty"`
-	Webhook *string            `yaml:"webhook,omitempty"`
-	Auth    *bool              `yaml:"auth,omitempty"`
-	Manual  *bool              `yaml:"manual,omitempty"`
-	Chain   *task.ChainTrigger `yaml:"chain,omitempty"`
-	Daemon  *bool              `yaml:"daemon,omitempty"`
-	Restart *string            `yaml:"restart,omitempty"`
-}
-
-// ParamOverride patches the default (and optionally required) of a named param.
-// It decodes from either a mapping form  {name: x, default: y}  or a scalar
-// "key: value" pair inside a YAML mapping — see ParamOverrides below.
-type ParamOverride struct {
-	Name     string `yaml:"name"`
-	Default  string `yaml:"default"`
-	Required *bool  `yaml:"required,omitempty"`
-}
-
-// ParamOverrides is a list of ParamOverride values that can be written in two
-// equivalent YAML forms:
-//
-//	# concise map (name → default):
-//	params:
-//	  provider: google
-//	  scope: "user,repo"
-//
-//	# explicit list (required: supported):
-//	params:
-//	  - { name: scope, default: "user,repo", required: true }
-type ParamOverrides []ParamOverride
-
-func (p *ParamOverrides) UnmarshalYAML(value *yaml.Node) error {
-	switch value.Kind {
-	case yaml.MappingNode:
-		// map form: each key/value pair → ParamOverride{Name: key, Default: value}
-		if len(value.Content)%2 != 0 {
-			return fmt.Errorf("params mapping has odd number of nodes")
-		}
-		*p = make(ParamOverrides, 0, len(value.Content)/2)
-		for i := 0; i < len(value.Content); i += 2 {
-			*p = append(*p, ParamOverride{
-				Name:    value.Content[i].Value,
-				Default: value.Content[i+1].Value,
-			})
-		}
-		return nil
-	case yaml.SequenceNode:
-		// list form: decode as []ParamOverride normally
-		type plain []ParamOverride
-		var list plain
-		if err := value.Decode(&list); err != nil {
-			return err
-		}
-		*p = ParamOverrides(list)
-		return nil
-	default:
-		return fmt.Errorf("params must be a mapping or sequence, got %v", value.Tag)
-	}
-}
-
-// Overrides is a patch applied to a resolved task or to a nested TaskSet entry.
-// Fields are applied in the three-level override cascade; later layers win.
-type Overrides struct {
-	Enabled     *bool          `yaml:"enabled,omitempty"`
-	Name        string         `yaml:"name,omitempty"`        // replaces spec.Name
-	Description string         `yaml:"description,omitempty"` // replaces spec.Description
-	Trigger     *TriggerPatch  `yaml:"trigger,omitempty"`
-	Params      ParamOverrides `yaml:"params,omitempty"`
-	// Env accepts full EnvEntry mappings (name/secret/from/value/optional) or bare "KEY" / "KEY=value" strings.
-	Env []task.EnvEntry `yaml:"env,omitempty"`
-	Net []string        `yaml:"net,omitempty"` // replaces permissions.net
-	// Fs replaces permissions.fs entirely (matches Net's full-replace pattern).
-	Fs      []task.FSEntry          `yaml:"fs,omitempty"`
-	Timeout time.Duration           `yaml:"timeout,omitempty"`
-	Retry   *RetryConfig            `yaml:"retry,omitempty"`
-	Runtime string                  `yaml:"runtime,omitempty"`
-	Notify  *task.NotifyConfig      `yaml:"notify,omitempty"`
-	Dicode  *task.DicodePermissions `yaml:"dicode,omitempty"` // replaces permissions.dicode
-
-	// For task_set entries only — Deprecated: Defaults cross-boundary cascade is no longer applied.
-	// Use per-entry overrides.entries[key] to patch nested tasks explicitly.
-	Defaults *Defaults `yaml:"defaults,omitempty"`
-	// For task_set entries only — Entries patches specific tasks within the nested set.
-	Entries map[string]*Overrides `yaml:"entries,omitempty"`
-}
+// Override-related types — Defaults, RetryConfig, TriggerPatch,
+// ParamOverride, ParamOverrides, Overrides — live in pkg/task so the same
+// data type can be referenced from per-edge override sites
+// (TriggerConfig.Before entries, ChainTrigger.Overrides) without creating
+// an import cycle. They are re-exported here as type aliases so existing
+// `taskset.Overrides{}` usage continues to compile unchanged.
+type (
+	Defaults       = task.Defaults
+	RetryConfig    = task.RetryConfig
+	TriggerPatch   = task.TriggerPatch
+	ParamOverride  = task.ParamOverride
+	ParamOverrides = task.ParamOverrides
+	Overrides      = task.Overrides
+)
 
 // Entry is one named item in spec.entries.
 // Exactly one of Ref or Inline must be set.

--- a/pkg/trigger/daemon_state.go
+++ b/pkg/trigger/daemon_state.go
@@ -1,0 +1,88 @@
+package trigger
+
+import "sync"
+
+// DaemonState describes the preflight/lifecycle phase of a daemon task as
+// observed by the trigger engine. Surfaced via Engine.DaemonState so the
+// WebUI (and operators reading API responses) can see *why* a daemon isn't
+// up — distinguishing "still waiting on the render task" from "render
+// failed" from "explicitly stopped".
+//
+// The five values are intentionally a closed set rather than a bag of
+// booleans. Adding a new phase should require an explicit case in any
+// switch that consumes this type.
+type DaemonState string
+
+const (
+	// DaemonStopped is the zero value. Returned for any task ID the engine
+	// hasn't tracked yet — including non-daemon tasks and unknown IDs — so
+	// callers don't have to special-case "not found".
+	DaemonStopped DaemonState = "stopped"
+
+	// DaemonPrereqRunning indicates the engine has dispatched the daemon's
+	// trigger.before tasks and is waiting for them to complete.
+	DaemonPrereqRunning DaemonState = "prereq_running"
+
+	// DaemonPrereqFailed indicates at least one prereq finished with
+	// status=failure (or was cancelled). The daemon was NOT started; the
+	// engine surfaces the most recent prereq run for the operator to inspect.
+	DaemonPrereqFailed DaemonState = "prereq_failed"
+
+	// DaemonRunning indicates the daemon's container/process is up. Set
+	// after preflight succeeds (or immediately, when before: is empty).
+	DaemonRunning DaemonState = "running"
+
+	// DaemonStopping indicates a restart is in flight — the engine is
+	// tearing down the current run before re-firing preflight. Distinct
+	// from DaemonStopped so operators can see the brief intermediate state
+	// during a prereq-driven restart.
+	DaemonStopping DaemonState = "stopping"
+)
+
+// daemonStateMap is a thread-safe taskID → DaemonState map. Kept as a
+// dedicated type so we can swap in a fancier representation later (e.g.
+// per-state event hooks) without touching every call site.
+type daemonStateMap struct {
+	mu sync.RWMutex
+	m  map[string]DaemonState
+}
+
+func newDaemonStateMap() *daemonStateMap {
+	return &daemonStateMap{m: make(map[string]DaemonState)}
+}
+
+func (d *daemonStateMap) get(taskID string) DaemonState {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	s, ok := d.m[taskID]
+	if !ok {
+		return DaemonStopped
+	}
+	return s
+}
+
+func (d *daemonStateMap) set(taskID string, s DaemonState) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if s == DaemonStopped {
+		// Conserve memory: stopped is the default, no need to persist it.
+		delete(d.m, taskID)
+		return
+	}
+	d.m[taskID] = s
+}
+
+// DaemonState returns the current lifecycle phase of the daemon with the
+// given task ID. Returns DaemonStopped for unknown / never-started tasks.
+//
+// Safe for concurrent use.
+func (e *Engine) DaemonState(taskID string) DaemonState {
+	return e.daemonStates.get(taskID)
+}
+
+// setDaemonState records the daemon's lifecycle phase. Internal helper:
+// only the engine's daemon-management paths should call it. Setting state
+// to DaemonStopped removes the entry from the map.
+func (e *Engine) setDaemonState(taskID string, s DaemonState) {
+	e.daemonStates.set(taskID, s)
+}

--- a/pkg/trigger/daemon_state.go
+++ b/pkg/trigger/daemon_state.go
@@ -2,13 +2,24 @@ package trigger
 
 import (
 	"context"
-	"slices"
 	"sync"
 	"time"
 
 	"github.com/dicode/dicode/pkg/task"
 	"go.uber.org/zap"
 )
+
+// beforeContains reports whether any BeforeEntry in entries names taskID.
+// Pulls only the Task field; per-edge overrides are irrelevant for
+// membership checks.
+func beforeContains(entries []task.BeforeEntry, taskID string) bool {
+	for _, e := range entries {
+		if e.Task == taskID {
+			return true
+		}
+	}
+	return false
+}
 
 // DaemonState describes the preflight/lifecycle phase of a daemon task as
 // observed by the trigger engine. Surfaced via Engine.DaemonState so the
@@ -109,7 +120,7 @@ func (e *Engine) notifyPrereqCompletion(completedTaskID string) {
 		if !spec.Trigger.Daemon {
 			continue
 		}
-		if !slices.Contains(spec.Trigger.Before, completedTaskID) {
+		if !beforeContains(spec.Trigger.Before, completedTaskID) {
 			continue
 		}
 		// Only attempt a restart if the daemon was actually up. Restarting

--- a/pkg/trigger/daemon_state.go
+++ b/pkg/trigger/daemon_state.go
@@ -1,6 +1,14 @@
 package trigger
 
-import "sync"
+import (
+	"context"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
+)
 
 // DaemonState describes the preflight/lifecycle phase of a daemon task as
 // observed by the trigger engine. Surfaced via Engine.DaemonState so the
@@ -85,4 +93,104 @@ func (e *Engine) DaemonState(taskID string) DaemonState {
 // to DaemonStopped removes the entry from the map.
 func (e *Engine) setDaemonState(taskID string, s DaemonState) {
 	e.daemonStates.set(taskID, s)
+}
+
+// notifyPrereqCompletion is the post-success hook the engine calls from
+// FireChain when ANY task finishes with status=success. It walks the
+// registered daemons and queues a restart for each one that lists
+// completedTaskID in its trigger.before.
+//
+// Coalescing: at most one restart per daemon is in flight at any time —
+// concurrent prereq completions are dropped via restartGate.tryAcquire.
+// This prevents thrash when a daemon depends on a prereq that's on a
+// short cron (credential rotation, periodic config render, etc.).
+func (e *Engine) notifyPrereqCompletion(completedTaskID string) {
+	for _, spec := range e.registry.All() {
+		if !spec.Trigger.Daemon {
+			continue
+		}
+		if !slices.Contains(spec.Trigger.Before, completedTaskID) {
+			continue
+		}
+		// Only attempt a restart if the daemon was actually up. Restarting
+		// a daemon we never managed to start (e.g. PrereqFailed on first
+		// boot) would race with the in-flight first-boot path; the
+		// prereq's success will fall through to the normal startDaemon
+		// path via the next registration cycle.
+		state := e.DaemonState(spec.ID)
+		if state != DaemonRunning {
+			e.log.Debug("prereq completion ignored — daemon not Running",
+				zap.String("daemon", spec.ID),
+				zap.String("prereq", completedTaskID),
+				zap.String("state", string(state)),
+			)
+			continue
+		}
+		e.queueDaemonRestart(spec)
+	}
+}
+
+// queueDaemonRestart performs the stop-then-start cycle for a daemon
+// whose trigger.before has just been re-satisfied. Holds a per-daemon
+// lock (sync.Map keyed on task ID) so a flurry of prereq completions
+// produces at most ONE outstanding restart. Subsequent calls during a
+// restart are silently dropped.
+func (e *Engine) queueDaemonRestart(spec *task.Spec) {
+	if !e.restartGates.tryAcquire(spec.ID) {
+		// A restart is already queued or in flight; coalesce.
+		e.log.Debug("daemon restart coalesced", zap.String("task", spec.ID))
+		return
+	}
+	go func() {
+		defer e.restartGates.release(spec.ID)
+
+		e.log.Info("daemon restart triggered by prereq completion",
+			zap.String("task", spec.ID),
+		)
+		e.setDaemonState(spec.ID, DaemonStopping)
+
+		// Stop the existing run. KillRun is best-effort; the daemon may
+		// already have exited between FireChain's success notification
+		// and this goroutine waking up.
+		e.daemonMu.Lock()
+		runID := e.daemonRuns[spec.ID]
+		e.daemonMu.Unlock()
+		if runID != "" {
+			e.KillRun(runID)
+			// Wait briefly for the run to actually terminate so the
+			// onDaemonRunFinished restart hook (which itself runs
+			// startDaemon) doesn't race with our explicit restart.
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			_, _ = e.WaitRun(ctx, runID)
+			cancel()
+		}
+
+		// Re-fire preflight + start. The onDaemonRunFinished path will
+		// ALSO try to restart on cancellation in some configurations;
+		// startDaemon's own idempotency (daemonRuns gating) keeps that
+		// safe.
+		e.startDaemon(spec)
+	}()
+}
+
+// restartGate is a per-task at-most-one-in-flight lock. Implemented as a
+// sync.Map keyed on task ID; values are unused (the presence/absence of
+// the key is the lock state).
+type restartGate struct {
+	gates sync.Map // map[string]struct{} — presence == locked
+}
+
+func newRestartGate() *restartGate { return &restartGate{} }
+
+// tryAcquire returns true if the caller now holds the lock for taskID,
+// false if another goroutine already does.
+func (g *restartGate) tryAcquire(taskID string) bool {
+	_, loaded := g.gates.LoadOrStore(taskID, struct{}{})
+	return !loaded
+}
+
+// release frees the lock for taskID. Must be called exactly once per
+// successful tryAcquire.
+func (g *restartGate) release(taskID string) {
+	g.gates.Delete(taskID)
 }

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -623,15 +623,32 @@ func (e *Engine) registerDaemon(spec *task.Spec) {
 	if alreadyRunning {
 		return
 	}
+	// Gate the start path with the same per-daemon lock used for restart
+	// coalescing. Two concurrent registerDaemon calls (e.g. the reconciler
+	// firing OnRegister twice while preflight is in flight, or a manual
+	// re-register racing the reconciler) would otherwise both observe
+	// `alreadyRunning=false` and both spawn a goroutine that runs preflight
+	// + fireAsync. The lock ensures at most one in-flight start per task ID.
+	// Release happens inside startDaemon after the daemon's run slot is
+	// recorded (or after a preflight/dispatch failure has been logged).
+	if !e.restartGates.tryAcquire(spec.ID) {
+		e.log.Debug("daemon start coalesced — another start is already in flight",
+			zap.String("task", spec.ID))
+		return
+	}
 	// startDaemon may block on preflight (trigger.before); detach so
 	// Register and the reconciler's OnRegister callback stay synchronous
 	// for non-preflight daemons and don't stall the registration sweep
 	// for preflight ones.
 	if len(spec.Trigger.Before) == 0 {
+		defer e.restartGates.release(spec.ID)
 		e.startDaemon(spec)
 		return
 	}
-	go e.startDaemon(spec)
+	go func() {
+		defer e.restartGates.release(spec.ID)
+		e.startDaemon(spec)
+	}()
 }
 
 // startDaemon brings a daemon up. When trigger.before is set, runs the

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -345,8 +345,17 @@ func (e *Engine) Start(ctx context.Context) error {
 	return nil
 }
 
-// Register adds or updates trigger registrations for a task spec.
-func (e *Engine) Register(spec *task.Spec) {
+// Register adds or updates trigger registrations for a task spec. Returns a
+// non-nil error when cross-spec validation fails (currently: invalid
+// trigger.before references). On error, no triggers are registered.
+func (e *Engine) Register(spec *task.Spec) error {
+	// Cross-spec validation must run BEFORE Unregister so that a previously
+	// valid registration isn't torn down when an updated spec fails its
+	// new-state checks. The registry-snapshot lookups are read-only.
+	if err := e.validateBeforeRefs(spec); err != nil {
+		return err
+	}
+
 	e.Unregister(spec.ID)
 
 	// Disabled tasks are kept in the registry for API visibility but must not
@@ -356,7 +365,7 @@ func (e *Engine) Register(spec *task.Spec) {
 			zap.String("task", spec.ID),
 			zap.String("runtime", string(spec.Runtime)),
 		)
-		return
+		return nil
 	}
 
 	if spec.Trigger.Cron != "" {
@@ -373,6 +382,31 @@ func (e *Engine) Register(spec *task.Spec) {
 		zap.String("trigger", string(triggerSource(spec))),
 		zap.String("runtime", string(spec.Runtime)),
 	)
+	return nil
+}
+
+// validateBeforeRefs checks each trigger.before entry against the current
+// registry. Per-spec validation (Spec.validate) already enforces shape;
+// here we only catch the things that need the full registry: unknown task
+// IDs and references to other daemons.
+//
+// On cycles: per-spec validation requires trigger.before only on daemon
+// tasks, and this function forbids before: references to daemons. Together
+// those constraints make cycles structurally unreachable — the only way a
+// cycle could form is through a prereq task carrying its own
+// trigger.before back to the daemon, but only daemons may have
+// trigger.before. We therefore do not implement explicit cycle detection.
+func (e *Engine) validateBeforeRefs(spec *task.Spec) error {
+	for _, refID := range spec.Trigger.Before {
+		ref, ok := e.registry.Get(refID)
+		if !ok {
+			return fmt.Errorf("trigger.before: task %q not found in registry", refID)
+		}
+		if ref.Trigger.Daemon {
+			return fmt.Errorf("trigger.before: task %q is a daemon (only one-shot tasks can be preflights)", refID)
+		}
+	}
+	return nil
 }
 
 // Unregister removes all trigger registrations for a task ID.

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -618,18 +618,108 @@ func (e *Engine) registerDaemon(spec *task.Spec) {
 	if alreadyRunning {
 		return
 	}
-	e.startDaemon(spec)
+	// startDaemon may block on preflight (trigger.before); detach so
+	// Register and the reconciler's OnRegister callback stay synchronous
+	// for non-preflight daemons and don't stall the registration sweep
+	// for preflight ones.
+	if len(spec.Trigger.Before) == 0 {
+		e.startDaemon(spec)
+		return
+	}
+	go e.startDaemon(spec)
 }
 
+// startDaemon brings a daemon up. When trigger.before is set, runs the
+// preflight chain first and only fires the daemon if every prereq returns
+// status=success. Sets daemonStates throughout for WebUI visibility.
 func (e *Engine) startDaemon(spec *task.Spec) {
+	if len(spec.Trigger.Before) > 0 {
+		e.setDaemonState(spec.ID, DaemonPrereqRunning)
+		if err := e.runPrereqs(context.Background(), spec); err != nil {
+			e.setDaemonState(spec.ID, DaemonPrereqFailed)
+			e.log.Warn("daemon preflight failed; daemon not started",
+				zap.String("task", spec.ID),
+				zap.Error(err),
+			)
+			return
+		}
+	}
+
 	runID, err := e.fireAsync(context.Background(), spec, pkgruntime.RunOptions{}, registry.TriggerDaemon)
 	if err != nil {
+		e.setDaemonState(spec.ID, DaemonStopped)
 		e.log.Error("daemon start failed", zap.String("task", spec.ID), zap.Error(err))
 		return
 	}
 	e.daemonMu.Lock()
 	e.daemonRuns[spec.ID] = runID
 	e.daemonMu.Unlock()
+	e.setDaemonState(spec.ID, DaemonRunning)
+}
+
+// runPrereqs fires every task listed in spec.Trigger.Before in parallel and
+// blocks until they all reach a terminal state. Returns nil only if every
+// prereq finishes with status=success; otherwise returns the first
+// non-success error observed.
+//
+// Re-fires every prereq on every preflight attempt — no "already satisfied"
+// short-circuit. The whole point of preflight is to refresh ephemeral
+// state (rendered configs, freshly-rotated credentials) right before the
+// daemon starts; reusing yesterday's success would defeat that. If
+// operators want caching, that belongs in the prereq task itself, not in
+// the trigger engine.
+func (e *Engine) runPrereqs(ctx context.Context, spec *task.Spec) error {
+	type prereqResult struct {
+		refID string
+		err   error
+	}
+	results := make(chan prereqResult, len(spec.Trigger.Before))
+	var wg sync.WaitGroup
+
+	for _, refID := range spec.Trigger.Before {
+		refID := refID
+		ref, ok := e.registry.Get(refID)
+		if !ok {
+			// validateBeforeRefs catches this at registration time, but the
+			// registry can change between registration and preflight (task
+			// unregistered while daemon was queued, etc.). Defensive check.
+			results <- prereqResult{refID: refID, err: fmt.Errorf("prereq %q vanished from registry", refID)}
+			continue
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runID, err := e.fireAsync(ctx, ref, pkgruntime.RunOptions{}, registry.TriggerPreflight)
+			if err != nil {
+				results <- prereqResult{refID: refID, err: fmt.Errorf("dispatch: %w", err)}
+				return
+			}
+			// Use WaitRun (the existing terminal-state waiter, channel-backed
+			// rather than polling) so this scales to many parallel prereqs
+			// without hammering the DB.
+			res, werr := e.WaitRun(ctx, runID)
+			if werr != nil {
+				results <- prereqResult{refID: refID, err: fmt.Errorf("wait: %w", werr)}
+				return
+			}
+			if res.Status != registry.StatusSuccess {
+				results <- prereqResult{refID: refID, err: fmt.Errorf("status=%s", res.Status)}
+				return
+			}
+			results <- prereqResult{refID: refID, err: nil}
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	var firstErr error
+	for r := range results {
+		if r.err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("prereq %q: %w", r.refID, r.err)
+		}
+	}
+	return firstErr
 }
 
 func (e *Engine) onDaemonRunFinished(spec *task.Spec, runID string) {

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -95,6 +95,10 @@ type Engine struct {
 	// never has to wait on a long preflight dispatch holding daemonMu.
 	daemonStates *daemonStateMap
 
+	// restartGates is a per-daemon at-most-one-in-flight lock for prereq-
+	// driven restarts. See daemon_state.go for the coalescing rationale.
+	restartGates *restartGate
+
 	notifier        notify.Notifier
 	notifyOnSuccess bool
 	notifyOnFailure bool
@@ -161,6 +165,7 @@ func New(r *registry.Registry, defaultExec pkgruntime.Executor, log *zap.Logger)
 		daemonRuns:   make(map[string]string),
 		daemonSpecs:  make(map[string]*task.Spec),
 		daemonStates: newDaemonStateMap(),
+		restartGates: newRestartGate(),
 		guards:       newChainGuards(),
 	}
 	e.executors[task.RuntimeDeno] = defaultExec
@@ -996,6 +1001,15 @@ func (e *Engine) KillRun(runID string) bool {
 // FireChain checks if any tasks declare a chain trigger from completedTaskID,
 // and fires the global on_failure_chain if configured.
 func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatus string, output interface{}) {
+	// Preflight restart hook: when a task that some daemon lists in
+	// trigger.before finishes with status=success, restart that daemon so
+	// it picks up newly-rendered config / freshly-rotated secrets. Failure
+	// or cancel does NOT trigger a restart — see the failure-semantics
+	// commit and tests for the rationale.
+	if runStatus == registry.StatusSuccess {
+		e.notifyPrereqCompletion(completedTaskID)
+	}
+
 	// Declared chain triggers.
 	for _, spec := range e.registry.All() {
 		chain := spec.Trigger.Chain

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dicode/dicode/pkg/runtime/envresolve"
 	"github.com/dicode/dicode/pkg/secrets"
 	"github.com/dicode/dicode/pkg/task"
+	"github.com/dicode/dicode/pkg/taskset"
 	"github.com/google/uuid"
 	"github.com/robfig/cron/v3"
 	"go.uber.org/zap"
@@ -409,13 +410,24 @@ func (e *Engine) Register(spec *task.Spec) error {
 // trigger.before back to the daemon, but only daemons may have
 // trigger.before. We therefore do not implement explicit cycle detection.
 func (e *Engine) validateBeforeRefs(spec *task.Spec) error {
-	for _, refID := range spec.Trigger.Before {
-		ref, ok := e.registry.Get(refID)
+	for _, entry := range spec.Trigger.Before {
+		ref, ok := e.registry.Get(entry.Task)
 		if !ok {
-			return fmt.Errorf("trigger.before: task %q not found in registry", refID)
+			return fmt.Errorf("trigger.before: task %q not found in registry", entry.Task)
 		}
 		if ref.Trigger.Daemon {
-			return fmt.Errorf("trigger.before: task %q is a daemon (only one-shot tasks can be preflights)", refID)
+			return fmt.Errorf("trigger.before: task %q is a daemon (only one-shot tasks can be preflights)", entry.Task)
+		}
+		// If this edge carries per-firing overrides, verify they merge
+		// onto the prereq spec without producing an invalid Spec. Doing
+		// this here surfaces malformed overrides at Register time rather
+		// than at the first daemon start — operators see a clean error
+		// path instead of a silently-failing preflight.
+		if entry.Overrides != nil {
+			merged := taskset.ApplyOverrides(ref, entry.Overrides)
+			if err := merged.Validate(); err != nil {
+				return fmt.Errorf("trigger.before: overrides for %q produce invalid spec: %w", entry.Task, err)
+			}
 		}
 	}
 	return nil
@@ -698,8 +710,9 @@ func (e *Engine) runPrereqs(ctx context.Context, spec *task.Spec) error {
 	results := make(chan prereqResult, len(spec.Trigger.Before))
 	var wg sync.WaitGroup
 
-	for _, refID := range spec.Trigger.Before {
-		refID := refID
+	for _, entry := range spec.Trigger.Before {
+		entry := entry
+		refID := entry.Task
 		ref, ok := e.registry.Get(refID)
 		if !ok {
 			// validateBeforeRefs catches this at registration time, but the
@@ -708,10 +721,29 @@ func (e *Engine) runPrereqs(ctx context.Context, spec *task.Spec) error {
 			results <- prereqResult{refID: refID, err: fmt.Errorf("prereq %q vanished from registry", refID)}
 			continue
 		}
+		// Per-edge overrides (#NNN): if this preflight edge declares
+		// `overrides:`, merge them onto a deep copy of the prereq spec
+		// before dispatching. The registry's canonical spec is left
+		// untouched so the prereq's standalone (manual / cron / chain)
+		// fires continue using the spec on disk. The merged spec is
+		// re-validated to surface override-induced invariant violations
+		// (e.g. an override that switches runtime to an unsupported
+		// value) — validateBeforeRefs already runs the same check at
+		// Register time, this is a defensive second pass for cases where
+		// the registry mutated between Register and the preflight fire.
+		dispatchSpec := ref
+		if entry.Overrides != nil {
+			merged := taskset.ApplyOverrides(ref, entry.Overrides)
+			if vErr := merged.Validate(); vErr != nil {
+				results <- prereqResult{refID: refID, err: fmt.Errorf("overrides produce invalid spec: %w", vErr)}
+				continue
+			}
+			dispatchSpec = merged
+		}
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			runID, err := e.fireAsync(ctx, ref, pkgruntime.RunOptions{}, registry.TriggerPreflight)
+			runID, err := e.fireAsync(ctx, dispatchSpec, pkgruntime.RunOptions{}, registry.TriggerPreflight)
 			if err != nil {
 				results <- prereqResult{refID: refID, err: fmt.Errorf("dispatch: %w", err)}
 				return
@@ -1037,12 +1069,32 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 		if on != "always" && on != runStatus {
 			continue
 		}
+		// Per-edge overrides (#NNN): when the downstream's trigger.chain
+		// declares `overrides:`, apply them to a deep copy of the
+		// downstream spec before dispatching. The registry's canonical
+		// spec is preserved so manual / cron / non-chain fires of the
+		// same downstream see the on-disk values. The merged spec is
+		// re-validated; on failure we log and skip this edge rather than
+		// dispatching a malformed spec.
+		dispatchSpec := spec
+		if chain.Overrides != nil {
+			merged := taskset.ApplyOverrides(spec, chain.Overrides)
+			if vErr := merged.Validate(); vErr != nil {
+				e.log.Error("chain trigger skipped — overrides produce invalid spec",
+					zap.String("from", completedTaskID),
+					zap.String("to", spec.ID),
+					zap.Error(vErr),
+				)
+				continue
+			}
+			dispatchSpec = merged
+		}
 		e.log.Info("chain trigger",
 			zap.String("from", completedTaskID),
 			zap.String("to", spec.ID),
 			zap.String("on", on),
 		)
-		go e.fireAsync(ctx, spec, pkgruntime.RunOptions{ //nolint:errcheck
+		go e.fireAsync(ctx, dispatchSpec, pkgruntime.RunOptions{ //nolint:errcheck
 			ParentRunID: runID,
 			Input:       buildChainInput(chain.Params, completedTaskID, runID, runStatus, output),
 		}, "chain")

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -89,6 +89,12 @@ type Engine struct {
 	daemonRuns  map[string]string
 	daemonSpecs map[string]*task.Spec
 
+	// daemonStates tracks the preflight/lifecycle phase of each daemon task
+	// for surfacing in the WebUI (Engine.DaemonState). Independent of
+	// daemonMu — guarded by its own RWMutex so a state-read in the API path
+	// never has to wait on a long preflight dispatch holding daemonMu.
+	daemonStates *daemonStateMap
+
 	notifier        notify.Notifier
 	notifyOnSuccess bool
 	notifyOnFailure bool
@@ -146,15 +152,16 @@ type PythonRuntimeAPI interface {
 // New creates a trigger Engine with a default Deno executor.
 func New(r *registry.Registry, defaultExec pkgruntime.Executor, log *zap.Logger) *Engine {
 	e := &Engine{
-		registry:    r,
-		executors:   make(map[task.Runtime]pkgruntime.Executor),
-		cron:        cron.New(),
-		log:         log,
-		cronEntries: make(map[string]cron.EntryID),
-		webhooks:    make(map[string]string),
-		daemonRuns:  make(map[string]string),
-		daemonSpecs: make(map[string]*task.Spec),
-		guards:      newChainGuards(),
+		registry:     r,
+		executors:    make(map[task.Runtime]pkgruntime.Executor),
+		cron:         cron.New(),
+		log:          log,
+		cronEntries:  make(map[string]cron.EntryID),
+		webhooks:     make(map[string]string),
+		daemonRuns:   make(map[string]string),
+		daemonSpecs:  make(map[string]*task.Spec),
+		daemonStates: newDaemonStateMap(),
+		guards:       newChainGuards(),
 	}
 	e.executors[task.RuntimeDeno] = defaultExec
 	return e

--- a/pkg/trigger/engine_per_edge_overrides_test.go
+++ b/pkg/trigger/engine_per_edge_overrides_test.go
@@ -1,0 +1,371 @@
+package trigger
+
+// Integration tests for per-edge overrides on trigger.before (preflight
+// chains) and trigger.chain (success chains). Both edges reuse
+// taskset.ApplyOverrides — these tests pin the contract that:
+//
+//  1. The override is applied to a deep copy of the prereq/downstream's
+//     spec at dispatch time.
+//  2. The registry's canonical spec is NOT mutated — manual / cron /
+//     unrelated fires of the same task still see the on-disk values.
+//  3. Overrides that produce an invalid Spec are rejected, not dispatched.
+//
+// The preflight test inspects the spec that the executor receives (timeout
+// + env) because those are the cheapest end-to-end-observable side effects.
+// The chain test goes through the real Deno runtime so it can read back
+// the merged Params.Default via the task script.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
+)
+
+// writeTaskFromYAML writes a fully-formed task.yaml + task.ts pair to dir/id
+// and returns nil on success. Unlike writeTask (engine_test.go) which takes
+// a strongly-typed TriggerConfig literal, this helper accepts the raw
+// task.yaml body so tests can exercise YAML-level constructs that the
+// strongly-typed builder doesn't reach (e.g. trigger.chain.overrides — a
+// late-bound *task.Overrides nested under chain).
+func writeTaskFromYAML(t *testing.T, dir, id, yaml, script string) error {
+	t.Helper()
+	td := filepath.Join(dir, id)
+	if err := os.MkdirAll(td, 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(td, "task.yaml"), []byte(yaml), 0o644); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(td, "task.ts"), []byte(script), 0o644)
+}
+
+// captureExec records the spec the executor was handed for every Execute
+// call, keyed by run ID. Lets per-edge override tests assert that the
+// override-merged spec (not the registry's canonical spec) is what reaches
+// the runtime layer. Adapted from preflightExec — kept separate so the
+// captureExec ↔ test contract is obvious from the call sites below.
+type captureExec struct {
+	reg *registry.Registry
+
+	mu       sync.Mutex
+	captured map[string]*task.Spec
+	daemonCh chan struct{}
+}
+
+func newCaptureExec(reg *registry.Registry) *captureExec {
+	return &captureExec{
+		reg:      reg,
+		captured: make(map[string]*task.Spec),
+		daemonCh: make(chan struct{}),
+	}
+}
+
+func (c *captureExec) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
+	c.mu.Lock()
+	// Take a shallow copy: tests assert on Timeout, Env, Params, Runtime —
+	// not on slice identity.
+	specCopy := *spec
+	c.captured[opts.RunID] = &specCopy
+	c.mu.Unlock()
+
+	// Daemons block until ctx cancelled — mirrors preflightExec's daemon path.
+	if spec.Trigger.Daemon {
+		<-ctx.Done()
+		_ = c.reg.FinishRun(context.Background(), opts.RunID, registry.StatusSuccess)
+		return &pkgruntime.RunResult{}, nil
+	}
+	_ = c.reg.FinishRun(context.Background(), opts.RunID, registry.StatusSuccess)
+	return &pkgruntime.RunResult{}, nil
+}
+
+func (c *captureExec) specFor(runID string) *task.Spec {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.captured[runID]
+}
+
+func (c *captureExec) specForTask(reg *registry.Registry, taskID string, triggerSrc registry.TriggerSource) *task.Spec {
+	runs, _ := reg.ListRuns(context.Background(), taskID, 20)
+	for _, r := range runs {
+		if r.TriggerSource == triggerSrc {
+			if s := c.specFor(r.ID); s != nil {
+				return s
+			}
+		}
+	}
+	return nil
+}
+
+func newCaptureEnv(t *testing.T) (*Engine, *registry.Registry, *captureExec) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+	exec := newCaptureExec(reg)
+	eng := New(reg, exec, zap.NewNop())
+	eng.RegisterExecutor(task.RuntimeDocker, exec)
+	return eng, reg, exec
+}
+
+// TestPerEdgeOverrides_BeforeAppliesAtPreflightOnly verifies that a
+// `before: [{task: render, overrides: {timeout: 5m}}]` edge dispatches
+// the prereq with the override-merged timeout, while the prereq's own
+// registry spec (and standalone manual fires) keep the 60s value from
+// task.yaml.
+func TestPerEdgeOverrides_BeforeAppliesAtPreflightOnly(t *testing.T) {
+	eng, reg, exec := newCaptureEnv(t)
+
+	// Prereq: on-disk timeout 60s.
+	prereqOriginalTimeout := 60 * time.Second
+	prereq := &task.Spec{
+		ID:      "render",
+		Name:    "render",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Timeout: prereqOriginalTimeout,
+		Enabled: true,
+	}
+	if err := reg.Register(prereq); err != nil {
+		t.Fatalf("reg.Register prereq: %v", err)
+	}
+
+	// Daemon: declares a per-edge override on the render prereq with
+	// timeout 5m. The override should apply only to the preflight fire.
+	overrideTimeout := 5 * time.Minute
+	daemon := &task.Spec{
+		ID:      "d",
+		Name:    "d",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{
+			Daemon:  true,
+			Restart: "never",
+			Before: []task.BeforeEntry{{
+				Task: "render",
+				Overrides: &task.Overrides{
+					Timeout: overrideTimeout,
+				},
+			}},
+		},
+		Enabled: true,
+	}
+	if err := reg.Register(daemon); err != nil {
+		t.Fatalf("reg.Register daemon: %v", err)
+	}
+	if err := eng.Register(daemon); err != nil {
+		t.Fatalf("eng.Register daemon: %v", err)
+	}
+
+	// Wait for daemon to come up (preflight succeeded).
+	waitUntil(t, 5*time.Second, func() bool {
+		return eng.DaemonState("d") == DaemonRunning
+	}, "daemon never reached Running")
+
+	// The preflight fire of render should have used the override timeout.
+	preflightSpec := exec.specForTask(reg, "render", registry.TriggerPreflight)
+	if preflightSpec == nil {
+		t.Fatal("preflight render run never reached executor")
+	}
+	if preflightSpec.Timeout != overrideTimeout {
+		t.Errorf("preflight render Timeout = %v, want %v (override should apply)",
+			preflightSpec.Timeout, overrideTimeout)
+	}
+
+	// The registry's canonical spec must NOT have been mutated.
+	regSpec, _ := reg.Get("render")
+	if regSpec.Timeout != prereqOriginalTimeout {
+		t.Errorf("registry render spec Timeout = %v, want %v (registry must not be mutated)",
+			regSpec.Timeout, prereqOriginalTimeout)
+	}
+
+	// Standalone manual fire must see the original timeout.
+	manualRunID, err := eng.FireManual(context.Background(), "render", nil)
+	if err != nil {
+		t.Fatalf("FireManual render: %v", err)
+	}
+	waitUntil(t, 5*time.Second, func() bool {
+		s := exec.specFor(manualRunID)
+		return s != nil
+	}, "manual render never reached executor")
+	manualSpec := exec.specFor(manualRunID)
+	if manualSpec.Timeout != prereqOriginalTimeout {
+		t.Errorf("manual render Timeout = %v, want %v (override must not leak to manual fires)",
+			manualSpec.Timeout, prereqOriginalTimeout)
+	}
+}
+
+// TestPerEdgeOverrides_BeforeInvalidOverrideRejectedAtRegister verifies
+// that overrides which would produce an invalid Spec are caught at
+// Engine.Register time. Operators see a clean error path rather than a
+// silently-failing daemon that stays in PrereqFailed forever.
+//
+// We use runtime: "" because Spec.validate accepts any non-empty runtime
+// but the empty case routes through the deno default path — instead
+// trigger an invariant we can actually break: a chain trigger with no
+// `from:`. The override switches the prereq to a chain trigger that
+// fails per-spec validation.
+func TestPerEdgeOverrides_BeforeInvalidOverrideRejectedAtRegister(t *testing.T) {
+	eng, reg, _ := newCaptureEnv(t)
+
+	prereq := &task.Spec{
+		ID:      "render",
+		Name:    "render",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Timeout: 60 * time.Second,
+		Enabled: true,
+	}
+	if err := reg.Register(prereq); err != nil {
+		t.Fatal(err)
+	}
+
+	emptyFrom := ""
+	daemon := &task.Spec{
+		ID:      "d",
+		Name:    "d",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{
+			Daemon: true,
+			Before: []task.BeforeEntry{{
+				Task: "render",
+				Overrides: &task.Overrides{
+					Trigger: &task.TriggerPatch{
+						Chain: &task.ChainTrigger{From: emptyFrom},
+					},
+				},
+			}},
+		},
+		Enabled: true,
+	}
+	if err := reg.Register(daemon); err != nil {
+		t.Fatal(err)
+	}
+
+	err := eng.Register(daemon)
+	if err == nil {
+		t.Fatal("expected Register to fail with invalid override, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid spec") {
+		t.Errorf("expected error mentioning invalid spec, got: %v", err)
+	}
+}
+
+// TestPerEdgeOverrides_ChainAppliesAtChainOnly is the end-to-end chain
+// dispatch test. It uses the real Deno runtime path (writeTask + newTestEnv
+// from engine_test.go's helpers) so we can read back the merged spec
+// values via the task script's return value.
+//
+// Upstream completes; downstream's trigger.chain.overrides patches
+// params.mode to "prod". The downstream task reads params.mode at runtime
+// and returns it; the test asserts the value is the override-merged
+// "prod", not the on-disk default "review".
+func TestPerEdgeOverrides_ChainAppliesAtChainOnly(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	// Downstream task: declares trigger.chain on "upstream-edge" with an
+	// override that changes the `mode` param default from "review" to
+	// "prod". The script echoes the param so the test can compare.
+	defaultMode := "review"
+	overrideMode := "prod"
+
+	downstreamYAML := `
+name: downstream-edge
+runtime: deno
+trigger:
+  chain:
+    from: upstream-edge
+    on: success
+    overrides:
+      params:
+        mode: ` + overrideMode + `
+params:
+  mode:
+    default: ` + defaultMode + `
+`
+	// writeTask doesn't support trigger.chain.overrides directly because
+	// the helper takes a strongly-typed TriggerConfig literal. Build the
+	// spec via WriteFile + LoadDir instead so we exercise the real YAML
+	// path the engine sees in production.
+	if err := writeTaskFromYAML(t, dir, "downstream-edge", downstreamYAML,
+		`export default async function main({ params }) { return await params.get("mode") }`); err != nil {
+		t.Fatalf("write downstream: %v", err)
+	}
+	downstream, err := task.LoadDir(dir + "/downstream-edge")
+	if err != nil {
+		t.Fatalf("load downstream: %v", err)
+	}
+	if err := e.reg.Register(downstream); err != nil {
+		t.Fatalf("reg.Register downstream: %v", err)
+	}
+	if err := e.engine.Register(downstream); err != nil {
+		t.Fatalf("eng.Register downstream: %v", err)
+	}
+
+	// Upstream: just returns; the engine fires downstream on success.
+	upstream := writeTask(t, dir, "upstream-edge",
+		`export default async function main() { return "go" }`,
+		task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(upstream)
+	if err := e.engine.Register(upstream); err != nil {
+		t.Fatalf("eng.Register upstream: %v", err)
+	}
+
+	// Fire upstream.
+	upstreamRunID, err := e.engine.FireManual(context.Background(), "upstream-edge", nil)
+	if err != nil {
+		t.Fatalf("FireManual upstream: %v", err)
+	}
+	primary := waitForTerminal(t, e.engine, upstreamRunID, 30*time.Second)
+	if primary.Status != registry.StatusSuccess {
+		t.Fatalf("upstream status = %q, want success", primary.Status)
+	}
+
+	// Wait for the chain-fired downstream run and inspect its return.
+	got := waitForRunOfTask(t, e.engine, "downstream-edge", 30*time.Second)
+	if got == nil {
+		t.Fatal("downstream-edge was never fired via chain")
+	}
+	if got.Status != registry.StatusSuccess {
+		t.Errorf("downstream status = %q, want success", got.Status)
+	}
+	returnValue := pollReturnValue(t, e.engine, got.ID, 5*time.Second)
+	var mode string
+	if err := json.Unmarshal([]byte(returnValue), &mode); err != nil {
+		t.Fatalf("unmarshal return %q: %v", returnValue, err)
+	}
+	if mode != overrideMode {
+		t.Errorf("chain-fired downstream params.mode = %q, want %q (override should apply)",
+			mode, overrideMode)
+	}
+
+	// Now fire the downstream manually — wait, downstream's trigger is
+	// chain-only, so manual fire would be rejected by the engine. The
+	// "doesn't leak to manual" half of this assertion is covered by the
+	// before-edge test above (where a manual fire is legal because the
+	// prereq's trigger is Manual). Instead assert the registry's
+	// canonical downstream spec was NOT mutated.
+	regDownstream, _ := e.reg.Get("downstream-edge")
+	if len(regDownstream.Params) != 1 || regDownstream.Params[0].Name != "mode" {
+		t.Fatalf("registry downstream params = %+v, want [mode]", regDownstream.Params)
+	}
+	if regDownstream.Params[0].Default != defaultMode {
+		t.Errorf("registry downstream params.mode.default = %q, want %q (registry must not be mutated)",
+			regDownstream.Params[0].Default, defaultMode)
+	}
+}

--- a/pkg/trigger/engine_preflight_test.go
+++ b/pkg/trigger/engine_preflight_test.go
@@ -195,7 +195,10 @@ func (p *preflightExec) Execute(ctx context.Context, spec *task.Spec, opts pkgru
 
 // newPreflightEnv returns a test engine + reg + controllable executor for
 // the preflight gating tests. Tasks complete synchronously (or block, for
-// marked daemons) without spawning Deno.
+// marked daemons) without spawning Deno or Docker — we register the same
+// preflightExec for both the deno and docker runtimes so daemon specs
+// (which are typically runtime: docker for container daemons) dispatch
+// without needing the real docker manager.
 func newPreflightEnv(t *testing.T) (*Engine, *registry.Registry, *preflightExec) {
 	t.Helper()
 	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
@@ -206,6 +209,7 @@ func newPreflightEnv(t *testing.T) (*Engine, *registry.Registry, *preflightExec)
 	reg := registry.New(d)
 	exec := newPreflightExec(reg)
 	eng := New(reg, exec, zap.NewNop())
+	eng.RegisterExecutor(task.RuntimeDocker, exec)
 	return eng, reg, exec
 }
 
@@ -449,6 +453,111 @@ func TestPreflight_RestartCoalesces(t *testing.T) {
 	}
 	if daemonRuns > 2 {
 		t.Errorf("expected at most 2 daemon runs (first boot + one coalesced restart), got %d", daemonRuns)
+	}
+}
+
+// TestPreflight_PrereqFailureBlocksFirstStart verifies that a daemon
+// whose preflight fails on the very first attempt:
+//
+//   - does NOT have its daemon-task fired,
+//   - ends up in state=DaemonPrereqFailed (operator-facing diagnosis).
+//
+// The default 'restart: always' would otherwise mask the failure by
+// retrying forever — preflight failure is a config-level error and
+// should surface, not loop.
+func TestPreflight_PrereqFailureBlocksFirstStart(t *testing.T) {
+	eng, reg, exec := newPreflightEnv(t)
+
+	prereq := makeOneShotSpec("render")
+	if err := reg.Register(prereq); err != nil {
+		t.Fatal(err)
+	}
+	// Make render fail.
+	exec.setFn("render", func(string, string) string { return registry.StatusFailure })
+
+	daemon := makeDaemonSpec("d", []string{"render"})
+	if err := reg.Register(daemon); err != nil {
+		t.Fatal(err)
+	}
+	exec.markDaemon("d")
+
+	if err := eng.Register(daemon); err != nil {
+		t.Fatalf("eng.Register: %v", err)
+	}
+
+	// Wait until the engine has finished its preflight attempt and
+	// settled into PrereqFailed.
+	waitUntil(t, 5*time.Second, func() bool {
+		return eng.DaemonState("d") == DaemonPrereqFailed
+	}, "daemon never reached PrereqFailed")
+
+	// No daemon run should have been recorded.
+	runs, _ := reg.ListRuns(context.Background(), "d", 10)
+	for _, r := range runs {
+		if r.TriggerSource == registry.TriggerDaemon {
+			t.Errorf("daemon run %s was fired despite failed prereq", r.ID)
+		}
+	}
+}
+
+// TestPreflight_PrereqFailureLeavesRunningDaemonAlone verifies that a
+// prereq failure that happens AFTER the daemon is already up does not
+// disturb the running daemon. Rationale: an in-flight credential rotator
+// that hits a transient API error shouldn't take down a long-running
+// service. The daemon keeps using the last-known-good config; the
+// failure is visible in the prereq's run log.
+func TestPreflight_PrereqFailureLeavesRunningDaemonAlone(t *testing.T) {
+	eng, reg, exec := newPreflightEnv(t)
+
+	prereq := makeOneShotSpec("render")
+	if err := reg.Register(prereq); err != nil {
+		t.Fatal(err)
+	}
+	// First attempt succeeds (so the daemon comes up). We'll flip to
+	// failure after the daemon is Running.
+	exec.setFn("render", func(string, string) string { return registry.StatusSuccess })
+
+	daemon := makeDaemonSpec("d", []string{"render"})
+	if err := reg.Register(daemon); err != nil {
+		t.Fatal(err)
+	}
+	exec.markDaemon("d")
+
+	if err := eng.Register(daemon); err != nil {
+		t.Fatalf("eng.Register: %v", err)
+	}
+	waitUntil(t, 5*time.Second, func() bool {
+		return eng.DaemonState("d") == DaemonRunning
+	}, "daemon never came up")
+
+	// Capture the current daemon run ID. The same run should still own
+	// the registry slot when the test ends.
+	eng.daemonMu.Lock()
+	originalRunID := eng.daemonRuns["d"]
+	eng.daemonMu.Unlock()
+	if originalRunID == "" {
+		t.Fatal("daemon has no recorded run ID after Running state")
+	}
+
+	// Flip render to failure and re-fire it.
+	exec.setFn("render", func(string, string) string { return registry.StatusFailure })
+	if _, err := eng.FireManual(context.Background(), "render", nil); err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+
+	// Give the engine time to (incorrectly) attempt a restart. A 1s
+	// settle window is generous given the engine doesn't sleep between
+	// FireChain and queueDaemonRestart.
+	time.Sleep(1 * time.Second)
+
+	if got := eng.DaemonState("d"); got != DaemonRunning {
+		t.Errorf("daemon state after prereq failure = %q, want running", got)
+	}
+	eng.daemonMu.Lock()
+	currentRunID := eng.daemonRuns["d"]
+	eng.daemonMu.Unlock()
+	if currentRunID != originalRunID {
+		t.Errorf("daemon run ID changed: was %q, now %q (the engine restarted on a failed prereq)", originalRunID, currentRunID)
 	}
 }
 

--- a/pkg/trigger/engine_preflight_test.go
+++ b/pkg/trigger/engine_preflight_test.go
@@ -66,6 +66,30 @@ func TestRegister_BeforeDaemonRejected(t *testing.T) {
 // impossible to write. The validator comment in validateBeforeRefs
 // captures this reasoning so future readers don't add a redundant check.
 
+// TestDaemonState_Default verifies that DaemonState() returns the zero
+// value (DaemonStopped) for unknown task IDs and for daemons that haven't
+// been started yet — operators viewing the WebUI before the engine has
+// fired the preflight should see "stopped", not a blank field.
+func TestDaemonState_Default(t *testing.T) {
+	e := newTestEnv(t)
+	if got := e.engine.DaemonState("unknown"); got != DaemonStopped {
+		t.Errorf("unknown daemon state = %q, want stopped", got)
+	}
+}
+
+// TestDaemonState_SetGet verifies that setDaemonState/DaemonState round-trip
+// the five enum values without contention.
+func TestDaemonState_SetGet(t *testing.T) {
+	e := newTestEnv(t)
+	states := []DaemonState{DaemonPrereqRunning, DaemonPrereqFailed, DaemonRunning, DaemonStopping, DaemonStopped}
+	for _, want := range states {
+		e.engine.setDaemonState("d", want)
+		if got := e.engine.DaemonState("d"); got != want {
+			t.Errorf("setDaemonState(%q) → DaemonState = %q, want %q", want, got, want)
+		}
+	}
+}
+
 // TestRegister_BeforeValid_NonDaemonTarget exercises the happy path: a
 // daemon with a `before:` list referencing a one-shot task that exists in
 // the registry registers without error.

--- a/pkg/trigger/engine_preflight_test.go
+++ b/pkg/trigger/engine_preflight_test.go
@@ -7,10 +7,20 @@ package trigger
 // one-shot task rather than another daemon. Both rules live here.
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
 	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
 )
 
 func TestRegister_BeforeUnknownTaskRejected(t *testing.T) {
@@ -117,3 +127,207 @@ func TestRegister_BeforeValid_NonDaemonTarget(t *testing.T) {
 		t.Errorf("unexpected error on valid before-list: %v", err)
 	}
 }
+
+// preflightExec is a controllable Executor for the preflight tests. Each
+// task is keyed by ID; the configured fn runs synchronously and decides
+// the final status. Daemons never finish unless explicitly released.
+type preflightExec struct {
+	reg *registry.Registry
+
+	mu     sync.Mutex
+	fns    map[string]func(taskID, runID string) string
+	daemon map[string]chan struct{} // daemon taskID → block channel (closed = exit)
+	runs   atomic.Int32             // count of executed runs (any task)
+}
+
+func newPreflightExec(reg *registry.Registry) *preflightExec {
+	return &preflightExec{
+		reg:    reg,
+		fns:    make(map[string]func(string, string) string),
+		daemon: make(map[string]chan struct{}),
+	}
+}
+
+func (p *preflightExec) setFn(taskID string, fn func(taskID, runID string) string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.fns[taskID] = fn
+}
+
+func (p *preflightExec) markDaemon(taskID string) chan struct{} {
+	ch := make(chan struct{})
+	p.mu.Lock()
+	p.daemon[taskID] = ch
+	p.mu.Unlock()
+	return ch
+}
+
+func (p *preflightExec) Execute(_ context.Context, spec *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
+	p.runs.Add(1)
+	p.mu.Lock()
+	daemonCh := p.daemon[spec.ID]
+	fn := p.fns[spec.ID]
+	p.mu.Unlock()
+
+	if daemonCh != nil {
+		// Long-running daemon: block until released.
+		<-daemonCh
+		_ = p.reg.FinishRun(context.Background(), opts.RunID, registry.StatusSuccess)
+		return &pkgruntime.RunResult{}, nil
+	}
+	status := registry.StatusSuccess
+	if fn != nil {
+		status = fn(spec.ID, opts.RunID)
+	}
+	if status == registry.StatusFailure {
+		_ = p.reg.FinishRunWithReason(context.Background(), opts.RunID, status, "test-injected: failure")
+		return &pkgruntime.RunResult{}, errors.New("injected failure")
+	}
+	_ = p.reg.FinishRun(context.Background(), opts.RunID, status)
+	return &pkgruntime.RunResult{}, nil
+}
+
+// newPreflightEnv returns a test engine + reg + controllable executor for
+// the preflight gating tests. Tasks complete synchronously (or block, for
+// marked daemons) without spawning Deno.
+func newPreflightEnv(t *testing.T) (*Engine, *registry.Registry, *preflightExec) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+	exec := newPreflightExec(reg)
+	eng := New(reg, exec, zap.NewNop())
+	return eng, reg, exec
+}
+
+func waitUntil(t *testing.T, timeout time.Duration, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting: %s", msg)
+}
+
+// hasSuccessfulRunFor reports whether taskID has at least one run row in
+// the registry with the given status.
+func hasRunWithStatus(t *testing.T, reg *registry.Registry, taskID, status string) bool {
+	t.Helper()
+	runs, err := reg.ListRuns(context.Background(), taskID, 5)
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	for _, r := range runs {
+		if r.Status == status {
+			return true
+		}
+	}
+	return false
+}
+
+// TestPreflight_DaemonWaitsForPrereqSuccess verifies the gating contract:
+// the daemon's run does not start until every task in its before-list has
+// finished with status=success. Asserted by ordering — prereq must have a
+// success run before the daemon's run shows up.
+func TestPreflight_DaemonWaitsForPrereqSuccess(t *testing.T) {
+	eng, reg, exec := newPreflightEnv(t)
+
+	// Prereq: completes successfully.
+	prereq := &task.Spec{
+		ID:      "render",
+		Name:    "render",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Enabled: true,
+	}
+	if err := reg.Register(prereq); err != nil {
+		t.Fatalf("reg.Register prereq: %v", err)
+	}
+
+	// Daemon: blocks until released.
+	daemon := &task.Spec{
+		ID:      "d",
+		Name:    "d",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{Daemon: true, Before: []string{"render"}},
+		Enabled: true,
+	}
+	if err := reg.Register(daemon); err != nil {
+		t.Fatalf("reg.Register daemon: %v", err)
+	}
+	releaseDaemon := exec.markDaemon("d")
+	defer close(releaseDaemon)
+
+	if err := eng.Register(daemon); err != nil {
+		t.Fatalf("eng.Register daemon: %v", err)
+	}
+
+	// Prereq must complete to success.
+	waitUntil(t, 5*time.Second, func() bool {
+		return hasRunWithStatus(t, reg, "render", registry.StatusSuccess)
+	}, "prereq render never succeeded")
+
+	// Daemon must transition to Running once preflight succeeds.
+	waitUntil(t, 5*time.Second, func() bool {
+		return eng.DaemonState("d") == DaemonRunning
+	}, "daemon never reached Running")
+}
+
+// TestPreflight_NoBefore_StartsImmediately verifies that a daemon with an
+// empty before-list does not pay any preflight overhead: it goes straight
+// to Running without the engine touching daemonStates' PrereqRunning state.
+func TestPreflight_NoBefore_StartsImmediately(t *testing.T) {
+	eng, reg, exec := newPreflightEnv(t)
+	daemon := &task.Spec{
+		ID:      "d-noprereq",
+		Name:    "d-noprereq",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{Daemon: true}, // no Before
+		Enabled: true,
+	}
+	if err := reg.Register(daemon); err != nil {
+		t.Fatalf("reg.Register: %v", err)
+	}
+	releaseDaemon := exec.markDaemon("d-noprereq")
+	defer close(releaseDaemon)
+
+	if err := eng.Register(daemon); err != nil {
+		t.Fatalf("eng.Register: %v", err)
+	}
+	waitUntil(t, 5*time.Second, func() bool {
+		return eng.DaemonState("d-noprereq") == DaemonRunning
+	}, "daemon-without-before never reached Running")
+}
+
+// makeDaemonSpec is a tiny convenience to keep the table-style tests below
+// from drowning in struct literals. Kept local to this file.
+func makeDaemonSpec(id string, before []string) *task.Spec {
+	return &task.Spec{
+		ID:      id,
+		Name:    id,
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{Daemon: true, Before: before},
+		Enabled: true,
+	}
+}
+
+func makeOneShotSpec(id string) *task.Spec {
+	return &task.Spec{
+		ID:      id,
+		Name:    id,
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Enabled: true,
+	}
+}
+
+var _ = fmt.Sprintf // keep fmt import live for future debug-helpers

--- a/pkg/trigger/engine_preflight_test.go
+++ b/pkg/trigger/engine_preflight_test.go
@@ -1,0 +1,95 @@
+package trigger
+
+// Tests for the cross-spec validation pass that the engine runs at
+// registration time on tasks declaring `trigger.before`. Per-spec validation
+// (see pkg/task.Spec.validate) can only enforce shape: it cannot check that
+// the referenced task actually exists in the registry or that it is itself a
+// one-shot task rather than another daemon. Both rules live here.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+func TestRegister_BeforeUnknownTaskRejected(t *testing.T) {
+	e := newTestEnv(t)
+	daemon := &task.Spec{
+		ID:      "d",
+		Name:    "d",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{Daemon: true, Before: []string{"missing"}},
+		Enabled: true,
+	}
+	err := e.engine.Register(daemon)
+	if err == nil || !strings.Contains(err.Error(), "missing") {
+		t.Errorf("expected error referencing unknown task, got %v", err)
+	}
+}
+
+func TestRegister_BeforeDaemonRejected(t *testing.T) {
+	e := newTestEnv(t)
+	other := &task.Spec{
+		ID:      "other-daemon",
+		Name:    "other-daemon",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{Daemon: true},
+		Enabled: true,
+	}
+	if err := e.reg.Register(other); err != nil {
+		t.Fatalf("seed reg.Register: %v", err)
+	}
+	target := &task.Spec{
+		ID:      "d",
+		Name:    "d",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{Daemon: true, Before: []string{"other-daemon"}},
+		Enabled: true,
+	}
+	err := e.engine.Register(target)
+	if err == nil || !strings.Contains(err.Error(), "daemon") {
+		t.Errorf("expected error rejecting daemon-as-before, got %v", err)
+	}
+}
+
+// Cycle case: rejected structurally by the per-spec + cross-spec rules.
+//
+// trigger.before is only valid on daemon tasks (per-spec) AND it cannot
+// reference a daemon (cross-spec). The only way a cycle could form is
+// through a prereq task having its own trigger.before pointing back at the
+// daemon — but only daemon tasks may have trigger.before. Therefore cycles
+// are unreachable, and an explicit cycle-detection test is structurally
+// impossible to write. The validator comment in validateBeforeRefs
+// captures this reasoning so future readers don't add a redundant check.
+
+// TestRegister_BeforeValid_NonDaemonTarget exercises the happy path: a
+// daemon with a `before:` list referencing a one-shot task that exists in
+// the registry registers without error.
+func TestRegister_BeforeValid_NonDaemonTarget(t *testing.T) {
+	e := newTestEnv(t)
+	prereq := &task.Spec{
+		ID:      "render",
+		Name:    "render",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Enabled: true,
+	}
+	if err := e.reg.Register(prereq); err != nil {
+		t.Fatalf("seed reg.Register: %v", err)
+	}
+	daemon := &task.Spec{
+		ID:      "d",
+		Name:    "d",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{Daemon: true, Before: []string{"render"}},
+		Enabled: true,
+	}
+	if err := e.engine.Register(daemon); err != nil {
+		t.Errorf("unexpected error on valid before-list: %v", err)
+	}
+}

--- a/pkg/trigger/engine_preflight_test.go
+++ b/pkg/trigger/engine_preflight_test.go
@@ -30,7 +30,7 @@ func TestRegister_BeforeUnknownTaskRejected(t *testing.T) {
 		Name:    "d",
 		Runtime: task.RuntimeDocker,
 		Docker:  &task.DockerConfig{Image: "alpine"},
-		Trigger: task.TriggerConfig{Daemon: true, Before: []string{"missing"}},
+		Trigger: task.TriggerConfig{Daemon: true, Before: []task.BeforeEntry{{Task: "missing"}}},
 		Enabled: true,
 	}
 	err := e.engine.Register(daemon)
@@ -57,7 +57,7 @@ func TestRegister_BeforeDaemonRejected(t *testing.T) {
 		Name:    "d",
 		Runtime: task.RuntimeDocker,
 		Docker:  &task.DockerConfig{Image: "alpine"},
-		Trigger: task.TriggerConfig{Daemon: true, Before: []string{"other-daemon"}},
+		Trigger: task.TriggerConfig{Daemon: true, Before: []task.BeforeEntry{{Task: "other-daemon"}}},
 		Enabled: true,
 	}
 	err := e.engine.Register(target)
@@ -120,7 +120,7 @@ func TestRegister_BeforeValid_NonDaemonTarget(t *testing.T) {
 		Name:    "d",
 		Runtime: task.RuntimeDocker,
 		Docker:  &task.DockerConfig{Image: "alpine"},
-		Trigger: task.TriggerConfig{Daemon: true, Before: []string{"render"}},
+		Trigger: task.TriggerConfig{Daemon: true, Before: []task.BeforeEntry{{Task: "render"}}},
 		Enabled: true,
 	}
 	if err := e.engine.Register(daemon); err != nil {
@@ -267,7 +267,7 @@ func TestPreflight_DaemonWaitsForPrereqSuccess(t *testing.T) {
 		Name:    "d",
 		Runtime: task.RuntimeDocker,
 		Docker:  &task.DockerConfig{Image: "alpine"},
-		Trigger: task.TriggerConfig{Daemon: true, Before: []string{"render"}, Restart: "never"},
+		Trigger: task.TriggerConfig{Daemon: true, Before: []task.BeforeEntry{{Task: "render"}}, Restart: "never"},
 		Enabled: true,
 	}
 	if err := reg.Register(daemon); err != nil {
@@ -319,6 +319,10 @@ func TestPreflight_NoBefore_StartsImmediately(t *testing.T) {
 // makeDaemonSpec is a tiny convenience to keep the table-style tests below
 // from drowning in struct literals. Kept local to this file.
 func makeDaemonSpec(id string, before []string) *task.Spec {
+	entries := make([]task.BeforeEntry, len(before))
+	for i, t := range before {
+		entries[i] = task.BeforeEntry{Task: t}
+	}
 	return &task.Spec{
 		ID:      id,
 		Name:    id,
@@ -328,7 +332,7 @@ func makeDaemonSpec(id string, before []string) *task.Spec {
 		// existing "always restart" hook AND the prereq-driven restart
 		// path together (would double-count daemon runs in the
 		// coalescing test).
-		Trigger: task.TriggerConfig{Daemon: true, Before: before, Restart: "never"},
+		Trigger: task.TriggerConfig{Daemon: true, Before: entries, Restart: "never"},
 		Enabled: true,
 	}
 }

--- a/pkg/trigger/engine_preflight_test.go
+++ b/pkg/trigger/engine_preflight_test.go
@@ -562,3 +562,104 @@ func TestPreflight_PrereqFailureLeavesRunningDaemonAlone(t *testing.T) {
 }
 
 var _ = fmt.Sprintf // keep fmt import live for future debug-helpers
+
+// TestPreflight_RegisterDaemon_Concurrent_NoDoubleStart pins finding #1 from
+// the PR-300 review: two concurrent registerDaemon calls for the same
+// preflight daemon must NOT each spawn a goroutine that fires preflight and
+// starts the daemon. Without coalescing, both callers observe `daemonRuns`
+// empty (since neither has populated it yet — the goroutine only assigns
+// `daemonRuns[id] = runID` AFTER preflight + fireAsync) and both run a
+// preflight chain + a daemon run, racing for the registry slot.
+//
+// The fix: gate the initial-start path with the same per-task lock used for
+// restart coalescing. The second concurrent call should be a no-op.
+//
+// We inject a barrier into the prereq executor so both registerDaemon calls
+// can reach `go startDaemon` before either preflight returns. After the
+// barrier releases, both goroutines (if the bug exists) would proceed to
+// fireAsync; with the fix, only one does.
+func TestPreflight_RegisterDaemon_Concurrent_NoDoubleStart(t *testing.T) {
+	eng, reg, exec := newPreflightEnv(t)
+
+	prereq := makeOneShotSpec("render")
+	if err := reg.Register(prereq); err != nil {
+		t.Fatal(err)
+	}
+
+	// Block the prereq until released so both registerDaemon callers are
+	// guaranteed to have spawned their goroutines before either preflight
+	// completes. Without this, the test would race against goroutine
+	// scheduling and the bug could slip past on a fast machine.
+	prereqRelease := make(chan struct{})
+	var prereqRuns atomic.Int32
+	exec.setFn("render", func(string, string) string {
+		prereqRuns.Add(1)
+		<-prereqRelease
+		return registry.StatusSuccess
+	})
+
+	daemon := makeDaemonSpec("d", []string{"render"})
+	if err := reg.Register(daemon); err != nil {
+		t.Fatal(err)
+	}
+	exec.markDaemon("d")
+
+	// Fire two concurrent Register calls. Use a barrier so they enter
+	// registerDaemon in true overlap rather than serially.
+	var startBarrier sync.WaitGroup
+	startBarrier.Add(1)
+	var done sync.WaitGroup
+	done.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer done.Done()
+			startBarrier.Wait()
+			if err := eng.Register(daemon); err != nil {
+				t.Errorf("eng.Register: %v", err)
+			}
+		}()
+	}
+	startBarrier.Done()
+	done.Wait()
+
+	// Wait until preflight has actually started for at least one caller.
+	// (Both should reach the barrier; we only need one to be sure both
+	// registerDaemon calls have completed their spawn step.)
+	waitUntil(t, 2*time.Second, func() bool {
+		return prereqRuns.Load() >= 1
+	}, "no prereq run started after concurrent Register calls")
+
+	// Release the prereq barrier so any in-flight preflight goroutine(s)
+	// proceed to fireAsync.
+	close(prereqRelease)
+
+	// Wait for the daemon to reach Running so any double-start would have
+	// surfaced by now.
+	waitUntil(t, 5*time.Second, func() bool {
+		return eng.DaemonState("d") == DaemonRunning
+	}, "daemon never reached Running")
+	// Extra settle window: a second goroutine's fireAsync may land after
+	// the first daemon run reached Running. Without this, the bug could
+	// slip past the assertion below.
+	time.Sleep(500 * time.Millisecond)
+
+	// Assertion 1: exactly one preflight run.
+	if got := prereqRuns.Load(); got != 1 {
+		t.Errorf("expected exactly 1 preflight run, got %d (double-start race)", got)
+	}
+
+	// Assertion 2: exactly one daemon run in the registry.
+	runs, err := reg.ListRuns(context.Background(), "d", 10)
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	var daemonRuns int
+	for _, r := range runs {
+		if r.TriggerSource == registry.TriggerDaemon {
+			daemonRuns++
+		}
+	}
+	if daemonRuns != 1 {
+		t.Errorf("expected exactly 1 daemon run, got %d (double-start race)", daemonRuns)
+	}
+}

--- a/pkg/trigger/engine_preflight_test.go
+++ b/pkg/trigger/engine_preflight_test.go
@@ -154,15 +154,18 @@ func (p *preflightExec) setFn(taskID string, fn func(taskID, runID string) strin
 	p.fns[taskID] = fn
 }
 
-func (p *preflightExec) markDaemon(taskID string) chan struct{} {
-	ch := make(chan struct{})
+// markDaemon flags a task ID as a long-running daemon. Subsequent Execute
+// calls for that task block until the run's context is cancelled (i.e.
+// until KillRun is invoked or the engine shuts down).
+func (p *preflightExec) markDaemon(taskID string) {
 	p.mu.Lock()
-	p.daemon[taskID] = ch
+	if p.daemon[taskID] == nil {
+		p.daemon[taskID] = make(chan struct{})
+	}
 	p.mu.Unlock()
-	return ch
 }
 
-func (p *preflightExec) Execute(_ context.Context, spec *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
+func (p *preflightExec) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
 	p.runs.Add(1)
 	p.mu.Lock()
 	daemonCh := p.daemon[spec.ID]
@@ -170,8 +173,11 @@ func (p *preflightExec) Execute(_ context.Context, spec *task.Spec, opts pkgrunt
 	p.mu.Unlock()
 
 	if daemonCh != nil {
-		// Long-running daemon: block until released.
-		<-daemonCh
+		// Long-running daemon: block until the run's context is cancelled
+		// (KillRun path). FinishRun(Success) before returning so onDaemon-
+		// RunFinished doesn't treat the daemon as crashed. Mirrors how a
+		// real daemon exits gracefully on shutdown.
+		<-ctx.Done()
 		_ = p.reg.FinishRun(context.Background(), opts.RunID, registry.StatusSuccess)
 		return &pkgruntime.RunResult{}, nil
 	}
@@ -250,20 +256,20 @@ func TestPreflight_DaemonWaitsForPrereqSuccess(t *testing.T) {
 		t.Fatalf("reg.Register prereq: %v", err)
 	}
 
-	// Daemon: blocks until released.
+	// Daemon: blocks until released. restart:never so the executor's
+	// eventual exit doesn't loop the test.
 	daemon := &task.Spec{
 		ID:      "d",
 		Name:    "d",
 		Runtime: task.RuntimeDocker,
 		Docker:  &task.DockerConfig{Image: "alpine"},
-		Trigger: task.TriggerConfig{Daemon: true, Before: []string{"render"}},
+		Trigger: task.TriggerConfig{Daemon: true, Before: []string{"render"}, Restart: "never"},
 		Enabled: true,
 	}
 	if err := reg.Register(daemon); err != nil {
 		t.Fatalf("reg.Register daemon: %v", err)
 	}
-	releaseDaemon := exec.markDaemon("d")
-	defer close(releaseDaemon)
+	exec.markDaemon("d")
 
 	if err := eng.Register(daemon); err != nil {
 		t.Fatalf("eng.Register daemon: %v", err)
@@ -290,14 +296,13 @@ func TestPreflight_NoBefore_StartsImmediately(t *testing.T) {
 		Name:    "d-noprereq",
 		Runtime: task.RuntimeDocker,
 		Docker:  &task.DockerConfig{Image: "alpine"},
-		Trigger: task.TriggerConfig{Daemon: true}, // no Before
+		Trigger: task.TriggerConfig{Daemon: true, Restart: "never"}, // no Before
 		Enabled: true,
 	}
 	if err := reg.Register(daemon); err != nil {
 		t.Fatalf("reg.Register: %v", err)
 	}
-	releaseDaemon := exec.markDaemon("d-noprereq")
-	defer close(releaseDaemon)
+	exec.markDaemon("d-noprereq")
 
 	if err := eng.Register(daemon); err != nil {
 		t.Fatalf("eng.Register: %v", err)
@@ -315,7 +320,11 @@ func makeDaemonSpec(id string, before []string) *task.Spec {
 		Name:    id,
 		Runtime: task.RuntimeDocker,
 		Docker:  &task.DockerConfig{Image: "alpine"},
-		Trigger: task.TriggerConfig{Daemon: true, Before: before},
+		// restart: never so a clean executor exit doesn't trigger the
+		// existing "always restart" hook AND the prereq-driven restart
+		// path together (would double-count daemon runs in the
+		// coalescing test).
+		Trigger: task.TriggerConfig{Daemon: true, Before: before, Restart: "never"},
 		Enabled: true,
 	}
 }
@@ -327,6 +336,119 @@ func makeOneShotSpec(id string) *task.Spec {
 		Runtime: task.RuntimeDeno,
 		Trigger: task.TriggerConfig{Manual: true},
 		Enabled: true,
+	}
+}
+
+// TestPreflight_DaemonRestartsOnPrereqRerun verifies that re-running a
+// prereq task after the daemon is up triggers a restart: the daemon's
+// current run is killed, preflight re-runs, and the daemon comes back up.
+//
+// Asserted by counting daemon-task runs in the registry — must transition
+// from 1 to 2 after the prereq is re-fired.
+func TestPreflight_DaemonRestartsOnPrereqRerun(t *testing.T) {
+	eng, reg, exec := newPreflightEnv(t)
+
+	prereq := makeOneShotSpec("render")
+	if err := reg.Register(prereq); err != nil {
+		t.Fatal(err)
+	}
+
+	daemon := makeDaemonSpec("d", []string{"render"})
+	if err := reg.Register(daemon); err != nil {
+		t.Fatal(err)
+	}
+	// markDaemon makes the executor block until the run's context is
+	// cancelled. KillRun (invoked by queueDaemonRestart) is the cancel
+	// trigger.
+	exec.markDaemon("d")
+
+	if err := eng.Register(daemon); err != nil {
+		t.Fatalf("eng.Register: %v", err)
+	}
+
+	// Wait for daemon's first run to be active.
+	waitUntil(t, 5*time.Second, func() bool {
+		return eng.DaemonState("d") == DaemonRunning
+	}, "daemon never reached Running for first start")
+
+	// Re-fire the prereq. The success completion notifies the engine,
+	// which should KillRun the current daemon run, re-run preflight, and
+	// start a fresh daemon run.
+	if _, err := eng.FireManual(context.Background(), "render", nil); err != nil {
+		t.Fatalf("FireManual prereq: %v", err)
+	}
+
+	// Wait for a second daemon run to appear AND reach Running.
+	waitUntil(t, 10*time.Second, func() bool {
+		runs, _ := reg.ListRuns(context.Background(), "d", 10)
+		var daemonRuns int
+		for _, r := range runs {
+			if r.TriggerSource == registry.TriggerDaemon {
+				daemonRuns++
+			}
+		}
+		return daemonRuns >= 2 && eng.DaemonState("d") == DaemonRunning
+	}, "daemon never restarted after prereq re-run")
+}
+
+// TestPreflight_RestartCoalesces verifies that two rapid prereq re-runs
+// produce AT MOST one extra daemon restart — the second prereq completion
+// arriving while a restart is already in flight is coalesced. Without
+// coalescing, busy prereq schedules (e.g. credential rotators on a short
+// cron) would thrash the daemon.
+func TestPreflight_RestartCoalesces(t *testing.T) {
+	eng, reg, exec := newPreflightEnv(t)
+
+	prereq := makeOneShotSpec("render")
+	if err := reg.Register(prereq); err != nil {
+		t.Fatal(err)
+	}
+	daemon := makeDaemonSpec("d", []string{"render"})
+	if err := reg.Register(daemon); err != nil {
+		t.Fatal(err)
+	}
+	exec.markDaemon("d")
+
+	if err := eng.Register(daemon); err != nil {
+		t.Fatalf("eng.Register: %v", err)
+	}
+	waitUntil(t, 5*time.Second, func() bool {
+		return eng.DaemonState("d") == DaemonRunning
+	}, "first start")
+
+	// Fire prereq twice in rapid succession. The second fire must be
+	// coalesced into the first restart (restartGate.tryAcquire returns
+	// false on the second attempt while the first is still in flight).
+	for i := 0; i < 2; i++ {
+		if _, err := eng.FireManual(context.Background(), "render", nil); err != nil {
+			t.Fatalf("FireManual prereq: %v", err)
+		}
+	}
+
+	// After the restart settles, total daemon runs should be 2 — first
+	// boot plus one coalesced restart. Wait briefly to allow any erroneous
+	// second restart to manifest.
+	waitUntil(t, 10*time.Second, func() bool {
+		runs, _ := reg.ListRuns(context.Background(), "d", 10)
+		var daemonRuns int
+		for _, r := range runs {
+			if r.TriggerSource == registry.TriggerDaemon {
+				daemonRuns++
+			}
+		}
+		return daemonRuns >= 2 && eng.DaemonState("d") == DaemonRunning
+	}, "restart never completed")
+	time.Sleep(500 * time.Millisecond)
+
+	runs, _ := reg.ListRuns(context.Background(), "d", 10)
+	var daemonRuns int
+	for _, r := range runs {
+		if r.TriggerSource == registry.TriggerDaemon {
+			daemonRuns++
+		}
+	}
+	if daemonRuns > 2 {
+		t.Errorf("expected at most 2 daemon runs (first boot + one coalesced restart), got %d", daemonRuns)
 	}
 }
 

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -1363,6 +1363,12 @@ type TaskDetail struct {
 	ScriptFile   string `json:"script_file"`
 	TestFile     string `json:"test_file"`
 	TestExists   bool   `json:"test_exists"`
+
+	// DaemonState surfaces the engine's preflight/lifecycle phase for
+	// daemon tasks. Empty for non-daemon tasks so the WebUI can hide the
+	// row entirely. Five-value enum — see pkg/trigger.DaemonState for the
+	// canonical list.
+	DaemonState string `json:"daemon_state,omitempty"`
 }
 
 func (s *Server) apiGetTask(w http.ResponseWriter, r *http.Request) {
@@ -1376,6 +1382,11 @@ func (s *Server) apiGetTask(w http.ResponseWriter, r *http.Request) {
 	detail := TaskDetail{
 		Spec:         spec,
 		TriggerLabel: triggerLabel(spec.Trigger),
+	}
+	// Daemon preflight state — empty for non-daemon tasks so the UI
+	// doesn't render "stopped" labels on every cron job.
+	if spec.Trigger.Daemon {
+		detail.DaemonState = string(s.engine.DaemonState(spec.ID))
 	}
 
 	// Determine script file

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -103,6 +103,80 @@ func TestAPI_GetTask(t *testing.T) {
 	}
 }
 
+// TestAPI_GetTask_DaemonState verifies that GET /api/tasks/{id} for a
+// daemon task includes the engine's current DaemonState in the response.
+// Operators viewing a daemon detail page need this to distinguish
+// "stopped", "waiting on render preflight", "preflight failed", and
+// "running" — a single boolean isn't enough.
+func TestAPI_GetTask_DaemonState(t *testing.T) {
+	srv, reg := newTestServer(t)
+
+	// Register a daemon task in the registry. We don't fire it via the
+	// engine — we only need the task detail handler to read DaemonState
+	// off the engine and surface it. The default (no entry in the engine's
+	// state map) is "stopped".
+	dir := t.TempDir()
+	td := filepath.Join(dir, "my-daemon")
+	_ = os.MkdirAll(td, 0755)
+	_ = os.WriteFile(filepath.Join(td, "task.yaml"),
+		[]byte("name: my-daemon\nruntime: docker\ntrigger:\n  daemon: true\ndocker: { image: alpine }\n"), 0644)
+	spec := &task.Spec{
+		ID:      "my-daemon",
+		Name:    "my-daemon",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{Daemon: true, Restart: "never"},
+		Enabled: true,
+		TaskDir: td,
+	}
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks/my-daemon", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+
+	var detail map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got, ok := detail["daemon_state"]
+	if !ok {
+		t.Fatalf("daemon_state field missing from response: %v", detail)
+	}
+	if got != "stopped" {
+		t.Errorf("daemon_state = %v, want \"stopped\"", got)
+	}
+}
+
+// TestAPI_GetTask_NonDaemonOmitsDaemonState verifies that the daemon_state
+// field is omitted (or empty) for non-daemon tasks — there's no
+// meaningful state to report, and surfacing "stopped" on every cron task
+// would confuse operators.
+func TestAPI_GetTask_NonDaemonOmitsDaemonState(t *testing.T) {
+	srv, reg := newTestServer(t)
+	registerTask(t, reg, "manual-task", `return 1`)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks/manual-task", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+
+	var detail map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got, ok := detail["daemon_state"]; ok && got != "" {
+		t.Errorf("daemon_state should be empty/omitted for non-daemon, got %q", got)
+	}
+}
+
 func TestAPI_GetTask_NotFound(t *testing.T) {
 	srv, _ := newTestServer(t)
 


### PR DESCRIPTION
## Summary

PRs #300 (daemon preflight via `trigger.before`) and #303 (per-edge overrides on `trigger.before` and `trigger.chain`) merged into their stacked base branches via the GitHub UI rather than into main. This PR rebases the resulting content on top of current main so it actually lands.

All commits in this PR have already been through code review and security review under their original PR numbers. No new logic — pure rebase to fix the merge graph.

## What's in here

- Everything from PR #300 (12 sub-tasks, ~13 commits in the original PR)
- Everything from PR #303 + its HIGH/MED fixup commit (#47f4054)
- Rebased on top of #302 (run_result.enabled flag) which is already on main

## Test plan

- [x] go build ./...
- [x] make format-check
- [x] go test ./... -timeout 120s (all green)

## Notes for reviewers

The original PRs #300 and #303 are already showing MERGED in the GitHub UI but their content didn't propagate to main due to stacked-branch base targeting. Compare the diff to those PRs combined to verify equivalence — no new content added.