### PR TITLE
refactor(trigger): rename stringRet to coerceStringReturn

### DIFF
--- a/pkg/trigger/e2e_input_output_test.go
+++ b/pkg/trigger/e2e_input_output_test.go
@@ -304,8 +304,8 @@ func TestE2E_InputOutput_NonStringUpstreamFailsLoudly(t *testing.T) {
 	}
 
 	// Upstream — input-output-non-string-upstream fixture returns a
-	// JSON object. stringRet's contract turns every non-string return
-	// into "", which propagates as ErrInputUnavailable through
+	// JSON object. coerceStringReturn's contract turns every non-string
+	// return into "", which propagates as ErrInputUnavailable through
 	// ResolveInputOutputMap and causes the chain dispatch to skip with
 	// an error log. The downstream fixture's chain.from references
 	// this ID directly so no rebind is needed.

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -1101,7 +1101,7 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 		// returns are treated as "no upstream available" — the chain
 		// dispatch is skipped (logged) rather than silently passing the
 		// literal token to the downstream.
-		upstreamRet := stringRet(output)
+		upstreamRet := coerceStringReturn(output)
 		resolvedParams, rerr := task.ResolveInputOutputMap(chain.Params, upstreamRet)
 		if rerr != nil {
 			e.log.Error("chain trigger skipped — failed to resolve ${input.output}",
@@ -1214,7 +1214,7 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 				// silently passing the literal token to the downstream.
 				// Release the chainGuards slot we just acquired so a failed
 				// resolution doesn't burn cap_per_task / cap_global.
-				upstreamRet := stringRet(output)
+				upstreamRet := coerceStringReturn(output)
 				resolvedParams, rerr := task.ResolveInputOutputMap(chainSpec.Params, upstreamRet)
 				if rerr != nil {
 					e.guards.releaseSlot(completedTaskID)
@@ -1282,12 +1282,12 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 	}
 }
 
-// stringRet returns the upstream's return value as a string for
-// ${input.output} interpolation. JSON-marshalled objects, numbers,
-// and lists are NOT auto-stringified — only direct string returns
-// flow through. Non-string returns produce "" which propagates as
-// ErrInputUnavailable through the resolver.
-func stringRet(rv interface{}) string {
+// coerceStringReturn coerces any return value to a string for
+// ${input.output} interpolation. Non-string returns (objects, numbers,
+// nil) yield ”. The empty string then propagates as ErrInputUnavailable
+// through the resolver, which is the loud-failure path we want for
+// non-string upstreams.
+func coerceStringReturn(rv interface{}) string {
 	s, _ := rv.(string)
 	return s
 }

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -1283,10 +1283,10 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 }
 
 // coerceStringReturn coerces any return value to a string for
-// ${input.output} interpolation. Non-string returns (objects, numbers,
-// nil) yield ”. The empty string then propagates as ErrInputUnavailable
-// through the resolver, which is the loud-failure path we want for
-// non-string upstreams.
+// ${input.output} interpolation. JSON-marshalled objects, numbers,
+// and lists are NOT auto-stringified — only direct string returns
+// flow through. Non-string returns produce "" which propagates as
+// ErrInputUnavailable through the resolver.
 func coerceStringReturn(rv interface{}) string {
 	s, _ := rv.(string)
 	return s

--- a/pkg/trigger/engine_chain_params_test.go
+++ b/pkg/trigger/engine_chain_params_test.go
@@ -343,8 +343,8 @@ func TestChainDispatch_ResolvesInputOutput(t *testing.T) {
 	}
 }
 
-// strPtr is a tiny helper for the TestStringRet table — Go has no literal
-// syntax for "address of a string literal" so the typed-nil and
+// strPtr is a tiny helper for the TestCoerceStringReturn table — Go has no
+// literal syntax for "address of a string literal" so the typed-nil and
 // pointer-to-string cases need a helper to construct the *string.
 func strPtr(s string) *string { return &s }
 
@@ -434,9 +434,9 @@ func TestOnFailureChainDispatch_ResolvesInputOutput(t *testing.T) {
 // skipped: the literal ${input.output} token must NOT pass through
 // unresolved.
 //
-// PR2's stringRet() turns non-string returns into "", which propagates
-// as ErrInputUnavailable through ResolveInputOutputMap, which causes
-// the dispatch to log + return without firing the downstream.
+// PR2's coerceStringReturn() turns non-string returns into "", which
+// propagates as ErrInputUnavailable through ResolveInputOutputMap, which
+// causes the dispatch to log + return without firing the downstream.
 func TestOnFailureChainDispatch_NonStringUpstreamSkips(t *testing.T) {
 	dir := t.TempDir()
 	e := newTestEnv(t)
@@ -466,8 +466,8 @@ func TestOnFailureChainDispatch_NonStringUpstreamSkips(t *testing.T) {
 		t.Fatalf("finish parent run: %v", err)
 	}
 
-	// Non-string output: a map. stringRet returns "", resolver fails,
-	// dispatch must skip.
+	// Non-string output: a map. coerceStringReturn returns "", resolver
+	// fails, dispatch must skip.
 	e.engine.FireChain(context.Background(), "source-skip", parentRunID, registry.StatusFailure,
 		map[string]any{"nested": "object"})
 
@@ -482,12 +482,12 @@ func TestOnFailureChainDispatch_NonStringUpstreamSkips(t *testing.T) {
 	}
 }
 
-// TestStringRet pins the helper's contract: only direct-string returns
-// flow through; everything else (maps, slices, numbers, nil, typed-nil
-// interfaces, pointers-to-string) becomes "". The empty string then
-// propagates as ErrInputUnavailable through the resolver, which is the
-// loud-failure path we want for non-string upstreams.
-func TestStringRet(t *testing.T) {
+// TestCoerceStringReturn pins the helper's contract: only direct-string
+// returns flow through; everything else (maps, slices, numbers, nil,
+// typed-nil interfaces, pointers-to-string) becomes "". The empty string
+// then propagates as ErrInputUnavailable through the resolver, which is
+// the loud-failure path we want for non-string upstreams.
+func TestCoerceStringReturn(t *testing.T) {
 	var typedNilString *string // (*string)(nil); interface-wraps to a typed-nil
 	cases := []struct {
 		name string
@@ -505,8 +505,8 @@ func TestStringRet(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := stringRet(c.in); got != c.want {
-				t.Errorf("stringRet(%v) = %q; want %q", c.in, got, c.want)
+			if got := coerceStringReturn(c.in); got != c.want {
+				t.Errorf("coerceStringReturn(%v) = %q; want %q", c.in, got, c.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Renames the `stringRet` helper in `pkg/trigger/engine.go` to `coerceStringReturn`. The original name read like a getter ("the string return from somewhere") rather than what it actually does: take an `any` upstream return value and coerce it to a string for `${input.output}` interpolation, yielding `""` for non-string returns (objects, numbers, nil).

Flagged by reviewer on #310 — single helper, two call sites (success-chain and on_failure_chain dispatch), no behavior change.

Closes #319.

## Changes

- `pkg/trigger/engine.go`: rename function + doc comment + 2 call sites in `FireChain`.
- `pkg/trigger/engine_chain_params_test.go`: rename `TestStringRet` -> `TestCoerceStringReturn`, update comments in adjacent tests, update `strPtr` helper comment.
- `pkg/trigger/e2e_input_output_test.go`: update one comment reference.

No behavior change; type-checker + tests catch any miss.

## Test plan

- [x] `go test ./pkg/trigger/ -run TestCoerceStringReturn -v` — PASS (8/8 subtests)
- [x] `go test ./pkg/trigger/ -timeout 120s` — PASS (30.7s)
- [x] `make build && make format && make format-check` — clean

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>