### PR TITLE
chore(override): unify chain-input merge; close 3 latent footguns

### DIFF
--- a/pkg/task/onfailurechain.go
+++ b/pkg/task/onfailurechain.go
@@ -110,6 +110,15 @@ var reservedChainParamKeys = map[string]struct{}{
 	"_chain_depth": {},
 }
 
+// IsReservedChainParamKey reports whether name is one of the engine-stamped
+// keys that user-supplied params cannot collide with (taskID, runID, status,
+// output, _chain_depth). Exposed so other packages (pkg/taskset) can enforce
+// the invariant at merge time without duplicating the key list.
+func IsReservedChainParamKey(name string) bool {
+	_, ok := reservedChainParamKeys[name]
+	return ok
+}
+
 // Validate enforces reserved-key constraints and strips per-task-only fields
 // (MaxConcurrentGlobal, Storm) that must not be set at the individual task
 // level. Called from per-task sites (Spec.validate); not called directly for

--- a/pkg/taskset/override.go
+++ b/pkg/taskset/override.go
@@ -298,6 +298,21 @@ func copySpec(s *task.Spec) *task.Spec {
 		chain := *s.Trigger.Chain
 		out.Trigger.Chain = &chain
 	}
+	// Trigger.Before is a slice of BeforeEntry; each BeforeEntry carries a
+	// *task.Overrides pointer that per-firing dispatch may mutate. Without
+	// this deep-clone two concurrent firings would alias the same Overrides
+	// instance (survey §5.3).
+	if s.Trigger.Before != nil {
+		before := make([]task.BeforeEntry, len(s.Trigger.Before))
+		for i, be := range s.Trigger.Before {
+			before[i] = be
+			if be.Overrides != nil {
+				o := *be.Overrides
+				before[i].Overrides = &o
+			}
+		}
+		out.Trigger.Before = before
+	}
 	if s.Docker != nil {
 		docker := *s.Docker
 		out.Docker = &docker
@@ -309,6 +324,35 @@ func copySpec(s *task.Spec) *task.Spec {
 	if s.Permissions.Dicode != nil {
 		d := *s.Permissions.Dicode
 		out.Permissions.Dicode = &d
+	}
+	// OnFailureChain pointer — deep-clone so a per-firing mutation can't
+	// reach back into the registry's canonical spec (survey §5.3). The
+	// inner Params map is also cloned because chain dispatch overlays
+	// engine-stamped keys onto it.
+	if s.OnFailureChain != nil {
+		ofc := *s.OnFailureChain
+		if s.OnFailureChain.Params != nil {
+			ofc.Params = make(map[string]any, len(s.OnFailureChain.Params))
+			for k, v := range s.OnFailureChain.Params {
+				ofc.Params[k] = v
+			}
+		}
+		out.OnFailureChain = &ofc
+	}
+	// RunInputs pointer — same deep-clone discipline as the other pointer
+	// fields. The inner *bool fields are cloned so a per-firing override
+	// flipping Enabled cannot reach back into the registry copy.
+	if s.RunInputs != nil {
+		ri := *s.RunInputs
+		if s.RunInputs.Enabled != nil {
+			b := *s.RunInputs.Enabled
+			ri.Enabled = &b
+		}
+		if s.RunInputs.BodyFullTextual != nil {
+			b := *s.RunInputs.BodyFullTextual
+			ri.BodyFullTextual = &b
+		}
+		out.RunInputs = &ri
 	}
 	return &out
 }

--- a/pkg/taskset/override_footguns_test.go
+++ b/pkg/taskset/override_footguns_test.go
@@ -1,0 +1,178 @@
+package taskset
+
+// Footgun pins for the override-machinery unification refactor
+// (docs/superpowers/specs/2026-05-15-override-machinery-survey.md §5.1–5.3).
+//
+// Each test below pins one of the three latent footguns the survey
+// identified. They fail on `origin/main` and pass once the refactor lands.
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// ── Footgun #1: resolver skips post-merge validation ─────────────────────────
+//
+// Survey §5.1: A/B (resolver) sites do NOT call merged.Validate() after
+// applying override layers. A taskset entry override that flips Runtime to
+// "docker" without supplying a Docker section produces an invalid Spec —
+// today the resolver returns it anyway and the failure is only caught later
+// at engine.Register, with a less specific error.
+//
+// After the fix, the resolver must reject the invalid merged spec (logged
+// + skipped, mirroring how it already handles failed LoadDirWithVars).
+func TestFootgun_ResolverValidatesAfterMerge(t *testing.T) {
+	repoDir := t.TempDir()
+	taskDir := writeTaskDir(t, repoDir, "deploy")
+
+	// Override flips runtime to docker on a task with no docker: section,
+	// producing a merged spec that fails Spec.validate() ("runtime docker
+	// requires a docker: section in task.yaml").
+	tsContent := `
+apiVersion: dicode/v1
+kind: TaskSet
+metadata:
+  name: infra
+spec:
+  entries:
+    deploy:
+      ref:
+        path: ` + filepath.Join(taskDir, "task.yaml") + `
+      overrides:
+        runtime: docker
+`
+	tsPath := writeTaskSetFile(t, repoDir, "taskset.yaml", tsContent)
+
+	log, logs := newObservedLogger()
+	r := newResolver(t)
+	r.log = log
+
+	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("Resolve top-level error: %v", err)
+	}
+
+	// The malformed entry should be skipped (warn-and-continue), exactly
+	// like a LoadDirWithVars failure today. The result list must NOT
+	// contain a spec whose Runtime=docker and Docker=nil.
+	for _, rt := range results {
+		if rt.Spec.Runtime == task.RuntimeDocker && rt.Spec.Docker == nil {
+			t.Fatalf("resolver returned a merged spec that fails Validate: id=%s runtime=%q docker=nil",
+				rt.ID, rt.Spec.Runtime)
+		}
+	}
+
+	// And the warning must surface so operators can find the bad override.
+	var sawWarn bool
+	for _, e := range logs.All() {
+		if strings.Contains(e.Message, "override") || strings.Contains(e.Message, "merged spec") || strings.Contains(e.Message, "validate") {
+			sawWarn = true
+			break
+		}
+	}
+	if !sawWarn {
+		t.Errorf("expected a warn log for invalid merged spec; got %v", logs.All())
+	}
+}
+
+// ── Footgun #2: copySpec doesn't deep-clone Trigger.Before / OnFailureChain /
+// RunInputs (survey §5.3 / §4) ───────────────────────────────────────────────
+//
+// `out := *s` copies the slice header for s.Trigger.Before — the backing
+// array is still shared. Per-firing dispatch sites that ever start writing
+// to merged.Trigger.Before would silently corrupt the registry's canonical
+// spec. The pointer fields (OnFailureChain, RunInputs) are also currently
+// aliased.
+//
+// After the fix, copySpec must deep-clone these.
+func TestFootgun_CopySpecDeepClonesNestedStructs(t *testing.T) {
+	enabled := true
+	orig := &task.Spec{
+		Name:    "src",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{
+			Daemon: true,
+			Before: []task.BeforeEntry{
+				{Task: "render", Overrides: &task.Overrides{Name: "orig-name"}},
+			},
+		},
+		OnFailureChain: &task.OnFailureChainSpec{Task: "auto-fix"},
+		RunInputs:      &task.RunInputsTaskOverride{Enabled: &enabled},
+	}
+
+	cp := copySpec(orig)
+
+	// Trigger.Before — must not share backing array.
+	if len(cp.Trigger.Before) != 1 {
+		t.Fatalf("Trigger.Before len: got %d, want 1", len(cp.Trigger.Before))
+	}
+	cp.Trigger.Before[0].Task = "mutated"
+	cp.Trigger.Before[0].Overrides = &task.Overrides{Name: "mutated-overrides"}
+	if orig.Trigger.Before[0].Task != "render" {
+		t.Errorf("Trigger.Before shallow copy: orig mutated to %q", orig.Trigger.Before[0].Task)
+	}
+	if orig.Trigger.Before[0].Overrides == nil || orig.Trigger.Before[0].Overrides.Name != "orig-name" {
+		t.Errorf("Trigger.Before[0].Overrides shallow copy: orig mutated to %+v", orig.Trigger.Before[0].Overrides)
+	}
+
+	// OnFailureChain pointer — must be cloned.
+	cp.OnFailureChain.Task = "different-fixer"
+	if orig.OnFailureChain.Task != "auto-fix" {
+		t.Errorf("OnFailureChain shallow copy: orig.Task mutated to %q", orig.OnFailureChain.Task)
+	}
+
+	// RunInputs pointer — must be cloned.
+	disabled := false
+	cp.RunInputs.Enabled = &disabled
+	if orig.RunInputs.Enabled == nil || !*orig.RunInputs.Enabled {
+		t.Errorf("RunInputs shallow copy: orig.Enabled = %v", orig.RunInputs.Enabled)
+	}
+}
+
+// ── Footgun #3: resolver mergeOverrides path lacks reserved-key enforcement ──
+//
+// Survey §5.2: reservedChainParamKeys (taskID, runID, status, output,
+// _chain_depth) are rejected at config-load by validatePerEdgeOverrides for
+// per-edge sites, but the resolver's *taskset-entry* override path goes
+// through mergeOverrides / applyLayer, which do NOT enforce the invariant.
+// A reserved-key Params entry inside a nested-taskset override silently
+// produces a merged Overrides containing the reserved key.
+//
+// After the fix, mergeOverrides drops or errors on any reserved-key param,
+// matching the per-edge validation contract.
+func TestFootgun_MergeOverridesRejectsReservedKey(t *testing.T) {
+	a := &Overrides{}
+	b := &Overrides{
+		Params: []ParamOverride{
+			{Name: "taskID", Default: "spoofed"},
+			{Name: "real-param", Default: "ok"},
+		},
+	}
+
+	got := mergeOverrides(a, b)
+	if got == nil {
+		t.Fatal("mergeOverrides returned nil")
+	}
+
+	// The merged result must NOT contain a reserved-key param. Today it
+	// does — pinning the regression.
+	for _, p := range got.Params {
+		if p.Name == "taskID" {
+			t.Errorf("mergeOverrides accepted reserved-key param %q (full result: %+v)", p.Name, got.Params)
+		}
+	}
+	// And the legitimate param must still survive the merge.
+	var sawReal bool
+	for _, p := range got.Params {
+		if p.Name == "real-param" {
+			sawReal = true
+		}
+	}
+	if !sawReal {
+		t.Error("legitimate param real-param was dropped")
+	}
+}

--- a/pkg/taskset/resolver.go
+++ b/pkg/taskset/resolver.go
@@ -168,6 +168,14 @@ func (r *Resolver) resolveBody(
 			resolved.ID = fullID
 			resolved.TaskDir = filepath.Dir(tsPath)
 			resolved.Enabled = enabled
+			// Re-validate after the override merge so a bad override
+			// surfaces here (with the operator-relevant taskset path)
+			// rather than later at engine.Register (survey §5.1).
+			if err := resolved.Validate(); err != nil {
+				r.log.Warn("taskset: merged spec failed validate after override apply; skipping",
+					zap.String("entry", fullID), zap.Error(err))
+				continue
+			}
 			results = append(results, &ResolvedTask{
 				Spec:    resolved,
 				ID:      fullID,
@@ -229,6 +237,14 @@ func (r *Resolver) resolveBody(
 			resolved := applyOverrides(spec, layers...)
 			resolved.ID = fullID
 			resolved.Enabled = enabled
+			// Re-validate after the override merge so a bad override
+			// surfaces here (with the operator-relevant taskset path)
+			// rather than later at engine.Register (survey §5.1).
+			if err := resolved.Validate(); err != nil {
+				r.log.Warn("taskset: merged spec failed validate after override apply; skipping",
+					zap.String("entry", fullID), zap.Error(err))
+				continue
+			}
 			results = append(results, &ResolvedTask{
 				Spec:    resolved,
 				ID:      fullID,

--- a/pkg/taskset/resolver.go
+++ b/pkg/taskset/resolver.go
@@ -430,12 +430,17 @@ func joinNamespace(ns, key string) string {
 
 // mergeOverrides merges b on top of a (b wins on conflict).
 // Used to combine a parent entry patch with an entry's own overrides.
+//
+// Reserved chain-param keys (task.ReservedChainParamKey) are stripped from
+// the merged Params list — they're rejected at config-load by
+// validatePerEdgeOverrides / OnFailureChainSpec.Validate, so a well-formed
+// caller never reaches this branch; the strip is defensive (survey §5.2).
 func mergeOverrides(a, b *Overrides) *Overrides {
 	if a == nil {
-		return b
+		return stripReservedParamKeys(b)
 	}
 	if b == nil {
-		return a
+		return stripReservedParamKeys(a)
 	}
 	out := *b // copy b; fill gaps from a
 
@@ -480,7 +485,43 @@ func mergeOverrides(a, b *Overrides) *Overrides {
 		}
 		out.Entries = entries
 	}
+	// Drop reserved chain-param keys (defensive — config-load validation
+	// rejects them upstream).
+	out.Params = filterReservedParamKeys(out.Params)
 	return &out
+}
+
+// stripReservedParamKeys returns o with any reserved-key Params entries
+// removed. Returns o unchanged (same pointer) when no entries are
+// stripped, to keep the nil-input fast paths in mergeOverrides cheap.
+func stripReservedParamKeys(o *Overrides) *Overrides {
+	if o == nil || len(o.Params) == 0 {
+		return o
+	}
+	filtered := filterReservedParamKeys(o.Params)
+	if len(filtered) == len(o.Params) {
+		return o
+	}
+	out := *o
+	out.Params = filtered
+	return &out
+}
+
+// filterReservedParamKeys returns ps with any reserved-key entries removed.
+// Allocates a new slice only when at least one entry is dropped.
+func filterReservedParamKeys(ps []ParamOverride) []ParamOverride {
+	for _, p := range ps {
+		if task.IsReservedChainParamKey(p.Name) {
+			out := make([]ParamOverride, 0, len(ps))
+			for _, p := range ps {
+				if !task.IsReservedChainParamKey(p.Name) {
+					out = append(out, p)
+				}
+			}
+			return out
+		}
+	}
+	return ps
 }
 
 // mergeParamOverrides merges src into dst by name (src wins on conflict).

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -1189,32 +1189,25 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 					zap.String("run", runID),
 					zap.Int("depth", nextDepth),
 				)
-				// Build input. Reserved keys (taskID, runID, status, output,
-				// _chain_depth) are populated by the engine and are NOT
-				// user-overridable. Config-load validation (#236 Task 11)
-				// rejects any chainSpec.Params containing these keys, so we
-				// can safely overlay user params first and then stamp the
-				// reserved keys — collisions cannot reach here in a
-				// well-validated config.
-				input := map[string]any{}
-				for k, v := range chainSpec.Params {
-					input[k] = v
-				}
+				// Build input via the shared buildChainPayload kernel so the
+				// failure-path and success-path stamps stay in lockstep.
+				// Reserved keys (taskID, runID, status, output, _chain_depth)
+				// are populated by the engine and are NOT user-overridable;
+				// config-load validation (#236 Task 11) rejects any
+				// chainSpec.Params containing these keys, so collisions
+				// cannot reach here in a well-validated config.
+				input := buildChainPayload(chainSpec.Params, completedTaskID, runID, runStatus, output, nextDepth)
 				// Auto-fix safety default: when the chain target is the
 				// buildin auto-fix preset, force mode=review unless the
 				// operator explicitly set it. Autonomous-by-default would
 				// be a foot-gun (the agent could push directly to main
-				// without human review).
+				// without human review). Stamped AFTER the kernel so a
+				// chainSpec.Params{mode:"yolo"} entry still wins.
 				if targetID == "buildin/auto-fix" {
 					if _, ok := input["mode"]; !ok {
 						input["mode"] = "review"
 					}
 				}
-				input["taskID"] = completedTaskID
-				input["runID"] = runID
-				input["status"] = runStatus
-				input["output"] = output
-				input["_chain_depth"] = nextDepth
 
 				// Synchronously invoke fireAsync — it returns once startRun
 				// completes, then continues the run on its own goroutine.
@@ -1272,6 +1265,19 @@ func buildChainInput(userParams map[string]any, completedTaskID, runID, status s
 	if len(userParams) == 0 {
 		return output
 	}
+	return buildChainPayload(userParams, completedTaskID, runID, status, output, 0)
+}
+
+// buildChainPayload is the shared kernel that produces the input map fed to
+// any chained task — success-path (trigger.chain) AND failure-path
+// (on_failure_chain). Both sites used to inline the same five engine-key
+// stamps; the unification eliminates that drift (survey §5.4 / 6.2.3).
+//
+// Reserved keys (taskID, runID, status, output, _chain_depth) are always
+// stamped *after* the userParams overlay, so a (well-validated) user map
+// cannot collide. Config-load validation enforces the reserved-key
+// invariant at three sites; this helper is the runtime backstop.
+func buildChainPayload(userParams map[string]any, completedTaskID, runID, status string, output any, depth int) map[string]any {
 	m := make(map[string]any, len(userParams)+5)
 	for k, v := range userParams {
 		m[k] = v
@@ -1280,7 +1286,7 @@ func buildChainInput(userParams map[string]any, completedTaskID, runID, status s
 	m["runID"] = runID
 	m["status"] = status
 	m["output"] = output
-	m["_chain_depth"] = 0
+	m["_chain_depth"] = depth
 	return m
 }
 


### PR DESCRIPTION
## Summary

Implements the unification proposed in [`docs/superpowers/specs/2026-05-15-override-machinery-survey.md`](https://github.com/dicode-ayo/dicode-core/blob/chore/overrides-survey/docs/superpowers/specs/2026-05-15-override-machinery-survey.md) (commit 866b696 on `chore/overrides-survey`).

### What changes

- Extracts `buildChainPayload` shared between success-chain and failure-chain dispatch sites (collapses ~25 LOC of near-duplicate map-build, survey §5.4 / 6.2.3).
- Closes 3 latent footguns the survey identified:
  1. Resolver now re-validates the merged spec after applying overrides (was silently skipping — survey §5.1).
  2. `copySpec` now deep-clones `Trigger.Before`, `OnFailureChain`, and `RunInputs` (prevents per-firing override mutation from corrupting registry state — survey §5.3).
  3. `mergeOverrides` now strips reserved `chain.params` keys at the merge layer (matches load-time validation, defensive backstop — survey §5.2).

### Why now

Survey result called this "not urgent" but worth doing — no behavior change for the happy path, closes real bug surface for edge cases. Exposes `task.IsReservedChainParamKey` so the reserved-key set has a single source of truth.

### Commit layout (5 commits, each independently reviewable)

1. `test(trigger): pin override-merge footguns` — three failing tests, one per footgun.
2. `refactor(trigger): unify chain-input building between success and failure paths` — extract `buildChainPayload`.
3. `fix(taskset): validate spec after override merge in resolver` — footgun #1.
4. `fix(task): deep-clone Trigger.Before/OnFailureChain/RunInputs in copySpec` — footgun #2.
5. `fix(taskset): reject reserved chain.params keys in mergeOverrides` — footgun #3.

## Test plan

- [x] Three new tests pin each footgun. Each failed on parent commit (verified during TDD).
- [x] All existing tests still pass.
- [x] `make format-check` + `make lint` clean.
- [x] `go test ./... -timeout 120s` green.
- [x] `go test ./pkg/trigger/ ./pkg/taskset/ -race` green.
- [x] E2E composed pipeline test (TestE2E_TemplatePreflightPipeline) still green.