### PR TITLE
feat(buildin/template): template_path param to load body from a file

### DIFF
--- a/tasks/buildin/template/task.test.ts
+++ b/tasks/buildin/template/task.test.ts
@@ -311,6 +311,25 @@ Deno.test("resolveTemplateBody: empty-string template treated as not supplied", 
   );
 });
 
+Deno.test("resolveTemplateBody: rejects relative template_path", async () => {
+  // Defence in depth: docs promise template_path must be absolute. A
+  // relative path would silently resolve against Deno's cwd (not
+  // ${TASK_DIR}) and surprise operators. Fail loud before readFile.
+  await assertRejects(
+    () =>
+      resolveTemplateBody(
+        null,
+        "relative/path.tpl",
+        // readFile must NOT be reached.
+        () => {
+          throw new Error("readFile should not be called for relative path");
+        },
+      ),
+    Error,
+    'invalid template_path: must be absolute (got "relative/path.tpl")',
+  );
+});
+
 Deno.test("resolveTemplateBody: reads file via injected readFile", async () => {
   const out = await resolveTemplateBody(
     null,
@@ -376,6 +395,17 @@ Deno.test("main: rejects neither template nor template_path", async () => {
     () => main(stubSdk({})),
     Error,
     "either",
+  );
+});
+
+Deno.test("main: rejects_relative_template_path", async () => {
+  // Docs promise template_path must be absolute. A relative path would
+  // silently resolve against Deno's cwd, contradicting the contract.
+  // main() should fail loud with "must be absolute" before touching IO.
+  await assertRejects(
+    () => main(stubSdk({ template_path: "relative/path.tpl" })),
+    Error,
+    "must be absolute",
   );
 });
 

--- a/tasks/buildin/template/task.test.ts
+++ b/tasks/buildin/template/task.test.ts
@@ -11,6 +11,7 @@ import {
   buildEnvMap,
   collectPlaceholders,
   renderTemplate,
+  resolveTemplateBody,
 } from "./task.ts";
 
 // --- renderTemplate (pure) ---
@@ -211,21 +212,28 @@ Deno.test("main: missing env var produces unresolved-placeholder error", async (
   );
 });
 
-Deno.test("main: empty template returns empty string", async () => {
-  const out = await main(stubSdk({ template: "" }));
-  assertEquals(out, "");
+Deno.test("main: empty template treated as not supplied (loud failure)", async () => {
+  // An empty `template` is almost always a misconfiguration —
+  // typically an unresolved caller-side ${VAR} or an empty default
+  // fallback. Treat it the same as "neither supplied" so the failure
+  // is the loud XOR-validation error, not a silent empty render.
+  await assertRejects(
+    () => main(stubSdk({ template: "" })),
+    Error,
+    "either template or template_path must be supplied",
+  );
 });
 
-Deno.test("main: missing template param throws (engine enforces required)", async () => {
-  // No 'template' key in the stub; params.get returns null. task.yaml
-  // declares `template: required: true`, so the engine would reject
-  // the run upstream — but main() also guards against a null leaking
-  // through (no silent ?? "" fallback). The thrown error keeps the
-  // contract loud for programmatic callers.
+Deno.test("main: missing template param throws loud XOR-validation error", async () => {
+  // No 'template' or 'template_path' key in the stub; both
+  // params.get() calls return null. task.yaml no longer marks
+  // template as required (since template_path is an alternative), so
+  // the engine doesn't reject upstream — main() owns the loud-failure
+  // contract via resolveTemplateBody.
   await assertRejects(
     () => main(stubSdk({})),
     Error,
-    "missing required param: template",
+    "either template or template_path must be supplied",
   );
 });
 
@@ -267,4 +275,160 @@ Deno.test("main: prototype-shaped placeholder also fails loud", async () => {
     Error,
     "unresolved placeholder: ${__proto__}",
   );
+});
+
+// --- resolveTemplateBody (XOR + file IO) ---
+
+Deno.test("resolveTemplateBody: returns inline template verbatim", async () => {
+  const out = await resolveTemplateBody("hello ${X}", null);
+  assertEquals(out, "hello ${X}");
+});
+
+Deno.test("resolveTemplateBody: rejects both template and template_path", async () => {
+  await assertRejects(
+    () => resolveTemplateBody("inline", "/tmp/whatever"),
+    Error,
+    "both template and template_path supplied; exactly one is required",
+  );
+});
+
+Deno.test("resolveTemplateBody: rejects neither template nor template_path", async () => {
+  await assertRejects(
+    () => resolveTemplateBody(null, null),
+    Error,
+    "either template or template_path must be supplied",
+  );
+});
+
+Deno.test("resolveTemplateBody: empty-string template treated as not supplied", async () => {
+  // Empty value is almost always a misconfiguration (unresolved
+  // caller-side ${VAR}, empty default fallback) — fall through to
+  // the XOR error instead of returning an empty render.
+  await assertRejects(
+    () => resolveTemplateBody("", ""),
+    Error,
+    "either template or template_path must be supplied",
+  );
+});
+
+Deno.test("resolveTemplateBody: reads file via injected readFile", async () => {
+  const out = await resolveTemplateBody(
+    null,
+    "/fake/path.tpl",
+    (p) => {
+      assertEquals(p, "/fake/path.tpl");
+      return Promise.resolve("body from file ${X}");
+    },
+  );
+  assertEquals(out, "body from file ${X}");
+});
+
+Deno.test("resolveTemplateBody: wraps readFile errors with path context", async () => {
+  await assertRejects(
+    () =>
+      resolveTemplateBody(
+        null,
+        "/missing/path.tpl",
+        () =>
+          Promise.reject(
+            new Deno.errors.NotFound("No such file or directory"),
+          ),
+      ),
+    Error,
+    "reading template_path /missing/path.tpl: No such file or directory",
+  );
+});
+
+// --- main() + template_path end-to-end (real Deno.readTextFile) ---
+
+Deno.test("main: template_path reads file then renders", async () => {
+  // Write a temp file with a placeholder; set the corresponding env
+  // var; invoke main() with template_path pointing at the file.
+  const tmp = await Deno.makeTempFile({
+    prefix: "buildin-template-test-",
+    suffix: ".tpl",
+  });
+  try {
+    await Deno.writeTextFile(tmp, "greeting: ${TPL_TEST_GREETING}");
+    await withEnv({ TPL_TEST_GREETING: "hello" }, async () => {
+      const out = await main(stubSdk({ template_path: tmp }));
+      assertEquals(out, "greeting: hello");
+    });
+  } finally {
+    await Deno.remove(tmp).catch(() => {});
+  }
+});
+
+Deno.test("main: rejects both template and template_path", async () => {
+  await assertRejects(
+    () =>
+      main(stubSdk({
+        template: "inline body",
+        template_path: "/tmp/whatever.tpl",
+      })),
+    Error,
+    "exactly one",
+  );
+});
+
+Deno.test("main: rejects neither template nor template_path", async () => {
+  await assertRejects(
+    () => main(stubSdk({})),
+    Error,
+    "either",
+  );
+});
+
+Deno.test("main: template_path missing file produces loud wrapped error", async () => {
+  // Build a path that we know doesn't exist. mkdtemp + immediate
+  // remove keeps the parent dir valid (no surprise ENOTDIR) but
+  // guarantees ENOENT on the target file.
+  const dir = await Deno.makeTempDir({ prefix: "buildin-template-test-" });
+  const bogus = `${dir}/does-not-exist.tpl`;
+  try {
+    await assertRejects(
+      () => main(stubSdk({ template_path: bogus })),
+      Error,
+      `reading template_path ${bogus}:`,
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+// runningAsRoot returns true when this Deno process can read uid 0,
+// false otherwise (including the common case where --allow-sys=uid is
+// not granted and Deno.uid() throws NotCapable). chmod 0 is a no-op
+// for root, so the permission-denied test below uses this to skip
+// rather than emit a false pass.
+function runningAsRoot(): boolean {
+  try {
+    return Deno.uid?.() === 0;
+  } catch {
+    return false;
+  }
+}
+
+Deno.test({
+  name: "main: template_path permission-denied produces loud wrapped error",
+  // chmod 0 is meaningless on Windows; root on Linux can bypass mode bits.
+  // Skip on Windows and when running as uid 0 to avoid a flaky false-pass.
+  ignore: Deno.build.os === "windows" || runningAsRoot(),
+  async fn() {
+    const dir = await Deno.makeTempDir({ prefix: "buildin-template-test-" });
+    const path = `${dir}/unreadable.tpl`;
+    try {
+      await Deno.writeTextFile(path, "shouldn't be reachable");
+      await Deno.chmod(path, 0o000);
+      await assertRejects(
+        () => main(stubSdk({ template_path: path })),
+        Error,
+        `reading template_path ${path}:`,
+      );
+    } finally {
+      // Restore mode so the cleanup can remove the file.
+      await Deno.chmod(path, 0o600).catch(() => {});
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    }
+  },
 });

--- a/tasks/buildin/template/task.test.ts
+++ b/tasks/buildin/template/task.test.ts
@@ -286,7 +286,7 @@ Deno.test("resolveTemplateBody: returns inline template verbatim", async () => {
 
 Deno.test("resolveTemplateBody: rejects both template and template_path", async () => {
   await assertRejects(
-    () => resolveTemplateBody("inline", "/tmp/whatever"),
+    () => resolveTemplateBody("inline", "<unused-path>"),
     Error,
     "both template and template_path supplied; exactly one is required",
   );
@@ -364,7 +364,7 @@ Deno.test("main: rejects both template and template_path", async () => {
     () =>
       main(stubSdk({
         template: "inline body",
-        template_path: "/tmp/whatever.tpl",
+        template_path: "<unused-path>",
       })),
     Error,
     "exactly one",
@@ -403,7 +403,7 @@ Deno.test("main: template_path missing file produces loud wrapped error", async 
 // rather than emit a false pass.
 function runningAsRoot(): boolean {
   try {
-    return Deno.uid?.() === 0;
+    return Deno.uid() === 0;
   } catch {
     return false;
   }

--- a/tasks/buildin/template/task.ts
+++ b/tasks/buildin/template/task.ts
@@ -149,6 +149,15 @@ export async function resolveTemplateBody(
   }
   // hasPath
   const path = templatePath as string;
+  // Require an absolute path. task.yaml documents this contract; enforce
+  // it loudly here rather than letting a relative path resolve against
+  // Deno's cwd (which would silently diverge from ${TASK_DIR} and
+  // surprise operators). Mirrors buildin/write-local's path validation.
+  if (!path.startsWith("/")) {
+    throw new Error(
+      `invalid template_path: must be absolute (got ${JSON.stringify(path)})`,
+    );
+  }
   try {
     return await readFile(path);
   } catch (err) {

--- a/tasks/buildin/template/task.ts
+++ b/tasks/buildin/template/task.ts
@@ -1,5 +1,9 @@
-// buildin/template — render ${VAR} placeholders in a template string
+// buildin/template — render ${VAR} placeholders in a template body
 // using values from the task's environment.
+//
+// The template body is supplied either inline as a string (template
+// param) or by absolute path to a sibling file (template_path param).
+// Exactly one of the two is required; both or neither fails loudly.
 //
 // Invoke from another task:
 //
@@ -7,6 +11,11 @@
 //     template: "tunnel: ${ID}\nhost: ${HOST}",
 //   });
 //   // rendered === "tunnel: abc-123\nhost: api.example.com"
+//
+//   // ...or, for large templates, point at a sibling file:
+//   const rendered2 = await dicode.run_task("buildin/template", {
+//     template_path: "/abs/path/to/template.tpl",
+//   });
 //
 // The rendered string is returned from main() — the runtime ships it
 // back as the run result. task.yaml sets `run_result.enabled: false`,
@@ -101,17 +110,61 @@ export function buildEnvMap(
   return map;
 }
 
-export default async function main({ params }: TaskSdk): Promise<string> {
-  // No `?? ""` fallback here: task.yaml declares `template: required:
-  // true`, and the trigger engine rejects a run that's missing a
-  // required param before main() is invoked. If the engine ever lets a
-  // null slip through (programmatic in-process callers, future
-  // regressions), fail loudly with a clear message rather than
-  // silently rendering an empty string.
-  const template = await params.get("template");
-  if (template === null) {
-    throw new Error("missing required param: template");
+// resolveTemplateBody enforces the XOR contract between the inline
+// `template` param and the file-backed `template_path` param. Exported
+// for testability — the file-IO path is small but worth a unit test.
+//
+// Both supplied → loud failure: exactly one is required.
+// Neither supplied → loud failure: at least one is required.
+// `template` supplied → use it verbatim.
+// `template_path` supplied → read the file; wrap IO errors with a clear
+// "reading template_path <path>: <reason>" message so the user sees the
+// path that failed (ENOENT, EACCES, etc.) instead of a bare Deno error.
+//
+// Empty-string is treated as "not supplied" — a zero-length value for
+// either param is almost certainly a misconfiguration (unresolved
+// caller-side ${VAR}, or an empty default fallback) rather than an
+// intentional empty template. The XOR check uses `!= null && != ""`
+// so an empty value behaves the same as a missing param.
+export async function resolveTemplateBody(
+  template: string | null,
+  templatePath: string | null,
+  readFile: (path: string) => Promise<string> = Deno.readTextFile,
+): Promise<string> {
+  const hasTemplate = template !== null && template !== "";
+  const hasPath = templatePath !== null && templatePath !== "";
+
+  if (hasTemplate && hasPath) {
+    throw new Error(
+      "both template and template_path supplied; exactly one is required",
+    );
   }
+  if (!hasTemplate && !hasPath) {
+    throw new Error(
+      "either template or template_path must be supplied",
+    );
+  }
+  if (hasTemplate) {
+    return template as string;
+  }
+  // hasPath
+  const path = templatePath as string;
+  try {
+    return await readFile(path);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`reading template_path ${path}: ${msg}`);
+  }
+}
+
+export default async function main({ params }: TaskSdk): Promise<string> {
+  // XOR validation lives in resolveTemplateBody. task.yaml no longer
+  // marks `template` as required: the trigger engine therefore can't
+  // reject "neither supplied" upstream, so we own the loud-failure
+  // contract entirely here.
+  const template = await params.get("template");
+  const templatePath = await params.get("template_path");
+  const body = await resolveTemplateBody(template, templatePath);
 
   // Drive env lookups by the placeholders found in the template. Using
   // per-name Deno.env.get() is required: Deno.env.toObject() needs
@@ -119,11 +172,11 @@ export default async function main({ params }: TaskSdk): Promise<string> {
   // permissions.env is a finite allowlist that compiles down to
   // `--allow-env=NAME1,NAME2,...`. Per-name get() works under both
   // scoped and unrestricted permissions and respects the allowlist.
-  const names = collectPlaceholders(template);
+  const names = collectPlaceholders(body);
   const envMap = buildEnvMap(names, (name) => Deno.env.get(name));
 
   // renderTemplate throws on any unresolved placeholder. Let it
   // propagate — the runtime turns the exception into a failed run,
   // which is the desired loud-failure contract.
-  return renderTemplate(template, envMap);
+  return renderTemplate(body, envMap);
 }

--- a/tasks/buildin/template/task.yaml
+++ b/tasks/buildin/template/task.yaml
@@ -2,11 +2,13 @@ apiVersion: dicode/v1
 kind: Task
 name: "Template Renderer"
 description: |
-  Substitutes ${VAR} placeholders in a template string using values
-  from the task's environment. Returns rendered output via run-result
-  (suppressed from runs.return_value via run_result.enabled: false)
-  so the value flows to chain triggers and dicode.run_task callers
-  without crossing the persistence boundary.
+  Substitutes ${VAR} placeholders in a template body using values from
+  the task's environment. The template body can be supplied inline
+  (template) or read from a sibling file at run time (template_path) —
+  exactly one of the two is required. Returns rendered output via
+  run-result (suppressed from runs.return_value via
+  run_result.enabled: false) so the value flows to chain triggers and
+  dicode.run_task callers without crossing the persistence boundary.
 
   Operator usage patterns:
 
@@ -27,6 +29,25 @@ description: |
      buffers, and any tee/script captures. Don't do this for templates
      that embed secrets unless you've redirected output to a file.
 
+  3. Template body in a sibling file (template_path):
+     For large template bodies, callers can store the body in a sibling
+     file inside their task folder and pass its absolute path via
+     template_path (typically expanded from ${TASK_DIR}/body.tpl in the
+     caller's per-edge overrides.params.default). The renderer reads
+     the file at run time. The renderer task itself ships with
+     permissions.fs: [] — callers MUST declare the read scope on their
+     sibling file via their per-edge overrides.fs.r block. Example:
+
+       trigger:
+         before:
+           - task: buildin/template
+             overrides:
+               params:
+                 - name: template_path
+                   default: "${TASK_DIR}/cloudflared.tpl"
+               fs:
+                 r: ["${TASK_DIR}/cloudflared.tpl"]
+
 runtime: deno
 
 trigger:
@@ -43,8 +64,15 @@ run_result:
 params:
   template:
     type: string
-    required: true
-    description: "Template body with ${VAR} placeholders."
+    description: "Template body with ${VAR} placeholders. Mutually exclusive with template_path."
+  template_path:
+    type: string
+    description: |
+      Absolute path to a file containing the template body. The file is
+      read at task run time; ${VAR} placeholders are then resolved from
+      the task's declared env. Mutually exclusive with template; exactly
+      one of the two must be supplied. Callers must declare permissions.fs.r
+      on the sibling file via their per-edge overrides.fs block.
 
 permissions:
   # Empty by default: each call site declares which env vars (typically

--- a/tasks/buildin/template/task.yaml
+++ b/tasks/buildin/template/task.yaml
@@ -44,8 +44,7 @@ description: |
            - task: buildin/template
              overrides:
                params:
-                 - name: template_path
-                   default: "${TASK_DIR}/cloudflared.tpl"
+                 template_path: "${TASK_DIR}/cloudflared.tpl"
                fs:
                  - path: "${TASK_DIR}/cloudflared.tpl"
                    permission: r

--- a/tasks/buildin/template/task.yaml
+++ b/tasks/buildin/template/task.yaml
@@ -35,8 +35,9 @@ description: |
      template_path (typically expanded from ${TASK_DIR}/body.tpl in the
      caller's per-edge overrides.params.default). The renderer reads
      the file at run time. The renderer task itself ships with
-     permissions.fs: [] — callers MUST declare the read scope on their
-     sibling file via their per-edge overrides.fs.r block. Example:
+     permissions.fs: [] — the caller's `permissions.fs` block (or
+     per-edge `overrides.fs`) must declare read access to the file.
+     Example:
 
        trigger:
          before:
@@ -46,7 +47,8 @@ description: |
                  - name: template_path
                    default: "${TASK_DIR}/cloudflared.tpl"
                fs:
-                 r: ["${TASK_DIR}/cloudflared.tpl"]
+                 - path: "${TASK_DIR}/cloudflared.tpl"
+                   permission: r
 
 runtime: deno
 
@@ -64,15 +66,21 @@ run_result:
 params:
   template:
     type: string
-    description: "Template body with ${VAR} placeholders. Mutually exclusive with template_path."
+    description: |
+      Template body with ${VAR} placeholders. Mutually exclusive with
+      template_path. An empty-string value is treated as "not supplied"
+      for the XOR check, so an unresolved caller-side ${VAR} fails loud
+      instead of silently rendering an empty string.
   template_path:
     type: string
     description: |
       Absolute path to a file containing the template body. The file is
       read at task run time; ${VAR} placeholders are then resolved from
       the task's declared env. Mutually exclusive with template; exactly
-      one of the two must be supplied. Callers must declare permissions.fs.r
-      on the sibling file via their per-edge overrides.fs block.
+      one of the two must be supplied. An empty-string value is treated
+      as "not supplied" for the XOR check. The caller's `permissions.fs`
+      block (or per-edge `overrides.fs`) must declare read access to
+      the file (list-of-mappings form, e.g. `- path: ... permission: r`).
 
 permissions:
   # Empty by default: each call site declares which env vars (typically


### PR DESCRIPTION
## Summary

Closes #313.

Adds `template_path` to `buildin/template` as a mutually-exclusive
alternative to the existing inline `template` string param. Callers
can now keep large template bodies in a sibling file inside their task
folder instead of inlining them as multi-line YAML scalars in
`trigger.before` per-edge overrides.

### Contract

- `params.template_path` (string, optional): absolute path to the
  template body file. Resolved at task-load time via the existing
  `expandSpec` template-var path (so `${TASK_DIR}`, `${DATADIR}`,
  `${HOME}` work in caller `default:` values — `params[].default` is
  already covered by `pkg/task/template.go`).
- Exactly one of `template` / `template_path` must be supplied.
  - Both set: `"both template and template_path supplied; exactly one is required"`.
  - Neither set (or both empty): `"either template or template_path must be supplied"`.
- The file is read at run time via `Deno.readTextFile`. IO errors
  (ENOENT, EACCES, ...) are wrapped with
  `"reading template_path <path>: <reason>"` so the user sees the
  failing path instead of a bare Deno error.
- `permissions.fs` on the renderer task remains `[]`. Callers
  declare the read scope on their sibling file via per-edge
  `overrides.fs.r` — documented in the updated task.yaml description.

### Backwards compat

The existing `template` string param keeps working unchanged. The
only XOR-driven behavior change for legacy callers: an empty-string
`template` is now treated as "not supplied" (the loud XOR error
fires) rather than rendering an empty string. Empty templates are
almost always a misconfiguration (unresolved caller-side `${VAR}`,
empty default fallback), so this is the safer default. The previous
`template` `required: true` declaration is dropped because the XOR
check now owns the validation.

### Follow-up (out of scope)

`buildin/relay-server` ships ~100 lines of inlined template body in
its per-edge override. That can migrate to `template_path` in a
follow-up — not required for this PR, no behavior change without it.

## Test plan

- [x] `deno test --allow-read --allow-write --allow-env --config=tasks/deno.json tasks/buildin/template/task.test.ts` — 31 passed (16 original + 15 new).
- [x] `go test ./pkg/trigger/ -timeout 120s` — green, no regressions in the engine / e2e_relay_template_pipeline / e2e_template_preflight_pipeline tests.
- [x] `go test ./... -timeout 300s` — full suite green.
- [x] `make build && make format && make format-check` — clean.

New deno tests cover:
- `template_path` reads file then renders
- rejects both `template` and `template_path` (loud "exactly one" failure)
- rejects neither (loud "either" failure)
- empty-string `template` treated as not supplied
- missing file produces wrapped error including the path
- chmod-0 file produces wrapped error (skipped on Windows / when uid==0)
- `resolveTemplateBody` unit tests for the XOR + file-IO seam (injected readFile, error-wrap path).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>