### PR TITLE
feat(task,trigger): allow trigger.before on one-shot tasks

### DIFF
--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -73,7 +73,7 @@ permissions:
 | `trigger.chain.overrides` | object | | Per-edge patch applied to a deep copy of the downstream's spec at firing time; manual fires of the same downstream are unaffected. See [per-edge overrides](#chain-params-and-per-edge-overrides). |
 | `trigger.daemon` | bool | | Start on app start, restart on exit |
 | `trigger.restart` | string | | daemon only: `always` (default), `on-failure`, `never` |
-| `trigger.before` | list | | daemon only: prereq task IDs (bare-string or `{task, overrides}` mapping) that must succeed before the daemon starts. See [`trigger.before` — daemon preflight](#daemon-preflight-via-triggerbefore). |
+| `trigger.before` | list | | prereq task IDs (bare-string or `{task, overrides}` mapping) that must succeed before the main task body runs. Valid on any trigger type (daemon, manual, cron, webhook, chain). See [`trigger.before` — preflight pipelines](#preflight-pipelines-via-triggerbefore). |
 | `permissions` | object | | Explicit access grants — nothing is implicit |
 | `permissions.env` | list | | Env vars the script may read (see below) |
 | `permissions.fs` | list | | Filesystem access declarations (Deno only) |
@@ -241,16 +241,37 @@ The `trigger` rejection is deliberate — per-edge dispatch invokes the
 downstream directly and ignores any rewired trigger config on the merged
 spec, so silently accepting it would mislead operators.
 
-### Daemon preflight via trigger.before
+### Preflight pipelines via trigger.before
 
-Only valid on daemon tasks. Lists one-shot prereq tasks that the engine
-runs as a **sequential output-piping pipeline** before the daemon
-container starts. Each stage must reach `status=success` for the
-pipeline to advance; a failure short-circuits the rest of the list and
-leaves the daemon in `prereq_failed`. The engine re-fires every stage
-on every preflight attempt — no "already-satisfied" short-circuit —
-because the point of preflight is to refresh ephemeral state (rendered
-configs, freshly rotated credentials) right before the daemon starts.
+`trigger.before:` declares a sequential preflight pipeline of one-shot
+prereq tasks. It is valid on **any** trigger type — daemon, manual,
+cron, webhook, or chain. Preflight stages run in declaration order
+before the main task body; if any stage fails, the main body does not
+run.
+
+Each stage must reach `status=success` for the pipeline to advance; a
+failure short-circuits the rest of the list. The engine re-fires every
+stage on every preflight attempt — no "already-satisfied" short-circuit
+— because the point of preflight is to refresh ephemeral state
+(rendered configs, freshly rotated credentials) right before the main
+body runs.
+
+**Run-row semantics on failure.** The behaviour differs slightly by
+trigger type:
+
+- **Daemon:** preflight failure leaves the daemon in `prereq_failed`
+  and no daemon-body run is created. (Daemons distinguish lifecycle
+  states; the preflight pipeline is part of bringing the daemon up.)
+- **One-shot (manual / cron / webhook / chain):** preflight + body
+  collapse into a single parent run row. On preflight failure, the
+  parent run surfaces as `status=failure` with
+  `fail_reason="preflight_failed: stage N (<task-id>): <error>"`. The
+  parent's `start_time` is the time the operator fired the task (i.e.
+  when the run was attempted), not the time the failure was detected.
+
+Preflight stages themselves run as their own child runs tagged
+`trigger_source=preflight`, linked back to the parent fire — the
+WebUI groups them under the parent for visibility.
 
 Each entry can be either a bare task-ID string (single-stage form) or
 a mapping with `task:` plus optional `overrides:`:
@@ -372,19 +393,34 @@ upstream return value, so any `${input.…}` reference on
 an explicit error. Use a literal default or an env-projected secret on
 stage 0; downstream stages can then pipe via the recognised tokens.
 
-**Mid-pipeline re-fire propagation.** When an intermediate stage at
-index `i` re-runs successfully (e.g. an operator runs
-`dicode run buildin/template` to pick up a rotated Doppler
+**Mid-pipeline re-fire propagation (daemon-only).** When an
+intermediate stage at index `i` re-runs successfully (e.g. an operator
+runs `dicode run buildin/template` to pick up a rotated Doppler
 secret), the engine re-fires stages `[i+1..n-1]` sequentially with the
 re-run's fresh return value as the initial `${input.output}`, then
 restarts the daemon to pick up the propagated config. Stages
 `[0..i-1]` are NOT re-fired. Propagations are coalesced per daemon
 (at most one in flight) so a flurry of upstream completions produces a
-single propagation + restart, not a thrash loop.
+single propagation + restart, not a thrash loop. One-shots do NOT
+auto-restart on a prereq re-run — if the operator wants the one-shot
+to re-run, they re-fire it themselves.
 
-**Cross-spec validation.** At registration time the engine rejects
-references to unknown tasks and to other daemons — only one-shot tasks
-can be preflights. Self-references are rejected at config-load.
+**Concurrency.** Daemons coalesce concurrent `Register` calls — a
+re-register while preflight is in flight does not spawn a second
+preflight goroutine. One-shots do NOT coalesce: each manual / cron /
+webhook / chain fire gets its own preflight + body, distinct from the
+daemon's coalesce-on-Register behaviour.
+
+**Cross-spec validation.** At registration time the engine rejects:
+
+- References to unknown tasks.
+- References to daemons (only one-shot tasks can be preflights).
+- Self-references (already rejected at config-load).
+- Cycles in the before-graph. Once one-shots can declare
+  `trigger.before`, `A.before: [B]; B.before: [A]` becomes
+  representable; the engine runs a DFS over the registered
+  before-edges and rejects cycles with a path like
+  `cycle detected: A -> B -> A`.
 
 **Semantic change vs PR #300.** Before PR3, `trigger.before` entries
 ran in parallel and were treated as independent prereqs (no piping).

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -186,13 +186,16 @@ type TriggerConfig struct {
 	Chain         *ChainTrigger `yaml:"chain,omitempty"`          // fire when another task completes
 	Daemon        bool          `yaml:"daemon,omitempty"`         // start on app start, restart on exit
 	Restart       string        `yaml:"restart,omitempty"`        // daemon only: "always"(default)|"on-failure"|"never"
-	// Before lists task IDs that must run to success before this daemon starts.
-	// Only valid alongside `daemon: true`; per-spec validation rejects it on
-	// non-daemon triggers. Cross-spec validation (in pkg/trigger.Engine.Register)
-	// additionally rejects references to unknown tasks and to other daemons —
-	// only one-shot tasks can be preflights. When a referenced task re-runs
-	// successfully after the daemon is up, the engine restarts the daemon so
-	// it picks up newly-rendered config.
+	// Before lists task IDs that must run to success before this task's main
+	// body runs. Valid on any trigger type (daemon, manual, cron, webhook,
+	// chain): for daemons the preflight gates the daemon body's start; for
+	// one-shots it gates the firing's run dispatch. Cross-spec validation
+	// (in pkg/trigger.Engine.Register) rejects references to unknown tasks
+	// and to other daemons — only one-shot tasks can be preflights — and
+	// rejects cycles in the before-graph. When a referenced task re-runs
+	// successfully after a daemon is up, the engine restarts the daemon so
+	// it picks up newly-rendered config (one-shots don't restart; each new
+	// firing simply re-runs the pipeline).
 	//
 	// Each entry can be either a bare task-ID string (legacy form) or a
 	// mapping with `task:` plus optional `overrides:` — see BeforeEntry's

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -702,14 +702,13 @@ func (s *Spec) validate() error {
 			return fmt.Errorf("trigger.restart must be always, on-failure, or never")
 		}
 	}
-	// trigger.before: declarative preflight dependency for daemon tasks. Only
-	// validated locally here; cross-spec checks (does the referenced task
-	// exist? is it a daemon?) live in pkg/trigger.Engine.Register because they
-	// need the full registry snapshot.
+	// trigger.before: declarative preflight pipeline. Valid on any trigger
+	// type — daemon, manual, cron, webhook, or chain — since issue #312.
+	// Only validated locally here; cross-spec checks (does the referenced
+	// task exist? is it a one-shot? does the before-graph contain a cycle?)
+	// live in pkg/trigger.Engine.Register because they need the full
+	// registry snapshot.
 	if len(s.Trigger.Before) > 0 {
-		if !s.Trigger.Daemon {
-			return fmt.Errorf("trigger.before: requires daemon: true (got non-daemon trigger)")
-		}
 		for i, entry := range s.Trigger.Before {
 			if entry.Task == "" {
 				return fmt.Errorf("trigger.before: empty task ID")

--- a/pkg/task/spec_test.go
+++ b/pkg/task/spec_test.go
@@ -479,11 +479,35 @@ func TestTriggerBefore_Validation(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "before without daemon",
+			// Post-#312: trigger.before is valid on any trigger type, not
+			// just daemons. Manual / cron / webhook / chain tasks may declare
+			// preflight pipelines too.
+			name: "before on manual task",
 			yaml: `name: t
 runtime: deno
 trigger: { manual: true, before: [x] }`,
-			wantErr: "before: requires daemon: true",
+			wantErr: "",
+		},
+		{
+			name: "before on cron task",
+			yaml: `name: t
+runtime: deno
+trigger: { cron: "*/5 * * * *", before: [x] }`,
+			wantErr: "",
+		},
+		{
+			name: "before on webhook task",
+			yaml: `name: t
+runtime: deno
+trigger: { webhook: /h, before: [x] }`,
+			wantErr: "",
+		},
+		{
+			name: "before on chain task",
+			yaml: `name: t
+runtime: deno
+trigger: { chain: { from: upstream }, before: [x] }`,
+			wantErr: "",
 		},
 		{
 			name: "self-reference",

--- a/pkg/trigger/daemon_state.go
+++ b/pkg/trigger/daemon_state.go
@@ -299,7 +299,12 @@ func (e *Engine) propagateBeforeRerun(daemonSpec *task.Spec, reranTaskID string,
 				return
 			}
 			entry := daemonSpec.Trigger.Before[i]
-			out, err := e.dispatchPipelineStage(stageCtx, entry, i, upstream)
+			// parent_run_id is "" here: the daemon's body run is created
+			// AFTER preflight finishes via startDaemonInternal's fireAsync,
+			// so we have no parent run ID to stamp on stage rows at this
+			// layer. See dispatchPipelineStage's parentRunID parameter
+			// doc.
+			out, err := e.dispatchPipelineStage(stageCtx, entry, i, upstream, "")
 			if err != nil {
 				e.log.Warn("daemon mid-pipeline re-fire: descendant stage failed; daemon left at current state",
 					zap.String("task", daemonSpec.ID),

--- a/pkg/trigger/e2e_oneshot_preflight_test.go
+++ b/pkg/trigger/e2e_oneshot_preflight_test.go
@@ -1,0 +1,233 @@
+package trigger
+
+// End-to-end test for issue #312: trigger.before on one-shot tasks.
+//
+// Composes the REAL buildin/template and buildin/write-local tasks
+// (loaded from disk) into a 2-stage preflight pipeline on a MANUAL
+// task. Pre-#312 spec.go:711 would have rejected this configuration
+// outright with "trigger.before: requires daemon: true". Post-#312 the
+// pipeline runs through real Deno:
+//
+//   1. buildin/template renders a literal config body (no placeholders →
+//      no env wiring needed). run_result.enabled:false in the on-disk
+//      task.yaml means the rendered string flows in-memory via
+//      ${input.output} interpolation rather than via the persisted
+//      runs.return_value column.
+//
+//   2. buildin/write-local persists the rendered string to disk at a
+//      caller-declared path. Its own permissions.fs ships empty, so
+//      the manual task's per-edge override must declare an fs:rw
+//      scope covering the target path.
+//
+//   3. The manual task body runs only after both stages succeed and
+//      asserts (via marker file) the pipeline composed correctly.
+//
+// Assertions:
+//   - The rendered file lands on disk at the expected path (proves
+//     buildin/template ran with its overrides AND buildin/write-local
+//     received the rendered string via ${input.output}).
+//   - The manual parent run's status is success (proves the body
+//     dispatched after both preflight stages cleared).
+//   - The preflight stages have their own runs in the registry tagged
+//     TriggerPreflight (data-model linkage for the WebUI).
+//
+// Gated on real Deno (skipped via newTestEnv's t.Skipf) — same gate
+// as the daemon-flavored TestE2E_TemplatePreflightPipeline.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// buildinWriteLocalDir returns the absolute path to the on-disk
+// `tasks/buildin/write-local/` task. Anchored the same way as
+// buildinTemplateDir — see that helper's comment for the walk-up
+// rationale.
+func buildinWriteLocalDir(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := goruntime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed; cannot anchor buildin/write-local path")
+	}
+	pkgDir := filepath.Dir(thisFile)               // .../pkg/trigger
+	repoRoot := filepath.Dir(filepath.Dir(pkgDir)) // .../
+	dir := filepath.Join(repoRoot, "tasks", "buildin", "write-local")
+	if _, err := os.Stat(filepath.Join(dir, "task.yaml")); err != nil {
+		t.Fatalf("buildin/write-local task.yaml not found at %s: %v", dir, err)
+	}
+	return dir
+}
+
+// loadBuildinWriteLocalAs mirrors loadBuildinTemplateAs but for the
+// write-local task. ID/Name rebinding keeps the registry from
+// collision when multiple subtests register their own instance.
+func loadBuildinWriteLocalAs(t *testing.T, id string) *task.Spec {
+	t.Helper()
+	spec, err := task.LoadDir(buildinWriteLocalDir(t))
+	if err != nil {
+		t.Fatalf("LoadDir buildin/write-local: %v", err)
+	}
+	spec.ID = id
+	spec.Name = id
+	if err := spec.Validate(); err != nil {
+		t.Fatalf("buildin/write-local re-validate after rebind: %v", err)
+	}
+	return spec
+}
+
+// TestE2E_OneShotPreflightPipeline_RealDeno wires a manual one-shot
+// task with a 2-stage preflight pipeline through REAL Deno. Pre-#312
+// this configuration was rejected at spec validation; post-#312 it
+// must compose end to end.
+func TestE2E_OneShotPreflightPipeline_RealDeno(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+
+	// Where the preflight pipeline writes its rendered config.
+	scratch := t.TempDir()
+	outpath := filepath.Join(scratch, "rendered.yaml")
+
+	e := newTestEnv(t)
+
+	const tmplID = "tmpl"
+	const writerID = "writer"
+	const consumerID = "consumer"
+
+	// Stage 1: buildin/template. The body has no ${VAR} placeholders so
+	// the renderer just echoes it back — keeps env wiring out of the
+	// test surface. The template body is passed via per-edge override
+	// on the consumer's before-list, not via params on the template
+	// spec itself.
+	tmpl := loadBuildinTemplateAs(t, tmplID, nil)
+	if err := e.reg.Register(tmpl); err != nil {
+		t.Fatalf("reg.Register tmpl: %v", err)
+	}
+	if err := e.engine.Register(tmpl); err != nil {
+		t.Fatalf("eng.Register tmpl: %v", err)
+	}
+
+	// Stage 2: buildin/write-local. fs:[] by default — the consumer's
+	// per-edge override declares the fs:rw scope.
+	writer := loadBuildinWriteLocalAs(t, writerID)
+	if err := e.reg.Register(writer); err != nil {
+		t.Fatalf("reg.Register writer: %v", err)
+	}
+	if err := e.engine.Register(writer); err != nil {
+		t.Fatalf("eng.Register writer: %v", err)
+	}
+
+	// Consumer: a manual task with the 2-stage preflight pipeline. The
+	// consumer body itself is a no-op (writes a marker proving it ran
+	// after the preflight cleared) — the meaningful side-effect is
+	// buildin/write-local laying down `outpath`.
+	consumerDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(consumerDir, "task.ts"),
+		[]byte(`export default async function main() { return "ok"; }`+"\n"),
+		0o644); err != nil {
+		t.Fatalf("write consumer task.ts: %v", err)
+	}
+	consumer := &task.Spec{
+		ID:      consumerID,
+		Name:    consumerID,
+		Runtime: task.RuntimeDeno,
+		TaskDir: consumerDir,
+		Trigger: task.TriggerConfig{
+			Manual: true,
+			Before: []task.BeforeEntry{
+				{
+					Task: tmplID,
+					Overrides: &task.Overrides{
+						Params: task.ParamOverrides{
+							{Name: "template", Default: "rendered: hello-from-preflight\n"},
+						},
+					},
+				},
+				{
+					Task: writerID,
+					Overrides: &task.Overrides{
+						Params: task.ParamOverrides{
+							{Name: "content", Default: "${input.output}"},
+							{Name: "path", Default: outpath},
+							{Name: "mode", Default: "0600"},
+						},
+						Fs: []task.FSEntry{
+							{Path: scratch, Permission: "rw"},
+						},
+					},
+				},
+			},
+		},
+		Enabled: true,
+	}
+	if err := consumer.Validate(); err != nil {
+		t.Fatalf("consumer Validate: %v", err)
+	}
+	if err := e.reg.Register(consumer); err != nil {
+		t.Fatalf("reg.Register consumer: %v", err)
+	}
+	if err := e.engine.Register(consumer); err != nil {
+		t.Fatalf("eng.Register consumer: %v", err)
+	}
+
+	// Fire manually.
+	parentRunID, err := e.engine.FireManual(context.Background(), consumerID, nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+
+	// Wait for the consumer body to finish — the only path to that is
+	// preflight success → body dispatch → body completion.
+	deadline := time.Now().Add(30 * time.Second)
+	var parent *registry.Run
+	for time.Now().Before(deadline) {
+		p, err := e.reg.GetRun(context.Background(), parentRunID)
+		if err == nil && p.FinishedAt != nil {
+			parent = p
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if parent == nil {
+		t.Fatal("consumer parent run never finished within 30s")
+	}
+	if parent.Status != registry.StatusSuccess {
+		t.Fatalf("consumer parent status = %q (fail_reason=%q), want success",
+			parent.Status, parent.FailureReason)
+	}
+
+	// Rendered file must exist on disk with the expected content.
+	got, err := os.ReadFile(outpath)
+	if err != nil {
+		t.Fatalf("rendered file not found at %s: %v", outpath, err)
+	}
+	want := "rendered: hello-from-preflight\n"
+	if string(got) != want {
+		t.Errorf("rendered file content = %q, want %q", string(got), want)
+	}
+
+	// Preflight stages must be recorded as their own runs.
+	for _, taskID := range []string{tmplID, writerID} {
+		runs, err := e.reg.ListRuns(context.Background(), taskID, 5)
+		if err != nil {
+			t.Fatalf("ListRuns %s: %v", taskID, err)
+		}
+		var found bool
+		for _, r := range runs {
+			if r.TriggerSource == registry.TriggerPreflight && r.Status == registry.StatusSuccess {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("no successful TriggerPreflight run found for %s; runs=%+v", taskID, runs)
+		}
+	}
+}

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -375,14 +375,14 @@ var inputParamsRefRe = regexp.MustCompile(`\$\{input\.params\.[A-Za-z_][A-Za-z0-
 // validateBeforeRefs checks each trigger.before entry against the current
 // registry. Per-spec validation (Spec.validate) already enforces shape;
 // here we only catch the things that need the full registry: unknown task
-// IDs and references to other daemons.
+// IDs, references to other daemons, and before-graph cycles.
 //
-// On cycles: per-spec validation requires trigger.before only on daemon
-// tasks, and this function forbids before: references to daemons. Together
-// those constraints make cycles structurally unreachable — the only way a
-// cycle could form is through a prereq task carrying its own
-// trigger.before back to the daemon, but only daemons may have
-// trigger.before. We therefore do not implement explicit cycle detection.
+// Pre-#312, cycles were structurally unreachable: trigger.before was
+// daemon-only and entries had to be one-shots, so the graph was at most
+// one edge deep. Issue #312 lifts the daemon-only restriction (one-shot
+// tasks can declare trigger.before too), reopening A→B→A as a realisable
+// shape. detectBeforeCycle runs a three-colour DFS over the registered
+// before-edges (plus the spec being registered) and rejects any cycle.
 func (e *Engine) validateBeforeRefs(spec *task.Spec) error {
 	for i, entry := range spec.Trigger.Before {
 		ref, ok := e.registry.Get(entry.Task)
@@ -463,7 +463,94 @@ func (e *Engine) validateBeforeRefs(spec *task.Spec) error {
 		}
 		seen[entry.Task] = struct{}{}
 	}
+
+	// Cycle detection (#312). Pre-#312, trigger.before was daemon-only and
+	// entries had to be one-shots — the graph was at most one edge deep,
+	// so cycles were structurally unreachable. Now that one-shots may
+	// declare trigger.before too, A→B→A is a realisable shape and we
+	// must reject it at registration. Build a directed graph spanning the
+	// registry plus the spec being registered (which may shadow an existing
+	// registration), then run a three-colour DFS rooted at spec.ID.
+	if cyclePath := e.detectBeforeCycle(spec); cyclePath != "" {
+		return fmt.Errorf("trigger.before: cycle detected: %s", cyclePath)
+	}
 	return nil
+}
+
+// detectBeforeCycle returns a printable "a -> b -> c -> a" path if the
+// before-graph contains a cycle reachable from spec.ID, else "". The graph
+// is built from the current registry snapshot with spec's edges overlaid
+// (so re-registrations see the new edges, not the stale ones). Tasks not
+// yet in the registry contribute no outgoing edges — the unknown-task
+// check elsewhere in validateBeforeRefs surfaces those separately.
+func (e *Engine) detectBeforeCycle(spec *task.Spec) string {
+	edges := map[string][]string{}
+	for _, s := range e.registry.All() {
+		if s.ID == spec.ID {
+			continue // overlay with the candidate spec's edges below
+		}
+		if len(s.Trigger.Before) == 0 {
+			continue
+		}
+		out := make([]string, 0, len(s.Trigger.Before))
+		for _, b := range s.Trigger.Before {
+			out = append(out, b.Task)
+		}
+		edges[s.ID] = out
+	}
+	if len(spec.Trigger.Before) > 0 {
+		out := make([]string, 0, len(spec.Trigger.Before))
+		for _, b := range spec.Trigger.Before {
+			out = append(out, b.Task)
+		}
+		edges[spec.ID] = out
+	}
+
+	const (
+		white = 0 // unvisited
+		gray  = 1 // in current DFS stack
+		black = 2 // finished
+	)
+	color := map[string]int{}
+	var stack []string
+
+	var dfs func(id string) string
+	dfs = func(id string) string {
+		color[id] = gray
+		stack = append(stack, id)
+		for _, next := range edges[id] {
+			switch color[next] {
+			case gray:
+				// Found a back-edge. Trim stack to the cycle.
+				start := 0
+				for i, n := range stack {
+					if n == next {
+						start = i
+						break
+					}
+				}
+				path := append([]string(nil), stack[start:]...)
+				path = append(path, next)
+				return strings.Join(path, " -> ")
+			case white:
+				if p := dfs(next); p != "" {
+					return p
+				}
+			}
+		}
+		stack = stack[:len(stack)-1]
+		color[id] = black
+		return ""
+	}
+
+	// Root the search at spec.ID — only cycles reachable from the
+	// task being registered matter. A pre-existing detached cycle in the
+	// registry is not introduced by this Register call and was rejected
+	// when its components were originally added.
+	if p := dfs(spec.ID); p != "" {
+		return p
+	}
+	return ""
 }
 
 // Unregister removes all trigger registrations for a task ID.
@@ -722,7 +809,10 @@ func (e *Engine) startDaemonInternal(spec *task.Spec, skipPrereqs bool) {
 		if prereqCtx == nil {
 			prereqCtx = context.Background()
 		}
-		if err := e.runPrereqs(prereqCtx, spec); err != nil {
+		// Daemon path: parentRunID is "" because the daemon's body run
+		// hasn't been created yet (fireAsync below produces it after
+		// preflight clears).
+		if err := e.runPrereqs(prereqCtx, spec, ""); err != nil {
 			e.setDaemonState(spec.ID, DaemonPrereqFailed)
 			e.log.Warn("daemon preflight failed; daemon not started",
 				zap.String("task", spec.ID),
@@ -804,10 +894,20 @@ func (e *Engine) startDaemonInternal(spec *task.Spec, skipPrereqs bool) {
 // kill the legitimate winner of the concurrent-Register race. From
 // stage 1 onward, an absence reflects a real operator Unregister
 // between stages, so the check stays.
-func (e *Engine) runPrereqs(ctx context.Context, spec *task.Spec) error {
+//
+// One-shot fires (#312) don't have a daemonSpecs entry to consult.
+// For them the daemonRegistered gate is skipped — the parent's runCtx
+// already carries the kill signal (KillRun cancels runCtx through
+// runCancels) and isShuttingDown() catches engine teardown.
+// parentRunID is the parent fire's run ID for one-shots (#312); stamped on
+// each preflight stage row's parent_run_id column so the WebUI can group
+// children under the parent. Daemons pass "" here — see dispatchPipeline-
+// Stage's parentRunID parameter doc for the rationale.
+func (e *Engine) runPrereqs(ctx context.Context, spec *task.Spec, parentRunID string) error {
 	if e.isShuttingDown() {
 		e.log.Debug("runPrereqs skipped: engine shutting down",
-			zap.String("daemon", spec.ID))
+			zap.String("task", spec.ID),
+			zap.Bool("daemon", spec.Trigger.Daemon))
 		return nil
 	}
 
@@ -821,17 +921,33 @@ func (e *Engine) runPrereqs(ctx context.Context, spec *task.Spec) error {
 		entry := entry
 		if e.isShuttingDown() {
 			e.log.Debug("runPrereqs aborted: engine shutting down",
-				zap.String("daemon", spec.ID),
+				zap.String("task", spec.ID),
+				zap.Bool("daemon", spec.Trigger.Daemon),
 				zap.Int("stage", i))
 			return nil
 		}
-		if i > 0 && !e.daemonRegistered(spec.ID) {
+		// Daemon-only bail: between-stage operator-unregister window.
+		// One-shots have no daemonSpecs entry; they rely on ctx +
+		// shutdown gates instead.
+		if spec.Trigger.Daemon && i > 0 && !e.daemonRegistered(spec.ID) {
 			e.log.Debug("runPrereqs aborted: daemon unregistered",
 				zap.String("daemon", spec.ID),
 				zap.Int("stage", i))
 			return nil
 		}
-		out, err := e.dispatchPipelineStage(ctx, entry, i, upstream)
+		// One-shot bail: parent run was killed mid-pipeline. Daemons
+		// don't have a meaningful per-fire ctx at this layer (start-
+		// DaemonInternal passes the engine shutdown ctx), so this
+		// branch is functionally one-shot-only — daemons bail via the
+		// daemonRegistered check above.
+		if !spec.Trigger.Daemon && ctx.Err() != nil {
+			e.log.Debug("runPrereqs aborted: parent run cancelled",
+				zap.String("task", spec.ID),
+				zap.Int("stage", i),
+				zap.Error(ctx.Err()))
+			return nil
+		}
+		out, err := e.dispatchPipelineStage(ctx, entry, i, upstream, parentRunID)
 		if err != nil {
 			return err
 		}
@@ -855,9 +971,16 @@ func (e *Engine) runPrereqs(ctx context.Context, spec *task.Spec) error {
 //     so the next stage's ${input.…} references resolve loudly rather
 //     than silently passing the literal token downstream.
 //
+// parentRunID, if non-empty, is stamped on the stage run row's
+// parent_run_id column so the WebUI can group preflight children
+// under the parent fire (#312, one-shot case). Daemons pass "" here:
+// the daemon body's run is created AFTER preflight finishes, so
+// linking stage runs to a not-yet-existing daemon-run row is
+// impossible at this layer.
+//
 // Shared by runPrereqs and the mid-pipeline re-fire propagation path
 // in daemon_state.go so both code paths apply identical semantics.
-func (e *Engine) dispatchPipelineStage(ctx context.Context, entry task.BeforeEntry, stageIdx int, upstream task.InputContext) (task.InputContext, error) {
+func (e *Engine) dispatchPipelineStage(ctx context.Context, entry task.BeforeEntry, stageIdx int, upstream task.InputContext, parentRunID string) (task.InputContext, error) {
 	refID := entry.Task
 	ref, ok := e.registry.Get(refID)
 	if !ok {
@@ -916,7 +1039,7 @@ func (e *Engine) dispatchPipelineStage(ctx context.Context, entry task.BeforeEnt
 	// this snapshot is always nil — but threading it through here lets
 	// a future change wire upstream params into the pipeline without
 	// touching the resolver contract again.
-	stageOpts := pkgruntime.RunOptions{}
+	stageOpts := pkgruntime.RunOptions{ParentRunID: parentRunID}
 	runID, err := e.fireAsync(ctx, dispatchSpec, stageOpts, registry.TriggerPreflight)
 	if err != nil {
 		return task.InputContext{}, fmt.Errorf("stage %d (%s): dispatch: %w", stageIdx, refID, err)
@@ -2171,6 +2294,45 @@ func (e *Engine) runTask(runCtx context.Context, spec *task.Spec, opts pkgruntim
 	return status, result
 }
 
+// finalizePreflightFailure closes out a one-shot run whose trigger.before
+// pipeline failed before the body was dispatched (#312). It records the
+// run as a failure with a fail_reason carrying the stage index + task ID
+// that broke the pipeline, fires the runFinishedHook so websocket
+// subscribers observe a matching started/finished pair, and fires
+// FireChain so chain-on-failure consumers observe the failure.
+//
+// The parent run's start_time was set at startRun (before preflight) —
+// that's "the time the operator fired the task", per the issue contract.
+// Preflight duration is included in the run's elapsed window.
+func (e *Engine) finalizePreflightFailure(spec *task.Spec, opts pkgruntime.RunOptions, source registry.TriggerSource, preflightErr error) {
+	reason := "preflight_failed: " + preflightErr.Error()
+	finishCtx, finishCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer finishCancel()
+	if err := e.registry.FinishRunWithReason(finishCtx, opts.RunID, registry.StatusFailure, reason); err != nil {
+		e.log.Error("failed to finalize preflight-failed run",
+			zap.String("run", opts.RunID),
+			zap.String("task", spec.ID),
+			zap.Error(err))
+	}
+	e.log.Warn("one-shot preflight failed; body not dispatched",
+		zap.String("task", spec.ID),
+		zap.String("run", opts.RunID),
+		zap.String("trigger", string(source)),
+		zap.String("reason", reason),
+	)
+	if h := e.runFinishedHook; h != nil {
+		// Duration is 0 — see finalizeCancelled for the same convention.
+		// The preflight stages themselves have their own runs with
+		// accurate durations; the parent's start_time→finished_at delta
+		// captures the operator-visible total.
+		h(spec.ID, opts.RunID, registry.StatusFailure, string(source), 0)
+	}
+	// Chain-on-failure semantics: dispatch normally fires FireChain;
+	// the preflight short-circuit replicates it so chain triggers and
+	// on_failure_chain still observe the failure.
+	go e.FireChain(context.Background(), spec.ID, opts.RunID, registry.StatusFailure, nil, opts.Params)
+}
+
 // finalizeCancelled closes out a run that was cancelled before ever executing
 // — e.g. user killed it while queued on the concurrency semaphore, or the
 // daemon is shutting down. It updates the registry row and fires the finished
@@ -2198,6 +2360,21 @@ func (e *Engine) finalizeCancelled(spec *task.Spec, opts pkgruntime.RunOptions, 
 // When a MaxConcurrentTasks semaphore is configured, the goroutine blocks
 // until a slot is available or the shutdown context is cancelled — ensuring
 // shutdown never deadlocks waiting tasks.
+//
+// One-shot preflight (#312): when the spec is a non-daemon with a
+// trigger.before pipeline AND we are NOT already inside a preflight fire,
+// the goroutine runs the preflight pipeline before the body. A failed
+// preflight short-circuits the body and finalizes the parent run with
+// status=failure and fail_reason="preflight_failed: stage N (<task>)".
+// The parent run row is created upfront (before preflight) so the
+// run's start_time reflects when the operator fired the task, not when
+// the failure was detected.
+//
+// Daemons keep their existing preflight path in startDaemonInternal —
+// this branch is skipped for them. Preflight stages themselves call
+// fireAsync with source=TriggerPreflight; that source also skips this
+// branch so a stage task that happens to declare its own trigger.before
+// doesn't recurse.
 func (e *Engine) fireAsync(ctx context.Context, spec *task.Spec, opts pkgruntime.RunOptions, source registry.TriggerSource) (string, error) {
 	opts.RunID = uuid.New().String()
 
@@ -2221,8 +2398,35 @@ func (e *Engine) fireAsync(ctx context.Context, spec *task.Spec, opts pkgruntime
 		}
 	}
 
+	runOneShotPreflight := !spec.Trigger.Daemon &&
+		len(spec.Trigger.Before) > 0 &&
+		source != registry.TriggerPreflight
+
 	go func() {
 		defer cleanup()
+
+		if runOneShotPreflight {
+			// Use runCtx so a KillRun on the parent run propagates into the
+			// preflight loop. The preflight stages themselves are dispatched
+			// via fireAsync (which honors its own runCtx via the parent
+			// goroutine's cancel propagation through dispatchPipelineStage's
+			// WaitRun call). Pass opts.RunID as the parent so each preflight
+			// stage's run row links back to the parent fire — gives the
+			// WebUI the data to render the pipeline + body under one row.
+			if perr := e.runPrereqs(runCtx, spec, opts.RunID); perr != nil {
+				e.finalizePreflightFailure(spec, opts, source, perr)
+				return
+			}
+			// Engine teardown / parent-run kill during preflight: runPrereqs
+			// returns nil on bail (matching daemon semantics), but we don't
+			// want to dispatch the body in that case either. Surface as a
+			// cancelled run so the websocket subscriber sees a matching
+			// started/finished pair.
+			if runCtx.Err() != nil || e.isShuttingDown() {
+				e.finalizeCancelled(spec, opts, source)
+				return
+			}
+		}
 
 		// Daemon tasks are long-running; they must not consume semaphore slots
 		// or they would permanently starve webhook/cron tasks.

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -59,6 +59,20 @@ type Engine struct {
 	cronEntries map[string]cron.EntryID // taskID → cron entry
 	webhooks    map[string]string       // webhook path → taskID
 
+	// registerMu serializes the entire Register path so that concurrent
+	// registrations cannot admit a cycle through interleaved snapshots of
+	// the before-graph (each call's detectBeforeCycle scans the current
+	// registry state; without a mutex two parallel Register calls could
+	// each clear cycle detection against their independent snapshots and
+	// jointly close A→B→A). Held across validateBeforeRefs through the
+	// final Unregister/register* mutations. Separate from `mu` because
+	// Unregister itself takes `mu`, and from `daemonMu` for the same
+	// reason — keeping registerMu coarse-but-shallow avoids re-entrance.
+	//
+	// In practice the reconciler is single-threaded so registrations
+	// don't race today; this is defense-in-depth for future callers.
+	registerMu sync.Mutex
+
 	runCancels       sync.Map // runID → context.CancelFunc
 	runDone          sync.Map // runID (string) → chan struct{}, closed when the run reaches a terminal state
 	runTriggerSource sync.Map // runID (string) → triggerSource (registry.TriggerSource)
@@ -327,7 +341,14 @@ func (e *Engine) Start(ctx context.Context) error {
 // Register adds or updates trigger registrations for a task spec. Returns a
 // non-nil error when cross-spec validation fails (currently: invalid
 // trigger.before references). On error, no triggers are registered.
+// Register registers a task with the engine. Cycle detection runs
+// against the registered before-graph as of method entry; the call is
+// serialized via registerMu so concurrent registrations cannot admit
+// a cycle through interleaved snapshots.
 func (e *Engine) Register(spec *task.Spec) error {
+	e.registerMu.Lock()
+	defer e.registerMu.Unlock()
+
 	// Cross-spec validation must run BEFORE Unregister so that a previously
 	// valid registration isn't torn down when an updated spec fails its
 	// new-state checks. The registry-snapshot lookups are read-only.
@@ -2330,7 +2351,15 @@ func (e *Engine) finalizePreflightFailure(spec *task.Spec, opts pkgruntime.RunOp
 	// Chain-on-failure semantics: dispatch normally fires FireChain;
 	// the preflight short-circuit replicates it so chain triggers and
 	// on_failure_chain still observe the failure.
-	go e.FireChain(context.Background(), spec.ID, opts.RunID, registry.StatusFailure, nil, opts.Params)
+	//
+	// Called synchronously so the caller's deferred cleanup() (which
+	// deletes runChainDepth[opts.RunID]) cannot race ahead of FireChain's
+	// depth lookup. An earlier draft used `go FireChain(...)` to mirror a
+	// fire-and-forget shape, but that allowed cleanup to observe a
+	// depth-of-zero and let a chain-fired parent take one hop past the
+	// MaxDepth ceiling. Matches the normal FireChain call site at the end
+	// of dispatch (~line 2668), which is also synchronous.
+	e.FireChain(context.Background(), spec.ID, opts.RunID, registry.StatusFailure, nil, opts.Params)
 }
 
 // finalizeCancelled closes out a run that was cancelled before ever executing

--- a/pkg/trigger/engine_oneshot_preflight_test.go
+++ b/pkg/trigger/engine_oneshot_preflight_test.go
@@ -1,0 +1,501 @@
+package trigger
+
+// Tests for issue #312: one-shot tasks (manual / cron / webhook / chain)
+// may declare trigger.before preflight pipelines. The engine runs the
+// pipeline from fireAsync (parallel to startDaemonInternal's invocation
+// for daemons); failures surface as a normal run with fail_reason
+// "preflight_failed: stage N (<task>)".
+//
+// Also covers the cycle-detection rule added to validateBeforeRefs:
+// once one-shots can declare trigger.before, A→B→A is realisable and
+// must be rejected at registration time.
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// TestRegister_RejectsBeforeCycle_TwoNode pins the simplest cycle the
+// post-#312 graph admits: A.before=[B], B.before=[A]. Pre-#312 this was
+// unrepresentable because trigger.before was daemon-only and entries had
+// to be one-shots — Spec.validate would have rejected B.before=[A]
+// outright. Now that one-shots can declare trigger.before, validateBefore-
+// Refs must catch the cycle.
+func TestRegister_RejectsBeforeCycle_TwoNode(t *testing.T) {
+	e := newTestEnv(t)
+
+	// Seed A as a one-shot manual task with no before-list.
+	a := &task.Spec{
+		ID:      "a",
+		Name:    "a",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Enabled: true,
+	}
+	if err := e.reg.Register(a); err != nil {
+		t.Fatalf("seed reg.Register a: %v", err)
+	}
+	if err := e.engine.Register(a); err != nil {
+		t.Fatalf("eng.Register a: %v", err)
+	}
+
+	// B references A as a preflight.
+	b := &task.Spec{
+		ID:      "b",
+		Name:    "b",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true, Before: []task.BeforeEntry{{Task: "a"}}},
+		Enabled: true,
+	}
+	if err := e.reg.Register(b); err != nil {
+		t.Fatalf("seed reg.Register b: %v", err)
+	}
+	if err := e.engine.Register(b); err != nil {
+		t.Fatalf("eng.Register b: %v", err)
+	}
+
+	// Now mutate A to also reference B — this closes the loop A→B→A.
+	aWithBefore := &task.Spec{
+		ID:      "a",
+		Name:    "a",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true, Before: []task.BeforeEntry{{Task: "b"}}},
+		Enabled: true,
+	}
+	// reg.Register replaces the previous A. eng.Register should reject.
+	if err := e.reg.Register(aWithBefore); err != nil {
+		t.Fatalf("reg.Register aWithBefore: %v", err)
+	}
+	err := e.engine.Register(aWithBefore)
+	if err == nil {
+		t.Fatal("expected cycle-detection error, got nil")
+	}
+	if !strings.Contains(err.Error(), "cycle detected") {
+		t.Errorf("expected error to mention cycle, got: %v", err)
+	}
+}
+
+// TestRegister_RejectsBeforeCycle_ThreeNode exercises a longer cycle
+// A→B→C→A so the DFS must walk through an intermediate node before
+// observing the back-edge.
+func TestRegister_RejectsBeforeCycle_ThreeNode(t *testing.T) {
+	e := newTestEnv(t)
+
+	// Seed all three as plain one-shots first; then close the cycle by
+	// adding before-edges in a second pass.
+	for _, id := range []string{"a", "b", "c"} {
+		s := &task.Spec{
+			ID:      id,
+			Name:    id,
+			Runtime: task.RuntimeDeno,
+			Trigger: task.TriggerConfig{Manual: true},
+			Enabled: true,
+		}
+		if err := e.reg.Register(s); err != nil {
+			t.Fatalf("seed reg.Register %s: %v", id, err)
+		}
+		if err := e.engine.Register(s); err != nil {
+			t.Fatalf("eng.Register %s: %v", id, err)
+		}
+	}
+
+	// B.before=[A], C.before=[B] — still acyclic.
+	bWithBefore := &task.Spec{
+		ID:      "b",
+		Name:    "b",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true, Before: []task.BeforeEntry{{Task: "a"}}},
+		Enabled: true,
+	}
+	if err := e.reg.Register(bWithBefore); err != nil {
+		t.Fatalf("reg.Register bWithBefore: %v", err)
+	}
+	if err := e.engine.Register(bWithBefore); err != nil {
+		t.Fatalf("eng.Register bWithBefore (acyclic): %v", err)
+	}
+
+	cWithBefore := &task.Spec{
+		ID:      "c",
+		Name:    "c",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true, Before: []task.BeforeEntry{{Task: "b"}}},
+		Enabled: true,
+	}
+	if err := e.reg.Register(cWithBefore); err != nil {
+		t.Fatalf("reg.Register cWithBefore: %v", err)
+	}
+	if err := e.engine.Register(cWithBefore); err != nil {
+		t.Fatalf("eng.Register cWithBefore (acyclic): %v", err)
+	}
+
+	// Now close the cycle: A.before=[C] ⇒ A→C→B→A or, traversed forward,
+	// A→C... wait the edges are: A.before=[C] means A depends on C, so
+	// the dep edge from A points to C. B.before=[A] → B→A. C.before=[B]
+	// → C→B. Cycle: A→C→B→A.
+	aClose := &task.Spec{
+		ID:      "a",
+		Name:    "a",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true, Before: []task.BeforeEntry{{Task: "c"}}},
+		Enabled: true,
+	}
+	if err := e.reg.Register(aClose); err != nil {
+		t.Fatalf("reg.Register aClose: %v", err)
+	}
+	err := e.engine.Register(aClose)
+	if err == nil {
+		t.Fatal("expected three-node cycle to be rejected, got nil error")
+	}
+	if !strings.Contains(err.Error(), "cycle detected") {
+		t.Errorf("expected cycle-detection error, got: %v", err)
+	}
+}
+
+// TestRegister_AcceptsBeforeAcyclic confirms the cycle detector doesn't
+// false-positive on a diamond / fan-in shape: A.before=[X], B.before=[X]
+// (X used by multiple consumers but with no back-edge). This is the
+// canonical safe shape — share a preflight stage between several
+// downstream tasks.
+func TestRegister_AcceptsBeforeAcyclic(t *testing.T) {
+	e := newTestEnv(t)
+
+	x := &task.Spec{
+		ID:      "x",
+		Name:    "x",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Enabled: true,
+	}
+	if err := e.reg.Register(x); err != nil {
+		t.Fatalf("seed reg.Register x: %v", err)
+	}
+	if err := e.engine.Register(x); err != nil {
+		t.Fatalf("eng.Register x: %v", err)
+	}
+
+	a := &task.Spec{
+		ID:      "a",
+		Name:    "a",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true, Before: []task.BeforeEntry{{Task: "x"}}},
+		Enabled: true,
+	}
+	if err := e.reg.Register(a); err != nil {
+		t.Fatalf("reg.Register a: %v", err)
+	}
+	if err := e.engine.Register(a); err != nil {
+		t.Errorf("eng.Register a (acyclic fan-in): unexpected error: %v", err)
+	}
+
+	b := &task.Spec{
+		ID:      "b",
+		Name:    "b",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true, Before: []task.BeforeEntry{{Task: "x"}}},
+		Enabled: true,
+	}
+	if err := e.reg.Register(b); err != nil {
+		t.Fatalf("reg.Register b: %v", err)
+	}
+	if err := e.engine.Register(b); err != nil {
+		t.Errorf("eng.Register b (acyclic fan-in): unexpected error: %v", err)
+	}
+}
+
+// TestFireManual_PreflightSuccess_FiresBody exercises the happy path: a
+// manual task with a 1-stage trigger.before runs the preflight, then
+// runs the body. Both end as success runs.
+func TestFireManual_PreflightSuccess_FiresBody(t *testing.T) {
+	eng, reg, _ := newPreflightEnv(t)
+
+	prereq := makeOneShotSpec("p1")
+	if err := reg.Register(prereq); err != nil {
+		t.Fatalf("reg.Register p1: %v", err)
+	}
+	if err := eng.Register(prereq); err != nil {
+		t.Fatalf("eng.Register p1: %v", err)
+	}
+
+	manual := &task.Spec{
+		ID:      "consumer",
+		Name:    "consumer",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true, Before: []task.BeforeEntry{{Task: "p1"}}},
+		Enabled: true,
+	}
+	if err := reg.Register(manual); err != nil {
+		t.Fatalf("reg.Register consumer: %v", err)
+	}
+	if err := eng.Register(manual); err != nil {
+		t.Fatalf("eng.Register consumer: %v", err)
+	}
+
+	runID, err := eng.FireManual(context.Background(), "consumer", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+
+	// Wait for the body run to finish successfully.
+	waitUntil(t, 5*time.Second, func() bool {
+		return hasRunWithStatus(t, reg, "consumer", registry.StatusSuccess)
+	}, "consumer body never reached success")
+
+	// The preflight run must exist as a child of the manual run, tagged
+	// TriggerPreflight. Verify the per-stage child run was recorded.
+	preflightRuns, _ := reg.ListRuns(context.Background(), "p1", 5)
+	var found bool
+	for _, r := range preflightRuns {
+		if r.TriggerSource == registry.TriggerPreflight && r.Status == registry.StatusSuccess {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected at least one successful preflight run for p1")
+	}
+
+	// Parent body run should be success — fetch by ID and check status.
+	parent, err := reg.GetRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("GetRun parent: %v", err)
+	}
+	if parent.Status != registry.StatusSuccess {
+		t.Errorf("parent run status = %q, want success", parent.Status)
+	}
+	if parent.FailureReason != "" {
+		t.Errorf("parent run fail_reason = %q, want empty on success path", parent.FailureReason)
+	}
+}
+
+// TestFireManual_PreflightFailure_BodyNotFired pins the failure-semantics
+// contract: when the preflight stage fails, the parent run surfaces as
+// status=failure with fail_reason="preflight_failed: stage N (<task>): …"
+// and the body is NEVER dispatched.
+func TestFireManual_PreflightFailure_BodyNotFired(t *testing.T) {
+	eng, reg, exec := newPreflightEnv(t)
+
+	prereq := makeOneShotSpec("p-fail")
+	if err := reg.Register(prereq); err != nil {
+		t.Fatalf("reg.Register p-fail: %v", err)
+	}
+	if err := eng.Register(prereq); err != nil {
+		t.Fatalf("eng.Register p-fail: %v", err)
+	}
+	exec.markFailing("p-fail")
+
+	// Pin a runner-counter on the consumer body so we can prove it never
+	// executed — if the preflight short-circuit broke, this count would
+	// be > 0.
+	var bodyRuns atomic.Int32
+	exec.setFn("consumer", func(_, _ string) string {
+		bodyRuns.Add(1)
+		return registry.StatusSuccess
+	})
+
+	consumer := &task.Spec{
+		ID:      "consumer",
+		Name:    "consumer",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true, Before: []task.BeforeEntry{{Task: "p-fail"}}},
+		Enabled: true,
+	}
+	if err := reg.Register(consumer); err != nil {
+		t.Fatalf("reg.Register consumer: %v", err)
+	}
+	if err := eng.Register(consumer); err != nil {
+		t.Fatalf("eng.Register consumer: %v", err)
+	}
+
+	runID, err := eng.FireManual(context.Background(), "consumer", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+
+	// Parent run must end as failure with a preflight_failed reason.
+	waitUntil(t, 5*time.Second, func() bool {
+		parent, err := reg.GetRun(context.Background(), runID)
+		if err != nil {
+			return false
+		}
+		return parent.Status == registry.StatusFailure
+	}, "parent consumer run never recorded as failure")
+
+	parent, err := reg.GetRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("GetRun parent: %v", err)
+	}
+	if !strings.HasPrefix(parent.FailureReason, "preflight_failed:") {
+		t.Errorf("parent fail_reason = %q, want prefix \"preflight_failed:\"", parent.FailureReason)
+	}
+	if !strings.Contains(parent.FailureReason, "p-fail") {
+		t.Errorf("parent fail_reason should name the failing stage id; got %q", parent.FailureReason)
+	}
+
+	// Body must NEVER have run.
+	if got := bodyRuns.Load(); got != 0 {
+		t.Errorf("consumer body executed %d times despite preflight failure; want 0", got)
+	}
+}
+
+// TestFireManual_PreflightChildRunsLinkToParent verifies that each
+// preflight stage's run row has parent_run_id set to the one-shot's
+// parent fire. The WebUI relies on this linkage to group the preflight
+// pipeline under the parent run; without it the children would show up
+// as orphans. Daemons can't carry this link (the daemon body run is
+// created AFTER preflight clears) — see dispatchPipelineStage's
+// parentRunID parameter doc.
+func TestFireManual_PreflightChildRunsLinkToParent(t *testing.T) {
+	eng, reg, _ := newPreflightEnv(t)
+
+	prereq := makeOneShotSpec("link-prereq")
+	if err := reg.Register(prereq); err != nil {
+		t.Fatalf("reg.Register prereq: %v", err)
+	}
+	if err := eng.Register(prereq); err != nil {
+		t.Fatalf("eng.Register prereq: %v", err)
+	}
+
+	consumer := &task.Spec{
+		ID:      "link-consumer",
+		Name:    "link-consumer",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true, Before: []task.BeforeEntry{{Task: "link-prereq"}}},
+		Enabled: true,
+	}
+	if err := reg.Register(consumer); err != nil {
+		t.Fatalf("reg.Register consumer: %v", err)
+	}
+	if err := eng.Register(consumer); err != nil {
+		t.Fatalf("eng.Register consumer: %v", err)
+	}
+
+	parentRunID, err := eng.FireManual(context.Background(), "link-consumer", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+
+	waitUntil(t, 5*time.Second, func() bool {
+		return hasRunWithStatus(t, reg, "link-consumer", registry.StatusSuccess)
+	}, "consumer body never succeeded")
+
+	// Children listed via parent_run_id must include the preflight
+	// stage row for link-prereq.
+	children, err := reg.ListChildren(context.Background(), parentRunID, 10)
+	if err != nil {
+		t.Fatalf("ListChildren: %v", err)
+	}
+	var foundPreflight bool
+	for _, c := range children {
+		if c.TaskID == "link-prereq" && c.TriggerSource == registry.TriggerPreflight {
+			foundPreflight = true
+		}
+	}
+	if !foundPreflight {
+		t.Errorf("expected preflight child run linked to parent %s; got children=%+v",
+			parentRunID, children)
+	}
+}
+
+// TestFireManual_PipesInputOutputThroughStages mirrors
+// TestBefore_PipesInputOutputThroughStages but for a manual one-shot.
+// Confirms the ${input.output} substitution flow is identical regardless
+// of trigger type — the only thing that changed in #312 is *which*
+// trigger kinds may declare a before-list.
+func TestFireManual_PipesInputOutputThroughStages(t *testing.T) {
+	eng, reg, exec := newPreflightEnv(t)
+
+	exec.setReturnFn("render", func(_, _ string, _ *task.Spec) interface{} {
+		return "manual-pipeline-value"
+	})
+	render := makeOneShotSpec("render")
+	if err := reg.Register(render); err != nil {
+		t.Fatalf("register render: %v", err)
+	}
+	if err := eng.Register(render); err != nil {
+		t.Fatalf("eng.Register render: %v", err)
+	}
+
+	writer := &task.Spec{
+		ID:      "write",
+		Name:    "write",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Params:  task.Params{{Name: "content", Required: true}},
+		Enabled: true,
+	}
+	if err := reg.Register(writer); err != nil {
+		t.Fatalf("register writer: %v", err)
+	}
+	if err := eng.Register(writer); err != nil {
+		t.Fatalf("eng.Register writer: %v", err)
+	}
+
+	consumer := &task.Spec{
+		ID:      "consumer",
+		Name:    "consumer",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{
+			Manual: true,
+			Before: []task.BeforeEntry{
+				{Task: "render"},
+				{
+					Task: "write",
+					Overrides: &task.Overrides{
+						Params: task.ParamOverrides{
+							{Name: "content", Default: "${input.output}"},
+						},
+					},
+				},
+			},
+		},
+		Enabled: true,
+	}
+	if err := reg.Register(consumer); err != nil {
+		t.Fatalf("register consumer: %v", err)
+	}
+	if err := eng.Register(consumer); err != nil {
+		t.Fatalf("eng.Register consumer: %v", err)
+	}
+
+	if _, err := eng.FireManual(context.Background(), "consumer", nil); err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+
+	// Wait until the writer stage captured a spec we can inspect.
+	var writeSpec *task.Spec
+	waitUntil(t, 5*time.Second, func() bool {
+		runs, _ := reg.ListRuns(context.Background(), "write", 5)
+		for _, r := range runs {
+			if r.TriggerSource == registry.TriggerPreflight {
+				if s := exec.specForRun(r.ID); s != nil {
+					writeSpec = s
+					return true
+				}
+			}
+		}
+		return false
+	}, "write preflight stage never captured")
+
+	var got string
+	for _, p := range writeSpec.Params {
+		if p.Name == "content" {
+			got = p.Default
+		}
+	}
+	if got != "manual-pipeline-value" {
+		t.Errorf("write.content default = %q; want %q (upstream output did not pipe through)",
+			got, "manual-pipeline-value")
+	}
+
+	// Consumer body must reach success — confirms both stages passed and
+	// the body did dispatch.
+	waitUntil(t, 5*time.Second, func() bool {
+		return hasRunWithStatus(t, reg, "consumer", registry.StatusSuccess)
+	}, "consumer body never reached success")
+}

--- a/pkg/trigger/engine_oneshot_preflight_test.go
+++ b/pkg/trigger/engine_oneshot_preflight_test.go
@@ -13,6 +13,7 @@ package trigger
 import (
 	"context"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -205,6 +206,120 @@ func TestRegister_AcceptsBeforeAcyclic(t *testing.T) {
 	}
 	if err := e.engine.Register(b); err != nil {
 		t.Errorf("eng.Register b (acyclic fan-in): unexpected error: %v", err)
+	}
+}
+
+// TestRegister_ConcurrentRegisterCannotAdmitCycle pins that the registerMu
+// serialization in Register makes the cycle-detection scan atomic with
+// respect to other in-flight registrations. Each goroutine mirrors the
+// production reconciler pattern (reg.Register then engine.Register) for
+// one half of an A→B→A cycle; the engine must never admit both edges.
+//
+// Without registerMu, two parallel engine.Register calls can interleave
+// such that each detectBeforeCycle reads a stale registry snapshot and
+// overlays its own candidate edge — passing cycle detection independently
+// even though the resulting registry state is cyclic.
+//
+// We assert the strong invariant: AT LEAST one engine.Register call
+// rejects with "cycle detected" — i.e. the final engine state is never
+// "both edges admitted". Either both interleavings observe the cycle
+// (one race ordering: both reg.Register commit before either engine
+// scan) or exactly one observes it (the other ordering: one engine
+// scan completes before the second reg.Register commits). Both
+// outcomes are correct; the failure mode the mutex eliminates is "zero
+// rejections" — a cycle admitted into the engine.
+//
+// In practice unreachable today because the reconciler is single-threaded,
+// but worth pinning for future concurrent-registration paths. Run with
+// `-race -count=20` for stress coverage.
+func TestRegister_ConcurrentRegisterCannotAdmitCycle(t *testing.T) {
+	e := newTestEnv(t)
+
+	// Seed both A and B as plain one-shots so they're known to the registry
+	// when the cycle-closing Register calls fire.
+	for _, id := range []string{"a", "b"} {
+		s := &task.Spec{
+			ID:      id,
+			Name:    id,
+			Runtime: task.RuntimeDeno,
+			Trigger: task.TriggerConfig{Manual: true},
+			Enabled: true,
+		}
+		if err := e.reg.Register(s); err != nil {
+			t.Fatalf("seed reg.Register %s: %v", id, err)
+		}
+		if err := e.engine.Register(s); err != nil {
+			t.Fatalf("seed eng.Register %s: %v", id, err)
+		}
+	}
+
+	aWithBefore := &task.Spec{
+		ID:      "a",
+		Name:    "a",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true, Before: []task.BeforeEntry{{Task: "b"}}},
+		Enabled: true,
+	}
+	bWithBefore := &task.Spec{
+		ID:      "b",
+		Name:    "b",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true, Before: []task.BeforeEntry{{Task: "a"}}},
+		Enabled: true,
+	}
+
+	// Mirror production order: reg.Register persists the candidate spec, then
+	// engine.Register validates + schedules. Run both pairs in parallel so
+	// registerMu's serialization is exercised against arbitrary interleavings
+	// of the reg.Register commits.
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	var errA, errB error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		if err := e.reg.Register(aWithBefore); err != nil {
+			errA = err
+			return
+		}
+		errA = e.engine.Register(aWithBefore)
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		if err := e.reg.Register(bWithBefore); err != nil {
+			errB = err
+			return
+		}
+		errB = e.engine.Register(bWithBefore)
+	}()
+	close(start)
+	wg.Wait()
+
+	// Invariant: the engine must never admit both edges (i.e. both calls
+	// returning nil). At least one — possibly both — must surface the
+	// cycle, depending on the order in which the two reg.Register commits
+	// land relative to each engine.Register's cycle scan.
+	successCount := 0
+	cycleCount := 0
+	for _, err := range []error{errA, errB} {
+		switch {
+		case err == nil:
+			successCount++
+		case strings.Contains(err.Error(), "cycle detected"):
+			cycleCount++
+		default:
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+	if cycleCount == 0 {
+		t.Fatalf("expected at least one cycle-detection error, got success=%d cycle=%d (errA=%v errB=%v)",
+			successCount, cycleCount, errA, errB)
+	}
+	if successCount+cycleCount != 2 {
+		t.Fatalf("expected success+cycle to cover both calls, got success=%d cycle=%d (errA=%v errB=%v)",
+			successCount, cycleCount, errA, errB)
 	}
 }
 


### PR DESCRIPTION
## Summary

Lifts the daemon-only restriction on `trigger.before` (closes #312). One-shot tasks (manual, cron, webhook, chain) can now declare a sequential preflight pipeline; stages run in declaration order before the main task body and pipe `\${input.output}` between stages exactly like the daemon flow shipped in PR #311.

## Design

**Engine.** `runPrereqs` is now called from `fireAsync` (in addition to `startDaemonInternal`). Behaviour by trigger type:

- **Daemon (unchanged):** preflight failure → `DaemonPrereqFailed` state, daemon body not started.
- **One-shot:** preflight failure → parent run row is finalized as `status=failure` with `fail_reason=\"preflight_failed: stage N (<task-id>): <error>\"`. The parent's `start_time` is the time the operator fired the task (so preflight duration is in the run's elapsed window).

**Run linkage.** Each preflight stage's run row carries `parent_run_id = parent fire's run ID` for one-shot fires, so the WebUI can group children under the parent. Daemons still pass `\"\"` (the daemon body run doesn't exist yet at preflight time).

**Cycle detection.** The \"before-entries must be one-shots\" rule (#311) prevented the trivial cycle; lifting that prohibition makes `A→B→A` realisable. `validateBeforeRefs` now runs a three-colour DFS over the registered before-graph (plus the spec being registered) and rejects cycles with a path like `cycle detected: a -> b -> a`.

**Concurrency.** One-shot fires don't coalesce — each fire gets its own preflight + body. The runPrereqs between-stage `daemonRegistered` bail is now daemon-only; one-shots bail on ctx cancellation instead.

## Tests

- `pkg/task/spec_test.go` — `TestTriggerBefore_Validation` now accepts `trigger.before` on manual / cron / webhook / chain triggers (the four new cases the issue named).
- `pkg/trigger/engine_oneshot_preflight_test.go` (new):
  - `TestRegister_RejectsBeforeCycle_TwoNode` — A→B→A rejected.
  - `TestRegister_RejectsBeforeCycle_ThreeNode` — A→C→B→A rejected.
  - `TestRegister_AcceptsBeforeAcyclic` — diamond / fan-in shape passes.
  - `TestFireManual_PreflightSuccess_FiresBody` — happy path.
  - `TestFireManual_PreflightFailure_BodyNotFired` — body never runs; fail_reason set.
  - `TestFireManual_PreflightChildRunsLinkToParent` — parent_run_id linkage.
  - `TestFireManual_PipesInputOutputThroughStages` — \${input.output} flows through stages.
- `pkg/trigger/e2e_oneshot_preflight_test.go` (new) — full pipeline through real Deno using `tasks/buildin/template` + `tasks/buildin/write-local`; asserts the rendered file lands on disk and the parent run is success.

## Docs

`docs/concepts/task-format.md` \"Daemon preflight\" section renamed to \"Preflight pipelines\". Lead paragraph explicitly notes trigger.before works on any trigger type. A new sub-paragraph documents the one-shot run-row semantics (parent fire as the visible run; preflight failures surface via fail_reason). Cross-spec validation block adds cycle-detection to its bullet list.

## Compatibility

Net-additive: no existing config is now invalid. Operators with one-shot tasks gain a new preflight capability that didn't exist before.

## Test plan

- [x] \`go test ./pkg/task/ ./pkg/trigger/ ./pkg/webui/ -timeout 300s\` — all green.
- [x] \`make build && make format && make format-check\` — clean.
- [x] \`go test ./pkg/trigger/ -race -count=20 -run \"TestFireManual_Preflight\" -timeout 120s\` — green.
- [x] \`go test ./pkg/trigger/ -race -timeout 300s\` — green (full -race trigger suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)