### PR TITLE
feat(task,trigger): richer ${input.*} interpolation grammar

### DIFF
--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -326,8 +326,25 @@ Embedded forms (`"prefix-${input.output}-suffix"`) and multi-token
 forms (`"${input.params.scheme}://${input.output.host}"`) are
 supported — any string containing one or more recognised tokens is
 rewritten in place. Unknown shapes (e.g. `${input.foo}`,
-`${input.output.a.b}`) are rejected at task-registration time with a
+`${input.params}` with no field, identifiers starting with a digit or
+punctuation) are rejected at task-registration time with a
 site-qualified error so operators see the failure at config-load.
+
+The `<field>` / `<name>` portion of a token is a permissive identifier:
+the first character must be a letter or underscore, but the remainder
+may include letters, digits, underscores, **hyphens, and dots**. This
+fits common real-world shapes — HTTP-header-style param names like
+`${input.params.x-forwarded-for}`, dotted YAML keys like
+`${input.output.db.host}`, and namespaced fields like
+`${input.output.parent.child}` — without needing escapes.
+
+**Preflight-edge restriction.** `${input.params.<name>}` is rejected
+at registration on **every** `trigger.before[]` edge (not just
+`before[0]`). Preflight stages run with an empty `RunOptions`, so the
+upstream params channel is statically unavailable for the entire
+pipeline. `${input.output…}` continues to work on `before[i > 0]`
+edges because runPrereqs pipes the previous stage's return value
+forward.
 
 Loud-failures at dispatch produce a structured log
 (`failed to resolve ${input.…} reference`) and skip the chain /

--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -204,6 +204,12 @@ are rejected at config-load if present in `params`. When `params` is
 empty (the default), `input` stays as the upstream's raw value — no
 wrapping — so existing chains keep working unchanged.
 
+String values in `params` may reference the upstream's runtime state
+via the dispatch-time interpolation grammar — `${input.output}`,
+`${input.output.<field>}`, `${input.params.<name>}`, and embedded
+forms. See [`${input.…}` interpolation](#input-interpolation) below
+for the full grammar and loud-failure semantics.
+
 The same params shape applies symmetrically to
 `on_failure_chain.params` (the failure-chain analogue).
 
@@ -305,21 +311,49 @@ trigger:
             permission: r
 ```
 
-**`${input.output}` interpolation.** The literal token `${input.output}`
-in a `before[i].overrides.params` `default` value (or in a
-`trigger.chain.params` value) is replaced at dispatch time with the
-upstream stage's return value. Only direct string returns flow through;
-non-string returns (numbers, lists, structured payloads) leave the
-downstream's `${input.output}` unresolved and the dispatch fails loudly
-rather than passing the literal token through. The interpolation is
-exact-match on the whole value — embedded forms like
-`"prefix-${input.output}-x"` are not currently substituted.
+<a id="input-interpolation"></a>
+**`${input.…}` interpolation.** Three reference shapes are recognised
+at dispatch time in `before[i].overrides.params` defaults and
+`trigger.chain.params` values:
+
+| Form | Resolves to | Loud-fail when |
+| --- | --- | --- |
+| `${input.output}` | upstream's full string return value | upstream returned a non-string |
+| `${input.output.<field>}` | named string field of an object-shaped upstream return (e.g. `{path: "..."}`) | upstream isn't an object, field absent, field non-string |
+| `${input.params.<name>}` | named entry from the upstream's `RunOptions.Params` (chain edge: the caller-supplied params on the upstream's fire; preflight edge: always empty today) | params map nil or named entry missing |
+
+Embedded forms (`"prefix-${input.output}-suffix"`) and multi-token
+forms (`"${input.params.scheme}://${input.output.host}"`) are
+supported — any string containing one or more recognised tokens is
+rewritten in place. Unknown shapes (e.g. `${input.foo}`,
+`${input.output.a.b}`) are rejected at task-registration time with a
+site-qualified error so operators see the failure at config-load.
+
+Loud-failures at dispatch produce a structured log
+(`failed to resolve ${input.…} reference`) and skip the chain /
+preflight dispatch rather than silently passing a literal token to
+the downstream.
+
+```yaml
+trigger:
+  chain:
+    from: render-config
+    params:
+      # bare token — upstream must return a string
+      content: "${input.output}"
+      # named field — upstream returned {path: "..."}
+      destPath: "${input.output.path}"
+      # caller-supplied param piped from the upstream
+      endpoint: "${input.params.url}"
+      # embedded form — splice into a literal
+      banner: "rendered at ${input.output} on ${input.params.host}"
+```
 
 **First-stage validation.** The first stage (`before[0]`) has no
-upstream return value, so any `${input.output}` reference on
+upstream return value, so any `${input.…}` reference on
 `before[0].overrides.params` is rejected at task-registration time with
 an explicit error. Use a literal default or an env-projected secret on
-stage 0; downstream stages can then pipe via `${input.output}`.
+stage 0; downstream stages can then pipe via the recognised tokens.
 
 **Mid-pipeline re-fire propagation.** When an intermediate stage at
 index `i` re-runs successfully (e.g. an operator runs

--- a/pkg/task/inputref.go
+++ b/pkg/task/inputref.go
@@ -6,8 +6,26 @@
 //
 // ResolveInputOutput{Map,List} are the dispatch-time complement: when
 // a downstream task is fired (via chain.from or via trigger.before
-// pipeline), any of its params whose VALUE is exactly "${input.output}"
-// is replaced with the upstream's return value.
+// pipeline), any of its params whose VALUE contains a recognised
+// `${input.…}` token is rewritten in place. Three shapes are
+// recognised:
+//
+//   - ${input.output}            — the upstream's full string return
+//     value. Non-string upstream → ErrInputUnavailable.
+//
+//   - ${input.output.<field>}    — a named field from an upstream that
+//     returned a structured (map-shaped) value. Field must exist and
+//     hold a string value; otherwise ErrInputUnavailable.
+//
+//   - ${input.params.<name>}     — a named param from the upstream's
+//     RunOptions.Params at dispatch time. Pipes the original caller-
+//     supplied param value into the downstream. Missing → ErrInputUnavailable.
+//
+// Embedded forms ("prefix-${input.output}-x") and multi-token forms
+// ("${input.params.scheme}://${input.output.path}") ARE supported —
+// any string containing one or more recognised tokens is rewritten
+// through ReplaceAllStringFunc. Strings without `${input.` short-circuit
+// and pass through literally with no allocation.
 //
 // Two shapes are supported because the two call sites use different
 // param containers:
@@ -19,85 +37,260 @@
 //     ([]ParamOverride). The Default string field carries the value.
 //     ResolveInputOutputList walks Default fields.
 //
-// Both share InputOutputToken + ErrInputUnavailable.
+// Both share InputContext + ErrInputUnavailable + ValidateInputRefs.
 //
-// Narrow grammar by design: only the exact token form is recognised.
-// Embedded references ("prefix-${input.output}-x") and other tokens
-// ("${input.params.foo}") remain literal. Future extensions can grow
-// the grammar without breaking the existing single-token contract.
+// Unknown shapes (e.g. `${input.foo}`, `${input.output.dotted.path}`,
+// `${input.params}` without a field name) are rejected loudly:
+//   - at registration time via ValidateInputRefs (the static path)
+//   - at dispatch time via ErrInputUnavailable (the runtime backstop,
+//     if a config skips the registration-time check)
 
 package task
 
-import "fmt"
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
 
-// InputOutputToken is the literal string the resolver looks for.
+// InputOutputToken is the canonical bare-token form: `${input.output}`
+// (no field). Retained as a named constant so external callers — and
+// the registration-time first-stage rejection in trigger.engine — can
+// reference the canonical literal without rebuilding the spelling. The
+// resolver itself uses inputRefRe; the token-form match is a regex
+// edge case (kind="output", field="").
 const InputOutputToken = "${input.output}"
 
-// ErrInputUnavailable is returned when a param references
-// ${input.output} but no upstream return value is available (e.g. the
-// first stage of a trigger.before pipeline, or a chain dispatch where
-// the upstream produced nothing or produced a non-string return value).
+// inputRefRe matches the three recognised reference shapes:
+//
+//	${input.output}              → kind="output",  field=""
+//	${input.output.<ident>}      → kind="output",  field=<ident>
+//	${input.params.<ident>}      → kind="params",  field=<ident>
+//
+// <ident> is a Go-identifier-ish name: [A-Za-z_][A-Za-z0-9_]*.
+// Anything else inside `${input.…}` (e.g. `${input.foo}`,
+// `${input.output.a.b}`, `${input.params}` with no field) does NOT
+// match the regex — ValidateInputRefs surfaces those as loud errors at
+// registration time.
+var inputRefRe = regexp.MustCompile(`\$\{input\.(output|params)(?:\.([A-Za-z_][A-Za-z0-9_]*))?\}`)
+
+// inputRefPrefixRe matches any `${input.…}` substring regardless of
+// shape — used by ValidateInputRefs to detect interpolation attempts
+// the strict regex would silently pass through.
+var inputRefPrefixRe = regexp.MustCompile(`\$\{input\.[^}]*\}`)
+
+// InputContext carries the dispatch-time values the resolver needs.
+// Output is the upstream's full return value (any type — the resolver
+// type-asserts per-token). Params is the upstream's RunOptions.Params
+// snapshot at dispatch time; nil is treated as "no params available"
+// and any ${input.params.X} reference returns ErrInputUnavailable.
+type InputContext struct {
+	Output interface{}
+	Params map[string]string
+}
+
+// ErrInputUnavailable is returned when a param references an
+// `${input.…}` token that cannot be resolved at dispatch time:
+//   - ${input.output} when the upstream returned a non-string
+//   - ${input.output.<field>} when the upstream returned a non-map,
+//     when the field is absent, or when the field's value is non-string
+//   - ${input.params.<name>} when the upstream's Params map is nil or
+//     the named entry is missing
+//
+// Param identifies the offending param so operators can see which
+// override or chain key tripped the resolver.
 type ErrInputUnavailable struct {
 	Param string // name of the offending param
+	Ref   string // the offending reference token, e.g. "${input.output.path}"
+	Why   string // short human-readable reason ("upstream returned no string", etc.)
 }
 
 func (e *ErrInputUnavailable) Error() string {
-	return fmt.Sprintf("param %q references ${input.output} but no upstream return value is available", e.Param)
+	if e.Ref == "" && e.Why == "" {
+		return fmt.Sprintf("param %q references ${input.output} but no upstream return value is available", e.Param)
+	}
+	if e.Why == "" {
+		return fmt.Sprintf("param %q references %s but no value is available", e.Param, e.Ref)
+	}
+	return fmt.Sprintf("param %q references %s: %s", e.Param, e.Ref, e.Why)
 }
 
-// ResolveInputOutputMap returns a NEW params map with the
-// "${input.output}" token substituted by upstreamOutput on every
-// string-typed value matching the token exactly. Non-string values
-// and string values containing other content are copied through
-// unchanged.
+// ValidateInputRefs walks s and surfaces any `${input.…}` substring
+// that does NOT match the strict regex (e.g. `${input.foo}`,
+// `${input.output.a.b}`, `${input.params}` with no field). Returns nil
+// when every interpolation attempt is well-formed AND when s contains
+// no interpolation attempts at all. Site is a free-form location
+// string ("trigger.chain.params.X", "trigger.before[2].overrides.params.X")
+// included in the error so operators can pinpoint the offending field
+// in their task.yaml.
 //
-// If upstreamOutput is "" and the token appears in a string value,
-// returns *ErrInputUnavailable identifying one of the offending
-// params (Go map iteration order is undefined; the loud failure
+// This is the registration-time gate; the dispatch-time resolver
+// (resolveString) accepts the same well-formed shapes but ALSO
+// passes through literal `${input.…}` substrings that aren't proper
+// `${input.output}` / `${input.params.X}` references — that's how a
+// literal `$${input.output}` would have to be handled if we ever
+// added escape syntax. For now, since ValidateInputRefs runs at
+// registration, an unknown shape can't reach the dispatch resolver
+// anyway.
+func ValidateInputRefs(site, s string) error {
+	if !strings.Contains(s, "${input.") {
+		return nil
+	}
+	matches := inputRefPrefixRe.FindAllString(s, -1)
+	for _, m := range matches {
+		sub := inputRefRe.FindStringSubmatch(m)
+		if sub == nil {
+			return fmt.Errorf("%s: unknown reference shape %s (allowed: ${input.output}, ${input.output.<field>}, ${input.params.<name>})", site, m)
+		}
+		// ${input.params} without a named field is rejected — the
+		// resolver needs a specific key. ${input.output} without a
+		// field is fine (it means "the whole upstream string").
+		kind, field := sub[1], sub[2]
+		if kind == "params" && field == "" {
+			return fmt.Errorf("%s: %s requires a named field (e.g. ${input.params.url})", site, m)
+		}
+	}
+	return nil
+}
+
+// resolveString rewrites s by substituting every recognised
+// `${input.…}` token against ctx. Strings without any `${input.`
+// substring pass through with no allocation. On the first
+// unresolvable token the function aborts and returns the underlying
+// ErrInputUnavailable (with the supplied paramName attached).
+//
+// Unknown shapes (well-formed `${input.…}` substrings that don't
+// match inputRefRe) are passed through unchanged — ValidateInputRefs
+// catches those at registration time, so the dispatch-time resolver
+// stays focused on resolving valid references.
+func resolveString(paramName, s string, ctx InputContext) (string, error) {
+	if !strings.Contains(s, "${input.") {
+		return s, nil
+	}
+	var resolveErr error
+	out := inputRefRe.ReplaceAllStringFunc(s, func(token string) string {
+		if resolveErr != nil {
+			return token // skip remaining substitutions once we've errored
+		}
+		m := inputRefRe.FindStringSubmatch(token)
+		kind, field := m[1], m[2]
+		val, err := resolveToken(paramName, token, kind, field, ctx)
+		if err != nil {
+			resolveErr = err
+			return token
+		}
+		return val
+	})
+	if resolveErr != nil {
+		return "", resolveErr
+	}
+	return out, nil
+}
+
+// resolveToken returns the substitution string for a single matched
+// token. kind is "output" or "params"; field is "" for the bare
+// ${input.output} form and a Go-identifier for the dotted forms. The
+// error path always returns *ErrInputUnavailable with Ref set so the
+// caller's wrapping log message includes the offending token.
+func resolveToken(paramName, token, kind, field string, ctx InputContext) (string, error) {
+	switch kind {
+	case "output":
+		if field == "" {
+			// ${input.output} — upstream must be a string.
+			s, ok := ctx.Output.(string)
+			if !ok || s == "" {
+				return "", &ErrInputUnavailable{Param: paramName, Ref: token, Why: "upstream returned no string value"}
+			}
+			return s, nil
+		}
+		// ${input.output.<field>} — upstream must be a map[string]any
+		// (the shape JSON decoding produces) with a string-valued entry
+		// at <field>. Maps reached via direct Go callers (e.g.
+		// runtime-test mocks) may use map[string]string; accept both.
+		switch m := ctx.Output.(type) {
+		case map[string]any:
+			raw, ok := m[field]
+			if !ok {
+				return "", &ErrInputUnavailable{Param: paramName, Ref: token, Why: fmt.Sprintf("upstream object has no field %q", field)}
+			}
+			s, ok := raw.(string)
+			if !ok {
+				return "", &ErrInputUnavailable{Param: paramName, Ref: token, Why: fmt.Sprintf("upstream field %q is not a string", field)}
+			}
+			return s, nil
+		case map[string]string:
+			s, ok := m[field]
+			if !ok {
+				return "", &ErrInputUnavailable{Param: paramName, Ref: token, Why: fmt.Sprintf("upstream object has no field %q", field)}
+			}
+			return s, nil
+		default:
+			return "", &ErrInputUnavailable{Param: paramName, Ref: token, Why: "upstream return value is not an object"}
+		}
+	case "params":
+		if field == "" {
+			// `${input.params}` (no field) is rejected at registration
+			// via ValidateInputRefs. If we reach here it's a bypass —
+			// fail loudly rather than silently substituting "".
+			return "", &ErrInputUnavailable{Param: paramName, Ref: token, Why: "${input.params} requires a named field"}
+		}
+		if ctx.Params == nil {
+			return "", &ErrInputUnavailable{Param: paramName, Ref: token, Why: "upstream params not available"}
+		}
+		v, ok := ctx.Params[field]
+		if !ok {
+			return "", &ErrInputUnavailable{Param: paramName, Ref: token, Why: fmt.Sprintf("upstream params has no entry %q", field)}
+		}
+		return v, nil
+	default:
+		// Unreachable: inputRefRe restricts kind to (output|params).
+		return "", &ErrInputUnavailable{Param: paramName, Ref: token, Why: "unknown reference kind"}
+	}
+}
+
+// ResolveInputOutputMap returns a NEW params map with every string
+// value rewritten to substitute recognised `${input.…}` tokens against
+// ctx. Non-string values and strings without `${input.…}` pass through
+// unchanged. The input map is NOT mutated.
+//
+// Returns *ErrInputUnavailable on the first param whose tokens cannot
+// be resolved (Go map iteration order is undefined; the loud failure
 // is what matters, not the specific Param name).
-//
-// The input map is NOT mutated.
-func ResolveInputOutputMap(params map[string]any, upstreamOutput string) (map[string]any, error) {
+func ResolveInputOutputMap(params map[string]any, ctx InputContext) (map[string]any, error) {
 	if params == nil {
 		return nil, nil
 	}
 	out := make(map[string]any, len(params))
 	for k, v := range params {
 		s, ok := v.(string)
-		if !ok || s != InputOutputToken {
+		if !ok {
 			out[k] = v
 			continue
 		}
-		if upstreamOutput == "" {
-			return nil, &ErrInputUnavailable{Param: k}
+		resolved, err := resolveString(k, s, ctx)
+		if err != nil {
+			return nil, err
 		}
-		out[k] = upstreamOutput
+		out[k] = resolved
 	}
 	return out, nil
 }
 
-// ResolveInputOutputList returns a NEW ParamOverrides slice with
-// "${input.output}" Default values substituted by upstreamOutput.
-// Other Default values are copied through unchanged.
-//
-// If upstreamOutput is "" and the token appears, returns
-// *ErrInputUnavailable identifying the offending entry.
-//
-// The input slice is NOT mutated; each ParamOverride is copied.
-func ResolveInputOutputList(params ParamOverrides, upstreamOutput string) (ParamOverrides, error) {
+// ResolveInputOutputList returns a NEW ParamOverrides slice with every
+// Default rewritten the same way as ResolveInputOutputMap. The input
+// slice is NOT mutated; each ParamOverride is copied.
+func ResolveInputOutputList(params ParamOverrides, ctx InputContext) (ParamOverrides, error) {
 	if params == nil {
 		return nil, nil
 	}
 	out := make(ParamOverrides, len(params))
 	for i, p := range params {
 		out[i] = p // copy by value — ParamOverride is a small struct
-		if p.Default != InputOutputToken {
-			continue
+		resolved, err := resolveString(p.Name, p.Default, ctx)
+		if err != nil {
+			return nil, err
 		}
-		if upstreamOutput == "" {
-			return nil, &ErrInputUnavailable{Param: p.Name}
-		}
-		out[i].Default = upstreamOutput
+		out[i].Default = resolved
 	}
 	return out, nil
 }

--- a/pkg/task/inputref.go
+++ b/pkg/task/inputref.go
@@ -53,26 +53,27 @@ import (
 	"strings"
 )
 
-// InputOutputToken is the canonical bare-token form: `${input.output}`
-// (no field). Retained as a named constant so external callers — and
-// the registration-time first-stage rejection in trigger.engine — can
-// reference the canonical literal without rebuilding the spelling. The
-// resolver itself uses inputRefRe; the token-form match is a regex
-// edge case (kind="output", field="").
-const InputOutputToken = "${input.output}"
-
 // inputRefRe matches the three recognised reference shapes:
 //
 //	${input.output}              → kind="output",  field=""
 //	${input.output.<ident>}      → kind="output",  field=<ident>
 //	${input.params.<ident>}      → kind="params",  field=<ident>
 //
-// <ident> is a Go-identifier-ish name: [A-Za-z_][A-Za-z0-9_]*.
+// <ident> is a permissive identifier-ish name shaped to fit real-world
+// YAML keys and HTTP header names: a leading [A-Za-z_], followed by
+// any mix of [A-Za-z0-9_], hyphens, and dots. This accepts common
+// header-style names like `x-forwarded-for` and dotted keys like
+// `db.host` without ambiguity — the upstream params map is itself
+// indexed by arbitrary string keys (params.go), so the resolver
+// shouldn't be narrower than its lookup target. The leading character
+// is still restricted to a letter or underscore so that genuinely
+// malformed shapes like `${input.output.0bad}` are still rejected by
+// ValidateInputRefs.
+//
 // Anything else inside `${input.…}` (e.g. `${input.foo}`,
-// `${input.output.a.b}`, `${input.params}` with no field) does NOT
-// match the regex — ValidateInputRefs surfaces those as loud errors at
-// registration time.
-var inputRefRe = regexp.MustCompile(`\$\{input\.(output|params)(?:\.([A-Za-z_][A-Za-z0-9_]*))?\}`)
+// `${input.params}` with no field) does NOT match the regex —
+// ValidateInputRefs surfaces those as loud errors at registration time.
+var inputRefRe = regexp.MustCompile(`\$\{input\.(output|params)(?:\.([A-Za-z_][A-Za-z0-9_.\-]*))?\}`)
 
 // inputRefPrefixRe matches any `${input.…}` substring regardless of
 // shape — used by ValidateInputRefs to detect interpolation attempts

--- a/pkg/task/inputref_test.go
+++ b/pkg/task/inputref_test.go
@@ -3,15 +3,22 @@ package task
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 )
+
+// ctxString builds an InputContext for the most common test case —
+// a string upstream return value with no params.
+func ctxString(s string) InputContext {
+	return InputContext{Output: s}
+}
 
 func TestResolveInputOutputMap_PassThroughWithoutToken(t *testing.T) {
 	params := map[string]any{
 		"path": "/foo/bar",
 		"mode": "0600",
 	}
-	got, err := ResolveInputOutputMap(params, "ignored")
+	got, err := ResolveInputOutputMap(params, ctxString("ignored"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -25,7 +32,7 @@ func TestResolveInputOutputMap_SubstitutesExactToken(t *testing.T) {
 		"content": "${input.output}",
 		"path":    "/foo/bar",
 	}
-	got, err := ResolveInputOutputMap(params, "rendered yaml here")
+	got, err := ResolveInputOutputMap(params, ctxString("rendered yaml here"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -37,16 +44,19 @@ func TestResolveInputOutputMap_SubstitutesExactToken(t *testing.T) {
 	}
 }
 
-func TestResolveInputOutputMap_EmbeddedTokenIsLiteral(t *testing.T) {
+// TestResolveInputOutputMap_EmbeddedTokenInterpolates verifies the
+// post-#316 contract: a string containing the recognised token is
+// rewritten in place. Was a literal pass-through in PR #310.
+func TestResolveInputOutputMap_EmbeddedTokenInterpolates(t *testing.T) {
 	params := map[string]any{
 		"content": "prefix-${input.output}-suffix",
 	}
-	got, err := ResolveInputOutputMap(params, "X")
+	got, err := ResolveInputOutputMap(params, ctxString("X"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got["content"] != "prefix-${input.output}-suffix" {
-		t.Errorf("embedded token should remain literal; got %q", got["content"])
+	if got["content"] != "prefix-X-suffix" {
+		t.Errorf("embedded token should be interpolated; got %q", got["content"])
 	}
 }
 
@@ -54,7 +64,7 @@ func TestResolveInputOutputMap_RejectsNoUpstream(t *testing.T) {
 	params := map[string]any{
 		"content": "${input.output}",
 	}
-	_, err := ResolveInputOutputMap(params, "")
+	_, err := ResolveInputOutputMap(params, InputContext{})
 	if err == nil {
 		t.Fatal("expected error for missing upstream")
 	}
@@ -72,7 +82,7 @@ func TestResolveInputOutputMap_NonStringValueUnchanged(t *testing.T) {
 		"count": 42,
 		"text":  "${input.output}",
 	}
-	got, err := ResolveInputOutputMap(params, "hi")
+	got, err := ResolveInputOutputMap(params, ctxString("hi"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -88,7 +98,7 @@ func TestResolveInputOutputMap_PreservesInput(t *testing.T) {
 	orig := map[string]any{
 		"content": "${input.output}",
 	}
-	_, err := ResolveInputOutputMap(orig, "resolved")
+	_, err := ResolveInputOutputMap(orig, ctxString("resolved"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -97,12 +107,153 @@ func TestResolveInputOutputMap_PreservesInput(t *testing.T) {
 	}
 }
 
+// TestResolveInputOutputMap_OutputField_StringOK exercises the
+// ${input.output.<field>} form with a map[string]any upstream return —
+// the shape JSON decoding produces. The named field's string value is
+// substituted.
+func TestResolveInputOutputMap_OutputField_StringOK(t *testing.T) {
+	params := map[string]any{
+		"file": "${input.output.path}",
+	}
+	ctx := InputContext{Output: map[string]any{"path": "/tmp/rendered.yaml"}}
+	got, err := ResolveInputOutputMap(params, ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got["file"] != "/tmp/rendered.yaml" {
+		t.Errorf("file = %q; want %q", got["file"], "/tmp/rendered.yaml")
+	}
+}
+
+// TestResolveInputOutputMap_OutputField_NonStringFails locks the loud
+// failure: a present-but-non-string field yields ErrInputUnavailable.
+func TestResolveInputOutputMap_OutputField_NonStringFails(t *testing.T) {
+	params := map[string]any{
+		"size": "${input.output.bytes}",
+	}
+	ctx := InputContext{Output: map[string]any{"bytes": 42}}
+	_, err := ResolveInputOutputMap(params, ctx)
+	if err == nil {
+		t.Fatal("expected ErrInputUnavailable for non-string field value")
+	}
+	var ire *ErrInputUnavailable
+	if !errors.As(err, &ire) {
+		t.Fatalf("expected ErrInputUnavailable; got %T: %v", err, err)
+	}
+	if !strings.Contains(ire.Error(), "not a string") {
+		t.Errorf("error should mention non-string; got %v", ire)
+	}
+}
+
+// TestResolveInputOutputMap_OutputField_MissingFails locks the loud
+// failure: a referenced field absent from the upstream map yields
+// ErrInputUnavailable.
+func TestResolveInputOutputMap_OutputField_MissingFails(t *testing.T) {
+	params := map[string]any{
+		"x": "${input.output.missing}",
+	}
+	ctx := InputContext{Output: map[string]any{"path": "/tmp/foo"}}
+	_, err := ResolveInputOutputMap(params, ctx)
+	if err == nil {
+		t.Fatal("expected ErrInputUnavailable for missing field")
+	}
+	var ire *ErrInputUnavailable
+	if !errors.As(err, &ire) {
+		t.Fatalf("expected ErrInputUnavailable; got %T: %v", err, err)
+	}
+	if !strings.Contains(ire.Error(), `field "missing"`) {
+		t.Errorf("error should name the missing field; got %v", ire)
+	}
+}
+
+// TestResolveInputOutputMap_OutputField_NonObjectFails pins the loud
+// failure when the upstream isn't object-shaped at all (e.g. an
+// upstream that returned a string but a downstream tries to address a
+// field on it).
+func TestResolveInputOutputMap_OutputField_NonObjectFails(t *testing.T) {
+	params := map[string]any{
+		"x": "${input.output.path}",
+	}
+	ctx := InputContext{Output: "this is a string, not an object"}
+	_, err := ResolveInputOutputMap(params, ctx)
+	if err == nil {
+		t.Fatal("expected ErrInputUnavailable for non-object upstream")
+	}
+}
+
+// TestResolveInputOutputMap_Params_OK pins ${input.params.<name>}
+// against a populated upstream Params map.
+func TestResolveInputOutputMap_Params_OK(t *testing.T) {
+	params := map[string]any{
+		"endpoint": "${input.params.url}",
+	}
+	ctx := InputContext{Params: map[string]string{"url": "https://example.com"}}
+	got, err := ResolveInputOutputMap(params, ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got["endpoint"] != "https://example.com" {
+		t.Errorf("endpoint = %q; want %q", got["endpoint"], "https://example.com")
+	}
+}
+
+// TestResolveInputOutputMap_Params_MissingFails locks the loud failure
+// when the named param is absent from the upstream's Params map.
+func TestResolveInputOutputMap_Params_MissingFails(t *testing.T) {
+	params := map[string]any{
+		"endpoint": "${input.params.url}",
+	}
+	ctx := InputContext{Params: map[string]string{"other": "x"}}
+	_, err := ResolveInputOutputMap(params, ctx)
+	if err == nil {
+		t.Fatal("expected ErrInputUnavailable for missing param")
+	}
+	var ire *ErrInputUnavailable
+	if !errors.As(err, &ire) {
+		t.Fatalf("expected ErrInputUnavailable; got %T: %v", err, err)
+	}
+}
+
+// TestResolveInputOutputMap_Params_NilMapFails locks the loud failure
+// when the upstream has no Params map at all (typical for preflight
+// stages today). A `${input.params.X}` reference must error rather
+// than substitute an empty string.
+func TestResolveInputOutputMap_Params_NilMapFails(t *testing.T) {
+	params := map[string]any{
+		"endpoint": "${input.params.url}",
+	}
+	_, err := ResolveInputOutputMap(params, InputContext{Output: "x"})
+	if err == nil {
+		t.Fatal("expected ErrInputUnavailable for nil Params")
+	}
+}
+
+// TestResolveInputOutputMap_MultiToken pins multi-token interpolation
+// — e.g. constructing a URL from two distinct references. Each token
+// resolves independently against the same InputContext.
+func TestResolveInputOutputMap_MultiToken(t *testing.T) {
+	params := map[string]any{
+		"url": "${input.params.scheme}://${input.output.host}/path",
+	}
+	ctx := InputContext{
+		Output: map[string]any{"host": "example.com"},
+		Params: map[string]string{"scheme": "https"},
+	}
+	got, err := ResolveInputOutputMap(params, ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got["url"] != "https://example.com/path" {
+		t.Errorf("url = %q; want %q", got["url"], "https://example.com/path")
+	}
+}
+
 func TestResolveInputOutputList_PassThroughWithoutToken(t *testing.T) {
 	params := ParamOverrides{
 		{Name: "path", Default: "/foo/bar"},
 		{Name: "mode", Default: "0600"},
 	}
-	got, err := ResolveInputOutputList(params, "ignored")
+	got, err := ResolveInputOutputList(params, ctxString("ignored"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -116,7 +267,7 @@ func TestResolveInputOutputList_SubstitutesExactToken(t *testing.T) {
 		{Name: "content", Default: "${input.output}"},
 		{Name: "path", Default: "/foo/bar"},
 	}
-	got, err := ResolveInputOutputList(params, "rendered yaml here")
+	got, err := ResolveInputOutputList(params, ctxString("rendered yaml here"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -128,16 +279,18 @@ func TestResolveInputOutputList_SubstitutesExactToken(t *testing.T) {
 	}
 }
 
-func TestResolveInputOutputList_EmbeddedTokenIsLiteral(t *testing.T) {
+// TestResolveInputOutputList_EmbeddedTokenInterpolates is the slice-
+// shaped twin of TestResolveInputOutputMap_EmbeddedTokenInterpolates.
+func TestResolveInputOutputList_EmbeddedTokenInterpolates(t *testing.T) {
 	params := ParamOverrides{
 		{Name: "content", Default: "prefix-${input.output}-suffix"},
 	}
-	got, err := ResolveInputOutputList(params, "X")
+	got, err := ResolveInputOutputList(params, ctxString("X"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got[0].Default != "prefix-${input.output}-suffix" {
-		t.Errorf("embedded token should remain literal; got %q", got[0].Default)
+	if got[0].Default != "prefix-X-suffix" {
+		t.Errorf("embedded token should be interpolated; got %q", got[0].Default)
 	}
 }
 
@@ -145,7 +298,7 @@ func TestResolveInputOutputList_RejectsNoUpstream(t *testing.T) {
 	params := ParamOverrides{
 		{Name: "content", Default: "${input.output}"},
 	}
-	_, err := ResolveInputOutputList(params, "")
+	_, err := ResolveInputOutputList(params, InputContext{})
 	if err == nil {
 		t.Fatal("expected error for missing upstream")
 	}
@@ -162,12 +315,33 @@ func TestResolveInputOutputList_PreservesInput(t *testing.T) {
 	orig := ParamOverrides{
 		{Name: "content", Default: "${input.output}"},
 	}
-	_, err := ResolveInputOutputList(orig, "resolved")
+	_, err := ResolveInputOutputList(orig, ctxString("resolved"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if orig[0].Default != "${input.output}" {
 		t.Errorf("input list was mutated; got %v", orig[0].Default)
+	}
+}
+
+// TestResolveInputOutputList_OutputField_Pipeline pins the slice-shaped
+// equivalent of TestResolveInputOutputMap_OutputField_StringOK — this is
+// the form used by trigger.before[].overrides.params at dispatch.
+func TestResolveInputOutputList_OutputField_Pipeline(t *testing.T) {
+	params := ParamOverrides{
+		{Name: "destPath", Default: "${input.output.path}"},
+		{Name: "mode", Default: "0600"},
+	}
+	ctx := InputContext{Output: map[string]any{"path": "/var/run/relay.yaml"}}
+	got, err := ResolveInputOutputList(params, ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got[0].Default != "/var/run/relay.yaml" {
+		t.Errorf("destPath = %q; want %q", got[0].Default, "/var/run/relay.yaml")
+	}
+	if got[1].Default != "0600" {
+		t.Errorf("mode = %q; want %q", got[1].Default, "0600")
 	}
 }
 
@@ -178,7 +352,7 @@ func TestResolveInputOutputList_PreservesInput(t *testing.T) {
 // short-circuit to avoid an unnecessary allocation + the surrounding
 // dispatch logic should treat the result as "nothing to substitute".
 func TestResolveInputOutputMap_NilMap(t *testing.T) {
-	got, err := ResolveInputOutputMap(nil, "anything")
+	got, err := ResolveInputOutputMap(nil, ctxString("anything"))
 	if err != nil {
 		t.Fatalf("nil map should not error: %v", err)
 	}
@@ -193,11 +367,54 @@ func TestResolveInputOutputMap_NilMap(t *testing.T) {
 // field is nil when the override declares no params, so the helper must
 // accept nil without error.
 func TestResolveInputOutputList_NilList(t *testing.T) {
-	got, err := ResolveInputOutputList(nil, "anything")
+	got, err := ResolveInputOutputList(nil, ctxString("anything"))
 	if err != nil {
 		t.Fatalf("nil list should not error: %v", err)
 	}
 	if got != nil {
 		t.Errorf("expected nil result; got %v", got)
+	}
+}
+
+// TestValidateInputRefs covers the registration-time gate that
+// surfaces malformed `${input.…}` shapes at config load. Well-formed
+// references (the three recognised shapes) and strings without any
+// `${input.…}` substring pass; everything else errors with a site-
+// qualified message.
+func TestValidateInputRefs(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		wantErr bool
+		wantSub string // expected substring of err.Error()
+	}{
+		{"empty", "", false, ""},
+		{"plain literal", "/tmp/foo", false, ""},
+		{"bare output", "${input.output}", false, ""},
+		{"output field", "${input.output.path}", false, ""},
+		{"params name", "${input.params.url}", false, ""},
+		{"embedded", "prefix-${input.output}-suffix", false, ""},
+		{"multi-token", "${input.params.scheme}://${input.output.host}", false, ""},
+		{"unknown kind", "${input.foo}", true, "${input.foo}"},
+		{"dotted path", "${input.output.a.b}", true, "${input.output.a.b}"},
+		{"params no field", "${input.params}", true, "${input.params}"},
+		{"output non-identifier", "${input.output.0bad}", true, "${input.output.0bad}"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ValidateInputRefs("site.x", c.in)
+			if c.wantErr && err == nil {
+				t.Fatalf("expected error for %q", c.in)
+			}
+			if !c.wantErr && err != nil {
+				t.Fatalf("unexpected error for %q: %v", c.in, err)
+			}
+			if err != nil && c.wantSub != "" && !strings.Contains(err.Error(), c.wantSub) {
+				t.Errorf("error %q should mention %q", err.Error(), c.wantSub)
+			}
+			if err != nil && !strings.Contains(err.Error(), "site.x") {
+				t.Errorf("error should include site; got %v", err)
+			}
+		})
 	}
 }

--- a/pkg/task/inputref_test.go
+++ b/pkg/task/inputref_test.go
@@ -228,6 +228,40 @@ func TestResolveInputOutputMap_Params_NilMapFails(t *testing.T) {
 	}
 }
 
+// TestResolveInputOutputMap_HyphenatedAndDottedIdents exercises the
+// widened identifier class (PR #330 follow-up). Hyphenated names
+// (`x-forwarded-for`, `db-host`) and dotted names (`db.host`) must
+// resolve against the upstream params map / output map exactly like
+// plain identifiers — operators legitimately use those shapes for
+// HTTP-header-style param names and namespaced YAML keys.
+func TestResolveInputOutputMap_HyphenatedAndDottedIdents(t *testing.T) {
+	params := map[string]any{
+		"hdr":  "${input.params.x-forwarded-for}",
+		"db":   "${input.output.db-host}",
+		"port": "${input.params.db.host}",
+	}
+	ctx := InputContext{
+		Output: map[string]any{"db-host": "db.internal"},
+		Params: map[string]string{
+			"x-forwarded-for": "10.0.0.1",
+			"db.host":         "primary",
+		},
+	}
+	got, err := ResolveInputOutputMap(params, ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got["hdr"] != "10.0.0.1" {
+		t.Errorf("hdr = %q; want %q", got["hdr"], "10.0.0.1")
+	}
+	if got["db"] != "db.internal" {
+		t.Errorf("db = %q; want %q", got["db"], "db.internal")
+	}
+	if got["port"] != "primary" {
+		t.Errorf("port = %q; want %q", got["port"], "primary")
+	}
+}
+
 // TestResolveInputOutputMap_MultiToken pins multi-token interpolation
 // — e.g. constructing a URL from two distinct references. Each token
 // resolves independently against the same InputContext.
@@ -395,10 +429,22 @@ func TestValidateInputRefs(t *testing.T) {
 		{"params name", "${input.params.url}", false, ""},
 		{"embedded", "prefix-${input.output}-suffix", false, ""},
 		{"multi-token", "${input.params.scheme}://${input.output.host}", false, ""},
+		// Widened identifier class (PR #330 follow-up): hyphenated names
+		// (common for HTTP header values like `x-forwarded-for`) and
+		// dotted names (common for namespaced YAML keys like `db.host`)
+		// must both be accepted — the upstream params map is itself
+		// indexed by arbitrary string keys, so this resolver shouldn't
+		// be narrower than its lookup target.
+		{"params hyphenated", "${input.params.x-forwarded-for}", false, ""},
+		{"output hyphenated", "${input.output.db-host}", false, ""},
+		{"params dotted", "${input.params.db.host}", false, ""},
+		{"output dotted multi", "${input.output.a.b}", false, ""},
 		{"unknown kind", "${input.foo}", true, "${input.foo}"},
-		{"dotted path", "${input.output.a.b}", true, "${input.output.a.b}"},
 		{"params no field", "${input.params}", true, "${input.params}"},
 		{"output non-identifier", "${input.output.0bad}", true, "${input.output.0bad}"},
+		// Leading char is still strict — must be letter or underscore.
+		{"output leading hyphen", "${input.output.-foo}", true, "${input.output.-foo}"},
+		{"output leading dot", "${input.output..foo}", true, "${input.output..foo}"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/task/onfailurechain.go
+++ b/pkg/task/onfailurechain.go
@@ -127,9 +127,18 @@ func IsReservedChainParamKey(name string) bool {
 // Mutates s in place (zeroes any stripped fields) and returns non-fatal
 // warnings that callers should surface via their structured logger.
 func (s *OnFailureChainSpec) Validate() (warnings []string, err error) {
-	for k := range s.Params {
+	for k, v := range s.Params {
 		if _, reserved := reservedChainParamKeys[k]; reserved {
 			return nil, fmt.Errorf("on_failure_chain.params: %q is a reserved key (used by the engine)", k)
+		}
+		// Static validation of `${input.…}` references — same gate as
+		// trigger.chain.params (see spec.go). Catches malformed shapes
+		// at config load instead of letting them silently flow through
+		// as literal strings on the failure-chain edge.
+		if sv, ok := v.(string); ok {
+			if err := ValidateInputRefs(fmt.Sprintf("on_failure_chain.params.%s", k), sv); err != nil {
+				return nil, err
+			}
 		}
 	}
 	// MaxConcurrentGlobal and Storm are operator-policy fields that apply only

--- a/pkg/task/overrides.go
+++ b/pkg/task/overrides.go
@@ -188,6 +188,15 @@ func validatePerEdgeOverrides(site string, o *Overrides) error {
 		if _, reserved := reservedChainParamKeys[p.Name]; reserved {
 			return fmt.Errorf("%s: params %q is a reserved key (used by the engine)", site, p.Name)
 		}
+		// Static validation of `${input.…}` references on per-edge
+		// override defaults — same gate as trigger.chain.params /
+		// on_failure_chain.params. Catches malformed shapes at config
+		// load. The chain-edge variant runs against every Overrides
+		// site; the before-edge variant additionally rejects ANY
+		// `${input.…}` on before[0] (handled in validateBeforeRefs).
+		if err := ValidateInputRefs(fmt.Sprintf("%s.params.%s", site, p.Name), p.Default); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/task/overrides_test.go
+++ b/pkg/task/overrides_test.go
@@ -2,11 +2,11 @@ package task
 
 import "testing"
 
-// TestValidatePerEdgeOverrides_AcceptsInputOutputToken locks the contract
+// TestValidatePerEdgeOverrides_AcceptsBareOutputToken locks the contract
 // that validatePerEdgeOverrides does NOT reject ${input.output} appearing
 // as a per-edge param Default. The token survives config-load and is
 // resolved by ResolveInputOutputList at dispatch time.
-func TestValidatePerEdgeOverrides_AcceptsInputOutputToken(t *testing.T) {
+func TestValidatePerEdgeOverrides_AcceptsBareOutputToken(t *testing.T) {
 	o := &Overrides{
 		Params: ParamOverrides{
 			{Name: "content", Default: "${input.output}"},

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -739,9 +739,19 @@ func (s *Spec) validate() error {
 		// Reject reserved keys at config load so the engine never has to
 		// disambiguate user vs. engine values at firing time. Mirrors the
 		// check on OnFailureChainSpec.Params (see onfailurechain.go).
-		for k := range s.Trigger.Chain.Params {
+		for k, v := range s.Trigger.Chain.Params {
 			if _, reserved := reservedChainParamKeys[k]; reserved {
 				return fmt.Errorf("trigger.chain.params: %q is a reserved key (used by the engine)", k)
+			}
+			// Static validation of `${input.…}` references: catches
+			// malformed shapes (${input.foo}, ${input.output.a.b}, …)
+			// at config load. The resolver type-asserts per token at
+			// dispatch time; this surfaces typos before the first
+			// chain fire.
+			if sv, ok := v.(string); ok {
+				if err := ValidateInputRefs(fmt.Sprintf("trigger.chain.params.%s", k), sv); err != nil {
+					return err
+				}
 			}
 		}
 		if s.Trigger.Chain.Overrides != nil {

--- a/pkg/trigger/daemon_state.go
+++ b/pkg/trigger/daemon_state.go
@@ -220,14 +220,14 @@ func (e *Engine) propagateBeforeRerun(daemonSpec *task.Spec, reranTaskID string,
 	go func() {
 		defer e.restartGates.release(daemonSpec.ID)
 
-		// Convert the upstream return value to a string. Non-string
-		// returns leave initialOutput="" so a descendant referencing
-		// ${input.output} fails loudly rather than silently passing
-		// the literal token.
-		initialOutput := ""
-		if s, ok := reranReturn.(string); ok {
-			initialOutput = s
-		}
+		// Wrap the re-fired stage's return value in an InputContext.
+		// The resolver type-asserts per-token at dispatch time:
+		// ${input.output} requires a string, ${input.output.X} a map,
+		// etc. — so a non-string reranReturn yields ErrInputUnavailable
+		// loudly rather than silently passing a literal token to
+		// descendants. Params is nil here because preflight stages run
+		// with empty RunOptions.Params today.
+		initialCtx := task.InputContext{Output: reranReturn}
 
 		// Find the re-fired stage's index in the daemon's before list.
 		startIdx := -1
@@ -284,7 +284,7 @@ func (e *Engine) propagateBeforeRerun(daemonSpec *task.Spec, reranTaskID string,
 		if stageCtx == nil {
 			stageCtx = context.Background()
 		}
-		prevOutput := initialOutput
+		upstream := initialCtx
 		for i := startIdx + 1; i < len(daemonSpec.Trigger.Before); i++ {
 			if e.isShuttingDown() {
 				e.log.Debug("propagation aborted: engine shutting down",
@@ -299,7 +299,7 @@ func (e *Engine) propagateBeforeRerun(daemonSpec *task.Spec, reranTaskID string,
 				return
 			}
 			entry := daemonSpec.Trigger.Before[i]
-			out, err := e.dispatchPipelineStage(stageCtx, entry, i, prevOutput)
+			out, err := e.dispatchPipelineStage(stageCtx, entry, i, upstream)
 			if err != nil {
 				e.log.Warn("daemon mid-pipeline re-fire: descendant stage failed; daemon left at current state",
 					zap.String("task", daemonSpec.ID),
@@ -308,7 +308,7 @@ func (e *Engine) propagateBeforeRerun(daemonSpec *task.Spec, reranTaskID string,
 				)
 				return
 			}
-			prevOutput = out
+			upstream = out
 		}
 
 		// Last guard before tearing down + restarting: a stage could

--- a/pkg/trigger/e2e_input_output_test.go
+++ b/pkg/trigger/e2e_input_output_test.go
@@ -304,11 +304,11 @@ func TestE2E_InputOutput_NonStringUpstreamFailsLoudly(t *testing.T) {
 	}
 
 	// Upstream — input-output-non-string-upstream fixture returns a
-	// JSON object. coerceStringReturn's contract turns every non-string
-	// return into "", which propagates as ErrInputUnavailable through
-	// ResolveInputOutputMap and causes the chain dispatch to skip with
-	// an error log. The downstream fixture's chain.from references
-	// this ID directly so no rebind is needed.
+	// JSON object. The resolver's per-token type-assert for
+	// ${input.output} requires a string; a map yields
+	// ErrInputUnavailable, which causes the chain dispatch to skip
+	// with an error log. The downstream fixture's chain.from
+	// references this ID directly so no rebind is needed.
 	upstream, err := task.LoadDir(inputOutputFixtureDir(t, "input-output-non-string-upstream"))
 	if err != nil {
 		t.Fatalf("LoadDir input-output-non-string-upstream: %v", err)
@@ -357,19 +357,20 @@ func TestE2E_InputOutput_NonStringUpstreamFailsLoudly(t *testing.T) {
 	}
 }
 
-// TestE2E_InputOutput_EmbeddedTokenPassesThroughLiterally pins the
-// narrow grammar of the resolver: only param values whose VALUE IS
-// EXACTLY `${input.output}` are interpolated. An embedded reference
-// like `"prefix-${input.output}-suffix"` must reach the downstream
-// as a literal string — no partial substitution, no error.
+// TestE2E_InputOutput_EmbeddedTokenInterpolates pins the post-#316
+// behaviour: any string containing one or more recognised
+// `${input.…}` tokens is rewritten through ReplaceAllStringFunc, so an
+// embedded reference like `"prefix-${input.output}-suffix"` reaches
+// the downstream with the resolved value spliced in:
+// `"prefix-<upstream return>-suffix"`. PR #310 deliberately left this
+// case literal; #316 extends the grammar to support embedded forms.
 //
-// The hand-written tests in pkg/task/inputref_test.go assert this at
-// the unit layer; this e2e pins it at the chain-dispatch boundary so
-// a future refactor that swaps in a more lenient regex-based resolver
-// can't accidentally pass through. Upstream is the REAL
-// `tasks/buildin/template/` task — the rendered string is what
-// flows into `input.output` via the in-memory cache.
-func TestE2E_InputOutput_EmbeddedTokenPassesThroughLiterally(t *testing.T) {
+// The hand-written tests in pkg/task/inputref_test.go cover this at
+// the unit layer; this e2e pins it at the chain-dispatch boundary so a
+// future regression to the narrow grammar can't slip through.
+// Upstream is the REAL `tasks/buildin/template/` task — the rendered
+// string is what flows into `input.output` via the in-memory cache.
+func TestE2E_InputOutput_EmbeddedTokenInterpolates(t *testing.T) {
 	if testing.Short() {
 		t.Skip("requires Deno subprocess")
 	}
@@ -381,13 +382,14 @@ func TestE2E_InputOutput_EmbeddedTokenPassesThroughLiterally(t *testing.T) {
 	e := newTestEnv(t)
 
 	const upstreamID = "input-output-upstream"
-	const embeddedLiteral = "prefix-${input.output}-suffix"
+	const upstreamReturn = "the-real-value"
+	const chainValue = "prefix-${input.output}-suffix"
+	const wantMarker = "prefix-the-real-value-suffix"
 
-	// Downstream — same fixture as the happy-path test, just with the
-	// embedded literal bound to chain.params.value. The marker MUST
-	// receive it verbatim because partial interpolation is outside
-	// the resolver's grammar.
-	downstream := loadInputOutputDownstream(t, embeddedLiteral)
+	// Downstream — same fixture as the happy-path test, with the
+	// embedded literal bound to chain.params.value. The marker
+	// receives the spliced result.
+	downstream := loadInputOutputDownstream(t, chainValue)
 	downstreamID := downstream.ID
 	if err := e.reg.Register(downstream); err != nil {
 		t.Fatalf("reg.Register downstream: %v", err)
@@ -399,7 +401,7 @@ func TestE2E_InputOutput_EmbeddedTokenPassesThroughLiterally(t *testing.T) {
 	}
 
 	upRunID, err := e.engine.FireManual(context.Background(), upstreamID,
-		map[string]string{"template": "the-real-value"})
+		map[string]string{"template": upstreamReturn})
 	if err != nil {
 		t.Fatalf("FireManual upstream: %v", err)
 	}
@@ -416,13 +418,90 @@ func TestE2E_InputOutput_EmbeddedTokenPassesThroughLiterally(t *testing.T) {
 		t.Errorf("downstream status = %q, want success", got.Status)
 	}
 
-	// The marker MUST hold the literal string verbatim — partial
-	// substitution like "prefix-the-real-value-suffix" would mean the
-	// resolver had moved beyond the narrow "value-is-exactly-token"
-	// grammar PR #310 ships.
 	markerContent := pollFileContents(t, markerPath, 5*time.Second)
-	if markerContent != embeddedLiteral {
-		t.Errorf("marker file = %q, want literal %q (resolver should not interpolate embedded tokens)",
-			markerContent, embeddedLiteral)
+	if markerContent != wantMarker {
+		t.Errorf("marker file = %q, want %q (embedded token was not interpolated)",
+			markerContent, wantMarker)
+	}
+}
+
+// TestE2E_InputOutput_ChainParamsOutputFieldSubstitution drives the
+// post-#316 ${input.output.<field>} grammar end-to-end through real
+// Deno. The upstream — the existing input-output-non-string-upstream
+// fixture — returns the JSON object `{x: 1, y: "hello"}`. The
+// downstream's chain.params.value references `${input.output.y}` so
+// the resolver must lift the string field out of the upstream's
+// structured return and splice it into the downstream's `input.value`.
+// The marker file pins the substituted value end-to-end.
+//
+// This is the e2e companion to TestResolveInputOutputMap_OutputField_StringOK
+// (unit-layer) and TestBefore_PipesInputOutputFieldThroughStages
+// (preflight-edge integration), closing out the new grammar's
+// coverage at the chain-dispatch boundary.
+func TestE2E_InputOutput_ChainParamsOutputFieldSubstitution(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+
+	markerDir := t.TempDir()
+	markerPath := filepath.Join(markerDir, "field.marker")
+	t.Setenv("MARKER_PATH", markerPath)
+
+	e := newTestEnv(t)
+
+	// Downstream — input-output-downstream's task.ts reads
+	// `input.value` and writes it to ${MARKER_PATH}. We rebind
+	// chain.from to point at the non-string upstream (whose on-disk
+	// chain.from would otherwise route to the buildin/template
+	// upstream this test doesn't use) and inject the
+	// `${input.output.y}` reference into chain.params.value.
+	downstream, err := task.LoadDir(inputOutputFixtureDir(t, "input-output-downstream"))
+	if err != nil {
+		t.Fatalf("LoadDir input-output-downstream: %v", err)
+	}
+	if downstream.Trigger.Chain == nil {
+		t.Fatal("input-output-downstream fixture missing trigger.chain block")
+	}
+	downstream.Trigger.Chain.From = "input-output-non-string-upstream"
+	downstream.Trigger.Chain.Params = map[string]any{"value": "${input.output.y}"}
+	if err := downstream.Validate(); err != nil {
+		t.Fatalf("downstream re-validate after rebind: %v", err)
+	}
+	downstreamID := downstream.ID
+	if err := e.reg.Register(downstream); err != nil {
+		t.Fatalf("reg.Register downstream: %v", err)
+	}
+
+	// Upstream — returns `{x: 1, y: "hello"}` (per the fixture's
+	// task.ts).
+	upstream, err := task.LoadDir(inputOutputFixtureDir(t, "input-output-non-string-upstream"))
+	if err != nil {
+		t.Fatalf("LoadDir input-output-non-string-upstream: %v", err)
+	}
+	upstreamID := upstream.ID
+	if err := e.reg.Register(upstream); err != nil {
+		t.Fatalf("reg.Register upstream: %v", err)
+	}
+
+	upRunID, err := e.engine.FireManual(context.Background(), upstreamID, nil)
+	if err != nil {
+		t.Fatalf("FireManual upstream: %v", err)
+	}
+	primary := waitForTerminal(t, e.engine, upRunID, 30*time.Second)
+	if primary.Status != registry.StatusSuccess {
+		t.Fatalf("upstream status = %q, want success", primary.Status)
+	}
+
+	got := waitForRunOfTask(t, e.engine, downstreamID, 30*time.Second)
+	if got == nil {
+		t.Fatal("downstream was not fired within the timeout")
+	}
+	if got.Status != registry.StatusSuccess {
+		t.Errorf("downstream status = %q, want success", got.Status)
+	}
+
+	markerContent := pollFileContents(t, markerPath, 5*time.Second)
+	if markerContent != "hello" {
+		t.Errorf("marker file = %q, want %q (output.field did not resolve)", markerContent, "hello")
 	}
 }

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -364,6 +364,14 @@ func (e *Engine) Register(spec *task.Spec) error {
 	return nil
 }
 
+// inputParamsRefRe matches any `${input.params.<name>}` token in a
+// per-edge override default. Used by validateBeforeRefs to reject
+// references to upstream params on preflight before-edges, where the
+// upstream params snapshot is statically unavailable (preflight stages
+// run with an empty RunOptions, see dispatchPipelineStage). The
+// identifier class mirrors task.inputRefRe so the two stay in sync.
+var inputParamsRefRe = regexp.MustCompile(`\$\{input\.params\.[A-Za-z_][A-Za-z0-9_.\-]*\}`)
+
 // validateBeforeRefs checks each trigger.before entry against the current
 // registry. Per-spec validation (Spec.validate) already enforces shape;
 // here we only catch the things that need the full registry: unknown task
@@ -399,9 +407,9 @@ func (e *Engine) validateBeforeRefs(spec *task.Spec) error {
 		// at dispatch time, so any well-formed `${input.output…}` or
 		// `${input.params…}` reference is statically unresolvable.
 		// Reject at registration so the operator sees the failure at
-		// config-load time. Non-first stages are allowed because
-		// runPrereqs pipes the previous stage's output (and, in
-		// future, params) forward.
+		// config-load time. Non-first stages are allowed to use
+		// `${input.output…}` because runPrereqs pipes the previous
+		// stage's return value forward.
 		//
 		// Malformed shapes (${input.foo}, ${input.output.a.b}, …) are
 		// caught by Spec.validate via validatePerEdgeOverrides; this
@@ -413,6 +421,25 @@ func (e *Engine) validateBeforeRefs(spec *task.Spec) error {
 					return fmt.Errorf(
 						"trigger.before[0].overrides.params.%s: ${input.…} references are not available on the first pipeline stage",
 						p.Name,
+					)
+				}
+			}
+		}
+		// `${input.params.X}` is rejected on every preflight before-edge,
+		// not just before[0]: dispatchPipelineStage fires each preflight
+		// stage with an empty RunOptions, so the upstream params snapshot
+		// it threads forward is always nil. A reference would always
+		// fail loudly at dispatch with ErrInputUnavailable("upstream
+		// params not available"), which is a confusing runtime error
+		// for what is really a static config bug. Surface it at
+		// registration instead. (`${input.output…}` continues to work
+		// on before[i > 0] — that channel IS populated.)
+		if i > 0 && entry.Overrides != nil {
+			for _, p := range entry.Overrides.Params {
+				if inputParamsRefRe.MatchString(p.Default) {
+					return fmt.Errorf(
+						"trigger.before[%d].overrides.params.%s: ${input.params.…} is not available on preflight stages — preflight stages don't receive a params context from upstream",
+						i, p.Name,
 					)
 				}
 			}

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -395,17 +395,23 @@ func (e *Engine) validateBeforeRefs(spec *task.Spec) error {
 				return fmt.Errorf("trigger.before: overrides for %q produce invalid spec: %w", entry.Task, err)
 			}
 		}
-		// ${input.output} on before[0] is statically unresolvable: the
-		// first pipeline stage has no upstream return value. Reject at
-		// registration so operators see the failure at config-load time
-		// rather than the first daemon dispatch. Non-first stages are
-		// allowed because PR3 will pipe the previous stage's output into
-		// upstreamOutput.
+		// before[0] has no upstream return value AND no upstream params
+		// at dispatch time, so any well-formed `${input.output…}` or
+		// `${input.params…}` reference is statically unresolvable.
+		// Reject at registration so the operator sees the failure at
+		// config-load time. Non-first stages are allowed because
+		// runPrereqs pipes the previous stage's output (and, in
+		// future, params) forward.
+		//
+		// Malformed shapes (${input.foo}, ${input.output.a.b}, …) are
+		// caught by Spec.validate via validatePerEdgeOverrides; this
+		// check focuses on the dispatch-time invariant unique to
+		// before[0].
 		if i == 0 && entry.Overrides != nil {
 			for _, p := range entry.Overrides.Params {
-				if p.Default == task.InputOutputToken {
+				if strings.Contains(p.Default, "${input.") {
 					return fmt.Errorf(
-						"trigger.before[0].overrides.params.%s: ${input.output} is not available on the first pipeline stage",
+						"trigger.before[0].overrides.params.%s: ${input.…} references are not available on the first pipeline stage",
 						p.Name,
 					)
 				}
@@ -778,7 +784,12 @@ func (e *Engine) runPrereqs(ctx context.Context, spec *task.Spec) error {
 		return nil
 	}
 
-	var prevOutput string
+	// The first stage runs against an empty InputContext — registration
+	// already rejects `${input.…}` references on before[0]. Subsequent
+	// stages carry the previous stage's full return value AND its
+	// RunOptions.Params (today: always empty), wired through
+	// dispatchPipelineStage.
+	var upstream task.InputContext
 	for i, entry := range spec.Trigger.Before {
 		entry := entry
 		if e.isShuttingDown() {
@@ -793,39 +804,40 @@ func (e *Engine) runPrereqs(ctx context.Context, spec *task.Spec) error {
 				zap.Int("stage", i))
 			return nil
 		}
-		out, err := e.dispatchPipelineStage(ctx, entry, i, prevOutput)
+		out, err := e.dispatchPipelineStage(ctx, entry, i, upstream)
 		if err != nil {
 			return err
 		}
-		prevOutput = out
+		upstream = out
 	}
 	return nil
 }
 
 // dispatchPipelineStage runs a single trigger.before stage:
 //
-//  1. Resolves ${input.output} in entry.Overrides.Params against
-//     upstreamOutput (the previous stage's return value, or "" for the
-//     first stage). The override pointer is shallow-copied before
-//     mutation so the registry-held spec is never written to —
-//     concurrent preflight fires therefore never race on this field.
+//  1. Resolves recognised `${input.…}` references in entry.Overrides.Params
+//     against the supplied InputContext (the previous stage's return value
+//     + the previous stage's RunOptions.Params, or empty for the first
+//     stage). The override pointer is shallow-copied before mutation so
+//     the registry-held spec is never written to — concurrent preflight
+//     fires therefore never race on this field.
 //  2. Applies per-edge overrides onto a deep copy of the registry
 //     spec and re-validates.
 //  3. Fires the stage and waits for terminal status via WaitRun.
-//  4. Returns the stage's string return value (empty for non-string
-//     returns) so the next stage's ${input.output} resolves loudly
-//     rather than silently passing the literal token downstream.
+//  4. Returns the stage's full return value AND its RunOptions.Params
+//     so the next stage's ${input.…} references resolve loudly rather
+//     than silently passing the literal token downstream.
 //
 // Shared by runPrereqs and the mid-pipeline re-fire propagation path
 // in daemon_state.go so both code paths apply identical semantics.
-func (e *Engine) dispatchPipelineStage(ctx context.Context, entry task.BeforeEntry, stageIdx int, upstreamOutput string) (string, error) {
+func (e *Engine) dispatchPipelineStage(ctx context.Context, entry task.BeforeEntry, stageIdx int, upstream task.InputContext) (task.InputContext, error) {
 	refID := entry.Task
 	ref, ok := e.registry.Get(refID)
 	if !ok {
 		// validateBeforeRefs catches this at registration time, but the
 		// registry can change between registration and preflight (task
 		// unregistered while daemon was queued, etc.). Defensive check.
-		return "", fmt.Errorf("stage %d (%s): prereq vanished from registry", stageIdx, refID)
+		return task.InputContext{}, fmt.Errorf("stage %d (%s): prereq vanished from registry", stageIdx, refID)
 	}
 
 	// Per-edge overrides (#303): if this preflight edge declares
@@ -837,16 +849,16 @@ func (e *Engine) dispatchPipelineStage(ctx context.Context, entry task.BeforeEnt
 	if entry.Overrides != nil {
 		ovPtr := entry.Overrides
 		if entry.Overrides.Params != nil {
-			// Resolve ${input.output} against the previous stage's
-			// return value. Shallow-copy entry.Overrides before
-			// mutating Params — *Overrides is shared with the
-			// registry-held spec, and concurrent preflight fires
-			// would otherwise race on this field. (Fixes the
-			// pointer-shared mutation hazard flagged in PR2's
-			// reviewer note.)
-			resolved, rerr := task.ResolveInputOutputList(entry.Overrides.Params, upstreamOutput)
+			// Resolve `${input.…}` references against the previous
+			// stage's return value + params. Shallow-copy
+			// entry.Overrides before mutating Params — *Overrides is
+			// shared with the registry-held spec, and concurrent
+			// preflight fires would otherwise race on this field.
+			// (Fixes the pointer-shared mutation hazard flagged in
+			// PR2's reviewer note.)
+			resolved, rerr := task.ResolveInputOutputList(entry.Overrides.Params, upstream)
 			if rerr != nil {
-				return "", fmt.Errorf("stage %d (%s): resolve input refs: %w", stageIdx, refID, rerr)
+				return task.InputContext{}, fmt.Errorf("stage %d (%s): resolve input refs: %w", stageIdx, refID, rerr)
 			}
 			// Shallow-copy entry.Overrides so the Params write below cannot
 			// reach the registry-held *Overrides via the pointer. Other fields
@@ -866,14 +878,21 @@ func (e *Engine) dispatchPipelineStage(ctx context.Context, entry task.BeforeEnt
 		// and the preflight fire.
 		merged := taskset.ApplyOverrides(ref, ovPtr)
 		if vErr := merged.Validate(); vErr != nil {
-			return "", fmt.Errorf("stage %d (%s): overrides produce invalid spec: %w", stageIdx, refID, vErr)
+			return task.InputContext{}, fmt.Errorf("stage %d (%s): overrides produce invalid spec: %w", stageIdx, refID, vErr)
 		}
 		dispatchSpec = merged
 	}
 
-	runID, err := e.fireAsync(ctx, dispatchSpec, pkgruntime.RunOptions{}, registry.TriggerPreflight)
+	// Snapshot the params we hand to fireAsync so the next stage's
+	// ${input.params.X} resolves against the params this stage saw.
+	// Preflight stages run with empty RunOptions.Params today — so
+	// this snapshot is always nil — but threading it through here lets
+	// a future change wire upstream params into the pipeline without
+	// touching the resolver contract again.
+	stageOpts := pkgruntime.RunOptions{}
+	runID, err := e.fireAsync(ctx, dispatchSpec, stageOpts, registry.TriggerPreflight)
 	if err != nil {
-		return "", fmt.Errorf("stage %d (%s): dispatch: %w", stageIdx, refID, err)
+		return task.InputContext{}, fmt.Errorf("stage %d (%s): dispatch: %w", stageIdx, refID, err)
 	}
 
 	// WaitRun (channel-backed) wakes on the runDone close and merges the
@@ -882,20 +901,19 @@ func (e *Engine) dispatchPipelineStage(ctx context.Context, entry task.BeforeEnt
 	// buildin/template) still surface their value to the next stage.
 	res, werr := e.WaitRun(ctx, runID)
 	if werr != nil {
-		return "", fmt.Errorf("stage %d (%s): wait: %w", stageIdx, refID, werr)
+		return task.InputContext{}, fmt.Errorf("stage %d (%s): wait: %w", stageIdx, refID, werr)
 	}
 	if res.Status != registry.StatusSuccess {
-		return "", fmt.Errorf("stage %d (%s): run %s ended with status %s", stageIdx, refID, runID, res.Status)
+		return task.InputContext{}, fmt.Errorf("stage %d (%s): run %s ended with status %s", stageIdx, refID, runID, res.Status)
 	}
 
-	// Only string returns flow as ${input.output} to the next stage.
-	// Non-string returns leave the next upstreamOutput="" so any
-	// reference downstream surfaces ErrInputUnavailable loudly rather
-	// than silently passing the literal token.
-	if s, ok := res.ReturnValue.(string); ok {
-		return s, nil
-	}
-	return "", nil
+	// Pass the FULL return value (not just a string-coerced view) into
+	// the next stage's InputContext.Output. The resolver type-asserts
+	// per-token: ${input.output} requires a string, ${input.output.X}
+	// requires a map. Non-resolvable references downstream now fail
+	// with a per-token reason instead of a one-size-fits-all "no
+	// upstream value".
+	return task.InputContext{Output: res.ReturnValue, Params: stageOpts.Params}, nil
 }
 
 func (e *Engine) onDaemonRunFinished(spec *task.Spec, runID string) {
@@ -1189,7 +1207,12 @@ func (e *Engine) KillRun(runID string) bool {
 
 // FireChain checks if any tasks declare a chain trigger from completedTaskID,
 // and fires the global on_failure_chain if configured.
-func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatus string, output interface{}) {
+//
+// upstreamParams is the upstream run's RunOptions.Params snapshot —
+// piped through to the dispatch-time `${input.params.<name>}`
+// resolver. Callers that don't track upstream params (e.g.
+// preflight-short-circuit paths) pass nil.
+func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatus string, output interface{}, upstreamParams map[string]string) {
 	// Preflight restart hook: when a task that some daemon lists in
 	// trigger.before finishes with status=success, restart that daemon so
 	// it picks up newly-rendered config / freshly-rotated secrets. Failure
@@ -1198,6 +1221,12 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 	if runStatus == registry.StatusSuccess {
 		e.notifyPrereqCompletion(completedTaskID, output)
 	}
+	// Shared resolver context for both the success-chain and
+	// on_failure_chain dispatch paths below. The full upstream return
+	// value flows through to the resolver — type-asserts happen
+	// per-token (${input.output} requires string, ${input.output.X}
+	// requires map).
+	upstreamCtx := task.InputContext{Output: output, Params: upstreamParams}
 
 	// Declared chain triggers.
 	for _, spec := range e.registry.All() {
@@ -1229,16 +1258,16 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 			}
 			dispatchSpec = merged
 		}
-		// Dispatch-time ${input.output} interpolation: substitute the
-		// literal token in chain.Params with the upstream's return value.
-		// Only direct-string upstream returns flow through; non-string
-		// returns are treated as "no upstream available" — the chain
-		// dispatch is skipped (logged) rather than silently passing the
-		// literal token to the downstream.
-		upstreamRet := coerceStringReturn(output)
-		resolvedParams, rerr := task.ResolveInputOutputMap(chain.Params, upstreamRet)
+		// Dispatch-time `${input.…}` interpolation against the upstream
+		// context (full return value + RunOptions.Params snapshot). The
+		// resolver type-asserts per-token: ${input.output} requires a
+		// string, ${input.output.X} requires a map, ${input.params.X}
+		// requires a non-nil Params map with the named entry. Any
+		// resolution failure skips the chain dispatch (logged) rather
+		// than silently passing a literal token to the downstream.
+		resolvedParams, rerr := task.ResolveInputOutputMap(chain.Params, upstreamCtx)
 		if rerr != nil {
-			e.log.Error("chain trigger skipped — failed to resolve ${input.output}",
+			e.log.Error("chain trigger skipped — failed to resolve ${input.…} reference",
 				zap.String("from", completedTaskID),
 				zap.String("to", spec.ID),
 				zap.Error(rerr),
@@ -1339,20 +1368,18 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 					return
 				}
 
-				// Dispatch-time ${input.output} interpolation: substitute
-				// the literal token in chainSpec.Params with the upstream's
-				// return value. Symmetric with the success-chain path above —
-				// any chain edge supports the token; non-string upstream
-				// returns are treated as "no upstream available" and the
-				// failure-chain dispatch is skipped (logged) rather than
-				// silently passing the literal token to the downstream.
-				// Release the chainGuards slot we just acquired so a failed
+				// Dispatch-time `${input.…}` interpolation against the
+				// upstream context. Symmetric with the success-chain
+				// path above — any chain edge supports the recognised
+				// shapes; failure-chain dispatch is skipped (logged) on
+				// resolution failure rather than silently passing a
+				// literal token to the downstream. Release the
+				// chainGuards slot we just acquired so a failed
 				// resolution doesn't burn cap_per_task / cap_global.
-				upstreamRet := coerceStringReturn(output)
-				resolvedParams, rerr := task.ResolveInputOutputMap(chainSpec.Params, upstreamRet)
+				resolvedParams, rerr := task.ResolveInputOutputMap(chainSpec.Params, upstreamCtx)
 				if rerr != nil {
 					e.guards.releaseSlot(completedTaskID)
-					e.log.Error("on_failure_chain skipped — failed to resolve ${input.output}",
+					e.log.Error("on_failure_chain skipped — failed to resolve ${input.…} reference",
 						zap.String("from", completedTaskID),
 						zap.String("to", targetID),
 						zap.Error(rerr),
@@ -1414,16 +1441,6 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 			}
 		}
 	}
-}
-
-// coerceStringReturn coerces any return value to a string for
-// ${input.output} interpolation. JSON-marshalled objects, numbers,
-// and lists are NOT auto-stringified — only direct string returns
-// flow through. Non-string returns produce "" which propagates as
-// ErrInputUnavailable through the resolver.
-func coerceStringReturn(rv interface{}) string {
-	s, _ := rv.(string)
-	return s
 }
 
 // buildChainInput shapes the `Input` value handed to a downstream task that
@@ -2094,7 +2111,7 @@ func (e *Engine) runTask(runCtx context.Context, spec *task.Spec, opts pkgruntim
 		_ = e.registry.FinishRunWithReason(context.Background(), opts.RunID, preStatus, preReason)
 		// dispatch normally fires FireChain; on the preflight short-circuit
 		// we replicate it so chain triggers still observe the failure.
-		go e.FireChain(context.Background(), spec.ID, opts.RunID, preStatus, nil)
+		go e.FireChain(context.Background(), spec.ID, opts.RunID, preStatus, nil, opts.Params)
 		status = preStatus
 		result = &pkgruntime.RunResult{RunID: opts.RunID, Error: errors.New(preReason)}
 	} else {
@@ -2479,7 +2496,7 @@ func (e *Engine) dispatch(ctx context.Context, spec *task.Spec, opts pkgruntime.
 		}
 	}
 
-	e.FireChain(context.Background(), spec.ID, opts.RunID, status, result.ChainInput)
+	e.FireChain(context.Background(), spec.ID, opts.RunID, status, result.ChainInput, opts.Params)
 	return status, result
 }
 

--- a/pkg/trigger/engine_chain_params_test.go
+++ b/pkg/trigger/engine_chain_params_test.go
@@ -343,10 +343,119 @@ func TestChainDispatch_ResolvesInputOutput(t *testing.T) {
 	}
 }
 
-// strPtr is a tiny helper for the TestCoerceStringReturn table — Go has no
-// literal syntax for "address of a string literal" so the typed-nil and
-// pointer-to-string cases need a helper to construct the *string.
-func strPtr(s string) *string { return &s }
+// TestChainDispatch_ResolvesInputParams pins the post-#316 grammar
+// for ${input.params.<name>}: when the upstream was fired with a
+// non-empty RunOptions.Params, those values pipe into the downstream's
+// chain.params. This exercises the success-chain edge with a real
+// upstream fire (FireManual carries the params snapshot through
+// runTask → FireChain).
+func TestChainDispatch_ResolvesInputParams(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	// Downstream — chain.params.endpoint references the upstream's
+	// `url` param.
+	downstream := writeTask(t, dir, "downstream-params-pipe",
+		`export default async function main({ input }) { return input }`,
+		task.TriggerConfig{
+			Chain: &task.ChainTrigger{
+				From:   "upstream-params-pipe",
+				On:     "success",
+				Params: map[string]any{"endpoint": "${input.params.url}"},
+			},
+		})
+	_ = e.reg.Register(downstream)
+
+	upstream := writeTask(t, dir, "upstream-params-pipe",
+		`export default async function main() { return "rendered" }`,
+		task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(upstream)
+
+	// Fire upstream with a param the chain edge will pull through.
+	upRunID, err := e.engine.FireManual(context.Background(), "upstream-params-pipe",
+		map[string]string{"url": "https://relay.example.com"})
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	primary := waitForTerminal(t, e.engine, upRunID, 30*time.Second)
+	if primary.Status != "success" {
+		t.Fatalf("upstream status = %q, want success", primary.Status)
+	}
+
+	got := waitForRunOfTask(t, e.engine, "downstream-params-pipe", 30*time.Second)
+	if got == nil {
+		t.Fatal("downstream-params-pipe was not fired within the timeout")
+	}
+	if got.Status != "success" {
+		t.Errorf("downstream status = %q, want success", got.Status)
+	}
+	returnValue := pollReturnValue(t, e.engine, got.ID, 5*time.Second)
+	var input map[string]any
+	if err := json.Unmarshal([]byte(returnValue), &input); err != nil {
+		t.Fatalf("unmarshal return value: %v", err)
+	}
+	if input["endpoint"] != "https://relay.example.com" {
+		t.Errorf("endpoint = %v, want https://relay.example.com (upstream params did not pipe through)", input["endpoint"])
+	}
+}
+
+// TestOnFailureChainDispatch_ResolvesInputOutputField drives FireChain
+// with an OBJECT-shaped `output` to verify the post-#316 grammar
+// extension: ${input.output.<field>} substitutes the named field's
+// string value. The path lifts a `{path: "..."}` return value
+// (the canonical write-local shape) into the downstream's params.
+func TestOnFailureChainDispatch_ResolvesInputOutputField(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	fallback := writeTask(t, dir, "fallback-field",
+		`export default async function main({ input }) { return input }`,
+		task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(fallback)
+
+	source := writeTask(t, dir, "source-field",
+		`export default async function main() { return "unused" }`,
+		task.TriggerConfig{Manual: true})
+	source.OnFailureChain = &task.OnFailureChainSpec{
+		Task:   "fallback-field",
+		Params: map[string]any{"target": "${input.output.path}", "literal": "untouched"},
+	}
+	_ = e.reg.Register(source)
+
+	parentRunID, err := e.reg.StartRunWithID(
+		context.Background(), "parent-field", "source-field", "", string(registry.TriggerManual),
+	)
+	if err != nil {
+		t.Fatalf("seed parent run: %v", err)
+	}
+	if err := e.reg.FinishRun(context.Background(), parentRunID, registry.StatusFailure); err != nil {
+		t.Fatalf("finish parent run: %v", err)
+	}
+
+	// Map-shaped output (the JSON-decode shape). The resolver picks
+	// "path" out and substitutes its string value into `target`.
+	e.engine.FireChain(context.Background(), "source-field", parentRunID, registry.StatusFailure,
+		map[string]any{"path": "/var/run/rendered.yaml"}, nil)
+
+	got := waitForRunOfTask(t, e.engine, "fallback-field", 30*time.Second)
+	if got == nil {
+		t.Fatal("fallback-field was not fired within the timeout")
+	}
+	if got.Status != "success" {
+		t.Errorf("fallback status = %q, want success", got.Status)
+	}
+	returnValue := pollReturnValue(t, e.engine, got.ID, 5*time.Second)
+	var input map[string]any
+	if err := json.Unmarshal([]byte(returnValue), &input); err != nil {
+		t.Fatalf("unmarshal return value: %v", err)
+	}
+	if input["target"] != "/var/run/rendered.yaml" {
+		t.Errorf("target = %v, want /var/run/rendered.yaml", input["target"])
+	}
+	if input["literal"] != "untouched" {
+		t.Errorf("literal = %v, want untouched", input["literal"])
+	}
+}
 
 // TestOnFailureChainDispatch_ResolvesInputOutput drives FireChain
 // directly with a controlled string `output` to verify that the
@@ -400,7 +509,7 @@ func TestOnFailureChainDispatch_ResolvesInputOutput(t *testing.T) {
 
 	// Drive FireChain with a string output. The resolver should
 	// substitute that string into chainSpec.Params["content"].
-	e.engine.FireChain(context.Background(), "source-interp", parentRunID, registry.StatusFailure, "rendered-error-output")
+	e.engine.FireChain(context.Background(), "source-interp", parentRunID, registry.StatusFailure, "rendered-error-output", nil)
 
 	got := waitForRunOfTask(t, e.engine, "fallback-interp", 30*time.Second)
 	if got == nil {
@@ -434,9 +543,10 @@ func TestOnFailureChainDispatch_ResolvesInputOutput(t *testing.T) {
 // skipped: the literal ${input.output} token must NOT pass through
 // unresolved.
 //
-// PR2's coerceStringReturn() turns non-string returns into "", which
-// propagates as ErrInputUnavailable through ResolveInputOutputMap, which
-// causes the dispatch to log + return without firing the downstream.
+// The resolver's per-token type-assert for ${input.output} requires
+// a string upstream; a map (or any non-string) yields
+// ErrInputUnavailable, which causes the dispatch to log + return
+// without firing the downstream.
 func TestOnFailureChainDispatch_NonStringUpstreamSkips(t *testing.T) {
 	dir := t.TempDir()
 	e := newTestEnv(t)
@@ -466,10 +576,10 @@ func TestOnFailureChainDispatch_NonStringUpstreamSkips(t *testing.T) {
 		t.Fatalf("finish parent run: %v", err)
 	}
 
-	// Non-string output: a map. coerceStringReturn returns "", resolver
-	// fails, dispatch must skip.
+	// Non-string output: a map. The resolver type-asserts ${input.output}
+	// as a string, so a map → ErrInputUnavailable → dispatch must skip.
 	e.engine.FireChain(context.Background(), "source-skip", parentRunID, registry.StatusFailure,
-		map[string]any{"nested": "object"})
+		map[string]any{"nested": "object"}, nil)
 
 	// Give the chain dispatcher a window to (incorrectly) fire.
 	time.Sleep(2 * time.Second)
@@ -482,32 +592,58 @@ func TestOnFailureChainDispatch_NonStringUpstreamSkips(t *testing.T) {
 	}
 }
 
-// TestCoerceStringReturn pins the helper's contract: only direct-string
-// returns flow through; everything else (maps, slices, numbers, nil,
-// typed-nil interfaces, pointers-to-string) becomes "". The empty string
-// then propagates as ErrInputUnavailable through the resolver, which is
-// the loud-failure path we want for non-string upstreams.
-func TestCoerceStringReturn(t *testing.T) {
-	var typedNilString *string // (*string)(nil); interface-wraps to a typed-nil
-	cases := []struct {
-		name string
-		in   interface{}
-		want string
-	}{
-		{"direct string", "hello", "hello"},
-		{"empty string", "", ""},
-		{"map", map[string]interface{}{"x": 1}, ""},
-		{"slice", []interface{}{1, 2}, ""},
-		{"number", 42, ""},
-		{"nil", nil, ""},
-		{"typed nil interface", typedNilString, ""},
-		{"pointer to string", strPtr("hello"), ""},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			if got := coerceStringReturn(c.in); got != c.want {
-				t.Errorf("coerceStringReturn(%v) = %q; want %q", c.in, got, c.want)
-			}
+// TestFireChain_RejectsNonStringForBareInputOutput is the modern
+// successor to TestCoerceStringReturn: it pins the contract that a
+// non-string upstream return value still triggers ErrInputUnavailable
+// when a downstream's chain.params references the bare ${input.output}
+// token. PR #316 retired the coerceStringReturn helper in favour of
+// per-token type-asserts inside the resolver; this test exercises the
+// same loud-failure path through the public FireChain entry point.
+func TestFireChain_RejectsNonStringForBareInputOutput(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+
+	// Downstream — chain.params.content references the bare token,
+	// which requires a string upstream. The upstream below returns a
+	// map; the resolver must short-circuit before fireAsync.
+	downstream := writeTask(t, dir, "ds-nonstring",
+		`export default async function main({ input }) { return input }`,
+		task.TriggerConfig{
+			Chain: &task.ChainTrigger{
+				From:   "us-nonstring",
+				On:     "success",
+				Params: map[string]any{"content": "${input.output}"},
+			},
 		})
+	_ = e.reg.Register(downstream)
+
+	upstream := writeTask(t, dir, "us-nonstring",
+		`export default async function main() { return "ignored" }`,
+		task.TriggerConfig{Manual: true})
+	_ = e.reg.Register(upstream)
+
+	// Seed a parent run so FireChain has a real runID to reference.
+	parentRunID, err := e.reg.StartRunWithID(
+		context.Background(), "ns-parent", "us-nonstring", "", string(registry.TriggerManual),
+	)
+	if err != nil {
+		t.Fatalf("seed parent run: %v", err)
+	}
+	if err := e.reg.FinishRun(context.Background(), parentRunID, registry.StatusSuccess); err != nil {
+		t.Fatalf("finish parent run: %v", err)
+	}
+
+	// Non-string output (map) → ${input.output} fails to resolve →
+	// dispatch must skip. We assert via the registry: downstream has
+	// zero runs.
+	e.engine.FireChain(context.Background(), "us-nonstring", parentRunID, registry.StatusSuccess,
+		map[string]any{"x": 1}, nil)
+	time.Sleep(2 * time.Second)
+	runs, err := e.engine.registry.ListRuns(context.Background(), "ds-nonstring", 5)
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) > 0 {
+		t.Errorf("ds-nonstring should not have run; got %d runs", len(runs))
 	}
 }

--- a/pkg/trigger/engine_preflight_test.go
+++ b/pkg/trigger/engine_preflight_test.go
@@ -856,6 +856,79 @@ func TestRegister_RejectsInputOutputOnFirstBeforeStage(t *testing.T) {
 	}
 }
 
+// TestRegister_RejectsInputParamsOnPreflightStage verifies that
+// validateBeforeRefs rejects ${input.params.X} on any preflight
+// before-edge, not just before[0]. dispatchPipelineStage fires each
+// preflight stage with an empty RunOptions, so the upstream params
+// snapshot it threads forward is always nil — a reference would always
+// fail loudly at dispatch with ErrInputUnavailable. Surfacing it at
+// registration produces the clearer config-load error.
+func TestRegister_RejectsInputParamsOnPreflightStage(t *testing.T) {
+	eng, reg, _ := newPreflightEnv(t)
+
+	render := &task.Spec{
+		ID:      "render",
+		Name:    "render",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Enabled: true,
+	}
+	if err := reg.Register(render); err != nil {
+		t.Fatalf("register render: %v", err)
+	}
+	write := &task.Spec{
+		ID:      "write",
+		Name:    "write",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Enabled: true,
+	}
+	if err := reg.Register(write); err != nil {
+		t.Fatalf("register write: %v", err)
+	}
+
+	daemon := &task.Spec{
+		ID:      "my-daemon",
+		Name:    "my-daemon",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{
+			Daemon: true,
+			Before: []task.BeforeEntry{
+				// before[0]: no ${input.…} — must be a valid first stage
+				{Task: "render"},
+				// before[1]: references upstream params, which preflight
+				// stages never receive. Must be rejected at registration.
+				{
+					Task: "write",
+					Overrides: &task.Overrides{
+						Params: task.ParamOverrides{
+							{Name: "endpoint", Default: "${input.params.url}"},
+						},
+					},
+				},
+			},
+		},
+		Enabled: true,
+	}
+	err := eng.Register(daemon)
+	if err == nil {
+		t.Fatal("expected register to reject ${input.params.X} on a preflight before-edge")
+	}
+	if !strings.Contains(err.Error(), "${input.params") {
+		t.Errorf("error should mention ${input.params; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "before[1]") {
+		t.Errorf("error should pinpoint the offending stage; got %v", err)
+	}
+	// ${input.output.X} on the same edge must continue to work —
+	// only the params channel is statically unresolvable on preflight.
+	daemon.Trigger.Before[1].Overrides.Params[0].Default = "${input.output.path}"
+	if err := eng.Register(daemon); err != nil {
+		t.Fatalf("${input.output.X} on before[i>0] should still register: %v", err)
+	}
+}
+
 // waitForCond polls cond until it returns true or the deadline expires.
 // Distinct from waitUntil (which fails the test on timeout): used by the
 // new sequential-pipeline tests where the caller wants to assert on the

--- a/pkg/trigger/engine_preflight_test.go
+++ b/pkg/trigger/engine_preflight_test.go
@@ -848,8 +848,8 @@ func TestRegister_RejectsInputOutputOnFirstBeforeStage(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected register to reject ${input.output} on before[0]")
 	}
-	if !strings.Contains(err.Error(), "input.output") {
-		t.Errorf("error should mention input.output; got %v", err)
+	if !strings.Contains(err.Error(), "${input.") {
+		t.Errorf("error should mention ${input. prefix; got %v", err)
 	}
 	if !strings.Contains(err.Error(), "before[0]") {
 		t.Errorf("error should pinpoint the offending stage; got %v", err)
@@ -920,6 +920,95 @@ func TestBefore_SequentialExecution(t *testing.T) {
 	want := []string{"stage-a", "stage-b", "stage-c"}
 	if !reflect.DeepEqual(order, want) {
 		t.Errorf("before-list ran out of order: got %v, want %v", order, want)
+	}
+}
+
+// TestBefore_PipesInputOutputFieldThroughStages exercises the
+// post-#316 grammar extension on the preflight edge:
+// ${input.output.<field>} lifts a named string field out of a
+// structured upstream return value. Stage 1 returns
+// {path: "/var/run/relay.yaml"}; stage 2's override.content references
+// the field directly. The captured spec's content default must equal
+// the field value — the resolver type-asserts the map and pulls the
+// string out before the writer fires.
+func TestBefore_PipesInputOutputFieldThroughStages(t *testing.T) {
+	eng, reg, exec := newPreflightEnv(t)
+
+	exec.setReturnFn("render-obj", func(_, _ string, _ *task.Spec) interface{} {
+		return map[string]any{"path": "/var/run/relay.yaml", "size": 42}
+	})
+	render := makeOneShotSpec("render-obj")
+	if err := reg.Register(render); err != nil {
+		t.Fatalf("register render-obj: %v", err)
+	}
+
+	writer := &task.Spec{
+		ID:      "write-obj",
+		Name:    "write-obj",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Params: task.Params{
+			{Name: "target", Required: true},
+		},
+		Enabled: true,
+	}
+	if err := reg.Register(writer); err != nil {
+		t.Fatalf("register writer: %v", err)
+	}
+
+	daemon := &task.Spec{
+		ID:      "d-obj",
+		Name:    "d-obj",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{
+			Daemon:  true,
+			Restart: "never",
+			Before: []task.BeforeEntry{
+				{Task: "render-obj"},
+				{
+					Task: "write-obj",
+					Overrides: &task.Overrides{
+						Params: task.ParamOverrides{
+							{Name: "target", Default: "${input.output.path}"},
+						},
+					},
+				},
+			},
+		},
+		Enabled: true,
+	}
+	if err := reg.Register(daemon); err != nil {
+		t.Fatalf("register daemon: %v", err)
+	}
+	exec.markDaemon("d-obj")
+
+	if err := eng.Register(daemon); err != nil {
+		t.Fatalf("eng.Register: %v", err)
+	}
+
+	var writeSpec *task.Spec
+	waitUntil(t, 5*time.Second, func() bool {
+		runs, _ := reg.ListRuns(context.Background(), "write-obj", 5)
+		for _, r := range runs {
+			if r.TriggerSource == registry.TriggerPreflight {
+				if s := exec.specForRun(r.ID); s != nil {
+					writeSpec = s
+					return true
+				}
+			}
+		}
+		return false
+	}, "write-obj stage never captured by executor")
+
+	var got string
+	for _, p := range writeSpec.Params {
+		if p.Name == "target" {
+			got = p.Default
+		}
+	}
+	if got != "/var/run/relay.yaml" {
+		t.Errorf("write-obj.target default = %q; want %q (output.field did not resolve)", got, "/var/run/relay.yaml")
 	}
 }
 


### PR DESCRIPTION
## Summary

Extends the dispatch-time `${input.*}` interpolation grammar (shipped in PR #310 as exact-token-only `${input.output}`) to three new recognised forms, plus embedded multi-token forms.

Closes #316.

### New grammar

| Form | Resolves to | Loud-fail when |
| --- | --- | --- |
| `${input.output}` | upstream's full string return value | upstream returned a non-string |
| `${input.output.<field>}` | named string field of an object-shaped upstream return (e.g. `{path: "..."}`) | upstream isn't an object, field absent, field non-string |
| `${input.params.<name>}` | named entry from the upstream's `RunOptions.Params` (chain edge: caller-supplied params on the upstream's fire; preflight edge: always empty today) | params map nil or named entry missing |

Embedded forms (`"prefix-${input.output}-suffix"`) and multi-token forms (`"${input.params.scheme}://${input.output.host}"`) are now supported — any string containing one or more recognised tokens is rewritten in place.

Unknown shapes (`${input.foo}`, `${input.output.a.b}`, `${input.params}` without a field) are rejected at task-registration time via `ValidateInputRefs` so operators see typos at config-load instead of at the first dispatch.

### Backwards-compat note

Embedded forms previously stayed literal. The repo audit (grep for `\${input.` across `.go`, `.yaml`, `.md`) found exactly one site asserting on the literal pass-through: the test `TestE2E_InputOutput_EmbeddedTokenPassesThroughLiterally`, which is replaced by `TestE2E_InputOutput_EmbeddedTokenInterpolates` (pins the new behaviour end-to-end through real Deno). No production / buildin task references embedded forms.

### Implementation

- `pkg/task/inputref.go` — regex-based resolver with `InputContext` (`Output any`, `Params map[string]string`); per-token type-asserts; `ValidateInputRefs` as the registration-time gate.
- `pkg/task/spec.go`, `pkg/task/onfailurechain.go`, `pkg/task/overrides.go` — call `ValidateInputRefs` at config-load for every interpolation site (`trigger.chain.params`, `on_failure_chain.params`, per-edge `overrides.params`).
- `pkg/trigger/engine.go` — `FireChain` now takes `upstreamParams`; the resolver runs against the full upstream return value (not just a string-coerced view); `coerceStringReturn` helper retired.
- `pkg/trigger/daemon_state.go`, `dispatchPipelineStage` — thread an `InputContext` (Output + Params snapshot) through pipeline stages.

## Test plan

- [x] `go test ./pkg/task/ ./pkg/trigger/ -timeout 600s` — green
- [x] `go test ./... -timeout 600s` — green across all packages
- [x] `make build && make format && make format-check` — clean
- [x] All four `TestE2E_InputOutput_*` tests pass against real Deno (including the new `TestE2E_InputOutput_ChainParamsOutputFieldSubstitution`)
- [x] New unit tests in `pkg/task/inputref_test.go` cover every form, every loud-failure path, and `ValidateInputRefs` registration-time rejection cases
- [x] New integration tests in `engine_chain_params_test.go` (`TestChainDispatch_ResolvesInputParams`, `TestOnFailureChainDispatch_ResolvesInputOutputField`) drive `FireChain` directly to verify chain-edge resolution
- [x] New integration test in `engine_preflight_test.go` (`TestBefore_PipesInputOutputFieldThroughStages`) verifies the pipeline edge pipes `${input.output.<field>}` through real dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)