### PR TITLE
feat(trigger,webui): distinguish failed-after-preflight from stopped

### DIFF
--- a/pkg/trigger/daemon_state.go
+++ b/pkg/trigger/daemon_state.go
@@ -27,7 +27,7 @@ func beforeContains(entries []task.BeforeEntry, taskID string) bool {
 // up — distinguishing "still waiting on the render task" from "render
 // failed" from "explicitly stopped".
 //
-// The five values are intentionally a closed set rather than a bag of
+// The six values are intentionally a closed set rather than a bag of
 // booleans. Adding a new phase should require an explicit case in any
 // switch that consumes this type.
 type DaemonState string
@@ -35,7 +35,8 @@ type DaemonState string
 const (
 	// DaemonStopped is the zero value. Returned for any task ID the engine
 	// hasn't tracked yet — including non-daemon tasks and unknown IDs — so
-	// callers don't have to special-case "not found".
+	// callers don't have to special-case "not found". Also the resting
+	// state after a deliberate Unregister or engine shutdown.
 	DaemonStopped DaemonState = "stopped"
 
 	// DaemonPrereqRunning indicates the engine has dispatched the daemon's
@@ -56,6 +57,17 @@ const (
 	// from DaemonStopped so operators can see the brief intermediate state
 	// during a prereq-driven restart.
 	DaemonStopping DaemonState = "stopping"
+
+	// DaemonFailedAfterPreflight indicates the daemon's preflight pipeline
+	// completed (or was deliberately skipped via skipPrereqs=true from the
+	// mid-pipeline re-fire path) but the subsequent fireAsync call to
+	// launch the daemon body failed — e.g. binary missing, port already
+	// bound, runtime resource exhaustion. Distinct from DaemonStopped so
+	// operators can tell "preflight is fine, daemon body broke" apart from
+	// "operator deliberately stopped it / never started it". Reachable
+	// only from startDaemonInternal's post-preflight error branch (issue
+	// #318).
+	DaemonFailedAfterPreflight DaemonState = "failed_after_preflight"
 )
 
 // daemonStateMap is a thread-safe taskID → DaemonState map. Kept as a

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -701,8 +701,19 @@ func (e *Engine) startDaemonInternal(spec *task.Spec, skipPrereqs bool) {
 
 	runID, err := e.fireAsync(context.Background(), spec, pkgruntime.RunOptions{}, registry.TriggerDaemon)
 	if err != nil {
-		e.setDaemonState(spec.ID, DaemonStopped)
-		e.log.Error("daemon start failed", zap.String("task", spec.ID), zap.Error(err))
+		// Preflight already ran (or was deliberately skipped via
+		// skipPrereqs=true from the mid-pipeline re-fire path). The
+		// fireAsync error here is a daemon-body launch failure — binary
+		// missing, port already bound, runtime resource exhaustion. Distinct
+		// from DaemonStopped so operators can tell "deliberately stopped /
+		// never started" apart from "preflight passed, daemon body broke"
+		// in the WebUI. See issue #318.
+		e.setDaemonState(spec.ID, DaemonFailedAfterPreflight)
+		e.log.Error("daemon start failed after preflight",
+			zap.String("task", spec.ID),
+			zap.Bool("skip_prereqs", skipPrereqs),
+			zap.Error(err),
+		)
 		return
 	}
 	e.daemonMu.Lock()

--- a/pkg/trigger/engine_preflight_test.go
+++ b/pkg/trigger/engine_preflight_test.go
@@ -89,10 +89,17 @@ func TestDaemonState_Default(t *testing.T) {
 }
 
 // TestDaemonState_SetGet verifies that setDaemonState/DaemonState round-trip
-// the five enum values without contention.
+// the six enum values without contention.
 func TestDaemonState_SetGet(t *testing.T) {
 	e := newTestEnv(t)
-	states := []DaemonState{DaemonPrereqRunning, DaemonPrereqFailed, DaemonRunning, DaemonStopping, DaemonStopped}
+	states := []DaemonState{
+		DaemonPrereqRunning,
+		DaemonPrereqFailed,
+		DaemonRunning,
+		DaemonStopping,
+		DaemonFailedAfterPreflight,
+		DaemonStopped,
+	}
 	for _, want := range states {
 		e.engine.setDaemonState("d", want)
 		if got := e.engine.DaemonState("d"); got != want {
@@ -1519,5 +1526,77 @@ func TestRegister_RejectsDuplicateBeforeTask(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "multiple times") {
 		t.Errorf("expected error mentioning duplication, got: %v", err)
+	}
+}
+
+// TestStartDaemonInternal_FireAsyncFailureAfterPreflight verifies that when
+// startDaemonInternal's preflight stage succeeds (or is deliberately skipped
+// via skipPrereqs=true from the mid-pipeline re-fire path) but the
+// subsequent fireAsync fails, the daemon transitions to
+// DaemonFailedAfterPreflight — NOT to the generic DaemonStopped.
+//
+// Operators looking at the WebUI must be able to tell "preflight is fine,
+// daemon body broke" apart from "deliberately stopped / never started".
+// See issue #318 for the motivating scenario (Doppler-rotated relay-server
+// preflight succeeds, but the daemon's docker run fails on a port-already-
+// bound or image-pull error).
+//
+// We force the fireAsync failure by closing the underlying DB so
+// StartRunWithID — the first thing startRun does inside fireAsync — fails.
+// That's a low-fidelity stand-in for the real failure modes (binary
+// missing, port bound) but exercises the same code path: fireAsync returns
+// an error, startDaemonInternal hits its post-preflight error branch, and
+// the state assignment is the system-under-test.
+func TestStartDaemonInternal_FireAsyncFailureAfterPreflight(t *testing.T) {
+	// Build the env inline so we own the DB and can close it
+	// out from under the engine to force fireAsync to fail.
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	reg := registry.New(d)
+	exec := newPreflightExec(reg)
+	eng := New(reg, exec, zap.NewNop())
+	eng.RegisterExecutor(task.RuntimeDocker, exec)
+
+	// No preflight stages — keeps the test focused on the post-preflight
+	// fireAsync failure. With skipPrereqs=false and an empty Before list,
+	// startDaemonInternal goes straight to the fireAsync call, which is
+	// the exact branch the issue is about.
+	daemon := &task.Spec{
+		ID:      "d",
+		Name:    "d",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{Daemon: true, Restart: "never"},
+		Enabled: true,
+	}
+	if err := reg.Register(daemon); err != nil {
+		t.Fatalf("reg.Register: %v", err)
+	}
+
+	// Close the DB so any subsequent registry write (StartRunWithID, in
+	// our case) fails. Mirrors what would happen if disk space ran out or
+	// the DB connection was severed mid-operation.
+	if err := d.Close(); err != nil {
+		t.Fatalf("db.Close: %v", err)
+	}
+
+	// Drive startDaemonInternal directly with skipPrereqs=true — mirrors
+	// the call path used by propagateBeforeRerun (the issue's motivating
+	// scenario). Synchronous: fireAsync returns the error inline, so we
+	// can assert the state immediately without polling.
+	eng.startDaemonInternal(daemon, true)
+
+	if got := eng.DaemonState("d"); got != DaemonFailedAfterPreflight {
+		t.Fatalf("DaemonState = %q, want %q (must distinguish post-preflight failure from deliberately-stopped)",
+			got, DaemonFailedAfterPreflight)
+	}
+
+	// Sanity check: a daemon that was never started and never failed
+	// must NOT appear as failed_after_preflight — that would be a false
+	// positive on every fresh task.
+	if got := eng.DaemonState("never-touched"); got != DaemonStopped {
+		t.Errorf("DaemonState(unknown) = %q, want %q", got, DaemonStopped)
 	}
 }

--- a/pkg/trigger/engine_preflight_test.go
+++ b/pkg/trigger/engine_preflight_test.go
@@ -1600,3 +1600,59 @@ func TestStartDaemonInternal_FireAsyncFailureAfterPreflight(t *testing.T) {
 		t.Errorf("DaemonState(unknown) = %q, want %q", got, DaemonStopped)
 	}
 }
+
+// TestStartDaemonInternal_FireAsyncFailureFirstBoot covers the sibling
+// branch of TestStartDaemonInternal_FireAsyncFailureAfterPreflight:
+// startDaemonInternal called with skipPrereqs=false (the first-boot path
+// taken by Engine.startDaemon when a daemon is initially scheduled). With
+// an empty trigger.before list the prereq block is skipped and execution
+// falls straight through to fireAsync — same error branch, different
+// caller — so the engine MUST still record DaemonFailedAfterPreflight
+// rather than DaemonStopped.
+//
+// The engine change in issue #318 applies to BOTH callers
+// (propagateBeforeRerun's skipPrereqs=true and the first-boot
+// skipPrereqs=false); without this sibling test, regressions on the
+// first-boot branch would pass CI.
+//
+// Same DB-close stand-in as the skipPrereqs=true sibling.
+func TestStartDaemonInternal_FireAsyncFailureFirstBoot(t *testing.T) {
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	reg := registry.New(d)
+	exec := newPreflightExec(reg)
+	eng := New(reg, exec, zap.NewNop())
+	eng.RegisterExecutor(task.RuntimeDocker, exec)
+
+	// Empty Before list + skipPrereqs=false means startDaemonInternal
+	// skips its prereq block via the len(spec.Trigger.Before) > 0 guard
+	// and goes straight to fireAsync — the exact branch this sibling
+	// covers. Adding stages here would couple the test to runPrereqs's
+	// behavior, which is not the system under test.
+	daemon := &task.Spec{
+		ID:      "d",
+		Name:    "d",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{Daemon: true, Restart: "never"},
+		Enabled: true,
+	}
+	if err := reg.Register(daemon); err != nil {
+		t.Fatalf("reg.Register: %v", err)
+	}
+
+	if err := d.Close(); err != nil {
+		t.Fatalf("db.Close: %v", err)
+	}
+
+	// skipPrereqs=false — the first-boot branch. fireAsync still fails
+	// (DB closed), so the state assignment must match the sibling test.
+	eng.startDaemonInternal(daemon, false)
+
+	if got := eng.DaemonState("d"); got != DaemonFailedAfterPreflight {
+		t.Fatalf("DaemonState = %q, want %q (first-boot path must record post-preflight failure identically to the mid-pipeline re-fire path)",
+			got, DaemonFailedAfterPreflight)
+	}
+}

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -1363,8 +1363,10 @@ type TaskDetail struct {
 
 	// DaemonState surfaces the engine's preflight/lifecycle phase for
 	// daemon tasks. Empty for non-daemon tasks so the WebUI can hide the
-	// row entirely. Five-value enum — see pkg/trigger.DaemonState for the
-	// canonical list.
+	// row entirely. Six-value enum — see pkg/trigger.DaemonState for the
+	// canonical list. The "failed_after_preflight" value is distinct from
+	// "stopped" so operators can tell "daemon body broke" apart from
+	// "deliberately stopped" (issue #318).
 	DaemonState string `json:"daemon_state,omitempty"`
 }
 

--- a/tasks/buildin/webui/app/components/dc-task-detail.js
+++ b/tasks/buildin/webui/app/components/dc-task-detail.js
@@ -366,6 +366,9 @@ class DcTaskDetail extends LitElement {
   // from "stopped" so operators can tell "preflight passed, daemon body
   // broke" apart from "deliberately stopped" (issue #318).
   _renderDaemonState(state) {
+    // Keep keys in sync with the DaemonState constants in
+    // pkg/trigger/daemon_state.go — out-of-sync entries fall through
+    // to the generic-text fallback below at render time.
     const STYLES = {
       running:                { bg: 'rgba(166, 227, 161, .15)', fg: 'var(--green)',  text: 'Running' },
       prereq_running:         { bg: 'rgba(137, 220, 235, .15)', fg: 'var(--sky)',    text: 'Preflight running…' },

--- a/tasks/buildin/webui/app/components/dc-task-detail.js
+++ b/tasks/buildin/webui/app/components/dc-task-detail.js
@@ -358,6 +358,30 @@ class DcTaskDetail extends LitElement {
       ${expanded ? item.runs.map(r => this._renderRunRow(r, { indent: 1 })) : ''}`;
   }
 
+  // Renders the daemon lifecycle phase as a colored badge in the trigger
+  // row. The engine reports a six-value enum (see pkg/trigger.DaemonState);
+  // the mapping below keeps colors aligned with the surrounding UI palette:
+  // green for healthy, yellow/sky for transient, red for failure, muted for
+  // resting. The "failed_after_preflight" badge is deliberately distinct
+  // from "stopped" so operators can tell "preflight passed, daemon body
+  // broke" apart from "deliberately stopped" (issue #318).
+  _renderDaemonState(state) {
+    const STYLES = {
+      running:                { bg: 'rgba(166, 227, 161, .15)', fg: 'var(--green)',  text: 'Running' },
+      prereq_running:         { bg: 'rgba(137, 220, 235, .15)', fg: 'var(--sky)',    text: 'Preflight running…' },
+      stopping:               { bg: 'rgba(249, 226, 175, .15)', fg: 'var(--yellow)', text: 'Stopping…' },
+      prereq_failed:          { bg: 'rgba(243, 139, 168, .15)', fg: 'var(--red)',    text: 'Preflight failed' },
+      failed_after_preflight: { bg: 'rgba(243, 139, 168, .15)', fg: 'var(--red)',    text: 'Crashed after preflight ✓' },
+      stopped:                { bg: 'rgba(166, 173, 200, .15)', fg: 'var(--muted)',  text: 'Stopped' },
+    };
+    const s = STYLES[state] || { bg: 'rgba(166, 173, 200, .15)', fg: 'var(--muted)', text: state };
+    return html`<span
+      data-daemon-state=${state}
+      title="Daemon state: ${state}"
+      style="font-size:0.75rem;font-weight:600;padding:2px 8px;border-radius:9999px;background:${s.bg};color:${s.fg};white-space:nowrap"
+      >${s.text}</span>`;
+  }
+
   _triggerFields() {
     const t = this._task?.trigger || this._task?.Trigger || {};
     const type = this._triggerType;
@@ -413,6 +437,7 @@ class DcTaskDetail extends LitElement {
 
       <div class="card" style="margin-bottom:var(--space-md);display:flex;align-items:center;gap:0.75rem">
         <span style="font-size:0.85rem"><strong>Trigger:</strong> ${task.trigger_label || 'manual'}</span>
+        ${task.daemon_state ? this._renderDaemonState(task.daemon_state) : ''}
         <button class="btn btn-sm" style="background:var(--muted);margin-left:auto"
           @click=${() => { this._triggerOpen = !this._triggerOpen; }}>&#9998; Edit trigger</button>
       </div>


### PR DESCRIPTION
## Summary

Closes #318.

PR #311 introduced `startDaemonInternal(spec, skipPrereqs bool)` so mid-pipeline re-fires (Doppler rotation re-runs the renderer) don't double-fire upstream stages. When step 4 of that flow — the post-propagation `fireAsync` to restart the daemon — fails (binary missing, port bound, runtime resource exhaustion), the engine transitioned to `DaemonStopped`, which is the same state used to represent a deliberately-stopped daemon. The WebUI rendered both identically, making troubleshooting harder.

Same issue applied to the `skipPrereqs=false` path: a daemon whose preflight passed but whose `fireAsync` failed showed up as plain "stopped".

## Design choice — Option A (new state)

Picked **Option A** (new state `DaemonFailedAfterPreflight`) over **Option B** (a sibling `failureReason` field on `DaemonStopped`).

Rationale (documented in the commit message too):
- `pkg/trigger.DaemonState`'s comment already declares it "a closed set rather than a bag of booleans" with every consumer required to handle each case in a switch.
- A sibling reason field would let consumers silently miss the failed-after-preflight signal — exactly the bug we're fixing.
- The new state serializes naturally over the existing `daemon_state` JSON field; no DTO surface changes.

## Engine change

Single call-site change in `startDaemonInternal`: the post-`fireAsync` error branch now transitions to `DaemonFailedAfterPreflight` instead of `DaemonStopped`, and the log line is augmented with the `skip_prereqs` flag.

The `Unregister` / `Shutdown` paths (the "deliberately stopped" case) are unchanged; they never called `setDaemonState` directly, so `DaemonStopped` remains the resting state for unknown/unregistered daemons via the zero-value contract in `daemonStateMap.get`.

`propagateBeforeRerun`'s logic is untouched per the issue's out-of-scope note — only the error-path state assignment in the daemon-start helper matters.

## WebUI change

`tasks/buildin/webui/app/components/dc-task-detail.js` now renders the daemon state as a colored pill next to the **Trigger:** label:

| State | Pill text | Color |
| --- | --- | --- |
| `running` | "Running" | green |
| `prereq_running` | "Preflight running…" | sky |
| `stopping` | "Stopping…" | yellow |
| `prereq_failed` | "Preflight failed" | red |
| **`failed_after_preflight`** | **"Crashed after preflight ✓"** | **red** |
| `stopped` | "Stopped" | muted |

The "✓" in the failed-after-preflight pill is the signal: preflight succeeded, but the daemon body broke. The pill carries a `data-daemon-state` attribute and a `title` tooltip with the raw enum value for power users / DOM-inspecting operators.

Non-daemon tasks emit `daemon_state=""` from the API (existing behaviour) so the pill is hidden — no "Stopped" badges spamming every cron job.

## Tests

- `pkg/trigger/engine_preflight_test.go`:
  - Extended `TestDaemonState_SetGet` to cover the new enum value.
  - Added `TestStartDaemonInternal_FireAsyncFailureAfterPreflight` — closes the DB out from under the engine, invokes `startDaemonInternal(spec, true)` (mirrors the mid-pipeline re-fire path), and asserts the daemon transitions to `DaemonFailedAfterPreflight`, not `DaemonStopped`.
- `pkg/webui/server.go` doc comment updated to reflect the six-value enum and the issue.

## Test plan

- [x] `go test ./pkg/trigger/ ./pkg/webui/ -timeout 180s` — green
- [x] `make build` — green
- [x] `make format && make format-check` — clean
- [ ] Manual smoke: register a daemon with `runtime: docker` and a missing image, observe the WebUI shows "Crashed after preflight ✓" in red rather than "Stopped"

🤖 Generated with [Claude Code](https://claude.com/claude-code)