### PR TITLE
refactor(buildin/relay-server): use template_path to externalize relay.yaml

### DIFF
--- a/tasks/buildin/relay-server/relay.yaml
+++ b/tasks/buildin/relay-server/relay.yaml
@@ -1,0 +1,82 @@
+server:
+  port: 5553
+  base_url: ${BASE_URL}
+  tls:
+    cert_file: ""
+    key_file: ""
+status:
+  password: ${STATUS_PASSWORD}
+relay:
+  timestamp_tolerance_s: 30
+  ping_interval_ms: 30000
+  pong_timeout_ms: 10000
+  request_timeout_ms: 30000
+  nonce_ttl_ms: 60000
+broker:
+  session_ttl_ms: 300000
+  signing_key_file: ${DICODE_DATADIR}/relay/broker-signing.key
+  providers:
+    github:
+      client_id: ${GITHUB_CLIENT_ID}
+      client_secret: ${GITHUB_CLIENT_SECRET}
+      pkce: true
+      scopes: [user, repo]
+    slack:
+      client_id: ${SLACK_CLIENT_ID}
+      pkce: true
+      scopes: [channels:read]
+    google:
+      client_id: ${GOOGLE_CLIENT_ID}
+      client_secret: ${GOOGLE_CLIENT_SECRET}
+      pkce: true
+      scopes: ["https://www.googleapis.com/auth/userinfo.email"]
+    spotify:
+      client_id: ${SPOTIFY_CLIENT_ID}
+      pkce: true
+      scopes: [user-read-private, user-read-email]
+    linear:
+      client_id: ${LINEAR_CLIENT_ID}
+      pkce: true
+      scopes: [read]
+    discord:
+      client_id: ${DISCORD_CLIENT_ID}
+      pkce: true
+      scopes: [identify, email]
+    gitlab:
+      client_id: ${GITLAB_CLIENT_ID}
+      client_secret: ${GITLAB_CLIENT_SECRET}
+      pkce: true
+      scopes: [read_user, read_api]
+    airtable:
+      client_id: ${AIRTABLE_CLIENT_ID}
+      client_secret: ${AIRTABLE_CLIENT_SECRET}
+      pkce: true
+      scopes: ["data.records:read"]
+    notion:
+      client_id: ${NOTION_CLIENT_ID}
+      client_secret: ${NOTION_CLIENT_SECRET}
+      pkce: false
+      scopes: []
+    confluence:
+      client_id: ${CONFLUENCE_CLIENT_ID}
+      pkce: true
+      scopes: ["read:me", "read:confluence-content.all", offline_access]
+    salesforce:
+      client_id: ${SALESFORCE_CLIENT_ID}
+      pkce: true
+      scopes: [api, refresh_token]
+    stripe:
+      client_id: ${STRIPE_CLIENT_ID}
+      client_secret: ${STRIPE_CLIENT_SECRET}
+      pkce: false
+      scopes: [read_write]
+    office365:
+      client_id: ${OFFICE365_CLIENT_ID}
+      client_secret: ${OFFICE365_CLIENT_SECRET}
+      pkce: true
+      scopes: [offline_access, User.Read, Mail.Read]
+    azure:
+      client_id: ${AZURE_CLIENT_ID}
+      client_secret: ${AZURE_CLIENT_SECRET}
+      pkce: true
+      scopes: [openid, profile, email, offline_access]

--- a/tasks/buildin/relay-server/task.yaml
+++ b/tasks/buildin/relay-server/task.yaml
@@ -7,7 +7,8 @@ description: |
   The relay's config (relay.yaml) is rendered by a 2-stage preflight
   pipeline before this daemon starts:
 
-    1. buildin/template renders the YAML body, substituting
+    1. buildin/template reads the renderer's template body from the
+       sibling relay.yaml (via the template_path param) and substitutes
        ${BASE_URL}, ${STATUS_PASSWORD}, and per-provider OAuth
        client_id/client_secret values from the env declared below
        (mix of literal value and Doppler-fed entries).
@@ -35,93 +36,10 @@ trigger:
       overrides:
         timeout: 30s
         params:
-          # The template body below is inlined here because buildin/template
-          # only accepts a `template: <string>` param. A future buildin/template
-          # `template_path:` param would let this body live in a sibling YAML
-          # file. Tracked as a follow-up to PR #311.
-          template: |
-            server:
-              port: 5553
-              base_url: ${BASE_URL}
-              tls:
-                cert_file: ""
-                key_file: ""
-            status:
-              password: ${STATUS_PASSWORD}
-            relay:
-              timestamp_tolerance_s: 30
-              ping_interval_ms: 30000
-              pong_timeout_ms: 10000
-              request_timeout_ms: 30000
-              nonce_ttl_ms: 60000
-            broker:
-              session_ttl_ms: 300000
-              signing_key_file: ${DICODE_DATADIR}/relay/broker-signing.key
-              providers:
-                github:
-                  client_id: ${GITHUB_CLIENT_ID}
-                  client_secret: ${GITHUB_CLIENT_SECRET}
-                  pkce: true
-                  scopes: [user, repo]
-                slack:
-                  client_id: ${SLACK_CLIENT_ID}
-                  pkce: true
-                  scopes: [channels:read]
-                google:
-                  client_id: ${GOOGLE_CLIENT_ID}
-                  client_secret: ${GOOGLE_CLIENT_SECRET}
-                  pkce: true
-                  scopes: ["https://www.googleapis.com/auth/userinfo.email"]
-                spotify:
-                  client_id: ${SPOTIFY_CLIENT_ID}
-                  pkce: true
-                  scopes: [user-read-private, user-read-email]
-                linear:
-                  client_id: ${LINEAR_CLIENT_ID}
-                  pkce: true
-                  scopes: [read]
-                discord:
-                  client_id: ${DISCORD_CLIENT_ID}
-                  pkce: true
-                  scopes: [identify, email]
-                gitlab:
-                  client_id: ${GITLAB_CLIENT_ID}
-                  client_secret: ${GITLAB_CLIENT_SECRET}
-                  pkce: true
-                  scopes: [read_user, read_api]
-                airtable:
-                  client_id: ${AIRTABLE_CLIENT_ID}
-                  client_secret: ${AIRTABLE_CLIENT_SECRET}
-                  pkce: true
-                  scopes: ["data.records:read"]
-                notion:
-                  client_id: ${NOTION_CLIENT_ID}
-                  client_secret: ${NOTION_CLIENT_SECRET}
-                  pkce: false
-                  scopes: []
-                confluence:
-                  client_id: ${CONFLUENCE_CLIENT_ID}
-                  pkce: true
-                  scopes: ["read:me", "read:confluence-content.all", offline_access]
-                salesforce:
-                  client_id: ${SALESFORCE_CLIENT_ID}
-                  pkce: true
-                  scopes: [api, refresh_token]
-                stripe:
-                  client_id: ${STRIPE_CLIENT_ID}
-                  client_secret: ${STRIPE_CLIENT_SECRET}
-                  pkce: false
-                  scopes: [read_write]
-                office365:
-                  client_id: ${OFFICE365_CLIENT_ID}
-                  client_secret: ${OFFICE365_CLIENT_SECRET}
-                  pkce: true
-                  scopes: [offline_access, User.Read, Mail.Read]
-                azure:
-                  client_id: ${AZURE_CLIENT_ID}
-                  client_secret: ${AZURE_CLIENT_SECRET}
-                  pkce: true
-                  scopes: [openid, profile, email, offline_access]
+          template_path: "${TASK_DIR}/relay.yaml"
+        fs:
+          - path: "${TASK_DIR}/relay.yaml"
+            permission: r
         env:
           - name: DICODE_DATADIR
           - name: BASE_URL


### PR DESCRIPTION
## Summary

Migrates `tasks/buildin/relay-server/relay.yaml` back to a sibling file (where it lived before PR #311) using the new `template_path` param shipped in PR #323. The ~80-line inlined multi-line YAML scalar in `task.yaml`'s `before[0].overrides.params.template:` block is replaced with a `template_path:` reference plus a one-entry `fs:` block granting `buildin/template` read access to the file.

Closes #326.

## Before / after

```yaml
# Before
trigger:
  before:
    - task: buildin/template
      overrides:
        timeout: 30s
        params:
          template: |
            server:
              port: 5553
              base_url: ${BASE_URL}
              ...
              (~80 lines)
        env:
          # Doppler env block
```

```yaml
# After
trigger:
  before:
    - task: buildin/template
      overrides:
        timeout: 30s
        params:
          template_path: "${TASK_DIR}/relay.yaml"
        fs:
          - path: "${TASK_DIR}/relay.yaml"
            permission: r
        env:
          # Doppler env block (unchanged)
```

## Why

PR #311 inlined relay.yaml into `task.yaml` as a stopgap because `buildin/template` only accepted `template: <string>`. PR #323 shipped `template_path:` to address this. This PR completes the migration that was flagged as a known wart in #311's spec.

After: `task.yaml` 135 lines (was 218), sibling `relay.yaml` 82 lines, total ~217 lines vs 218 before — but split into a cleaner two-file layout.

## Behavior

Unchanged — `buildin/template` reads the same body at preflight and renders the same output. The Doppler env block on stage 1's per-edge override is preserved verbatim. Verified the dedented inlined body matches the new `relay.yaml` byte-for-byte.

## Test plan

- [x] `make build` clean
- [x] `make format && make format-check` clean
- [x] `go test ./... -timeout 300s` green (all packages pass)
- [x] `go test ./pkg/task/ -run TestLoadDir_BuildinTasksParse -v` — relay-server subtest passes (strict validator added in #279 accepts the new shape)
- [x] `go test ./pkg/trigger/ -run TestE2E_RelayTemplatePipeline -timeout 180s -v` green
- [x] Deno test: `deno test --allow-read --allow-write --allow-env --config=tasks/deno.json tasks/buildin/relay-server/task.test.ts` — 4 passed, 0 failed