### PR TITLE
feat(task): PipelineTask spec-layer foundation (kind: PipelineTask, PR1/8)

### DIFF
--- a/pkg/db/migrate_test.go
+++ b/pkg/db/migrate_test.go
@@ -67,3 +67,18 @@ func TestAddColumnIfMissing_AddsWithDefault(t *testing.T) {
 		t.Errorf("default not applied; flag = %d", flag)
 	}
 }
+
+func TestRunsKindColumnDefaultsToTask(t *testing.T) {
+	d := newTestDB(t).(*SQLiteDB)
+	ctx := context.Background()
+	if _, err := d.db.ExecContext(ctx, `INSERT INTO runs (id, task_id, status, started_at) VALUES ('r1','t1','running',0)`); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	var kind string
+	if err := d.db.QueryRowContext(ctx, `SELECT kind FROM runs WHERE id = 'r1'`).Scan(&kind); err != nil {
+		t.Fatal(err)
+	}
+	if kind != "task" {
+		t.Errorf("kind = %q, want %q", kind, "task")
+	}
+}

--- a/pkg/db/sqlite.go
+++ b/pkg/db/sqlite.go
@@ -161,6 +161,11 @@ func (s *SQLiteDB) migrate() error {
 		// dicode.set_group(). Column is `run_group` (not `group`) because the
 		// latter is a SQL keyword and our migrate helper rejects quoted idents.
 		{"run_group", "TEXT NOT NULL DEFAULT ''"},
+		// kind discriminator for PipelineTask runs. 'task' (default) for
+		// normal Task runs; 'pipeline' will be set on a PipelineTask's
+		// parent run by the engine (upcoming PR). SQLite backfills existing
+		// rows to 'task' at ALTER time.
+		{"kind", "TEXT NOT NULL DEFAULT 'task'"},
 	}
 	ctx := context.Background()
 	for _, m := range runsMigrations {

--- a/pkg/task/inputref.go
+++ b/pkg/task/inputref.go
@@ -80,6 +80,11 @@ var inputRefRe = regexp.MustCompile(`\$\{input\.(output|params)(?:\.([A-Za-z_][A
 // the strict regex would silently pass through.
 var inputRefPrefixRe = regexp.MustCompile(`\$\{input\.[^}]*\}`)
 
+// inputParamsRefRe matches any ${input.params.<name>} reference specifically —
+// used by PipelineTask.Validate to reject ${input.params.…} references in
+// sequential pipelines (where the upstream params map is not forwarded).
+var inputParamsRefRe = regexp.MustCompile(`\$\{input\.params\.[A-Za-z_][A-Za-z0-9_.\-]*\}`)
+
 // InputContext carries the dispatch-time values the resolver needs.
 // Output is the upstream's full return value (any type — the resolver
 // type-asserts per-token). Params is the upstream's RunOptions.Params

--- a/pkg/task/kinded.go
+++ b/pkg/task/kinded.go
@@ -1,0 +1,35 @@
+package task
+
+// Kind discriminator values for the top-level `kind:` field in a task's
+// task.yaml. pkg/taskset carries a parallel typed Kind constant with the
+// same string value ("Task"); the two are intentionally independent to
+// avoid a circular import (pkg/taskset imports pkg/task, not vice versa).
+const (
+	KindTask         = "Task"
+	KindPipelineTask = "PipelineTask"
+)
+
+// Kinded is the common surface the transport layer (source events, registry,
+// reconciler, engine registration) needs to handle any task kind uniformly.
+// Both *Spec (kind: Task) and *PipelineTask (kind: PipelineTask) implement it.
+//
+// Method names deliberately avoid clashing with the underlying struct fields
+// (ID, Enabled, Warnings) — Go forbids a method and field of the same name.
+type Kinded interface {
+	KindOf() string
+	TaskID() string
+	SetTaskID(id string)
+	IsEnabled() bool
+	SetEnabled(b bool)
+	LoadWarnings() []string
+	Validate() error
+}
+
+// --- *Spec implements Kinded ---
+
+func (s *Spec) KindOf() string         { return KindTask }
+func (s *Spec) TaskID() string         { return s.ID }
+func (s *Spec) SetTaskID(id string)    { s.ID = id }
+func (s *Spec) IsEnabled() bool        { return s.Enabled }
+func (s *Spec) SetEnabled(b bool)      { s.Enabled = b }
+func (s *Spec) LoadWarnings() []string { return s.Warnings }

--- a/pkg/task/kinded.go
+++ b/pkg/task/kinded.go
@@ -25,6 +25,9 @@ type Kinded interface {
 	Validate() error
 }
 
+// Compile-time assertions that both task kinds satisfy Kinded.
+var _ Kinded = (*Spec)(nil)
+
 // --- *Spec implements Kinded ---
 
 func (s *Spec) KindOf() string         { return KindTask }

--- a/pkg/task/kinded_test.go
+++ b/pkg/task/kinded_test.go
@@ -1,0 +1,27 @@
+package task
+
+import "testing"
+
+func TestSpecImplementsKinded(t *testing.T) {
+	var k Kinded = &Spec{ID: "a", Name: "A", Enabled: true}
+	if k.KindOf() != KindTask {
+		t.Fatalf("KindOf = %q, want %q", k.KindOf(), KindTask)
+	}
+	if k.TaskID() != "a" {
+		t.Fatalf("TaskID = %q, want a", k.TaskID())
+	}
+	k.SetTaskID("b")
+	if k.TaskID() != "b" {
+		t.Fatalf("SetTaskID failed: %q", k.TaskID())
+	}
+	if !k.IsEnabled() {
+		t.Fatal("IsEnabled = false, want true")
+	}
+	k.SetEnabled(false)
+	if k.IsEnabled() {
+		t.Fatal("SetEnabled(false) failed")
+	}
+	if ws := k.LoadWarnings(); ws != nil {
+		t.Fatalf("LoadWarnings: want nil, got %v", ws)
+	}
+}

--- a/pkg/task/loadkinded.go
+++ b/pkg/task/loadkinded.go
@@ -1,0 +1,51 @@
+package task
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// peekKind reads only the top-level kind field from <dir>/task.yaml without a
+// full decode. Returns "" when the field is absent (legacy task.yaml). Defined
+// here (not via pkg/taskset.DetectKind) to avoid an import cycle: pkg/taskset
+// imports pkg/task, not vice versa.
+func peekKind(dir string) (string, error) {
+	f, err := os.Open(filepath.Join(dir, "task.yaml"))
+	if err != nil {
+		return "", fmt.Errorf("open task.yaml in %s: %w", dir, err)
+	}
+	defer f.Close()
+	var h struct {
+		Kind string `yaml:"kind"`
+	}
+	if err := yaml.NewDecoder(f).Decode(&h); err != nil {
+		if errors.Is(err, io.EOF) {
+			return "", fmt.Errorf("task.yaml in %s is empty", dir)
+		}
+		return "", fmt.Errorf("read kind from %s/task.yaml: %w", dir, err)
+	}
+	return h.Kind, nil
+}
+
+// LoadKindedDir loads <dir>/task.yaml as the appropriate kind. A missing or
+// "Task" kind loads a *Spec; "PipelineTask" loads a *PipelineTask. Any other
+// kind is an error.
+func LoadKindedDir(dir string, extras map[string]string) (Kinded, error) {
+	kind, err := peekKind(dir)
+	if err != nil {
+		return nil, err
+	}
+	switch kind {
+	case "", KindTask:
+		return LoadDirWithVars(dir, extras)
+	case KindPipelineTask:
+		return LoadPipelineDir(dir, extras)
+	default:
+		return nil, fmt.Errorf("task.yaml in %s: unknown kind %q (expected %q or %q)", dir, kind, KindTask, KindPipelineTask)
+	}
+}

--- a/pkg/task/loadkinded_test.go
+++ b/pkg/task/loadkinded_test.go
@@ -1,0 +1,94 @@
+package task
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeKindedYAML(t *testing.T, dir, src string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "task.yaml"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadKindedDir_Pipeline(t *testing.T) {
+	dir := t.TempDir()
+	writeKindedYAML(t, dir, `apiVersion: dicode/v1
+kind: PipelineTask
+name: P
+subtype: sequential
+trigger: { manual: true }
+stages: [ { task: buildin/template } ]
+`)
+	k, err := LoadKindedDir(dir, nil)
+	if err != nil {
+		t.Fatalf("LoadKindedDir: %v", err)
+	}
+	if k.KindOf() != KindPipelineTask {
+		t.Fatalf("KindOf = %q", k.KindOf())
+	}
+	if _, ok := k.(*PipelineTask); !ok {
+		t.Fatalf("want *PipelineTask, got %T", k)
+	}
+}
+
+func TestLoadKindedDir_TaskExplicitAndMissing(t *testing.T) {
+	// Missing kind defaults to Task (existing task.yaml files have no kind field).
+	dir := t.TempDir()
+	writeKindedYAML(t, dir, `name: T
+runtime: deno
+trigger: { manual: true }
+`)
+	if err := os.WriteFile(filepath.Join(dir, "task.ts"),
+		[]byte("export default async function main(){return 1}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	k, err := LoadKindedDir(dir, nil)
+	if err != nil {
+		t.Fatalf("LoadKindedDir: %v", err)
+	}
+	if _, ok := k.(*Spec); !ok {
+		t.Fatalf("want *Spec, got %T", k)
+	}
+
+	// Explicit kind: Task also routes to *Spec.
+	dir2 := t.TempDir()
+	writeKindedYAML(t, dir2, `kind: Task
+name: T2
+runtime: deno
+trigger: { manual: true }
+`)
+	if err := os.WriteFile(filepath.Join(dir2, "task.ts"),
+		[]byte("export default async function main(){return 1}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	k2, err := LoadKindedDir(dir2, nil)
+	if err != nil {
+		t.Fatalf("LoadKindedDir (explicit Task): %v", err)
+	}
+	if _, ok := k2.(*Spec); !ok {
+		t.Fatalf("want *Spec, got %T", k2)
+	}
+}
+
+func TestLoadKindedDir_UnknownKind(t *testing.T) {
+	dir := t.TempDir()
+	writeKindedYAML(t, dir, `kind: Frobnicator
+name: X
+`)
+	if _, err := LoadKindedDir(dir, nil); err == nil {
+		t.Fatal("expected error for unknown kind")
+	}
+}
+
+func TestLoadKindedDir_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	writeKindedYAML(t, dir, "")
+	_, err := LoadKindedDir(dir, nil)
+	if err == nil || !strings.Contains(err.Error(), "is empty") {
+		t.Fatalf("expected empty-file error, got %v", err)
+	}
+}

--- a/pkg/task/overrides.go
+++ b/pkg/task/overrides.go
@@ -200,3 +200,42 @@ func validatePerEdgeOverrides(site string, o *Overrides) error {
 	}
 	return nil
 }
+
+// validatePipelineStageOverrides is the per-stage override allowlist for
+// kind: PipelineTask. It is identical to validatePerEdgeOverrides EXCEPT it
+// permits a Trigger patch — a pipeline may override a stage task's trigger
+// (e.g. flip a manual-only task to fireable). Params/Env/Net/Fs/Timeout/
+// Dicode/Runtime are allowed; Enabled/Name/Description/Retry/Defaults/Entries
+// are rejected.
+func validatePipelineStageOverrides(site string, o *Overrides) error {
+	if o == nil {
+		return nil
+	}
+	if o.Enabled != nil {
+		return fmt.Errorf("%s: field %q is not supported at a pipeline stage", site, "enabled")
+	}
+	if o.Name != "" {
+		return fmt.Errorf("%s: field %q is not supported at a pipeline stage", site, "name")
+	}
+	if o.Description != "" {
+		return fmt.Errorf("%s: field %q is not supported at a pipeline stage", site, "description")
+	}
+	if o.Retry != nil {
+		return fmt.Errorf("%s: field %q is not supported at a pipeline stage", site, "retry")
+	}
+	if o.Defaults != nil {
+		return fmt.Errorf("%s: field %q is not supported at a pipeline stage (taskset-level construct)", site, "defaults")
+	}
+	if o.Entries != nil {
+		return fmt.Errorf("%s: field %q is not supported at a pipeline stage (taskset-level construct)", site, "entries")
+	}
+	for _, p := range o.Params {
+		if _, reserved := reservedChainParamKeys[p.Name]; reserved {
+			return fmt.Errorf("%s: params %q is a reserved key (used by the engine)", site, p.Name)
+		}
+		if err := ValidateInputRefs(fmt.Sprintf("%s.params.%s", site, p.Name), p.Default); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/task/pipeline.go
+++ b/pkg/task/pipeline.go
@@ -1,0 +1,128 @@
+package task
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// PipelineTask is the spec for kind: PipelineTask — a sequential orchestration
+// of one or more kind: Task stages. It is a peer of Spec, not a Spec.
+type PipelineTask struct {
+	APIVersion  string          `yaml:"apiVersion" json:"apiVersion"`
+	Kind        string          `yaml:"kind"       json:"kind"`
+	Name        string          `yaml:"name"       json:"name"`
+	Description string          `yaml:"description,omitempty" json:"description,omitempty"`
+	Subtype     string          `yaml:"subtype"    json:"subtype"` // "sequential" (v1) | "parallel" (v2+)
+	Trigger     PipelineTrigger `yaml:"trigger,omitempty" json:"trigger"`
+	Stages      []Stage         `yaml:"stages"     json:"stages"`
+	Timeout     time.Duration   `yaml:"timeout,omitempty" json:"timeout,omitempty"`
+
+	// Not stored in YAML — set by the loader/reconciler (mirrors Spec).
+	TaskDir  string   `yaml:"-" json:"-"`
+	ID       string   `yaml:"-" json:"id"`
+	Enabled  bool     `yaml:"-" json:"enabled"`
+	Warnings []string `yaml:"-" json:"-"`
+}
+
+// PipelineTrigger is the subset of trigger shapes valid on a pipeline.
+// Notably no Daemon: a pipeline is daemon-shaped iff its terminal stage is a
+// kind: Task with trigger.daemon: true.
+type PipelineTrigger struct {
+	Manual        bool          `yaml:"manual,omitempty"`
+	Cron          string        `yaml:"cron,omitempty"`
+	Webhook       string        `yaml:"webhook,omitempty"`
+	WebhookSecret string        `yaml:"webhook_secret,omitempty"`
+	WebhookAuth   bool          `yaml:"auth,omitempty"`
+	Chain         *ChainTrigger `yaml:"chain,omitempty"`
+}
+
+// Stage is one entry in a PipelineTask.Stages list. Structurally identical to
+// BeforeEntry, but stage overrides additionally permit a Trigger patch.
+type Stage struct {
+	Task      string     `yaml:"task"`
+	Overrides *Overrides `yaml:"overrides,omitempty"`
+}
+
+func (p *PipelineTask) KindOf() string         { return KindPipelineTask }
+func (p *PipelineTask) TaskID() string         { return p.ID }
+func (p *PipelineTask) SetTaskID(id string)    { p.ID = id }
+func (p *PipelineTask) IsEnabled() bool        { return p.Enabled }
+func (p *PipelineTask) SetEnabled(b bool)      { p.Enabled = b }
+func (p *PipelineTask) LoadWarnings() []string { return p.Warnings }
+
+// count reports how many trigger shapes are set (for the at-most-one check).
+func (t PipelineTrigger) count() int {
+	n := 0
+	if t.Manual {
+		n++
+	}
+	if t.Cron != "" {
+		n++
+	}
+	if t.Webhook != "" {
+		n++
+	}
+	if t.Chain != nil {
+		n++
+	}
+	return n
+}
+
+// pipelineParallelFollowupIssue is referenced in the subtype error so operators
+// have a pointer to the planned parallel-mode work. Filled in once filed.
+const pipelineParallelFollowupIssue = "the parallel-pipeline support follow-up (planned; not yet filed)"
+
+// Validate runs all load-time (non-registry) checks. Cross-spec checks (stage
+// existence, cycle detection, stages-must-be-kind-Task) run in the engine's
+// registerPipeline because they need the registry snapshot.
+func (p *PipelineTask) Validate() error {
+	if p.APIVersion != "dicode/v1" {
+		return fmt.Errorf("pipeline: apiVersion must be %q, got %q", "dicode/v1", p.APIVersion)
+	}
+	if p.Kind != KindPipelineTask {
+		return fmt.Errorf("pipeline: kind must be %q, got %q", KindPipelineTask, p.Kind)
+	}
+	if p.Name == "" {
+		return fmt.Errorf("pipeline: name is required")
+	}
+	if p.Subtype != "sequential" {
+		return fmt.Errorf("pipeline: subtype %q not implemented in v1 (only \"sequential\"); see %s",
+			p.Subtype, pipelineParallelFollowupIssue)
+	}
+	if p.Trigger.count() > 1 {
+		return fmt.Errorf("pipeline: at most one trigger type may be set")
+	}
+	if len(p.Stages) == 0 {
+		return fmt.Errorf("pipeline: at least one stage is required")
+	}
+	seen := make(map[string]struct{}, len(p.Stages))
+	for i, st := range p.Stages {
+		if st.Task == "" {
+			return fmt.Errorf("pipeline: stage %d has an empty task ID", i)
+		}
+		if st.Task == p.ID {
+			return fmt.Errorf("pipeline: stage %d cannot reference itself (%q)", i, st.Task)
+		}
+		if _, dup := seen[st.Task]; dup {
+			return fmt.Errorf("pipeline: stage %d duplicate task ID %q (v1 has no stage-id disambiguation)", i, st.Task)
+		}
+		seen[st.Task] = struct{}{}
+
+		if st.Overrides != nil {
+			site := fmt.Sprintf("pipeline.stages[%d].overrides (task %q)", i, st.Task)
+			if err := validatePipelineStageOverrides(site, st.Overrides); err != nil {
+				return err
+			}
+			for _, pr := range st.Overrides.Params {
+				if i == 0 && strings.Contains(pr.Default, "${input.") {
+					return fmt.Errorf("pipeline.stages[0].overrides.params.%s: ${input.…} references are not available on the first stage", pr.Name)
+				}
+				if inputParamsRefRe.MatchString(pr.Default) {
+					return fmt.Errorf("pipeline.stages[%d].overrides.params.%s: ${input.params.…} is not available in sequential pipelines", i, pr.Name)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/task/pipeline.go
+++ b/pkg/task/pipeline.go
@@ -56,6 +56,9 @@ func (p *PipelineTask) IsEnabled() bool        { return p.Enabled }
 func (p *PipelineTask) SetEnabled(b bool)      { p.Enabled = b }
 func (p *PipelineTask) LoadWarnings() []string { return p.Warnings }
 
+// Compile-time assertion that PipelineTask satisfies Kinded.
+var _ Kinded = (*PipelineTask)(nil)
+
 // count reports how many trigger shapes are set (for the at-most-one check).
 func (t PipelineTrigger) count() int {
 	n := 0
@@ -73,10 +76,6 @@ func (t PipelineTrigger) count() int {
 	}
 	return n
 }
-
-// pipelineParallelFollowupIssue is referenced in the subtype error so operators
-// have a pointer to the planned parallel-mode work. Filled in once filed.
-const pipelineParallelFollowupIssue = "the parallel-pipeline support follow-up (planned; not yet filed)"
 
 // LoadPipelineDir parses a kind: PipelineTask from <dir>/task.yaml. The caller
 // is responsible for having already determined the kind (see LoadKindedDir).
@@ -144,9 +143,11 @@ func (p *PipelineTask) Validate() error {
 	if p.Name == "" {
 		return fmt.Errorf("pipeline: name is required")
 	}
+	if p.Subtype == "" {
+		return fmt.Errorf("pipeline: subtype is required (use \"sequential\")")
+	}
 	if p.Subtype != "sequential" {
-		return fmt.Errorf("pipeline: subtype %q not implemented in v1 (only \"sequential\"); see %s",
-			p.Subtype, pipelineParallelFollowupIssue)
+		return fmt.Errorf("pipeline: subtype %q is not supported in v1 (only \"sequential\"; parallel pipelines are a planned follow-up)", p.Subtype)
 	}
 	if p.Trigger.count() > 1 {
 		return fmt.Errorf("pipeline: at most one trigger type may be set")

--- a/pkg/task/pipeline.go
+++ b/pkg/task/pipeline.go
@@ -2,8 +2,13 @@ package task
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 // PipelineTask is the spec for kind: PipelineTask — a sequential orchestration
@@ -72,6 +77,59 @@ func (t PipelineTrigger) count() int {
 // pipelineParallelFollowupIssue is referenced in the subtype error so operators
 // have a pointer to the planned parallel-mode work. Filled in once filed.
 const pipelineParallelFollowupIssue = "the parallel-pipeline support follow-up (planned; not yet filed)"
+
+// LoadPipelineDir parses a kind: PipelineTask from <dir>/task.yaml. The caller
+// is responsible for having already determined the kind (see LoadKindedDir).
+func LoadPipelineDir(dir string, extras map[string]string) (*PipelineTask, error) {
+	specPath := filepath.Join(dir, "task.yaml")
+	f, err := os.Open(specPath)
+	if err != nil {
+		return nil, fmt.Errorf("open task.yaml in %s: %w", dir, err)
+	}
+	defer f.Close()
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("read task.yaml in %s: %w", dir, err)
+	}
+
+	// Probe for the removed `notify:` block before decoding (mirrors LoadDirWithVars).
+	var probe struct {
+		Notify any `yaml:"notify"`
+	}
+	if err := yaml.Unmarshal(data, &probe); err == nil && probe.Notify != nil {
+		return nil, fmt.Errorf("task.yaml in %s: legacy `notify` block detected. "+
+			"The per-task notify field was removed (#279). Use `on_failure_chain` "+
+			"to fire a notification task on failure — see docs.", dir)
+	}
+
+	var p PipelineTask
+	if err := yaml.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("parse task.yaml in %s: %w", dir, err)
+	}
+
+	// Set ID before Validate: PipelineTask.Validate's self-reference check
+	// compares each stage against p.ID, so it must be populated first.
+	// (This intentionally differs from LoadDirWithVars's ordering.)
+	p.TaskDir = dir
+	p.ID = filepath.Base(dir)
+	p.Enabled = true
+
+	expandPipeline(&p, builtinVars(dir, extras))
+
+	if err := p.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid pipeline in %s: %w", dir, err)
+	}
+	return &p, nil
+}
+
+// expandPipeline expands ${VAR} template variables in stage override params and
+// fs paths, reusing expandOverrides (which mirrors the envFallback policy from
+// expandSpec: Params[].Default gets envFallback=false, Fs[].Path gets true).
+func expandPipeline(p *PipelineTask, vars map[string]string) {
+	for i := range p.Stages {
+		expandOverrides(p.Stages[i].Overrides, vars)
+	}
+}
 
 // Validate runs all load-time (non-registry) checks. Cross-spec checks (stage
 // existence, cycle detection, stages-must-be-kind-Task) run in the engine's

--- a/pkg/task/pipeline_test.go
+++ b/pkg/task/pipeline_test.go
@@ -47,7 +47,8 @@ func TestPipelineValidate(t *testing.T) {
 		{"bad apiVersion", func(p *PipelineTask) { p.APIVersion = "v2" }, "apiVersion"},
 		{"bad kind", func(p *PipelineTask) { p.Kind = "Task" }, "kind"},
 		{"no name", func(p *PipelineTask) { p.Name = "" }, "name"},
-		{"bad subtype", func(p *PipelineTask) { p.Subtype = "parallel" }, "not implemented in v1"},
+		{"missing subtype", func(p *PipelineTask) { p.Subtype = "" }, "subtype is required"},
+		{"bad subtype", func(p *PipelineTask) { p.Subtype = "parallel" }, "is not supported in v1"},
 		{"multi trigger", func(p *PipelineTask) {
 			p.Trigger = PipelineTrigger{Manual: true, Cron: "0 * * * *"}
 		}, "at most one trigger"},
@@ -64,6 +65,15 @@ func TestPipelineValidate(t *testing.T) {
 		{"stage override rejects enabled", func(p *PipelineTask) {
 			en := true
 			p.Stages[1].Overrides.Enabled = &en
+		}, "not supported at a pipeline stage"},
+		{"stage override rejects name", func(p *PipelineTask) {
+			p.Stages[1].Overrides.Name = "nope"
+		}, "not supported at a pipeline stage"},
+		{"stage override rejects description", func(p *PipelineTask) {
+			p.Stages[1].Overrides.Description = "nope"
+		}, "not supported at a pipeline stage"},
+		{"stage override rejects entries", func(p *PipelineTask) {
+			p.Stages[1].Overrides.Entries = map[string]*Overrides{"x": {}}
 		}, "not supported at a pipeline stage"},
 	}
 	for _, tc := range cases {

--- a/pkg/task/pipeline_test.go
+++ b/pkg/task/pipeline_test.go
@@ -1,6 +1,8 @@
 package task
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -85,5 +87,53 @@ func TestPipelineStageTriggerOverrideAllowed(t *testing.T) {
 	p.Stages[0].Overrides = &Overrides{Trigger: &TriggerPatch{Manual: &disable}}
 	if err := p.Validate(); err != nil {
 		t.Fatalf("stage trigger override should be allowed: %v", err)
+	}
+}
+
+func TestLoadPipelineDir(t *testing.T) {
+	dir := t.TempDir()
+	yamlSrc := `apiVersion: dicode/v1
+kind: PipelineTask
+name: Demo Pipeline
+subtype: sequential
+trigger:
+  manual: true
+stages:
+  - task: buildin/template
+    overrides:
+      params:
+        template: "hello"
+  - task: buildin/write-local
+    overrides:
+      params:
+        content: "${input.output}"
+        path: "${DATADIR}/out.txt"
+`
+	if err := os.WriteFile(filepath.Join(dir, "task.yaml"), []byte(yamlSrc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p, err := LoadPipelineDir(dir, map[string]string{VarDataDir: "/data"})
+	if err != nil {
+		t.Fatalf("LoadPipelineDir: %v", err)
+	}
+	if p.Name != "Demo Pipeline" || len(p.Stages) != 2 {
+		t.Fatalf("parsed wrong: %+v", p)
+	}
+	if p.ID != filepath.Base(dir) {
+		t.Fatalf("ID = %q, want %q", p.ID, filepath.Base(dir))
+	}
+	if !p.Enabled {
+		t.Fatal("Enabled should default true")
+	}
+	// ${DATADIR} expansion applies to stage override params (lookup by name,
+	// not position, so a fixture reorder can't silently break this).
+	var pathDefault string
+	for _, pr := range p.Stages[1].Overrides.Params {
+		if pr.Name == "path" {
+			pathDefault = pr.Default
+		}
+	}
+	if pathDefault != "/data/out.txt" {
+		t.Fatalf("DATADIR not expanded: %q", pathDefault)
 	}
 }

--- a/pkg/task/pipeline_test.go
+++ b/pkg/task/pipeline_test.go
@@ -1,0 +1,89 @@
+package task
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPipelineTaskImplementsKinded(t *testing.T) {
+	var k Kinded = &PipelineTask{ID: "p", Name: "P", Subtype: "sequential", Enabled: true,
+		Stages: []Stage{{Task: "buildin/template"}}}
+	if k.KindOf() != KindPipelineTask {
+		t.Fatalf("KindOf = %q, want %q", k.KindOf(), KindPipelineTask)
+	}
+	if k.TaskID() != "p" {
+		t.Fatalf("TaskID = %q, want p", k.TaskID())
+	}
+	k.SetTaskID("q")
+	k.SetEnabled(false)
+	if k.TaskID() != "q" || k.IsEnabled() {
+		t.Fatal("setters failed")
+	}
+}
+
+func validPipeline() *PipelineTask {
+	return &PipelineTask{
+		APIVersion: "dicode/v1", Kind: KindPipelineTask, Name: "P",
+		Subtype: "sequential", ID: "p",
+		Stages: []Stage{
+			{Task: "buildin/template"},
+			{Task: "buildin/write-local", Overrides: &Overrides{
+				Params: ParamOverrides{{Name: "content", Default: "${input.output}"}}}},
+		},
+	}
+}
+
+func TestPipelineValidate(t *testing.T) {
+	if err := validPipeline().Validate(); err != nil {
+		t.Fatalf("valid pipeline rejected: %v", err)
+	}
+	cases := []struct {
+		name string
+		mut  func(p *PipelineTask)
+		want string
+	}{
+		{"bad apiVersion", func(p *PipelineTask) { p.APIVersion = "v2" }, "apiVersion"},
+		{"bad kind", func(p *PipelineTask) { p.Kind = "Task" }, "kind"},
+		{"no name", func(p *PipelineTask) { p.Name = "" }, "name"},
+		{"bad subtype", func(p *PipelineTask) { p.Subtype = "parallel" }, "not implemented in v1"},
+		{"multi trigger", func(p *PipelineTask) {
+			p.Trigger = PipelineTrigger{Manual: true, Cron: "0 * * * *"}
+		}, "at most one trigger"},
+		{"no stages", func(p *PipelineTask) { p.Stages = nil }, "at least one stage"},
+		{"empty stage task", func(p *PipelineTask) { p.Stages[0].Task = "" }, "empty task"},
+		{"self ref", func(p *PipelineTask) { p.Stages[0].Task = "p" }, "cannot reference itself"},
+		{"dup stage", func(p *PipelineTask) { p.Stages[1].Task = "buildin/template" }, "duplicate"},
+		{"input on stage0", func(p *PipelineTask) {
+			p.Stages[0].Overrides = &Overrides{Params: ParamOverrides{{Name: "x", Default: "${input.output}"}}}
+		}, "first stage"},
+		{"input.params anywhere", func(p *PipelineTask) {
+			p.Stages[1].Overrides.Params[0].Default = "${input.params.foo}"
+		}, "${input.params"},
+		{"stage override rejects enabled", func(p *PipelineTask) {
+			en := true
+			p.Stages[1].Overrides.Enabled = &en
+		}, "not supported at a pipeline stage"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := validPipeline()
+			tc.mut(p)
+			err := p.Validate()
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestPipelineStageTriggerOverrideAllowed(t *testing.T) {
+	p := validPipeline()
+	disable := false
+	p.Stages[0].Overrides = &Overrides{Trigger: &TriggerPatch{Manual: &disable}}
+	if err := p.Validate(); err != nil {
+		t.Fatalf("stage trigger override should be allowed: %v", err)
+	}
+}


### PR DESCRIPTION
## PR1/8 — Spec-layer foundation for `kind: PipelineTask`

First PR of the **PipelineTask epic**, which introduces `kind: PipelineTask` as a first-class, separately-typed peer of `kind: Task` and (in later PRs) hard-cuts `trigger.before:`. This PR is **behavior-neutral**: it only adds new types, an interface, a kind-aware loader, and a DB column. No existing code path changes (zero deletions; +596 lines).

### What's here
- **`task.Kinded` interface** (`pkg/task/kinded.go`) — the common surface (`KindOf`/`TaskID`/`SetTaskID`/`IsEnabled`/`SetEnabled`/`LoadWarnings`/`Validate`) that both `*task.Spec` and the new `*task.PipelineTask` satisfy. `*Spec` implements it (methods named to avoid clashing with its `ID`/`Enabled`/`Warnings` fields).
- **`task.PipelineTask` / `PipelineTrigger` / `Stage`** (`pkg/task/pipeline.go`) — the spec types + non-registry `Validate()` (apiVersion/kind/name/subtype, at-most-one trigger, ≥1 stage, empty/self/duplicate stage checks, `${input.*}` on stage 0 rejection, `${input.params.*}` rejection).
- **`validatePipelineStageOverrides`** (`pkg/task/overrides.go`) — per-stage override allowlist; mirrors `validatePerEdgeOverrides` but **permits** a `Trigger` patch (stage trigger override).
- **`LoadPipelineDir` + `LoadKindedDir`** (`pkg/task/pipeline.go`, `loadkinded.go`) — kind-aware loading. Filename stays `task.yaml` (discriminated by the `kind:` field), so the source scanner/hash are untouched. Missing `kind:` defaults to `Task` (backward compat).
- **`runs.kind` column** (`pkg/db/sqlite.go`) — `TEXT NOT NULL DEFAULT 'task'`, appended to the idempotent `runsMigrations`; SQLite backfills existing rows. Used by later PRs to mark a pipeline's parent run `'pipeline'`.

### Design note (deviation from the original spec sketch)
The spec illustrated a separate `pipeline.yaml` file; grounding showed `task.ScanDir` keys off `task.yaml`, so pipelines reuse `task.yaml` discriminated by `kind:` — avoiding scanner/hash/source-walk changes. The registry/transport polymorphism (the `Kinded` plumbing through `source.Event`/reconciler/engine) lands in **PR2**.

### Testing
TDD throughout. `go build ./...`, `go vet ./pkg/task/... ./pkg/db/...`, and `go test ./... -short` all green. `make format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)