### PR TITLE
fix(task): unify empty-string handling across ${input.*} forms

### DIFF
--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -339,9 +339,18 @@ at dispatch time in `before[i].overrides.params` defaults and
 
 | Form | Resolves to | Loud-fail when |
 | --- | --- | --- |
-| `${input.output}` | upstream's full string return value | upstream returned a non-string |
-| `${input.output.<field>}` | named string field of an object-shaped upstream return (e.g. `{path: "..."}`) | upstream isn't an object, field absent, field non-string |
-| `${input.params.<name>}` | named entry from the upstream's `RunOptions.Params` (chain edge: the caller-supplied params on the upstream's fire; preflight edge: always empty today) | params map nil or named entry missing |
+| `${input.output}` | upstream's full string return value | upstream returned a non-string, or the string is empty |
+| `${input.output.<field>}` | named string field of an object-shaped upstream return (e.g. `{path: "..."}`) | upstream isn't an object, field absent, field non-string, or the field's string value is empty |
+| `${input.params.<name>}` | named entry from the upstream's `RunOptions.Params` (chain edge: the caller-supplied params on the upstream's fire; preflight edge: always empty today) | params map nil, named entry missing, or the entry's value is empty |
+
+**Empty-string contract.** Empty strings are treated as "not provided"
+uniformly across all three forms. A token whose resolution would yield
+`""` fails loudly with `ErrInputUnavailable`, identifying the offending
+param and token. Operators must either supply a non-empty value or
+omit the reference — empty values are never substituted silently. This
+preserves the loud-failure contract across the bare and dotted forms
+so operators can assume the same semantics everywhere `${input.…}`
+appears.
 
 Embedded forms (`"prefix-${input.output}-suffix"`) and multi-token
 forms (`"${input.params.scheme}://${input.output.host}"`) are

--- a/pkg/task/inputref.go
+++ b/pkg/task/inputref.go
@@ -105,6 +105,12 @@ type InputContext struct {
 //
 // Param identifies the offending param so operators can see which
 // override or chain key tripped the resolver.
+//
+// BREAKING CHANGE (PR #336 / issue #333): previously, ${input.output.<field>}
+// and ${input.params.<name>} silently substituted empty-string values without
+// failing. Operators upgrading should audit any task.yaml relying on that
+// loose behavior; the loud-failure contract now applies uniformly to all
+// three ${input.*} forms.
 type ErrInputUnavailable struct {
 	Param string // name of the offending param
 	Ref   string // the offending reference token, e.g. "${input.output.path}"

--- a/pkg/task/inputref.go
+++ b/pkg/task/inputref.go
@@ -91,12 +91,17 @@ type InputContext struct {
 }
 
 // ErrInputUnavailable is returned when a param references an
-// `${input.…}` token that cannot be resolved at dispatch time:
-//   - ${input.output} when the upstream returned a non-string
+// `${input.…}` token that cannot be resolved at dispatch time. The
+// resolver treats an empty-string value as "not provided" uniformly
+// across all three forms (the loud-failure contract):
+//   - ${input.output} when the upstream returned a non-string or an
+//     empty string
 //   - ${input.output.<field>} when the upstream returned a non-map,
-//     when the field is absent, or when the field's value is non-string
-//   - ${input.params.<name>} when the upstream's Params map is nil or
-//     the named entry is missing
+//     when the field is absent, when the field's value is non-string,
+//     or when the field's string value is empty
+//   - ${input.params.<name>} when the upstream's Params map is nil,
+//     when the named entry is missing, or when the named entry's value
+//     is empty
 //
 // Param identifies the offending param so operators can see which
 // override or chain key tripped the resolver.
@@ -194,20 +199,31 @@ func resolveString(paramName, s string, ctx InputContext) (string, error) {
 // error path always returns *ErrInputUnavailable with Ref set so the
 // caller's wrapping log message includes the offending token.
 func resolveToken(paramName, token, kind, field string, ctx InputContext) (string, error) {
+	// emptyStringWhy is the canonical Why suffix when a token resolves
+	// to "". Empty values are treated as "not provided" uniformly across
+	// all three forms — see ErrInputUnavailable's doc comment for the
+	// rationale. Surfacing the same phrasing on every form makes the
+	// loud-failure contract obvious in logs.
+	const emptyStringWhy = "resolves to empty string (empty values are treated as \"not provided\"; pass a non-empty value or omit the reference)"
+
 	switch kind {
 	case "output":
 		if field == "" {
-			// ${input.output} — upstream must be a string.
+			// ${input.output} — upstream must be a non-empty string.
 			s, ok := ctx.Output.(string)
-			if !ok || s == "" {
+			if !ok {
 				return "", &ErrInputUnavailable{Param: paramName, Ref: token, Why: "upstream returned no string value"}
+			}
+			if s == "" {
+				return "", &ErrInputUnavailable{Param: paramName, Ref: token, Why: emptyStringWhy}
 			}
 			return s, nil
 		}
 		// ${input.output.<field>} — upstream must be a map[string]any
-		// (the shape JSON decoding produces) with a string-valued entry
-		// at <field>. Maps reached via direct Go callers (e.g.
-		// runtime-test mocks) may use map[string]string; accept both.
+		// (the shape JSON decoding produces) with a non-empty string-
+		// valued entry at <field>. Maps reached via direct Go callers
+		// (e.g. runtime-test mocks) may use map[string]string; accept
+		// both.
 		switch m := ctx.Output.(type) {
 		case map[string]any:
 			raw, ok := m[field]
@@ -218,11 +234,17 @@ func resolveToken(paramName, token, kind, field string, ctx InputContext) (strin
 			if !ok {
 				return "", &ErrInputUnavailable{Param: paramName, Ref: token, Why: fmt.Sprintf("upstream field %q is not a string", field)}
 			}
+			if s == "" {
+				return "", &ErrInputUnavailable{Param: paramName, Ref: token, Why: emptyStringWhy}
+			}
 			return s, nil
 		case map[string]string:
 			s, ok := m[field]
 			if !ok {
 				return "", &ErrInputUnavailable{Param: paramName, Ref: token, Why: fmt.Sprintf("upstream object has no field %q", field)}
+			}
+			if s == "" {
+				return "", &ErrInputUnavailable{Param: paramName, Ref: token, Why: emptyStringWhy}
 			}
 			return s, nil
 		default:
@@ -241,6 +263,9 @@ func resolveToken(paramName, token, kind, field string, ctx InputContext) (strin
 		v, ok := ctx.Params[field]
 		if !ok {
 			return "", &ErrInputUnavailable{Param: paramName, Ref: token, Why: fmt.Sprintf("upstream params has no entry %q", field)}
+		}
+		if v == "" {
+			return "", &ErrInputUnavailable{Param: paramName, Ref: token, Why: emptyStringWhy}
 		}
 		return v, nil
 	default:

--- a/pkg/task/inputref_test.go
+++ b/pkg/task/inputref_test.go
@@ -410,6 +410,108 @@ func TestResolveInputOutputList_NilList(t *testing.T) {
 	}
 }
 
+// TestResolveString_RejectsEmptyOutput pins the existing loud failure
+// for the bare `${input.output}` form: an upstream that returns an
+// empty string is treated as "not provided" and yields
+// ErrInputUnavailable. This is the pre-existing contract from PR #310,
+// captured here so the regression net covers all three forms together.
+func TestResolveString_RejectsEmptyOutput(t *testing.T) {
+	params := map[string]any{
+		"content": "${input.output}",
+	}
+	_, err := ResolveInputOutputMap(params, ctxString(""))
+	if err == nil {
+		t.Fatal("expected ErrInputUnavailable for empty upstream string")
+	}
+	var ire *ErrInputUnavailable
+	if !errors.As(err, &ire) {
+		t.Fatalf("expected ErrInputUnavailable; got %T: %v", err, err)
+	}
+	if ire.Param != "content" {
+		t.Errorf("ErrInputUnavailable.Param = %q; want %q", ire.Param, "content")
+	}
+}
+
+// TestResolveString_RejectsEmptyOutputField locks the symmetric loud
+// failure for the `${input.output.<field>}` form: a present-but-empty
+// string field is treated as "not provided" rather than substituted
+// silently. Mirrors TestResolveString_RejectsEmptyOutput for the
+// dotted-form to preserve the Failed-loudly contract uniformly. Issue
+// #333.
+func TestResolveString_RejectsEmptyOutputField(t *testing.T) {
+	params := map[string]any{
+		"file": "${input.output.path}",
+	}
+	ctx := InputContext{Output: map[string]any{"path": ""}}
+	_, err := ResolveInputOutputMap(params, ctx)
+	if err == nil {
+		t.Fatal("expected ErrInputUnavailable for empty output field")
+	}
+	var ire *ErrInputUnavailable
+	if !errors.As(err, &ire) {
+		t.Fatalf("expected ErrInputUnavailable; got %T: %v", err, err)
+	}
+	if ire.Param != "file" {
+		t.Errorf("ErrInputUnavailable.Param = %q; want %q", ire.Param, "file")
+	}
+	if ire.Ref != "${input.output.path}" {
+		t.Errorf("ErrInputUnavailable.Ref = %q; want %q", ire.Ref, "${input.output.path}")
+	}
+	if !strings.Contains(ire.Error(), "empty string") {
+		t.Errorf("error should mention empty-string contract; got %v", ire)
+	}
+}
+
+// TestResolveString_RejectsEmptyOutputField_StringMap is the
+// map[string]string twin of TestResolveString_RejectsEmptyOutputField —
+// runtime-test mocks reach the resolver via map[string]string and that
+// path must also fail loudly when the field's value is empty.
+func TestResolveString_RejectsEmptyOutputField_StringMap(t *testing.T) {
+	params := map[string]any{
+		"file": "${input.output.path}",
+	}
+	ctx := InputContext{Output: map[string]string{"path": ""}}
+	_, err := ResolveInputOutputMap(params, ctx)
+	if err == nil {
+		t.Fatal("expected ErrInputUnavailable for empty output field (map[string]string)")
+	}
+	var ire *ErrInputUnavailable
+	if !errors.As(err, &ire) {
+		t.Fatalf("expected ErrInputUnavailable; got %T: %v", err, err)
+	}
+	if !strings.Contains(ire.Error(), "empty string") {
+		t.Errorf("error should mention empty-string contract; got %v", ire)
+	}
+}
+
+// TestResolveString_RejectsEmptyParam locks the symmetric loud failure
+// for the `${input.params.<name>}` form: a present-but-empty entry in
+// the upstream's Params map is treated as "not provided" rather than
+// substituted silently. Issue #333.
+func TestResolveString_RejectsEmptyParam(t *testing.T) {
+	params := map[string]any{
+		"endpoint": "${input.params.X}",
+	}
+	ctx := InputContext{Params: map[string]string{"X": ""}}
+	_, err := ResolveInputOutputMap(params, ctx)
+	if err == nil {
+		t.Fatal("expected ErrInputUnavailable for empty param value")
+	}
+	var ire *ErrInputUnavailable
+	if !errors.As(err, &ire) {
+		t.Fatalf("expected ErrInputUnavailable; got %T: %v", err, err)
+	}
+	if ire.Param != "endpoint" {
+		t.Errorf("ErrInputUnavailable.Param = %q; want %q", ire.Param, "endpoint")
+	}
+	if ire.Ref != "${input.params.X}" {
+		t.Errorf("ErrInputUnavailable.Ref = %q; want %q", ire.Ref, "${input.params.X}")
+	}
+	if !strings.Contains(ire.Error(), "empty string") {
+		t.Errorf("error should mention empty-string contract; got %v", ire)
+	}
+}
+
 // TestValidateInputRefs covers the registration-time gate that
 // surfaces malformed `${input.…}` shapes at config load. Well-formed
 // references (the three recognised shapes) and strings without any

--- a/pkg/task/inputref_test.go
+++ b/pkg/task/inputref_test.go
@@ -512,6 +512,34 @@ func TestResolveString_RejectsEmptyParam(t *testing.T) {
 	}
 }
 
+// TestResolveString_RejectsEmptyEmbedded pins the loud-failure contract
+// for embedded `${input.…}` tokens: when a single token inside an
+// otherwise-valid embedded form ("prefix-${input.output}-suffix") would
+// resolve to an empty string, the resolver fails the entire param the
+// same way the bare form does — resolveString short-circuits on the
+// first token error, so an empty substitution can't silently produce
+// "prefix--suffix". Companion to TestResolveString_RejectsEmptyOutput,
+// kept separate so the embedded-form contract is greppable. Issue #333.
+func TestResolveString_RejectsEmptyEmbedded(t *testing.T) {
+	params := map[string]any{
+		"endpoint": "https://${input.output}/api",
+	}
+	_, err := ResolveInputOutputMap(params, ctxString(""))
+	if err == nil {
+		t.Fatal("expected ErrInputUnavailable for empty upstream in embedded form")
+	}
+	var ire *ErrInputUnavailable
+	if !errors.As(err, &ire) {
+		t.Fatalf("expected *ErrInputUnavailable; got %T: %v", err, err)
+	}
+	if ire.Param != "endpoint" {
+		t.Errorf("ErrInputUnavailable.Param = %q; want %q", ire.Param, "endpoint")
+	}
+	if !strings.Contains(ire.Error(), "empty string") {
+		t.Errorf("error should mention empty-string contract; got %v", ire)
+	}
+}
+
 // TestValidateInputRefs covers the registration-time gate that
 // surfaces malformed `${input.…}` shapes at config load. Well-formed
 // references (the three recognised shapes) and strings without any


### PR DESCRIPTION
## Summary

- PR #330's richer grammar introduced an asymmetry: bare `${input.output}` rejected empty-string upstream returns (preserved from PR #310's narrow grammar), but `${input.output.<field>}` and `${input.params.<name>}` silently substituted empty strings.
- Tightens `.field` / `.params` resolution to reject empty-string substitution with the same `ErrInputUnavailable` shape, so operators see the same loud-failure contract everywhere `${input.…}` appears.
- Error messages identify the offending param and token form (`${input.output.path} resolves to empty string …`) and the `Why` text is shared across forms so logs are uniform.
- Docs (`docs/concepts/task-format.md`) call out the empty-string contract explicitly under the loud-fail table.

Closes #333.

## Test plan

- [x] `go test ./pkg/task/ ./pkg/trigger/ -timeout 180s -race -count=1` — green
- [x] `go test ./... -timeout 300s -count=1` — green; no pre-existing fixtures relied on the loose empty-string behavior
- [x] `make build` — clean
- [x] `make format-check` — clean
- [x] New unit tests cover all three forms:
  - `TestResolveString_RejectsEmptyOutput` (locks the pre-existing bare-form contract)
  - `TestResolveString_RejectsEmptyOutputField` + `_StringMap` (both `map[string]any` and `map[string]string`)
  - `TestResolveString_RejectsEmptyParam`

## Out of scope

- No opt-in "allow empty" flag — issue #333 recommends strict by default; file a follow-up if a real use case surfaces.
- Regex / identifier grammar unchanged.

Generated with [Claude Code](https://claude.com/claude-code)