### PR TITLE
feat(trigger,webui): distinguish crashed daemon from cleanly-stopped

### DIFF
--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -348,9 +348,9 @@ issue requesting a `parallel: true` opt-in.
 Daemons cycle through a small set of states observable in the WebUI
 and via the REST API's `daemon_state` field:
 
-- `stopped` — Resting state. Either the daemon was deliberately
-  stopped, the engine never started it, or it ran to completion with
-  no restart configured.
+- `stopped` — Resting state (clean-exit case). Either the daemon was
+  deliberately stopped, the engine never started it, or it ran to
+  completion with `status: success` and no restart is configured.
 - `prereq_running` — The `trigger.before` pipeline is executing.
 - `prereq_failed` — One stage of the preflight pipeline returned a
   non-success status. The daemon will not start until the failing
@@ -364,8 +364,10 @@ and via the REST API's `daemon_state` field:
   from the WebUI's task list via the Run button, or from the CLI
   via `dicode run <task-id>`.
 - `crashed` — The daemon's body ran but exited with a non-success
-  status (failure, timeout, etc.) and the configured restart policy
-  isn't going to restart it. Terminal: an operator must re-fire the
+  status (failure, cancelled, etc.) and the configured restart policy
+  isn't going to restart it. The success/failure split versus
+  `stopped` is explicit: clean exits land in `stopped`, non-clean
+  exits land in `crashed`. Terminal: an operator must re-fire the
   daemon to retry.
 
 For an end-to-end example combining daemon preflight, per-edge

--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -363,6 +363,10 @@ and via the REST API's `daemon_state` field:
   Terminal: an operator must re-fire the daemon task to retry —
   from the WebUI's task list via the Run button, or from the CLI
   via `dicode run <task-id>`.
+- `crashed` — The daemon's body ran but exited with a non-success
+  status (failure, timeout, etc.) and the configured restart policy
+  isn't going to restart it. Terminal: an operator must re-fire the
+  daemon to retry.
 
 For an end-to-end example combining daemon preflight, per-edge
 overrides, `${DATADIR}` volumes, and `run_result.enabled: false`, see

--- a/pkg/trigger/daemon_state.go
+++ b/pkg/trigger/daemon_state.go
@@ -72,8 +72,8 @@ const (
 	DaemonFailedAfterPreflight DaemonState = "failed_after_preflight"
 
 	// DaemonCrashed indicates the daemon's body successfully started but
-	// then exited with a non-success status (failure, timeout, etc.) AND
-	// the configured restart policy will NOT restart it — i.e. either
+	// then exited with any non-success status (failure, cancelled, etc.)
+	// AND the configured restart policy will NOT restart it — i.e. either
 	// restart=never, or restart=on-failure with a status the engine
 	// doesn't treat as a failure. Reachable only from
 	// onDaemonRunFinished's no-restart branch.

--- a/pkg/trigger/daemon_state.go
+++ b/pkg/trigger/daemon_state.go
@@ -27,7 +27,7 @@ func beforeContains(entries []task.BeforeEntry, taskID string) bool {
 // up — distinguishing "still waiting on the render task" from "render
 // failed" from "explicitly stopped".
 //
-// The six values are intentionally a closed set rather than a bag of
+// The seven values are intentionally a closed set rather than a bag of
 // booleans. Adding a new phase should require an explicit case in any
 // switch that consumes this type.
 type DaemonState string
@@ -36,7 +36,9 @@ const (
 	// DaemonStopped is the zero value. Returned for any task ID the engine
 	// hasn't tracked yet — including non-daemon tasks and unknown IDs — so
 	// callers don't have to special-case "not found". Also the resting
-	// state after a deliberate Unregister or engine shutdown.
+	// state after a deliberate Unregister or engine shutdown, AND after a
+	// daemon body exits cleanly (status=success) with no configured
+	// auto-restart. See DaemonCrashed for the non-success counterpart.
 	DaemonStopped DaemonState = "stopped"
 
 	// DaemonPrereqRunning indicates the engine has dispatched the daemon's
@@ -68,6 +70,23 @@ const (
 	// only from startDaemonInternal's post-preflight error branch (issue
 	// #318).
 	DaemonFailedAfterPreflight DaemonState = "failed_after_preflight"
+
+	// DaemonCrashed indicates the daemon's body successfully started but
+	// then exited with a non-success status (failure, timeout, etc.) AND
+	// the configured restart policy will NOT restart it — i.e. either
+	// restart=never, or restart=on-failure with a status the engine
+	// doesn't treat as a failure. Reachable only from
+	// onDaemonRunFinished's no-restart branch.
+	//
+	// Distinct from DaemonStopped (clean exit / operator-initiated) and
+	// from DaemonFailedAfterPreflight (fireAsync-time error, before the
+	// daemon body got to run) so operators can tell the three apart in
+	// the WebUI / API.
+	//
+	// Terminal: like DaemonFailedAfterPreflight, an operator must re-fire
+	// the daemon (e.g. via manual run or a registry reload) to retry. The
+	// engine does not automatically transition out of this state.
+	DaemonCrashed DaemonState = "crashed"
 )
 
 // daemonStateMap is a thread-safe taskID → DaemonState map. Kept as a

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -923,15 +923,33 @@ func (e *Engine) onDaemonRunFinished(spec *task.Spec, runID string) {
 	if restart == "" {
 		restart = "always"
 	}
+	// noRestartTransition records the terminal state when the engine
+	// will NOT spawn an automatic restart for this exit. Status-aware
+	// split (issue #325):
+	//   - success exit, no restart  → DaemonStopped (clean shutdown)
+	//   - non-success exit, no restart → DaemonCrashed (operator
+	//     attention required)
+	// Without this, the no-restart branches return without touching
+	// daemonStates, leaving the WebUI showing a stale "Running" pill
+	// for a daemon that's no longer running.
+	noRestartTransition := func() {
+		if run.Status == registry.StatusSuccess {
+			e.setDaemonState(spec.ID, DaemonStopped)
+		} else {
+			e.setDaemonState(spec.ID, DaemonCrashed)
+		}
+	}
 	switch restart {
 	case "never":
 		e.log.Info("daemon exited — restart=never, not restarting",
 			zap.String("task", spec.ID), zap.String("status", run.Status))
+		noRestartTransition()
 		return
 	case "on-failure":
 		if run.Status != registry.StatusFailure {
 			e.log.Info("daemon exited — restart=on-failure, not restarting (no failure)",
 				zap.String("task", spec.ID), zap.String("status", run.Status))
+			noRestartTransition()
 			return
 		}
 	}

--- a/pkg/trigger/engine_preflight_test.go
+++ b/pkg/trigger/engine_preflight_test.go
@@ -89,7 +89,7 @@ func TestDaemonState_Default(t *testing.T) {
 }
 
 // TestDaemonState_SetGet verifies that setDaemonState/DaemonState round-trip
-// the six enum values without contention.
+// the seven enum values without contention.
 func TestDaemonState_SetGet(t *testing.T) {
 	e := newTestEnv(t)
 	states := []DaemonState{
@@ -98,6 +98,7 @@ func TestDaemonState_SetGet(t *testing.T) {
 		DaemonRunning,
 		DaemonStopping,
 		DaemonFailedAfterPreflight,
+		DaemonCrashed,
 		DaemonStopped,
 	}
 	for _, want := range states {
@@ -1654,5 +1655,105 @@ func TestStartDaemonInternal_FireAsyncFailureFirstBoot(t *testing.T) {
 	if got := eng.DaemonState("d"); got != DaemonFailedAfterPreflight {
 		t.Fatalf("DaemonState = %q, want %q (first-boot path must record post-preflight failure identically to the mid-pipeline re-fire path)",
 			got, DaemonFailedAfterPreflight)
+	}
+}
+
+// finishedRunEnv stages a daemon spec + a finished registry run so the
+// onDaemonRunFinished tests can call the hook directly without going
+// through the full fireAsync → daemon-execute path. Keeping the setup
+// inline (rather than reusing preflightExec/newPreflightEnv) avoids
+// coupling the test to the executor's daemon-block semantics — these
+// tests are about the post-run state-transition decision only.
+func finishedRunEnv(t *testing.T, restartPolicy string, status string) (*Engine, *task.Spec, string) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+	exec := newPreflightExec(reg)
+	eng := New(reg, exec, zap.NewNop())
+	eng.RegisterExecutor(task.RuntimeDocker, exec)
+
+	spec := &task.Spec{
+		ID:      "d",
+		Name:    "d",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{Daemon: true, Restart: restartPolicy},
+		Enabled: true,
+	}
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("reg.Register: %v", err)
+	}
+	// Mark the daemon as still-registered with the engine so the
+	// onDaemonRunFinished early-return guard doesn't bail out.
+	eng.daemonMu.Lock()
+	eng.daemonSpecs[spec.ID] = spec
+	eng.daemonMu.Unlock()
+
+	// Seed a run row in the registry and finalize it with the requested
+	// terminal status — onDaemonRunFinished looks the run up via GetRun
+	// to decide whether to restart.
+	ctx := context.Background()
+	runID, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	if err := reg.FinishRun(ctx, runID, status); err != nil {
+		t.Fatalf("FinishRun: %v", err)
+	}
+
+	// Pre-seed daemonStates with DaemonRunning so we can assert the
+	// transition actually fires (rather than just observing the default
+	// "stopped" fall-through that DaemonState() returns for absent keys).
+	// This mirrors reality: the WebUI's stale-Running pill described in
+	// issue #325 only appears because the engine successfully set
+	// DaemonRunning before the body crashed.
+	eng.setDaemonState(spec.ID, DaemonRunning)
+	return eng, spec, runID
+}
+
+// TestOnDaemonRunFinished_NoRestartFailure_TransitionsToCrashed exercises
+// the issue #325 fix: a daemon whose body exits with status=failure under
+// `restart: never` must transition to DaemonCrashed so the WebUI shows a
+// distinct pill (operator attention required) rather than a stale Running
+// indicator. Mirror test for the success path lives in the sibling
+// _TransitionsToStopped test below.
+func TestOnDaemonRunFinished_NoRestartFailure_TransitionsToCrashed(t *testing.T) {
+	eng, spec, runID := finishedRunEnv(t, "never", registry.StatusFailure)
+	eng.onDaemonRunFinished(spec, runID)
+	if got := eng.DaemonState(spec.ID); got != DaemonCrashed {
+		t.Fatalf("DaemonState = %q, want %q (non-success exit + no restart must surface as Crashed, not stale Running)",
+			got, DaemonCrashed)
+	}
+}
+
+// TestOnDaemonRunFinished_NoRestartSuccess_TransitionsToStopped covers
+// the clean-exit half of issue #325's status-aware split: a daemon body
+// that exits successfully under `restart: never` (e.g. a long-running
+// migration that completes) is NOT a crash — it's a clean shutdown, and
+// the operator should see Stopped, not Crashed.
+func TestOnDaemonRunFinished_NoRestartSuccess_TransitionsToStopped(t *testing.T) {
+	eng, spec, runID := finishedRunEnv(t, "never", registry.StatusSuccess)
+	eng.onDaemonRunFinished(spec, runID)
+	if got := eng.DaemonState(spec.ID); got != DaemonStopped {
+		t.Fatalf("DaemonState = %q, want %q (clean exit + no restart must surface as Stopped, not Crashed)",
+			got, DaemonStopped)
+	}
+}
+
+// TestOnDaemonRunFinished_OnFailurePolicy_SuccessExit_TransitionsToStopped
+// covers the second no-restart branch: restart=on-failure with a
+// success exit. The engine won't restart (no failure to react to), so
+// the daemon is in the same terminal Stopped state as the
+// restart=never+success case.
+func TestOnDaemonRunFinished_OnFailurePolicy_SuccessExit_TransitionsToStopped(t *testing.T) {
+	eng, spec, runID := finishedRunEnv(t, "on-failure", registry.StatusSuccess)
+	eng.onDaemonRunFinished(spec, runID)
+	if got := eng.DaemonState(spec.ID); got != DaemonStopped {
+		t.Fatalf("DaemonState = %q, want %q (on-failure + clean exit must surface as Stopped — no failure to restart, no crash to surface)",
+			got, DaemonStopped)
 	}
 }

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -1363,10 +1363,11 @@ type TaskDetail struct {
 
 	// DaemonState surfaces the engine's preflight/lifecycle phase for
 	// daemon tasks. Empty for non-daemon tasks so the WebUI can hide the
-	// row entirely. Six-value enum — see pkg/trigger.DaemonState for the
-	// canonical list. The "failed_after_preflight" value is distinct from
-	// "stopped" so operators can tell "daemon body broke" apart from
-	// "deliberately stopped" (issue #318).
+	// row entirely. Seven-value enum — see pkg/trigger.DaemonState for
+	// the canonical list. The "failed_after_preflight" and "crashed"
+	// values are distinct from "stopped" so operators can tell
+	// "fireAsync broke" (#318) and "body crashed without auto-restart"
+	// (#325) apart from "deliberately stopped".
 	DaemonState string `json:"daemon_state,omitempty"`
 }
 

--- a/tasks/buildin/webui/app/components/dc-task-detail.js
+++ b/tasks/buildin/webui/app/components/dc-task-detail.js
@@ -359,12 +359,13 @@ class DcTaskDetail extends LitElement {
   }
 
   // Renders the daemon lifecycle phase as a colored badge in the trigger
-  // row. The engine reports a six-value enum (see pkg/trigger.DaemonState);
+  // row. The engine reports a seven-value enum (see pkg/trigger.DaemonState);
   // the mapping below keeps colors aligned with the surrounding UI palette:
   // green for healthy, yellow/sky for transient, red for failure, muted for
-  // resting. The "failed_after_preflight" badge is deliberately distinct
-  // from "stopped" so operators can tell "preflight passed, daemon body
-  // broke" apart from "deliberately stopped" (issue #318).
+  // resting. The three failure badges are deliberately distinguishable so
+  // operators can tell "preflight failed" (issue #300) from "preflight
+  // passed, fireAsync handoff broke" (issue #318) from "daemon body ran
+  // then crashed without an auto-restart" (issue #325).
   _renderDaemonState(state) {
     // Keep keys in sync with the DaemonState constants in
     // pkg/trigger/daemon_state.go — out-of-sync entries fall through
@@ -375,6 +376,7 @@ class DcTaskDetail extends LitElement {
       stopping:               { bg: 'rgba(249, 226, 175, .15)', fg: 'var(--yellow)', text: 'Stopping…' },
       prereq_failed:          { bg: 'rgba(243, 139, 168, .15)', fg: 'var(--red)',    text: 'Preflight failed' },
       failed_after_preflight: { bg: 'rgba(243, 139, 168, .15)', fg: 'var(--red)',    text: 'Crashed after preflight ✓' },
+      crashed:                { bg: 'rgba(243, 139, 168, .28)', fg: 'var(--red)',    text: '⨯ Crashed (no restart)' },
       stopped:                { bg: 'rgba(166, 173, 200, .15)', fg: 'var(--muted)',  text: 'Stopped' },
     };
     const s = STYLES[state] || { bg: 'rgba(166, 173, 200, .15)', fg: 'var(--muted)', text: state };


### PR DESCRIPTION
Closes #325.

## Summary

PR #324 added `DaemonFailedAfterPreflight` for fireAsync-time errors (failures BEFORE the daemon body started). This PR addresses the parallel concern: errors AFTER the daemon body has launched and then exited without an automatic restart. `onDaemonRunFinished` deliberately didn't call `setDaemonState` on the no-restart path, so the WebUI showed a stale `Running` pill for a daemon that was no longer running.

Going with **Option C** from the issue — a status-aware split that keeps the new state's semantic focused on "successfully started, then crashed without auto-restart":

- `DaemonStopped` — operator-initiated, or **successful** exit + no restart.
- **New** `DaemonCrashed` — **non-success** exit + no restart (`status: failure`, `status: timeout`, etc.).
- `DaemonFailedAfterPreflight` — fireAsync handoff error (PR #324's scope, untouched here).

## State machine — before / after

`onDaemonRunFinished`'s no-restart branch:

| Restart policy | Exit status | Before (this PR) | After |
| --- | --- | --- | --- |
| `never` | success | stale `running` | `stopped` |
| `never` | failure | stale `running` | `crashed` |
| `on-failure` | success | stale `running` | `stopped` |
| `on-failure` | failure | (restarts — unchanged) | (restarts — unchanged) |
| `always` | any | (restarts — unchanged) | (restarts — unchanged) |

The auto-restart branches are deliberately left alone — those paths correctly keep `DaemonRunning` (or transition through prereq states on the restart cycle).

## WebUI

The `STYLES` map in `dc-task-detail.js` gets a new `crashed` entry: same `var(--red)` foreground as the other failure states but with a stronger red-tinted background (0.28 alpha vs 0.15) and a `⨯` icon prefix. Text reads `⨯ Crashed (no restart)` so the operator immediately knows (a) something failed and (b) it won't auto-recover.

The three failure pills (`prereq_failed`, `failed_after_preflight`, `crashed`) now visually correspond to *where* in the lifecycle the daemon stopped working — preflight, handoff, or post-startup — without forcing operators to dig into run records.

## Tests

- `TestOnDaemonRunFinished_NoRestartFailure_TransitionsToCrashed` — `restart: never` + `StatusFailure` → `DaemonCrashed`.
- `TestOnDaemonRunFinished_NoRestartSuccess_TransitionsToStopped` — `restart: never` + `StatusSuccess` → `DaemonStopped`.
- `TestOnDaemonRunFinished_OnFailurePolicy_SuccessExit_TransitionsToStopped` — `restart: on-failure` + `StatusSuccess` → `DaemonStopped` (second no-restart branch).
- `TestDaemonState_SetGet` extended to round-trip the seven enum values.

All seed `daemonStates[id] = DaemonRunning` before invoking the hook so the assertions exercise the *transition*, not the absent-key fallback — that's the actual stale-pill scenario the issue describes.

## Docs

`docs/concepts/task-format.md` gets a new **Daemon states** subsection enumerating the seven values with their semantics and clarifying which are terminal (operator must re-fire).

## Test plan

- [x] `go test ./pkg/trigger/ ./pkg/webui/ -timeout 180s` — green.
- [x] `make build && make format && make format-check` — clean.
- [ ] Manual smoke (optional): start a daemon whose body exits with failure + `restart: never`, observe the WebUI shows `⨯ Crashed (no restart)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)