### PR TITLE
chore(buildin): drop legacy notify blocks from remaining task.yaml files

### DIFF
--- a/pkg/task/spec_test.go
+++ b/pkg/task/spec_test.go
@@ -3,6 +3,7 @@ package task
 import (
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"strings"
 	"testing"
 	"time"
@@ -822,5 +823,60 @@ notify:
 	}
 	if !strings.Contains(err.Error(), "on_failure_chain") {
 		t.Errorf("error = %v; want mention of on_failure_chain migration", err)
+	}
+}
+
+// TestLoadDir_BuildinTasksParse walks every on-disk `tasks/buildin/*/task.yaml`
+// (and nested provider tasks like secret-providers/doppler/) and asserts that
+// LoadDir succeeds for each. This locks in the cleanup from #317 — a future
+// regression that reintroduces the legacy `notify:` block (or any other field
+// the strict validator rejects) surfaces immediately rather than waiting for a
+// downstream test to exercise the load path.
+func TestLoadDir_BuildinTasksParse(t *testing.T) {
+	_, thisFile, _, ok := goruntime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed; cannot anchor tasks/buildin path")
+	}
+	// thisFile is .../pkg/task/spec_test.go
+	// → repo root is two levels up from the file's directory.
+	pkgDir := filepath.Dir(thisFile)               // .../pkg/task
+	repoRoot := filepath.Dir(filepath.Dir(pkgDir)) // .../
+	buildinRoot := filepath.Join(repoRoot, "tasks", "buildin")
+	if _, err := os.Stat(buildinRoot); err != nil {
+		t.Fatalf("tasks/buildin not found at %s: %v", buildinRoot, err)
+	}
+
+	var taskDirs []string
+	err := filepath.Walk(buildinRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || filepath.Base(path) != "task.yaml" {
+			return nil
+		}
+		taskDirs = append(taskDirs, filepath.Dir(path))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", buildinRoot, err)
+	}
+	if len(taskDirs) == 0 {
+		t.Fatalf("no task.yaml files found under %s", buildinRoot)
+	}
+
+	for _, dir := range taskDirs {
+		rel, _ := filepath.Rel(repoRoot, dir)
+		t.Run(rel, func(t *testing.T) {
+			// Provide TASK_SET_DIR so tasks that reference ${TASK_SET_DIR}
+			// (e.g. ai-agent-claude-cli) resolve to a concrete path. The
+			// buildin source's effective TASK_SET_DIR is the tasks/buildin
+			// directory itself (where the taskset.yaml lives).
+			extras := map[string]string{
+				VarTaskSetDir: buildinRoot,
+			}
+			if _, err := LoadDirWithVars(dir, extras); err != nil {
+				t.Fatalf("LoadDirWithVars(%s): %v", dir, err)
+			}
+		})
 	}
 }

--- a/tasks/buildin/relay-server/task.yaml
+++ b/tasks/buildin/relay-server/task.yaml
@@ -215,7 +215,3 @@ permissions:
   env:
     - DICODE_DATADIR
     - DICODE_VERSION
-
-notify:
-  on_success: false
-  on_failure: true

--- a/tasks/buildin/write-local/task.yaml
+++ b/tasks/buildin/write-local/task.yaml
@@ -46,7 +46,3 @@ run_result:
   enabled: false
 
 timeout: 30s
-
-notify:
-  on_success: false
-  on_failure: true


### PR DESCRIPTION
## Summary

Closes #317.

PR #279 removed the per-task `notify:` field on origin/main and added a strict validator that rejects it at `task.LoadDir`. PR #310's CI hotfix (commit `6e1cc4a`) cleaned up `tasks/buildin/template/task.yaml`; PR #281 swept the rest at the time. After that, two new buildins landed still carrying the legacy block:

- `tasks/buildin/relay-server/task.yaml` (PR #311)
- `tasks/buildin/write-local/task.yaml` (PR #309)

The buildin source loader on origin/main doesn't currently go through the strict validator — it loads via a path that tolerates the legacy block. The failure surfaces only when something explicitly calls `task.LoadDir` on these tasks (which is what the PR #310 e2e for buildin/template did, exposing the issue).

The original issue listed 17 files; on the current origin/main only these 2 still had a `notify:` block remaining. Both are now cleaned.

## Files modified

- `tasks/buildin/relay-server/task.yaml` — removed trailing 3-line `notify:` block
- `tasks/buildin/write-local/task.yaml` — removed trailing 3-line `notify:` block
- `pkg/task/spec_test.go` — added `TestLoadDir_BuildinTasksParse`

## Smoke test

Added `TestLoadDir_BuildinTasksParse` in `pkg/task/spec_test.go`. It walks every on-disk `tasks/buildin/*/task.yaml` (including nested provider tasks like `secret-providers/doppler/`) and asserts `task.LoadDir` succeeds for each. Locks in the cleanup — any future regression that reintroduces a deprecated field surfaces immediately rather than waiting for a downstream test to exercise the load path.

## Test plan

- [x] `make build` clean
- [x] `make format` clean (no changes)
- [x] `make format-check` clean
- [x] `go test ./... -timeout 300s` — full suite passes
- [x] `TestLoadDir_BuildinTasksParse` covers all 20 buildin task.yaml files on disk and passes
- [x] No `on_failure_chain` added — these are library tasks; callers own their failure chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)