### PR TITLE
feat(transport): PipelineTask polymorphic transport + registration (PR2/8)

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -233,14 +233,18 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	// 30 s, flooding the log. LoadOrStore ensures at most one WARN per task ID
 	// per daemon lifetime.
 	var bodyFullTextualWarned sync.Map
-	rec.OnRegister = func(spec *task.Spec) {
+	rec.OnRegister = func(k task.Kinded) {
+		// The webhook-gateway and footgun checks below only apply to kind: Task.
+		// Pipelines (kind: PipelineTask) register through the engine for routing
+		// but their trigger wiring lands in a later PR; skip the Spec-only logic.
+		spec, isSpec := k.(*task.Spec)
 		// Override buildin/run-inputs-cleanup's retention_seconds default to
 		// match dicode.yaml's defaults.run_inputs.retention. This must happen
 		// before eng.Register so the engine sees the correct default when
 		// building the param map for the next cron fire. We mutate the spec
 		// slice element in place; the reconciler replaces the spec on each
 		// reload, so the override is re-applied on every registration.
-		if spec.ID == "buildin/run-inputs-cleanup" && cfg.Defaults.RunInputs.Retention > 0 {
+		if isSpec && spec.ID == "buildin/run-inputs-cleanup" && cfg.Defaults.RunInputs.Retention > 0 {
 			retStr := fmt.Sprintf("%d", int64(cfg.Defaults.RunInputs.Retention.Seconds()))
 			for i := range spec.Params {
 				if spec.Params[i].Name == "retention_seconds" {
@@ -249,18 +253,21 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 				}
 			}
 		}
-		if err := eng.Register(spec); err != nil {
+		if err := eng.Register(k); err != nil {
 			// Cross-spec validation (trigger.before pointing at an unknown
-			// task or at another daemon) is the only error Register currently
-			// returns. The reconciler will retry on the next reload, so a
-			// transient registry mismatch heals itself; a persistent config
-			// error surfaces here every cycle. Log at WARN — matches how the
-			// reconciler/engine surface other config-validation failures —
-			// and skip the downstream webhook/footgun checks so a half-
-			// registered task doesn't claim its gateway path.
+			// task or at another daemon, or pipeline ref/cycle errors) is the
+			// only error Register currently returns. The reconciler will retry
+			// on the next reload, so a transient registry mismatch heals itself;
+			// a persistent config error surfaces here every cycle. Log at WARN —
+			// matches how the reconciler/engine surface other config-validation
+			// failures — and skip the downstream webhook/footgun checks so a
+			// half-registered task doesn't claim its gateway path.
 			log.Warn("task registration rejected by engine — fix the spec to re-enable",
-				zap.String("task", spec.ID),
+				zap.String("task", k.TaskID()),
 				zap.Error(err))
+			return
+		}
+		if !isSpec {
 			return
 		}
 		if spec.Trigger.Webhook != "" {

--- a/pkg/ipc/server_test.go
+++ b/pkg/ipc/server_test.go
@@ -813,7 +813,7 @@ func TestServer_Dicode_SetGroup_Persists(t *testing.T) {
 	// The server doesn't auto-create a runs row; do it ourselves so the
 	// UPDATE has a target. (In production fireAsync inserts the row before
 	// the task starts.)
-	if _, err := e.reg.StartRunWithID(context.Background(), srv.runID, "test-task", "", "manual"); err != nil {
+	if _, err := e.reg.StartRunWithID(context.Background(), srv.runID, "test-task", "", "manual", "task"); err != nil {
 		t.Fatalf("StartRunWithID: %v", err)
 	}
 

--- a/pkg/registry/reconciler.go
+++ b/pkg/registry/reconciler.go
@@ -18,7 +18,9 @@ type Reconciler struct {
 	log      *zap.Logger
 
 	// OnRegister is called after a task is registered (used by trigger engine).
-	OnRegister func(spec *task.Spec)
+	// It receives the registered task as a task.Kinded; consumers that only act
+	// on kind: Task type-assert to *task.Spec.
+	OnRegister func(k task.Kinded)
 	// OnUnregister is called after a task is removed.
 	OnUnregister func(id string)
 
@@ -130,13 +132,11 @@ func (rc *Reconciler) startSource(src source.Source) error {
 func (rc *Reconciler) handle(ev source.Event) {
 	switch ev.Kind {
 	case source.EventAdded, source.EventUpdated:
-		var spec *task.Spec
-		if ev.Spec != nil {
-			// TaskSet sources pre-resolve the spec (overrides already applied).
-			spec = ev.Spec
-			spec.ID = ev.TaskID
+		var k task.Kinded
+		if ev.Kinded != nil {
+			// TaskSet sources pre-resolve the task (overrides already applied).
+			k = ev.Kinded
 		} else {
-			var err error
 			extras := ev.ExtraVars
 			if extras == nil {
 				extras = make(map[string]string, 1)
@@ -145,13 +145,13 @@ func (rc *Reconciler) handle(ev source.Event) {
 				// Don't clobber a source-supplied DATADIR (allows tests to override).
 				// Clone before mutate — ev.ExtraVars may be shared across event consumers.
 				cloned := make(map[string]string, len(extras)+1)
-				for k, v := range extras {
-					cloned[k] = v
+				for key, v := range extras {
+					cloned[key] = v
 				}
 				cloned[task.VarDataDir] = rc.dataDir
 				extras = cloned
 			}
-			spec, err = task.LoadDirWithVars(ev.TaskDir, extras)
+			loaded, err := task.LoadKindedDir(ev.TaskDir, extras)
 			if err != nil {
 				rc.log.Warn("failed to load task",
 					zap.String("task", ev.TaskID),
@@ -160,23 +160,32 @@ func (rc *Reconciler) handle(ev source.Event) {
 				)
 				return
 			}
+			k = loaded
 		}
-		for _, w := range spec.Warnings {
+		// The registry keys on the event's TaskID. Flat git/local sources already
+		// load with ID == basename == TaskID, but namespaced/pre-resolved tasks
+		// need the canonical ID stamped here so every layer agrees.
+		k.SetTaskID(ev.TaskID)
+		for _, w := range k.LoadWarnings() {
 			rc.log.Warn("task config warning",
 				zap.String("task", ev.TaskID),
 				zap.String("source", ev.Source),
 				zap.String("warning", w),
 			)
 		}
-		if err := rc.validateTaskProviders(spec); err != nil {
-			rc.log.Warn("task references unknown provider",
-				zap.String("task", ev.TaskID),
-				zap.String("source", ev.Source),
-				zap.Error(err),
-			)
-			return
+		// Provider validation (issue #119) only applies to kind: Task env entries;
+		// pipelines declare no env providers.
+		if spec, ok := k.(*task.Spec); ok {
+			if err := rc.validateTaskProviders(spec); err != nil {
+				rc.log.Warn("task references unknown provider",
+					zap.String("task", ev.TaskID),
+					zap.String("source", ev.Source),
+					zap.Error(err),
+				)
+				return
+			}
 		}
-		if err := rc.registry.Register(spec); err != nil {
+		if err := rc.registry.Register(k); err != nil {
 			rc.log.Error("failed to register task", zap.String("task", ev.TaskID), zap.Error(err))
 			return
 		}
@@ -185,7 +194,7 @@ func (rc *Reconciler) handle(ev source.Event) {
 			zap.String("kind", string(ev.Kind)),
 		)
 		if rc.OnRegister != nil {
-			rc.OnRegister(spec)
+			rc.OnRegister(k)
 		}
 
 	case source.EventRemoved:

--- a/pkg/registry/reconciler_test.go
+++ b/pkg/registry/reconciler_test.go
@@ -158,10 +158,10 @@ func TestReconciler_OnRegisterCallback(t *testing.T) {
 	_, rec := newTestReconciler(t, fs)
 
 	var mu sync.Mutex
-	var called *task.Spec
-	rec.OnRegister = func(spec *task.Spec) {
+	var called task.Kinded
+	rec.OnRegister = func(k task.Kinded) {
 		mu.Lock()
-		called = spec
+		called = k
 		mu.Unlock()
 	}
 
@@ -175,8 +175,40 @@ func TestReconciler_OnRegisterCallback(t *testing.T) {
 	mu.Lock()
 	got := called
 	mu.Unlock()
-	if got == nil || got.ID != "cb-task" {
+	if got == nil || got.TaskID() != "cb-task" {
 		t.Errorf("OnRegister not called, got %v", got)
+	}
+}
+
+// TestReconcilerLoadsPipelineKind asserts a raw source event whose task.yaml
+// declares kind: PipelineTask is loaded as a *task.PipelineTask, registered
+// under the event's TaskID, and surfaced through the kind-aware OnRegister hook.
+func TestReconcilerLoadsPipelineKind(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "task.yaml"), []byte(`apiVersion: dicode/v1
+kind: PipelineTask
+name: P
+subtype: sequential
+trigger:
+  manual: true
+stages:
+  - task: buildin/template
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg, rec := newTestReconciler(t)
+
+	var registered task.Kinded
+	rec.OnRegister = func(k task.Kinded) { registered = k }
+
+	rec.handle(source.Event{Kind: source.EventAdded, TaskID: "demo/p", TaskDir: dir})
+
+	if registered == nil || registered.KindOf() != task.KindPipelineTask {
+		t.Fatalf("expected pipeline registration via OnRegister, got %v", registered)
+	}
+	if k, ok := reg.GetKinded("demo/p"); !ok || k.KindOf() != task.KindPipelineTask {
+		t.Fatalf("registry missing pipeline under event TaskID: %v %v", k, ok)
 	}
 }
 
@@ -207,7 +239,7 @@ func TestReconciler_RejectsUnknownTaskProvider(t *testing.T) {
 	rc.handle(source.Event{
 		Kind:    source.EventAdded,
 		TaskID:  "consumer",
-		Spec:    consumer,
+		Kinded:  consumer,
 		Source:  "test",
 		TaskDir: "",
 	})

--- a/pkg/registry/reconciler_test.go
+++ b/pkg/registry/reconciler_test.go
@@ -180,9 +180,14 @@ func TestReconciler_OnRegisterCallback(t *testing.T) {
 	}
 }
 
-// TestReconcilerLoadsPipelineKind asserts a raw source event whose task.yaml
-// declares kind: PipelineTask is loaded as a *task.PipelineTask, registered
-// under the event's TaskID, and surfaced through the kind-aware OnRegister hook.
+// TestReconcilerLoadsPipelineKind covers the reconciler boundary only: a raw
+// source event whose task.yaml declares kind: PipelineTask is loaded as a
+// *task.PipelineTask, stored in the registry under the event's TaskID, and
+// surfaced through the kind-aware OnRegister hook. Engine-side acceptance
+// (registerPipeline's stage-ref + cycle validation) is exercised in
+// pkg/trigger/registerpipeline_test.go; it can't be cross-tested here because
+// pkg/trigger imports pkg/registry, not the reverse, so wiring a real engine
+// into a package registry test would be an import cycle.
 func TestReconcilerLoadsPipelineKind(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "task.yaml"), []byte(`apiVersion: dicode/v1

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -26,10 +26,20 @@ const (
 	StatusCancelled = "cancelled"
 )
 
+// Run kind values for the runs.kind column. These are the lowercase run-row
+// discriminators — distinct from pkg/task's task-kind strings ("Task" /
+// "PipelineTask"). RunKindPipeline is written by the PipelineTask dispatcher
+// (a later PR); everything else is RunKindTask.
+const (
+	RunKindTask     = "task"
+	RunKindPipeline = "pipeline"
+)
+
 // Run is a single execution record.
 type Run struct {
 	ID          string
 	TaskID      string
+	Kind        string // run kind: "task" (default) or "pipeline" (see RunKindTask/RunKindPipeline)
 	Status      string
 	StartedAt   time.Time
 	FinishedAt  *time.Time
@@ -152,16 +162,20 @@ func (r *Registry) AllKinded() []task.Kinded {
 
 // StartRun records a new run in sqlite and returns its ID.
 func (r *Registry) StartRun(ctx context.Context, taskID, parentRunID string) (string, error) {
-	return r.StartRunWithID(ctx, uuid.New().String(), taskID, parentRunID, "")
+	return r.StartRunWithID(ctx, uuid.New().String(), taskID, parentRunID, "", RunKindTask)
 }
 
 // StartRunWithID records a new run using a caller-supplied ID.
 // Use this when the run ID must be known before execution begins (e.g. async fire).
-func (r *Registry) StartRunWithID(ctx context.Context, id, taskID, parentRunID, triggerSource string) (string, error) {
+// kind may be "task" or "pipeline"; empty defaults to "task".
+func (r *Registry) StartRunWithID(ctx context.Context, id, taskID, parentRunID, triggerSource, kind string) (string, error) {
+	if kind == "" {
+		kind = RunKindTask
+	}
 	now := time.Now().UnixMilli()
 	err := r.db.Exec(ctx,
-		`INSERT INTO runs (id, task_id, status, started_at, parent_run_id, trigger_source) VALUES (?, ?, ?, ?, ?, ?)`,
-		id, taskID, StatusRunning, now, parentRunID, triggerSource,
+		`INSERT INTO runs (id, task_id, status, started_at, parent_run_id, trigger_source, kind) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		id, taskID, StatusRunning, now, parentRunID, triggerSource, kind,
 	)
 	if err != nil {
 		return "", fmt.Errorf("start run: %w", err)
@@ -275,7 +289,7 @@ func (r *Registry) BulkAppendLogs(ctx context.Context, entries []PendingLogEntry
 func (r *Registry) GetRun(ctx context.Context, runID string) (*Run, error) {
 	var run *Run
 	err := r.db.Query(ctx,
-		`SELECT id, task_id, status, started_at, finished_at, parent_run_id, trigger_source,
+		`SELECT id, task_id, COALESCE(kind, 'task'), status, started_at, finished_at, parent_run_id, trigger_source,
 		        COALESCE(return_value, ''), COALESCE(output_content_type, ''), COALESCE(output_content, ''),
 		        COALESCE(fail_reason, ''),
 		        COALESCE(input_storage_key, ''), COALESCE(input_size, 0), COALESCE(input_stored_at, 0),
@@ -292,7 +306,7 @@ func (r *Registry) GetRun(ctx context.Context, runID string) (*Run, error) {
 				var redactedFieldsJSON string
 				var tsStr string
 				if err := rows.Scan(
-					&run.ID, &run.TaskID, &run.Status, &startedMs, &finishedMs, &parentID,
+					&run.ID, &run.TaskID, &run.Kind, &run.Status, &startedMs, &finishedMs, &parentID,
 					&tsStr, &run.ReturnValue, &run.OutputContentType, &run.OutputContent,
 					&run.FailureReason,
 					&run.InputStorageKey, &run.InputSize, &run.InputStoredAt, &redactedFieldsJSON, &run.InputPinned,
@@ -377,7 +391,7 @@ func (r *Registry) ListByGroup(ctx context.Context, taskID, group string, limit 
 func (r *Registry) queryRuns(ctx context.Context, whereAndLimit string, args []any) ([]*Run, error) {
 	var runs []*Run
 	err := r.db.Query(ctx,
-		`SELECT id, task_id, status, started_at, finished_at, parent_run_id, trigger_source,
+		`SELECT id, task_id, COALESCE(kind, 'task'), status, started_at, finished_at, parent_run_id, trigger_source,
 		        COALESCE(return_value, ''), COALESCE(output_content_type, ''), COALESCE(output_content, ''),
 		        COALESCE(fail_reason, ''), COALESCE(run_group, '')
 		 FROM runs `+whereAndLimit,
@@ -389,7 +403,7 @@ func (r *Registry) queryRuns(ctx context.Context, whereAndLimit string, args []a
 				var finishedMs *int64
 				var parentID *string
 				var tsStr string
-				if err := rows.Scan(&run.ID, &run.TaskID, &run.Status, &startedMs, &finishedMs, &parentID, &tsStr, &run.ReturnValue, &run.OutputContentType, &run.OutputContent, &run.FailureReason, &run.Group); err != nil {
+				if err := rows.Scan(&run.ID, &run.TaskID, &run.Kind, &run.Status, &startedMs, &finishedMs, &parentID, &tsStr, &run.ReturnValue, &run.OutputContentType, &run.OutputContent, &run.FailureReason, &run.Group); err != nil {
 					return err
 				}
 				run.TriggerSource = TriggerSource(tsStr)

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -72,7 +72,7 @@ type LogEntry struct {
 // Registry is an in-memory map of tasks backed by a sqlite run log.
 type Registry struct {
 	mu      sync.RWMutex
-	tasks   map[string]*task.Spec
+	tasks   map[string]task.Kinded // was map[string]*task.Spec
 	db      db.DB
 	logHook func(runID, level, msg string, ts int64)
 	logMu   sync.Mutex
@@ -81,16 +81,17 @@ type Registry struct {
 // New creates an empty Registry backed by the given DB.
 func New(database db.DB) *Registry {
 	return &Registry{
-		tasks: make(map[string]*task.Spec),
+		tasks: make(map[string]task.Kinded),
 		db:    database,
 	}
 }
 
-// Register upserts a task spec into the registry.
-func (r *Registry) Register(spec *task.Spec) error {
+// Register upserts any task kind into the registry. *task.Spec satisfies
+// task.Kinded, so existing callers passing a *task.Spec keep compiling.
+func (r *Registry) Register(k task.Kinded) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.tasks[spec.ID] = spec
+	r.tasks[k.TaskID()] = k
 	return nil
 }
 
@@ -101,23 +102,51 @@ func (r *Registry) Unregister(id string) {
 	delete(r.tasks, id)
 }
 
-// Get returns the spec for a task ID, or (nil, false) if not found.
+// Get returns the *task.Spec for a Task-kind task, or (nil, false) if not
+// found OR if the ID names a non-Task kind. Existing consumers only want
+// kind: Task, so this filter keeps them unchanged.
 func (r *Registry) Get(id string) (*task.Spec, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	s, ok := r.tasks[id]
+	k, ok := r.tasks[id]
+	if !ok {
+		return nil, false
+	}
+	s, ok := k.(*task.Spec)
 	return s, ok
 }
 
-// All returns a snapshot of all registered task specs sorted by ID.
+// GetKinded returns any registered task kind by ID, or (nil, false) if not found.
+func (r *Registry) GetKinded(id string) (task.Kinded, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	k, ok := r.tasks[id]
+	return k, ok
+}
+
+// All returns a snapshot of all kind: Task specs, sorted by ID.
 func (r *Registry) All() []*task.Spec {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	out := make([]*task.Spec, 0, len(r.tasks))
-	for _, s := range r.tasks {
-		out = append(out, s)
+	for _, k := range r.tasks {
+		if s, ok := k.(*task.Spec); ok {
+			out = append(out, s)
+		}
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// AllKinded returns a snapshot of every registered task kind, sorted by ID.
+func (r *Registry) AllKinded() []task.Kinded {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]task.Kinded, 0, len(r.tasks))
+	for _, k := range r.tasks {
+		out = append(out, k)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TaskID() < out[j].TaskID() })
 	return out
 }
 

--- a/pkg/registry/registry_input_test.go
+++ b/pkg/registry/registry_input_test.go
@@ -18,7 +18,7 @@ func TestListExpiredInputs_Basic(t *testing.T) {
 	pinnedID := uuid.New().String()
 
 	for _, id := range []string{expiredID, freshID, pinnedID} {
-		if _, err := r.StartRunWithID(ctx, id, "task-a", "", "manual"); err != nil {
+		if _, err := r.StartRunWithID(ctx, id, "task-a", "", "manual", "task"); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -53,7 +53,7 @@ func TestPinUnpinRunInput(t *testing.T) {
 	ctx := context.Background()
 
 	id := uuid.New().String()
-	if _, err := r.StartRunWithID(ctx, id, "t", "", "manual"); err != nil {
+	if _, err := r.StartRunWithID(ctx, id, "t", "", "manual", "task"); err != nil {
 		t.Fatal(err)
 	}
 	if err := r.SetRunInput(ctx, id, "k", 1, time.Now().Unix(), nil); err != nil {
@@ -84,7 +84,7 @@ func TestClearRunInput(t *testing.T) {
 	r := newTestRegistry(t)
 	ctx := context.Background()
 	id := uuid.New().String()
-	if _, err := r.StartRunWithID(ctx, id, "t", "", "manual"); err != nil {
+	if _, err := r.StartRunWithID(ctx, id, "t", "", "manual", "task"); err != nil {
 		t.Fatal(err)
 	}
 	if err := r.SetRunInput(ctx, id, "k", 1, time.Now().Unix(), []string{"x"}); err != nil {
@@ -105,7 +105,7 @@ func TestSweepStalePins_ClearsFinishedPinnedRows(t *testing.T) {
 
 	// Live + pinned: must NOT be cleared.
 	live := uuid.New().String()
-	if _, err := r.StartRunWithID(ctx, live, "task-a", "", "manual"); err != nil {
+	if _, err := r.StartRunWithID(ctx, live, "task-a", "", "manual", "task"); err != nil {
 		t.Fatal(err)
 	}
 	if err := r.SetRunInput(ctx, live, "k1", 100, time.Now().Unix(), nil); err != nil {
@@ -117,7 +117,7 @@ func TestSweepStalePins_ClearsFinishedPinnedRows(t *testing.T) {
 
 	// Finished + pinned: MUST be cleared.
 	dead := uuid.New().String()
-	if _, err := r.StartRunWithID(ctx, dead, "task-b", "", "manual"); err != nil {
+	if _, err := r.StartRunWithID(ctx, dead, "task-b", "", "manual", "task"); err != nil {
 		t.Fatal(err)
 	}
 	if err := r.SetRunInput(ctx, dead, "k2", 100, time.Now().Unix(), nil); err != nil {
@@ -132,7 +132,7 @@ func TestSweepStalePins_ClearsFinishedPinnedRows(t *testing.T) {
 
 	// Finished + already-unpinned: must remain unpinned (no double-write).
 	finishedClean := uuid.New().String()
-	if _, err := r.StartRunWithID(ctx, finishedClean, "task-c", "", "manual"); err != nil {
+	if _, err := r.StartRunWithID(ctx, finishedClean, "task-c", "", "manual", "task"); err != nil {
 		t.Fatal(err)
 	}
 	if err := r.SetRunInput(ctx, finishedClean, "k3", 100, time.Now().Unix(), nil); err != nil {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -367,3 +367,38 @@ func TestRegistry_BulkAppendLogs_HookFired(t *testing.T) {
 		t.Errorf("hook got %v, want [a b]", hooked)
 	}
 }
+
+func TestRegistryKindedStorage(t *testing.T) {
+	r := newTestRegistry(t)
+
+	spec := makeSpec("t")
+	spec.Enabled = true
+	pipe := &task.PipelineTask{ID: "p", Name: "P", Subtype: "sequential", Enabled: true,
+		Stages: []task.Stage{{Task: "t"}}}
+
+	if err := r.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Register(pipe); err != nil {
+		t.Fatal(err)
+	}
+
+	// GetKinded sees both kinds.
+	if k, ok := r.GetKinded("p"); !ok || k.KindOf() != task.KindPipelineTask {
+		t.Fatalf("GetKinded(p) = %v,%v", k, ok)
+	}
+	// Get (typed) returns only Task-kind.
+	if _, ok := r.Get("p"); ok {
+		t.Fatal("Get(p) should not return a pipeline as *task.Spec")
+	}
+	if s, ok := r.Get("t"); !ok || s.ID != "t" {
+		t.Fatalf("Get(t) = %v,%v", s, ok)
+	}
+	// All (typed) filters to Task-kind; AllKinded returns both.
+	if got := len(r.All()); got != 1 {
+		t.Fatalf("All() = %d, want 1", got)
+	}
+	if got := len(r.AllKinded()); got != 2 {
+		t.Fatalf("AllKinded() = %d, want 2", got)
+	}
+}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -402,3 +402,42 @@ func TestRegistryKindedStorage(t *testing.T) {
 		t.Fatalf("AllKinded() = %d, want 2", got)
 	}
 }
+
+func TestStartRunKind(t *testing.T) {
+	r := newTestRegistry(t)
+	ctx := context.Background()
+	if _, err := r.StartRunWithID(ctx, "r1", "t1", "", "manual", RunKindPipeline); err != nil {
+		t.Fatal(err)
+	}
+	run, err := r.GetRun(ctx, "r1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Kind != RunKindPipeline {
+		t.Fatalf("Kind = %q, want %q", run.Kind, RunKindPipeline)
+	}
+	// Default path: StartRun wrapper writes kind=RunKindTask.
+	id, err := r.StartRun(ctx, "t2", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run2, err := r.GetRun(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run2.Kind != RunKindTask {
+		t.Fatalf("Kind = %q, want %q", run2.Kind, RunKindTask)
+	}
+
+	// Empty kind falls back to RunKindTask.
+	if _, err := r.StartRunWithID(ctx, "r3", "t3", "", "manual", ""); err != nil {
+		t.Fatal(err)
+	}
+	run3, err := r.GetRun(ctx, "r3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run3.Kind != RunKindTask {
+		t.Fatalf("empty kind: got %q, want %q", run3.Kind, RunKindTask)
+	}
+}

--- a/pkg/registry/replay_test.go
+++ b/pkg/registry/replay_test.go
@@ -44,7 +44,7 @@ func TestReplay_FetchesInputAndFires(t *testing.T) {
 	is := NewInputStore(c, mr, "fake-storage")
 
 	originalRunID := uuid.New().String()
-	if _, err := r.StartRunWithID(ctx, originalRunID, "user-task", "", "manual"); err != nil {
+	if _, err := r.StartRunWithID(ctx, originalRunID, "user-task", "", "manual", "task"); err != nil {
 		t.Fatal(err)
 	}
 	in := PersistedInput{Source: "webhook", Method: "POST"}
@@ -93,7 +93,7 @@ func TestReplay_TaskNameOverride(t *testing.T) {
 	is := NewInputStore(newTestInputCrypto(t), mr, "fake-storage")
 
 	originalRunID := uuid.New().String()
-	if _, err := r.StartRunWithID(ctx, originalRunID, "user-task", "", "manual"); err != nil {
+	if _, err := r.StartRunWithID(ctx, originalRunID, "user-task", "", "manual", "task"); err != nil {
 		t.Fatal(err)
 	}
 	key, size, storedAt, err := is.Persist(ctx, originalRunID, PersistedInput{Source: "webhook"})
@@ -123,7 +123,7 @@ func TestReplay_NoStoredInput_ReturnsErrInputUnavailable(t *testing.T) {
 	is := NewInputStore(newTestInputCrypto(t), mr, "fake-storage")
 
 	originalRunID := uuid.New().String()
-	if _, err := r.StartRunWithID(ctx, originalRunID, "user-task", "", "manual"); err != nil {
+	if _, err := r.StartRunWithID(ctx, originalRunID, "user-task", "", "manual", "task"); err != nil {
 		t.Fatal(err)
 	}
 	// Note: no SetRunInput — column is empty.

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -23,10 +23,11 @@ type Event struct {
 	TaskID  string // namespaced task ID, e.g. "infra/backend/deploy"
 	TaskDir string // absolute path to the task directory (used by reconciler for LoadDir)
 	Source  string // source identifier (URL or path) for logging
-	// Spec, when non-nil, is a fully resolved task spec (overrides already applied).
-	// The reconciler uses it directly instead of calling task.LoadDir(TaskDir).
-	// Set by taskset sources; nil for plain git/local sources.
-	Spec *task.Spec
+	// Kinded, when non-nil, is a fully resolved task of any kind (overrides
+	// already applied). The reconciler uses it directly instead of loading from
+	// TaskDir. Set by taskset sources; nil for plain git/local sources, which
+	// the reconciler loads via task.LoadKindedDir(TaskDir).
+	Kinded task.Kinded
 	// ExtraVars carries per-source template variables injected into
 	// task.yaml's ${VAR} expansion at load time. Sources populate this with
 	// e.g. TASK_SET_DIR (the source's root path) so tasks can reference

--- a/pkg/taskset/loader.go
+++ b/pkg/taskset/loader.go
@@ -14,9 +14,10 @@ import (
 type Kind string
 
 const (
-	KindTaskSet Kind = "TaskSet"
-	KindTask    Kind = "Task"
-	KindConfig  Kind = "Config"
+	KindTaskSet      Kind = "TaskSet"
+	KindTask         Kind = "Task"
+	KindConfig       Kind = "Config"
+	KindPipelineTask Kind = "PipelineTask" // mirrors task.KindPipelineTask; kept as a literal so pkg/taskset stays decoupled from pkg/task's constant
 )
 
 // fileHeader peeks at the kind field without decoding the full document.

--- a/pkg/taskset/override_footguns_test.go
+++ b/pkg/taskset/override_footguns_test.go
@@ -60,9 +60,9 @@ spec:
 	// like a LoadDirWithVars failure today. The result list must NOT
 	// contain a spec whose Runtime=docker and Docker=nil.
 	for _, rt := range results {
-		if rt.Spec.Runtime == task.RuntimeDocker && rt.Spec.Docker == nil {
+		if rtSpec(rt).Runtime == task.RuntimeDocker && rtSpec(rt).Docker == nil {
 			t.Fatalf("resolver returned a merged spec that fails Validate: id=%s runtime=%q docker=nil",
-				rt.ID, rt.Spec.Runtime)
+				rt.ID, rtSpec(rt).Runtime)
 		}
 	}
 

--- a/pkg/taskset/resolver.go
+++ b/pkg/taskset/resolver.go
@@ -177,7 +177,7 @@ func (r *Resolver) resolveBody(
 				continue
 			}
 			results = append(results, &ResolvedTask{
-				Spec:    resolved,
+				Kinded:  resolved,
 				ID:      fullID,
 				TaskDir: resolved.TaskDir,
 			})
@@ -246,7 +246,45 @@ func (r *Resolver) resolveBody(
 				continue
 			}
 			results = append(results, &ResolvedTask{
-				Spec:    resolved,
+				Kinded:  resolved,
+				ID:      fullID,
+				TaskDir: taskDir,
+			})
+
+		case KindPipelineTask:
+			taskDir := filepath.Dir(localPath)
+			extras := extraVars
+			if extras == nil {
+				extras = make(map[string]string, 1)
+			}
+			if _, ok := extras[task.VarDataDir]; !ok && r.dataDir != "" {
+				// Don't clobber a caller-supplied DATADIR (allows tests to override).
+				// Clone before mutate — extraVars may be shared across loop iterations.
+				cloned := make(map[string]string, len(extras)+1)
+				for k, v := range extras {
+					cloned[k] = v
+				}
+				cloned[task.VarDataDir] = r.dataDir
+				extras = cloned
+			}
+			p, err := task.LoadPipelineDir(taskDir, extras)
+			if err != nil {
+				r.log.Warn("taskset: failed to load pipeline",
+					zap.String("entry", fullID), zap.Error(err))
+				continue
+			}
+			p.ID = fullID
+			p.Enabled = enabled
+			// Pipelines do not support taskset override layers in v1 — stage
+			// overrides live in the pipeline spec. Re-validate after stamping the
+			// namespaced ID so a stage self-reference surfaces with the taskset path.
+			if err := p.Validate(); err != nil {
+				r.log.Warn("taskset: pipeline failed validate; skipping",
+					zap.String("entry", fullID), zap.Error(err))
+				continue
+			}
+			results = append(results, &ResolvedTask{
+				Kinded:  p,
 				ID:      fullID,
 				TaskDir: taskDir,
 			})
@@ -269,7 +307,7 @@ func (r *Resolver) resolveBody(
 			// so the whole sub-tree stays visible in the API but is not scheduled.
 			if !enabled {
 				for _, rt := range nested {
-					rt.Spec.Enabled = false
+					rt.Kinded.SetEnabled(false)
 				}
 			}
 			results = append(results, nested...)

--- a/pkg/taskset/resolver_test.go
+++ b/pkg/taskset/resolver_test.go
@@ -43,6 +43,24 @@ func writeTaskDir(t *testing.T, parent, name string, extra ...string) string {
 	return dir
 }
 
+// writePipelineDir writes a minimal kind: PipelineTask task.yaml into dir/name/
+// and returns the absolute path to the task directory.
+func writePipelineDir(t *testing.T, parent, name string) string {
+	t.Helper()
+	dir := filepath.Join(parent, name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "apiVersion: dicode/v1\nkind: PipelineTask\nname: " + name +
+		"\nsubtype: sequential\ntrigger:\n  manual: true\nstages:\n  - task: buildin/template\n"
+	writeFile(t, dir, "task.yaml", yaml)
+	return dir
+}
+
+// rtSpec extracts the *task.Spec carried by a resolved kind: Task. Tests use it
+// after ResolvedTask migrated from a typed *task.Spec field to task.Kinded.
+func rtSpec(rt *ResolvedTask) *task.Spec { return rt.Kinded.(*task.Spec) }
+
 // writeTaskSet writes a taskset.yaml into dir/name.yaml and returns the path.
 func writeTaskSetFile(t *testing.T, dir, name, content string) string {
 	t.Helper()
@@ -145,8 +163,47 @@ spec:
 	if results[0].ID != "infra/deploy" {
 		t.Errorf("ID: got %q", results[0].ID)
 	}
-	if results[0].Spec.Name != "deploy" {
-		t.Errorf("spec.name: %q", results[0].Spec.Name)
+	if rtSpec(results[0]).Name != "deploy" {
+		t.Errorf("spec.name: %q", rtSpec(results[0]).Name)
+	}
+}
+
+// TestResolvePipelineKind asserts a taskset ref to a kind: PipelineTask dir
+// resolves to a ResolvedTask carrying a *task.PipelineTask under the namespaced
+// ID (no override layers — pipelines carry stage overrides in their own spec).
+func TestResolvePipelineKind(t *testing.T) {
+	repoDir := t.TempDir()
+	pipeDir := writePipelineDir(t, repoDir, "release")
+
+	tsContent := `
+apiVersion: dicode/v1
+kind: TaskSet
+metadata:
+  name: infra
+spec:
+  entries:
+    release:
+      ref:
+        path: ` + filepath.Join(pipeDir, "task.yaml") + `
+`
+	tsPath := writeTaskSetFile(t, repoDir, "taskset.yaml", tsContent)
+
+	r := newResolver(t)
+	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	if results[0].ID != "infra/release" {
+		t.Errorf("ID: got %q", results[0].ID)
+	}
+	if results[0].Kinded == nil || results[0].Kinded.KindOf() != task.KindPipelineTask {
+		t.Fatalf("want PipelineTask, got %v", results[0].Kinded)
+	}
+	if results[0].Kinded.TaskID() != "infra/release" {
+		t.Errorf("pipeline ID: got %q, want infra/release", results[0].Kinded.TaskID())
 	}
 }
 
@@ -213,7 +270,7 @@ spec:
 	if len(results) != 1 {
 		t.Fatalf("want 1")
 	}
-	spec := results[0].Spec
+	spec := rtSpec(results[0])
 	if spec.Trigger.Cron != "0 2 * * *" {
 		t.Errorf("cron: %q", spec.Trigger.Cron)
 	}
@@ -251,7 +308,7 @@ spec:
 	if len(results) != 1 {
 		t.Fatalf("disabled task should appear with Enabled=false: got %d results", len(results))
 	}
-	if results[0].Spec.Enabled {
+	if rtSpec(results[0]).Enabled {
 		t.Errorf("disabled task should have Enabled=false, got Enabled=true")
 	}
 }
@@ -289,7 +346,7 @@ spec:
 	if len(results) != 1 {
 		t.Fatalf("parent-disabled task should appear with Enabled=false: got %d results", len(results))
 	}
-	if results[0].Spec.Enabled {
+	if rtSpec(results[0]).Enabled {
 		t.Errorf("parent-disabled task should have Enabled=false, got Enabled=true")
 	}
 }
@@ -322,7 +379,7 @@ spec:
 	if len(results) != 1 {
 		t.Fatalf("want 1")
 	}
-	spec := results[0].Spec
+	spec := rtSpec(results[0])
 	if spec.Timeout != 90*time.Second {
 		t.Errorf("timeout from defaults: got %v", spec.Timeout)
 	}
@@ -364,7 +421,7 @@ spec:
 	if len(results) != 1 {
 		t.Fatalf("want 1")
 	}
-	spec := results[0].Spec
+	spec := rtSpec(results[0])
 	// Timeout should NOT be overridden by configDefaults.
 	if spec.Timeout == 120*time.Second {
 		t.Errorf("deprecated configDefaults should not be applied: timeout was set to 120s")
@@ -405,8 +462,8 @@ spec:
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
-	if results[0].Spec.Timeout != 30*time.Second {
-		t.Errorf("entry override should beat set defaults: got %v", results[0].Spec.Timeout)
+	if rtSpec(results[0]).Timeout != 30*time.Second {
+		t.Errorf("entry override should beat set defaults: got %v", rtSpec(results[0]).Timeout)
 	}
 }
 
@@ -503,8 +560,8 @@ spec:
 		t.Fatalf("want 1, got %d", len(results))
 	}
 	// Nested entry's own override (0 4 * * *) beats parent entry patch (0 3 * * *) — leaf wins.
-	if results[0].Spec.Trigger.Cron != "0 4 * * *" {
-		t.Errorf("leaf should win: got %q", results[0].Spec.Trigger.Cron)
+	if rtSpec(results[0]).Trigger.Cron != "0 4 * * *" {
+		t.Errorf("leaf should win: got %q", rtSpec(results[0]).Trigger.Cron)
 	}
 }
 
@@ -569,8 +626,8 @@ spec:
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
-	if results[0].Spec.Trigger.Cron != "0 8 * * *" {
-		t.Errorf("dev mode off: got %q", results[0].Spec.Trigger.Cron)
+	if rtSpec(results[0]).Trigger.Cron != "0 8 * * *" {
+		t.Errorf("dev mode off: got %q", rtSpec(results[0]).Trigger.Cron)
 	}
 
 	// dev mode ON — should use dev ref (0 1)
@@ -579,8 +636,8 @@ spec:
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
-	if resultsDev[0].Spec.Trigger.Cron != "0 1 * * *" {
-		t.Errorf("dev mode on: got %q", resultsDev[0].Spec.Trigger.Cron)
+	if rtSpec(resultsDev[0]).Trigger.Cron != "0 1 * * *" {
+		t.Errorf("dev mode on: got %q", rtSpec(resultsDev[0]).Trigger.Cron)
 	}
 }
 
@@ -613,7 +670,7 @@ spec:
 	if results[0].ID != "infra/health-check" {
 		t.Errorf("ID: %q", results[0].ID)
 	}
-	if !results[0].Spec.Trigger.Manual {
+	if !rtSpec(results[0]).Trigger.Manual {
 		t.Error("trigger.manual should be true")
 	}
 }
@@ -712,7 +769,7 @@ spec:
 		t.Fatalf("want 1 result, got %d", len(results))
 	}
 
-	spec := results[0].Spec
+	spec := rtSpec(results[0])
 	if len(spec.Permissions.FS) != 1 {
 		t.Fatalf("want 1 fs entry, got %d", len(spec.Permissions.FS))
 	}
@@ -777,7 +834,7 @@ spec:
 	if len(results) != 1 {
 		t.Fatalf("want 1 result, got %d", len(results))
 	}
-	if got, want := results[0].Spec.Permissions.FS[0].Path, "/caller/wins/pool"; got != want {
+	if got, want := rtSpec(results[0]).Permissions.FS[0].Path, "/caller/wins/pool"; got != want {
 		t.Errorf("fs.path: got %q, want %q — caller extraVars should override resolver derivation", got, want)
 	}
 }
@@ -826,8 +883,8 @@ spec:
 	if len(results) != 1 {
 		t.Fatalf("want 1 result, got %d", len(results))
 	}
-	if results[0].Spec.Timeout != 5*time.Minute {
-		t.Errorf("timeout = %v, want 5m (root spec.entries override should cascade)", results[0].Spec.Timeout)
+	if rtSpec(results[0]).Timeout != 5*time.Minute {
+		t.Errorf("timeout = %v, want 5m (root spec.entries override should cascade)", rtSpec(results[0]).Timeout)
 	}
 }
 
@@ -866,7 +923,7 @@ spec:
 	if len(results) != 1 {
 		t.Fatalf("want 1 result (Enabled=false), got %d", len(results))
 	}
-	if results[0].Spec.Enabled {
+	if rtSpec(results[0]).Enabled {
 		t.Errorf("relay-client should be Enabled=false via root spec.entries override")
 	}
 }
@@ -897,7 +954,7 @@ spec:
 	if len(results) != 1 {
 		t.Fatalf("want 1 result, got %d", len(results))
 	}
-	if !results[0].Spec.Enabled {
+	if !rtSpec(results[0]).Enabled {
 		t.Errorf("task without enabled override should default to Enabled=true")
 	}
 }

--- a/pkg/taskset/source.go
+++ b/pkg/taskset/source.go
@@ -77,7 +77,7 @@ func WithParentOverrides(ov *Overrides) SourceOption {
 
 type taskSnap struct {
 	specHash string
-	spec     *task.Spec
+	kinded   task.Kinded
 	taskDir  string
 }
 
@@ -542,8 +542,8 @@ func (s *Source) syncAndEmit(ctx context.Context, ch chan<- source.Event) error 
 	current := make(map[string]taskSnap, len(tasks))
 	for _, rt := range tasks {
 		current[rt.ID] = taskSnap{
-			specHash: hashSpec(rt.Spec),
-			spec:     rt.Spec,
+			specHash: hashKinded(rt.Kinded),
+			kinded:   rt.Kinded,
 			taskDir:  rt.TaskDir,
 		}
 	}
@@ -558,13 +558,13 @@ func (s *Source) syncAndEmit(ctx context.Context, ch chan<- source.Event) error 
 	for _, id := range added {
 		cur := current[id]
 		s.send(ch, source.Event{
-			Kind: source.EventAdded, TaskID: id, TaskDir: cur.taskDir, Source: s.id, Kinded: cur.spec,
+			Kind: source.EventAdded, TaskID: id, TaskDir: cur.taskDir, Source: s.id, Kinded: cur.kinded,
 		})
 	}
 	for _, id := range updated {
 		cur := current[id]
 		s.send(ch, source.Event{
-			Kind: source.EventUpdated, TaskID: id, TaskDir: cur.taskDir, Source: s.id, Kinded: cur.spec,
+			Kind: source.EventUpdated, TaskID: id, TaskDir: cur.taskDir, Source: s.id, Kinded: cur.kinded,
 		})
 	}
 	for _, id := range removed {
@@ -634,8 +634,11 @@ func (s *Source) loadConfigDefaults() (*Defaults, error) {
 	return cs.Spec.Defaults, nil
 }
 
-func hashSpec(spec *task.Spec) string {
-	b, _ := json.Marshal(spec)
+// hashKinded computes a content hash for change detection over any resolved
+// task kind. *task.Spec and *task.PipelineTask both marshal to distinct JSON,
+// so a kind change (or any field change) yields a different hash.
+func hashKinded(k task.Kinded) string {
+	b, _ := json.Marshal(k)
 	h := sha256.Sum256(b)
 	return fmt.Sprintf("%x", h)
 }

--- a/pkg/taskset/source.go
+++ b/pkg/taskset/source.go
@@ -558,13 +558,13 @@ func (s *Source) syncAndEmit(ctx context.Context, ch chan<- source.Event) error 
 	for _, id := range added {
 		cur := current[id]
 		s.send(ch, source.Event{
-			Kind: source.EventAdded, TaskID: id, TaskDir: cur.taskDir, Source: s.id, Spec: cur.spec,
+			Kind: source.EventAdded, TaskID: id, TaskDir: cur.taskDir, Source: s.id, Kinded: cur.spec,
 		})
 	}
 	for _, id := range updated {
 		cur := current[id]
 		s.send(ch, source.Event{
-			Kind: source.EventUpdated, TaskID: id, TaskDir: cur.taskDir, Source: s.id, Spec: cur.spec,
+			Kind: source.EventUpdated, TaskID: id, TaskDir: cur.taskDir, Source: s.id, Kinded: cur.spec,
 		})
 	}
 	for _, id := range removed {

--- a/pkg/taskset/source_test.go
+++ b/pkg/taskset/source_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/dicode/dicode/pkg/source"
+	"github.com/dicode/dicode/pkg/task"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
@@ -80,13 +81,18 @@ spec:
 	if ev.TaskID != "infra/deploy" {
 		t.Errorf("TaskID: %q", ev.TaskID)
 	}
-	if ev.Spec == nil {
-		t.Error("Spec should be non-nil")
+	if ev.Kinded == nil {
+		t.Error("Kinded should be non-nil")
 	}
-	if ev.Spec.Trigger.Cron != "0 8 * * *" {
-		t.Errorf("cron: %q", ev.Spec.Trigger.Cron)
+	if asSpec(ev.Kinded).Trigger.Cron != "0 8 * * *" {
+		t.Errorf("cron: %q", asSpec(ev.Kinded).Trigger.Cron)
 	}
 }
+
+// asSpec extracts the *task.Spec carried by a kind: Task value. Tests use it
+// after source.Event/ResolvedTask migrated from a typed *task.Spec field to a
+// task.Kinded field; every fixture in these tests is a kind: Task.
+func asSpec(k task.Kinded) *task.Spec { return k.(*task.Spec) }
 
 func TestSource_UpdateEmitted(t *testing.T) {
 	dir := t.TempDir()
@@ -219,8 +225,8 @@ spec:
 	if len(events) != 1 {
 		t.Fatalf("want 1, got %d", len(events))
 	}
-	if events[0].Spec.Trigger.Cron != "0 2 * * *" {
-		t.Errorf("override not applied: cron=%q", events[0].Spec.Trigger.Cron)
+	if asSpec(events[0].Kinded).Trigger.Cron != "0 2 * * *" {
+		t.Errorf("override not applied: cron=%q", asSpec(events[0].Kinded).Trigger.Cron)
 	}
 }
 
@@ -268,7 +274,7 @@ spec:
 	if len(events) != 1 {
 		t.Fatalf("want 1, got %d", len(events))
 	}
-	spec := events[0].Spec
+	spec := asSpec(events[0].Kinded)
 	// Deprecated: config defaults should NOT be applied.
 	if spec.Timeout == 90*time.Second {
 		t.Errorf("deprecated kind:Config defaults should not be applied: timeout was set to 90s")
@@ -369,7 +375,7 @@ spec:
 		if ev.Kind != source.EventAdded {
 			t.Fatalf("first event kind = %v, want Added", ev.Kind)
 		}
-		if !ev.Spec.Enabled {
+		if !asSpec(ev.Kinded).Enabled {
 			t.Fatal("initial spec should be Enabled=true")
 		}
 	case <-time.After(5 * time.Second):
@@ -388,7 +394,7 @@ spec:
 		if ev.Kind != source.EventUpdated {
 			t.Fatalf("second event kind = %v, want Updated", ev.Kind)
 		}
-		if ev.Spec.Enabled {
+		if asSpec(ev.Kinded).Enabled {
 			t.Error("post-refresh spec.Enabled = true, want false")
 		}
 	case <-time.After(5 * time.Second):

--- a/pkg/taskset/source_test.go
+++ b/pkg/taskset/source_test.go
@@ -328,7 +328,7 @@ spec:
 	if len(tasks) != 1 {
 		t.Fatalf("want 1 task, got %d", len(tasks))
 	}
-	if tasks[0].Spec.Enabled {
+	if asSpec(tasks[0].Kinded).Enabled {
 		t.Errorf("Enabled = true, want false (parent override should disable)")
 	}
 }

--- a/pkg/taskset/spec.go
+++ b/pkg/taskset/spec.go
@@ -122,10 +122,11 @@ type RuntimePinConfig struct {
 	Version string `yaml:"version"`
 }
 
-// ResolvedTask is a fully resolved task: base spec with all override layers applied,
-// a namespaced ID, and the local path to the task directory.
+// ResolvedTask is a fully resolved task of any kind: for kind: Task, the base
+// spec with all override layers applied; for kind: PipelineTask, the validated
+// pipeline. It also carries a namespaced ID and the local task directory path.
 type ResolvedTask struct {
-	Spec    *task.Spec
-	ID      string // namespaced, e.g. "infra/backend/deploy"
-	TaskDir string // absolute local path to the task directory
+	Kinded  task.Kinded // resolved task of any kind (overrides already applied)
+	ID      string      // namespaced, e.g. "infra/backend/deploy"
+	TaskDir string      // absolute local path to the task directory
 }

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -338,51 +338,58 @@ func (e *Engine) Start(ctx context.Context) error {
 	return nil
 }
 
-// Register adds or updates trigger registrations for a task spec. Returns a
+// Register adds or updates trigger registrations for a task. Returns a
 // non-nil error when cross-spec validation fails (currently: invalid
 // trigger.before references). On error, no triggers are registered.
 // Register registers a task with the engine. Cycle detection runs
 // against the registered before-graph as of method entry; the call is
 // serialized via registerMu so concurrent registrations cannot admit
 // a cycle through interleaved snapshots.
-func (e *Engine) Register(spec *task.Spec) error {
+func (e *Engine) Register(k task.Kinded) error {
 	e.registerMu.Lock()
 	defer e.registerMu.Unlock()
 
-	// Cross-spec validation must run BEFORE Unregister so that a previously
-	// valid registration isn't torn down when an updated spec fails its
-	// new-state checks. The registry-snapshot lookups are read-only.
-	if err := e.validateBeforeRefs(spec); err != nil {
-		return err
-	}
+	switch s := k.(type) {
+	case *task.PipelineTask:
+		return e.registerPipeline(s)
+	case *task.Spec:
+		// Cross-spec validation must run BEFORE Unregister so that a previously
+		// valid registration isn't torn down when an updated spec fails its
+		// new-state checks. The registry-snapshot lookups are read-only.
+		if err := e.validateBeforeRefs(s); err != nil {
+			return err
+		}
 
-	e.Unregister(spec.ID)
+		e.Unregister(s.ID)
 
-	// Disabled tasks are kept in the registry for API visibility but must not
-	// be scheduled, spawned as daemons, or registered as webhook endpoints.
-	if !spec.Enabled {
-		e.log.Info("task registered (disabled — no triggers scheduled)",
-			zap.String("task", spec.ID),
-			zap.String("runtime", string(spec.Runtime)),
+		// Disabled tasks are kept in the registry for API visibility but must not
+		// be scheduled, spawned as daemons, or registered as webhook endpoints.
+		if !s.Enabled {
+			e.log.Info("task registered (disabled — no triggers scheduled)",
+				zap.String("task", s.ID),
+				zap.String("runtime", string(s.Runtime)),
+			)
+			return nil
+		}
+
+		if s.Trigger.Cron != "" {
+			e.registerCron(s)
+		}
+		if s.Trigger.Webhook != "" {
+			e.registerWebhook(s)
+		}
+		if s.Trigger.Daemon {
+			e.registerDaemon(s)
+		}
+		e.log.Info("task registered",
+			zap.String("task", s.ID),
+			zap.String("trigger", string(triggerSource(s))),
+			zap.String("runtime", string(s.Runtime)),
 		)
 		return nil
+	default:
+		return fmt.Errorf("engine: unsupported task kind %q", k.KindOf())
 	}
-
-	if spec.Trigger.Cron != "" {
-		e.registerCron(spec)
-	}
-	if spec.Trigger.Webhook != "" {
-		e.registerWebhook(spec)
-	}
-	if spec.Trigger.Daemon {
-		e.registerDaemon(spec)
-	}
-	e.log.Info("task registered",
-		zap.String("task", spec.ID),
-		zap.String("trigger", string(triggerSource(spec))),
-		zap.String("runtime", string(spec.Runtime)),
-	)
-	return nil
 }
 
 // inputParamsRefRe matches any `${input.params.<name>}` token in a

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -338,13 +338,14 @@ func (e *Engine) Start(ctx context.Context) error {
 	return nil
 }
 
-// Register adds or updates trigger registrations for a task. Returns a
-// non-nil error when cross-spec validation fails (currently: invalid
-// trigger.before references). On error, no triggers are registered.
-// Register registers a task with the engine. Cycle detection runs
-// against the registered before-graph as of method entry; the call is
-// serialized via registerMu so concurrent registrations cannot admit
-// a cycle through interleaved snapshots.
+// Register adds or updates trigger registrations for the given task, routing by
+// kind: a *task.PipelineTask is validated via registerPipeline; a *task.Spec
+// follows the cron/webhook/daemon registration path. The call is serialized via
+// registerMu so concurrent registrations cannot admit a cycle through
+// interleaved registry snapshots. Returns a non-nil error if validation fails
+// (e.g. invalid trigger.before refs for a Task, or pipeline ref/cycle errors);
+// on error, no triggers are modified. Callers may pass any task.Kinded;
+// *task.Spec satisfies it, so existing call sites are unaffected.
 func (e *Engine) Register(k task.Kinded) error {
 	e.registerMu.Lock()
 	defer e.registerMu.Unlock()

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -2151,7 +2151,7 @@ func (e *Engine) serveTaskAsset(w http.ResponseWriter, r *http.Request, taskDir,
 // hook, and returns a ready-to-run context. The caller is responsible for
 // calling the returned cleanup func when the run finishes.
 func (e *Engine) startRun(spec *task.Spec, opts *pkgruntime.RunOptions, source registry.TriggerSource) (runCtx context.Context, cleanup func(), err error) {
-	if _, err = e.registry.StartRunWithID(context.Background(), opts.RunID, spec.ID, opts.ParentRunID, string(source)); err != nil {
+	if _, err = e.registry.StartRunWithID(context.Background(), opts.RunID, spec.ID, opts.ParentRunID, string(source), registry.RunKindTask); err != nil {
 		return nil, nil, fmt.Errorf("start run record: %w", err)
 	}
 

--- a/pkg/trigger/engine_chain_params_test.go
+++ b/pkg/trigger/engine_chain_params_test.go
@@ -423,7 +423,7 @@ func TestOnFailureChainDispatch_ResolvesInputOutputField(t *testing.T) {
 	_ = e.reg.Register(source)
 
 	parentRunID, err := e.reg.StartRunWithID(
-		context.Background(), "parent-field", "source-field", "", string(registry.TriggerManual),
+		context.Background(), "parent-field", "source-field", "", string(registry.TriggerManual), "task",
 	)
 	if err != nil {
 		t.Fatalf("seed parent run: %v", err)
@@ -498,7 +498,7 @@ func TestOnFailureChainDispatch_ResolvesInputOutput(t *testing.T) {
 	// exist for the registry to satisfy SetRunGroup / parent lookups
 	// downstream).
 	parentRunID, err := e.reg.StartRunWithID(
-		context.Background(), "parent-run", "source-interp", "", string(registry.TriggerManual),
+		context.Background(), "parent-run", "source-interp", "", string(registry.TriggerManual), "task",
 	)
 	if err != nil {
 		t.Fatalf("seed parent run: %v", err)
@@ -567,7 +567,7 @@ func TestOnFailureChainDispatch_NonStringUpstreamSkips(t *testing.T) {
 	_ = e.reg.Register(source)
 
 	parentRunID, err := e.reg.StartRunWithID(
-		context.Background(), "parent-skip-run", "source-skip", "", string(registry.TriggerManual),
+		context.Background(), "parent-skip-run", "source-skip", "", string(registry.TriggerManual), "task",
 	)
 	if err != nil {
 		t.Fatalf("seed parent run: %v", err)
@@ -624,7 +624,7 @@ func TestFireChain_RejectsNonStringForBareInputOutput(t *testing.T) {
 
 	// Seed a parent run so FireChain has a real runID to reference.
 	parentRunID, err := e.reg.StartRunWithID(
-		context.Background(), "ns-parent", "us-nonstring", "", string(registry.TriggerManual),
+		context.Background(), "ns-parent", "us-nonstring", "", string(registry.TriggerManual), "task",
 	)
 	if err != nil {
 		t.Fatalf("seed parent run: %v", err)

--- a/pkg/trigger/registerpipeline.go
+++ b/pkg/trigger/registerpipeline.go
@@ -1,0 +1,132 @@
+package trigger
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dicode/dicode/pkg/task"
+	"github.com/dicode/dicode/pkg/taskset"
+	"go.uber.org/zap"
+)
+
+// validatePipelineRefs runs the registry-aware checks for a PipelineTask:
+// every stage task exists, is kind: Task (not a pipeline — v1 rule), each
+// stage's override merge yields a valid spec, and the pipeline-stage graph is
+// acyclic.
+func (e *Engine) validatePipelineRefs(p *task.PipelineTask) error {
+	for i, st := range p.Stages {
+		k, ok := e.registry.GetKinded(st.Task)
+		if !ok {
+			return fmt.Errorf("pipeline.stages[%d]: task %q not found in registry", i, st.Task)
+		}
+		ref, ok := k.(*task.Spec)
+		if !ok {
+			return fmt.Errorf("pipeline.stages[%d]: task %q is a %s; pipeline stages must be kind: Task (v1)", i, st.Task, k.KindOf())
+		}
+		if st.Overrides != nil {
+			// Default to the original overrides; replaced with a stripped copy below only when Params need ${input.…} cleared.
+			ovPtr := st.Overrides
+			// Strip ${input.…} param defaults before the merge-validate; they
+			// resolve at dispatch time, not registration time.
+			if st.Overrides.Params != nil {
+				ovCopy := *st.Overrides
+				cleaned := make(task.ParamOverrides, len(st.Overrides.Params))
+				copy(cleaned, st.Overrides.Params)
+				for j := range cleaned {
+					if strings.Contains(cleaned[j].Default, "${input.") {
+						cleaned[j].Default = ""
+					}
+				}
+				ovCopy.Params = cleaned
+				ovPtr = &ovCopy
+			}
+			merged := taskset.ApplyOverrides(ref, ovPtr)
+			if vErr := merged.Validate(); vErr != nil {
+				return fmt.Errorf("pipeline.stages[%d] (%s): overrides produce invalid spec: %w", i, st.Task, vErr)
+			}
+		}
+	}
+	if cyclePath := e.detectPipelineCycle(p); cyclePath != "" {
+		return fmt.Errorf("pipeline: cycle detected: %s", cyclePath)
+	}
+	return nil
+}
+
+// detectPipelineCycle runs a three-colour DFS over the pipeline-stage graph
+// overlaid on the registry (mirrors detectBeforeCycle, edges are
+// PipelineTask -> Stage.Task). Returns a printable path or "".
+// Currently unreachable in v1 (stages are kind: Task only, so pipeline->pipeline edges can't form); retained for when nested pipelines land.
+func (e *Engine) detectPipelineCycle(p *task.PipelineTask) string {
+	edges := map[string][]string{}
+	for _, k := range e.registry.AllKinded() {
+		pt, ok := k.(*task.PipelineTask)
+		if !ok || pt.ID == p.ID {
+			continue
+		}
+		out := make([]string, 0, len(pt.Stages))
+		for _, st := range pt.Stages {
+			out = append(out, st.Task)
+		}
+		edges[pt.ID] = out
+	}
+	out := make([]string, 0, len(p.Stages))
+	for _, st := range p.Stages {
+		out = append(out, st.Task)
+	}
+	edges[p.ID] = out
+
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	color := map[string]int{}
+	var stack []string
+	var dfs func(id string) string
+	dfs = func(id string) string {
+		color[id] = gray
+		stack = append(stack, id)
+		for _, next := range edges[id] {
+			switch color[next] {
+			case gray:
+				start := 0
+				for idx, n := range stack {
+					if n == next {
+						start = idx
+						break
+					}
+				}
+				path := append([]string(nil), stack[start:]...)
+				path = append(path, next)
+				return strings.Join(path, " -> ")
+			case white:
+				if cp := dfs(next); cp != "" {
+					return cp
+				}
+			}
+		}
+		stack = stack[:len(stack)-1]
+		color[id] = black
+		return ""
+	}
+	return dfs(p.ID)
+}
+
+// registerPipeline validates a PipelineTask against the registry. Trigger
+// scheduling (cron/webhook) and execution wiring land in a later PR; manual
+// pipelines need no scheduling here.
+// TODO(registerMu): acquire e.registerMu (like Register does) once registerPipeline gains a production caller that mutates engine state (scheduling, later PR), to match Register's cycle-detection locking.
+func (e *Engine) registerPipeline(p *task.PipelineTask) error {
+	if err := p.Validate(); err != nil {
+		return err
+	}
+	if err := e.validatePipelineRefs(p); err != nil {
+		return err
+	}
+	if !p.Enabled {
+		e.log.Info("pipeline registered (disabled — no triggers scheduled)", zap.String("task", p.ID))
+		return nil
+	}
+	e.log.Info("pipeline registered", zap.String("task", p.ID), zap.Int("stages", len(p.Stages)))
+	return nil
+}

--- a/pkg/trigger/registerpipeline.go
+++ b/pkg/trigger/registerpipeline.go
@@ -115,7 +115,7 @@ func (e *Engine) detectPipelineCycle(p *task.PipelineTask) string {
 // registerPipeline validates a PipelineTask against the registry. Trigger
 // scheduling (cron/webhook) and execution wiring land in a later PR; manual
 // pipelines need no scheduling here.
-// TODO(registerMu): acquire e.registerMu (like Register does) once registerPipeline gains a production caller that mutates engine state (scheduling, later PR), to match Register's cycle-detection locking.
+// NOTE: registerPipeline must be called with e.registerMu already held (Engine.Register does this).
 func (e *Engine) registerPipeline(p *task.PipelineTask) error {
 	if err := p.Validate(); err != nil {
 		return err

--- a/pkg/trigger/registerpipeline_test.go
+++ b/pkg/trigger/registerpipeline_test.go
@@ -99,3 +99,31 @@ func TestRegisterPipelineValidates(t *testing.T) {
 		t.Fatal("expected subtype rejection")
 	}
 }
+
+func TestEngineRegisterRoutesByKind(t *testing.T) {
+	env := newTestEnv(t)
+	stage := &task.Spec{ID: "s", Name: "S", Enabled: true,
+		Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}}
+	if err := env.reg.Register(stage); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.engine.Register(stage); err != nil { // *task.Spec path still works
+		t.Fatalf("Register(spec) = %v", err)
+	}
+	pipe := &task.PipelineTask{APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "p", Name: "P", Subtype: "sequential", Enabled: true,
+		Stages: []task.Stage{{Task: "s"}}}
+	if err := env.reg.Register(pipe); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.engine.Register(pipe); err != nil {
+		t.Fatalf("Register(pipeline) = %v", err)
+	}
+	// A bad pipeline (invalid subtype) is rejected.
+	bad := &task.PipelineTask{APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "p2", Name: "P2", Subtype: "parallel",
+		Stages: []task.Stage{{Task: "s"}}}
+	if err := env.engine.Register(bad); err == nil {
+		t.Fatal("expected subtype rejection")
+	}
+}

--- a/pkg/trigger/registerpipeline_test.go
+++ b/pkg/trigger/registerpipeline_test.go
@@ -1,0 +1,101 @@
+package trigger
+
+import (
+	"testing"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+func TestValidatePipelineRefs(t *testing.T) {
+	env := newTestEnv(t)
+	stage := &task.Spec{ID: "stage-a", Name: "A", Enabled: true,
+		Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}}
+	if err := env.reg.Register(stage); err != nil {
+		t.Fatal(err)
+	}
+
+	good := &task.PipelineTask{ID: "p", Name: "P", Subtype: "sequential", Enabled: true,
+		Stages: []task.Stage{{Task: "stage-a"}}}
+	if err := env.engine.validatePipelineRefs(good); err != nil {
+		t.Fatalf("good pipeline rejected: %v", err)
+	}
+
+	unknown := &task.PipelineTask{ID: "p2", Name: "P2", Subtype: "sequential",
+		Stages: []task.Stage{{Task: "nope"}}}
+	if err := env.engine.validatePipelineRefs(unknown); err == nil {
+		t.Fatal("expected unknown-task error")
+	}
+
+	// A pipeline cannot be a stage (v1: stages must be kind: Task).
+	if err := env.reg.Register(good); err != nil {
+		t.Fatal(err)
+	}
+	nested := &task.PipelineTask{ID: "p3", Name: "P3", Subtype: "sequential",
+		Stages: []task.Stage{{Task: "p"}}}
+	if err := env.engine.validatePipelineRefs(nested); err == nil {
+		t.Fatal("expected stages-must-be-Task error")
+	}
+}
+
+func TestDetectPipelineCycle(t *testing.T) {
+	env := newTestEnv(t)
+	a := &task.Spec{ID: "a", Name: "A", Enabled: true, Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}}
+	_ = env.reg.Register(a)
+	// Self-cycle: pipeline whose stage references itself is caught by Validate (self-ref),
+	// so test a 2-node cycle via two pipelines referencing each other is impossible in v1
+	// (stages must be Task). So just assert a healthy pipeline has no cycle.
+	p := &task.PipelineTask{ID: "p", Name: "P", Subtype: "sequential", Enabled: true,
+		Stages: []task.Stage{{Task: "a"}}}
+	if got := env.engine.detectPipelineCycle(p); got != "" {
+		t.Fatalf("unexpected cycle: %q", got)
+	}
+}
+
+func TestValidatePipelineRefs_InputRefStageAccepted(t *testing.T) {
+	env := newTestEnv(t)
+	stage := &task.Spec{ID: "writer", Name: "Writer", Enabled: true,
+		Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}}
+	if err := env.reg.Register(stage); err != nil {
+		t.Fatal(err)
+	}
+	p := &task.PipelineTask{ID: "p", Name: "P", Subtype: "sequential", Enabled: true,
+		Stages: []task.Stage{
+			{Task: "writer", Overrides: &task.Overrides{
+				Params: task.ParamOverrides{{Name: "content", Default: "${input.output}"}}}},
+		},
+	}
+	if err := env.engine.validatePipelineRefs(p); err != nil {
+		t.Fatalf("stage with ${input.output} override should be accepted, got: %v", err)
+	}
+}
+
+func TestRegisterPipelineValidates(t *testing.T) {
+	env := newTestEnv(t)
+	stage := &task.Spec{ID: "s", Name: "S", Enabled: true, Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}}
+	_ = env.reg.Register(stage)
+
+	good := &task.PipelineTask{
+		APIVersion: "dicode/v1",
+		Kind:       task.KindPipelineTask,
+		ID:         "p",
+		Name:       "P",
+		Subtype:    "sequential",
+		Enabled:    true,
+		Stages:     []task.Stage{{Task: "s"}},
+	}
+	if err := env.engine.registerPipeline(good); err != nil {
+		t.Fatalf("registerPipeline(good) = %v", err)
+	}
+	// Invalid subtype is rejected (Validate runs inside registerPipeline).
+	bad := &task.PipelineTask{
+		APIVersion: "dicode/v1",
+		Kind:       task.KindPipelineTask,
+		ID:         "p2",
+		Name:       "P2",
+		Subtype:    "parallel",
+		Stages:     []task.Stage{{Task: "s"}},
+	}
+	if err := env.engine.registerPipeline(bad); err == nil {
+		t.Fatal("expected subtype rejection")
+	}
+}

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -362,9 +362,9 @@ func New(port int, r *registry.Registry, eng *trigger.Engine, cfg *config.Config
 	// Chain with the existing callbacks (already wired to the trigger engine in main).
 	if rec != nil {
 		prev := rec.OnRegister
-		rec.OnRegister = func(spec *task.Spec) {
+		rec.OnRegister = func(k task.Kinded) {
 			if prev != nil {
-				prev(spec)
+				prev(k)
 			}
 			s.ws.Broadcast(WSMsg{Type: "tasks:changed"})
 		}


### PR DESCRIPTION
## Summary

PR2 of the **kind: PipelineTask** epic (successor to PR1 #339). Threads `task.Kinded` through the whole transport path — `source.Event` → reconciler → registry → `OnRegister` → `Engine.Register` — so a `kind: PipelineTask` is loaded, validated, and registered. **No pipeline firing yet** — dispatch/execution lands in PR3.

- **Registry stores `task.Kinded`** (`Get`/`All` stay typed to `kind: Task`; new `GetKinded`/`AllKinded`); run rows carry `kind` (`runs.kind`).
- **`registerPipeline`** does registry-aware validation: stage-ref existence + three-colour-DFS cycle detection. `Engine.Register` routes by kind (`*task.Spec` → cron/webhook/daemon path; `*task.PipelineTask` → `registerPipeline`).
- **`source.Event.Spec` → `Kinded task.Kinded`**; the reconciler loads raw sources via `task.LoadKindedDir`, stamps the canonical `ev.TaskID`, and `OnRegister` now hands consumers a `task.Kinded` (daemon/webui type-assert to `*task.Spec` for the `kind: Task`-only webhook/footgun logic).
- **taskset resolver** gains a `KindPipelineTask` case; `ResolvedTask` + the taskset source carry `task.Kinded` and hash via `hashKinded` for change detection.

Maps to plan Tasks 7–12 (`docs/superpowers/plans/2026-05-18-pipeline-task-plan.md`).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./...` green
- [x] `go test -race` on changed packages (registry, taskset, source, daemon, webui) green
- [x] New coverage: `TestReconcilerLoadsPipelineKind`, `TestResolvePipelineKind`, plus the registry/run-kind/registerPipeline/Engine.Register tests from earlier PR2 commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)