### PR TITLE
feat(trigger): PipelineRunner — sequential execution + dispatch (PR3/8)

### DIFF
--- a/pkg/registry/trigger_source.go
+++ b/pkg/registry/trigger_source.go
@@ -23,4 +23,9 @@ const (
 	// WebUI can group preflight runs under the daemon they're gating
 	// rather than under their own chain-trigger history.
 	TriggerPreflight TriggerSource = "preflight"
+	// TriggerPipelineStage marks a run fired as a stage of a kind: PipelineTask.
+	// Distinct from TriggerPreflight so the WebUI can group pipeline stage runs
+	// under their parent pipeline run. Replaces TriggerPreflight once
+	// trigger.before is removed (PR6).
+	TriggerPipelineStage TriggerSource = "pipeline-stage"
 )

--- a/pkg/trigger/e2e_pipeline_task_test.go
+++ b/pkg/trigger/e2e_pipeline_task_test.go
@@ -1,0 +1,122 @@
+package trigger
+
+// End-to-end test for the kind: PipelineTask runner (PR3). Composes the REAL
+// buildin/template and buildin/write-local tasks (loaded from disk) into a
+// 2-stage sequential pipeline fired manually through real Deno:
+//
+//   1. buildin/template renders a literal config body (no ${VAR} placeholders →
+//      no env wiring). Its on-disk run_result.enabled:false means the rendered
+//      string flows in-memory via ${input.output} rather than the persisted
+//      runs.return_value column — exercising the WaitRun cache fallback.
+//   2. buildin/write-local persists the rendered string to a caller-declared
+//      path. Its permissions.fs ships empty, so the stage override declares an
+//      fs:rw scope covering the target path.
+//
+// Assertions:
+//   - The rendered file lands on disk (proves template ran with its override
+//     AND write-local received the rendered string via ${input.output}).
+//   - The pipeline parent run is success.
+//   - Both stages have their own runs tagged TriggerPipelineStage, linked to
+//     the parent (data-model linkage for the WebUI).
+//
+// Gated on real Deno (newTestEnv skips when absent).
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+func TestE2E_PipelineTask_RealDeno(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+
+	scratch := t.TempDir()
+	outpath := filepath.Join(scratch, "rendered.yaml")
+
+	e := newTestEnv(t)
+
+	tmpl := loadBuildinTemplateAs(t, "tmpl", nil)
+	writer := loadBuildinWriteLocalAs(t, "writer")
+	for _, s := range []*task.Spec{tmpl, writer} {
+		if err := e.reg.Register(s); err != nil {
+			t.Fatalf("reg.Register %s: %v", s.ID, err)
+		}
+		if err := e.engine.Register(s); err != nil {
+			t.Fatalf("eng.Register %s: %v", s.ID, err)
+		}
+	}
+
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "render-and-write", Name: "render-and-write", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Manual: true},
+		Stages: []task.Stage{
+			{
+				Task: "tmpl",
+				Overrides: &task.Overrides{
+					Params: task.ParamOverrides{
+						{Name: "template", Default: "rendered: hello-from-pipeline\n"},
+					},
+				},
+			},
+			{
+				Task: "writer",
+				Overrides: &task.Overrides{
+					Params: task.ParamOverrides{
+						{Name: "content", Default: "${input.output}"},
+						{Name: "path", Default: outpath},
+						{Name: "mode", Default: "0600"},
+					},
+					Fs: []task.FSEntry{{Path: scratch, Permission: "rw"}},
+				},
+			},
+		},
+	}
+	if err := e.reg.Register(pipe); err != nil {
+		t.Fatalf("reg.Register pipe: %v", err)
+	}
+	if err := e.engine.Register(pipe); err != nil {
+		t.Fatalf("eng.Register pipe: %v", err)
+	}
+
+	parentRunID, err := e.engine.FireManual(context.Background(), "render-and-write", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+
+	parent := waitForTerminal(t, e.engine, parentRunID, 30*time.Second)
+	if parent.Status != registry.StatusSuccess {
+		t.Fatalf("pipeline status = %q (reason=%q), want success", parent.Status, parent.FailureReason)
+	}
+
+	got, err := os.ReadFile(outpath)
+	if err != nil {
+		t.Fatalf("rendered file not found at %s: %v", outpath, err)
+	}
+	if want := "rendered: hello-from-pipeline\n"; string(got) != want {
+		t.Errorf("rendered file content = %q, want %q", string(got), want)
+	}
+
+	kids, err := e.reg.ListChildren(context.Background(), parentRunID, 10)
+	if err != nil {
+		t.Fatalf("ListChildren: %v", err)
+	}
+	if len(kids) != 2 {
+		t.Fatalf("want 2 stage children, got %d: %+v", len(kids), kids)
+	}
+	for _, c := range kids {
+		if c.TriggerSource != registry.TriggerPipelineStage {
+			t.Errorf("child %s source = %q, want %q", c.TaskID, c.TriggerSource, registry.TriggerPipelineStage)
+		}
+		if c.ParentRunID != parentRunID {
+			t.Errorf("child %s parent = %q, want %q", c.TaskID, c.ParentRunID, parentRunID)
+		}
+	}
+}

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -1197,12 +1197,12 @@ func (e *Engine) getShutdownCtx() context.Context {
 
 // FireManual triggers a task by ID with optional param overrides.
 func (e *Engine) FireManual(ctx context.Context, taskID string, params map[string]string) (string, error) {
-	spec, ok := e.registry.Get(taskID)
+	k, ok := e.registry.GetKinded(taskID)
 	if !ok {
 		return "", fmt.Errorf("task %q not found", taskID)
 	}
 	e.log.Info("manual trigger", zap.String("task", taskID))
-	return e.fireAsync(context.Background(), spec, pkgruntime.RunOptions{Params: params}, registry.TriggerManual)
+	return e.fireKinded(context.Background(), k, pkgruntime.RunOptions{Params: params}, registry.TriggerManual)
 }
 
 // FireFromTask triggers a task as a child of an in-flight run. Used by the
@@ -1212,12 +1212,12 @@ func (e *Engine) FireFromTask(ctx context.Context, taskID, parentRunID string, p
 	if parentRunID == "" {
 		return e.FireManual(ctx, taskID, params)
 	}
-	spec, ok := e.registry.Get(taskID)
+	k, ok := e.registry.GetKinded(taskID)
 	if !ok {
 		return "", fmt.Errorf("task %q not found", taskID)
 	}
 	e.log.Info("subtask trigger", zap.String("task", taskID), zap.String("parent", parentRunID))
-	return e.fireAsync(context.Background(), spec,
+	return e.fireKinded(context.Background(), k,
 		pkgruntime.RunOptions{Params: params, ParentRunID: parentRunID},
 		registry.TriggerManual)
 }
@@ -2431,6 +2431,21 @@ func (e *Engine) finalizeCancelled(spec *task.Spec, opts pkgruntime.RunOptions, 
 // fireAsync with source=TriggerPreflight; that source also skips this
 // branch so a stage task that happens to declare its own trigger.before
 // doesn't recurse.
+// fireKinded dispatches any task kind, returning the (parent) run ID: a
+// *task.PipelineTask runs via the PipelineRunner (firePipeline); a *task.Spec
+// runs via fireAsync. Trigger entrypoints (manual/cron/webhook/chain) route
+// through here so a pipeline and a plain task fire uniformly.
+func (e *Engine) fireKinded(ctx context.Context, k task.Kinded, opts pkgruntime.RunOptions, source registry.TriggerSource) (string, error) {
+	switch s := k.(type) {
+	case *task.PipelineTask:
+		return e.firePipeline(ctx, s, opts, source)
+	case *task.Spec:
+		return e.fireAsync(ctx, s, opts, source)
+	default:
+		return "", fmt.Errorf("engine: cannot fire unsupported kind %q", k.KindOf())
+	}
+}
+
 func (e *Engine) fireAsync(ctx context.Context, spec *task.Spec, opts pkgruntime.RunOptions, source registry.TriggerSource) (string, error) {
 	opts.RunID = uuid.New().String()
 

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -1504,6 +1504,29 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 		}, "chain")
 	}
 
+	// Pipeline chain subscribers: a kind: PipelineTask may chain from an
+	// upstream task's outcome. v1 fires the pipeline without injecting the
+	// upstream output into stage 0 (deferred follow-up — stages thread their own
+	// output via ${input.*}); the upstream's status still gates the fire.
+	for _, k := range e.registry.AllKinded() {
+		p, ok := k.(*task.PipelineTask)
+		if !ok || p.Trigger.Chain == nil || p.Trigger.Chain.From != completedTaskID {
+			continue
+		}
+		on := p.Trigger.Chain.ChainOn()
+		if on != "always" && on != runStatus {
+			continue
+		}
+		e.log.Info("chain trigger (pipeline)",
+			zap.String("from", completedTaskID), zap.String("to", p.ID), zap.String("on", on))
+		go func(p *task.PipelineTask) {
+			if _, err := e.firePipeline(ctx, p, pkgruntime.RunOptions{ParentRunID: runID}, registry.TriggerChain); err != nil {
+				e.log.Warn("chain-triggered pipeline failed to start",
+					zap.String("from", completedTaskID), zap.String("to", p.ID), zap.Error(err))
+			}
+		}(p)
+	}
+
 	// Config-level default on_failure_chain.
 	if runStatus == "failure" {
 		chainSpec := e.defaultsOnFailureChain

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -628,47 +628,70 @@ func cronNextRun(expr string) (time.Time, error) {
 }
 
 func (e *Engine) registerCron(spec *task.Spec) {
-	id, err := e.cron.AddFunc(spec.Trigger.Cron, func() {
+	e.scheduleCron(spec.ID, spec.Trigger.Cron, func() error {
 		s, ok := e.registry.Get(spec.ID)
 		if !ok {
-			return
+			return fmt.Errorf("cron task %q gone from registry", spec.ID)
 		}
-		// Advance next_run_at AFTER fireAsync so that a failed dispatch does not
-		// silently advance the schedule and cause the missed run to be invisible
-		// on the next restart.
-		if _, ferr := e.fireAsync(context.Background(), s, pkgruntime.RunOptions{}, registry.TriggerCron); ferr == nil && e.db != nil {
-			if next, nerr := cronNextRun(spec.Trigger.Cron); nerr == nil {
+		_, ferr := e.fireAsync(context.Background(), s, pkgruntime.RunOptions{}, registry.TriggerCron)
+		return ferr
+	})
+}
+
+// registerPipelineCron schedules a kind: PipelineTask on its cron expression,
+// firing the PipelineRunner via fireKinded. Mirrors registerCron's scheduling
+// through the shared scheduleCron primitive.
+func (e *Engine) registerPipelineCron(p *task.PipelineTask) {
+	e.scheduleCron(p.ID, p.Trigger.Cron, func() error {
+		k, ok := e.registry.GetKinded(p.ID)
+		if !ok {
+			return fmt.Errorf("cron pipeline %q gone from registry", p.ID)
+		}
+		_, ferr := e.fireKinded(context.Background(), k, pkgruntime.RunOptions{}, registry.TriggerCron)
+		return ferr
+	})
+}
+
+// scheduleCron registers a cron entry that runs fire() on each tick, records the
+// entry under id (kind-agnostic — keyed by task ID), and persists the cron_jobs
+// row. next_run_at is advanced only when fire() succeeds, so a failed dispatch
+// doesn't silently skip the missed run on the next restart. Shared by kind: Task
+// (registerCron) and kind: PipelineTask (registerPipelineCron).
+func (e *Engine) scheduleCron(id, cronExpr string, fire func() error) {
+	entryID, err := e.cron.AddFunc(cronExpr, func() {
+		if ferr := fire(); ferr == nil && e.db != nil {
+			if next, nerr := cronNextRun(cronExpr); nerr == nil {
 				if dbErr := e.db.Exec(context.Background(),
 					`UPDATE cron_jobs SET last_run_at=?, next_run_at=? WHERE task_id=?`,
-					time.Now().Unix(), next.Unix(), spec.ID,
+					time.Now().Unix(), next.Unix(), id,
 				); dbErr != nil {
 					e.log.Warn("cron: failed to persist next_run_at",
-						zap.String("task", spec.ID), zap.Error(dbErr))
+						zap.String("task", id), zap.Error(dbErr))
 				}
 			}
 		}
 	})
 	if err != nil {
 		e.log.Error("invalid cron expression",
-			zap.String("task", spec.ID),
-			zap.String("cron", spec.Trigger.Cron),
+			zap.String("task", id),
+			zap.String("cron", cronExpr),
 			zap.Error(err),
 		)
 		return
 	}
 	e.mu.Lock()
-	e.cronEntries[spec.ID] = id
+	e.cronEntries[id] = entryID
 	e.mu.Unlock()
 
 	if e.db != nil {
-		if next, nerr := cronNextRun(spec.Trigger.Cron); nerr == nil {
+		if next, nerr := cronNextRun(cronExpr); nerr == nil {
 			if dbErr := e.db.Exec(context.Background(),
 				`INSERT INTO cron_jobs(task_id,cron_expr,next_run_at) VALUES(?,?,?)
 				 ON CONFLICT(task_id) DO UPDATE SET cron_expr=excluded.cron_expr, next_run_at=excluded.next_run_at`,
-				spec.ID, spec.Trigger.Cron, next.Unix(),
+				id, cronExpr, next.Unix(),
 			); dbErr != nil {
 				e.log.Warn("cron: failed to persist cron_jobs row",
-					zap.String("task", spec.ID), zap.Error(dbErr))
+					zap.String("task", id), zap.Error(dbErr))
 			}
 		}
 	}
@@ -764,14 +787,22 @@ const reservedOAuthCompletePath = "/hooks/oauth-complete"
 const oauthRelayBuiltinID = "buildin/auth-relay"
 
 func (e *Engine) registerWebhook(spec *task.Spec) {
-	if spec.Trigger.Webhook == reservedOAuthCompletePath && spec.ID != oauthRelayBuiltinID {
+	e.registerWebhookPath(spec.ID, spec.Trigger.Webhook)
+}
+
+// registerWebhookPath claims a webhook path for a task ID (kind-agnostic). The
+// webhooks map routes incoming requests by path → task ID; the dispatcher
+// resolves the kind. Shared by kind: Task (registerWebhook) and kind:
+// PipelineTask (registerPipeline).
+func (e *Engine) registerWebhookPath(id, path string) {
+	if path == reservedOAuthCompletePath && id != oauthRelayBuiltinID {
 		e.log.Warn("rejecting task that tries to shadow reserved OAuth delivery path",
-			zap.String("task", spec.ID),
+			zap.String("task", id),
 			zap.String("path", reservedOAuthCompletePath))
 		return
 	}
 	e.mu.Lock()
-	e.webhooks[spec.Trigger.Webhook] = spec.ID
+	e.webhooks[path] = id
 	e.mu.Unlock()
 }
 
@@ -1740,7 +1771,13 @@ else { pre.innerHTML = logs.map(l => {
 // protection for a webhook request. Returns nil when the request is authentic.
 // When no secret is configured on the task the check is skipped (open webhook).
 func verifyWebhookSignature(spec *task.Spec, r *http.Request, body []byte) error {
-	secret := spec.Trigger.WebhookSecret
+	return verifyWebhookSignatureSecret(spec.Trigger.WebhookSecret, r, body)
+}
+
+// verifyWebhookSignatureSecret is the kind-agnostic HMAC verification core,
+// shared by kind: Task (verifyWebhookSignature) and kind: PipelineTask webhook
+// dispatch. An empty secret means the webhook is unauthenticated (back-compat).
+func verifyWebhookSignatureSecret(secret string, r *http.Request, body []byte) error {
 	if secret == "" {
 		return nil // unauthenticated webhook — allowed for backwards-compat
 	}
@@ -1773,6 +1810,39 @@ func verifyWebhookSignature(spec *task.Spec, r *http.Request, body []byte) error
 		return fmt.Errorf("signature mismatch")
 	}
 	return nil
+}
+
+// handlePipelineWebhook fires a kind: PipelineTask in response to a webhook
+// request and writes the parent run ID as JSON. Pipelines run asynchronously
+// (multi-stage), so there is no synchronous inline-result mode — callers poll
+// the returned runId. assetPath is non-empty only when the request targeted a
+// sub-path; pipelines expose no asset surface, so that is a 404.
+func (e *Engine) handlePipelineWebhook(w http.ResponseWriter, r *http.Request, pipe *task.PipelineTask, assetPath string) {
+	if assetPath != "" {
+		http.NotFound(w, r)
+		return
+	}
+	var body []byte
+	if r.Method != http.MethodGet && r.Body != nil {
+		body, _ = io.ReadAll(io.LimitReader(r.Body, webhookMaxBodyBytes))
+	}
+	if err := verifyWebhookSignatureSecret(pipe.Trigger.WebhookSecret, r, body); err != nil {
+		e.log.Warn("pipeline webhook signature verification failed",
+			zap.String("path", r.URL.Path), zap.String("task", pipe.ID), zap.Error(err))
+		http.Error(w, "forbidden: "+err.Error(), http.StatusForbidden)
+		return
+	}
+	e.log.Info("pipeline webhook trigger", zap.String("path", r.URL.Path), zap.String("task", pipe.ID))
+	// Decouple from the request context so the async pipeline survives the HTTP
+	// response (mirrors fireAsync's use of context.Background()).
+	runID, err := e.firePipeline(context.Background(), pipe, pkgruntime.RunOptions{}, registry.TriggerWebhook)
+	if err != nil {
+		http.Error(w, "pipeline failed to start: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("X-Run-Id", runID)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"runId": runID})
 }
 
 // WebhookHandler returns an HTTP handler that dispatches webhook-triggered tasks.
@@ -1824,6 +1894,16 @@ func (e *Engine) WebhookHandler() http.Handler {
 		if !ok {
 			http.NotFound(w, r)
 			return
+		}
+
+		// kind: PipelineTask webhooks have no task directory, index.html, or
+		// assets — fire the runner directly and return the parent run ID. Stage
+		// UIs/assets belong to the individual stage tasks, not the pipeline.
+		if k, isKinded := e.registry.GetKinded(taskID); isKinded {
+			if pipe, isPipe := k.(*task.PipelineTask); isPipe {
+				e.handlePipelineWebhook(w, r, pipe, assetPath)
+				return
+			}
 		}
 
 		spec, ok := e.registry.Get(taskID)

--- a/pkg/trigger/pipeline_runner.go
+++ b/pkg/trigger/pipeline_runner.go
@@ -1,0 +1,136 @@
+package trigger
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+	"github.com/dicode/dicode/pkg/task"
+	"github.com/dicode/dicode/pkg/taskset"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+// PipelineRunner orchestrates one fire of a kind: PipelineTask. It owns the
+// pipeline's parent run row and drives its stages sequentially. One runner per
+// fire; it holds no state beyond the in-flight pipeline.
+type PipelineRunner struct {
+	engine *Engine
+	spec   *task.PipelineTask
+	runID  string // the pipeline's own parent run ID
+}
+
+// firePipeline creates the pipeline's parent run row (kind=pipeline) and starts
+// the runner asynchronously, returning the parent run ID immediately (mirrors
+// fireAsync's contract for kind: Task).
+//
+// It re-validates the pipeline against the live registry before creating any
+// run row. Manual and chain fires reach this path via GetKinded without going
+// through engine registration, so a pipeline whose stages were deregistered (or
+// that lost the reconcile-ordering race, see #341) is rejected loudly here
+// rather than dispatched and failed mid-flight.
+func (e *Engine) firePipeline(ctx context.Context, p *task.PipelineTask, opts pkgruntime.RunOptions, source registry.TriggerSource) (string, error) {
+	if err := e.validatePipelineRefs(p); err != nil {
+		return "", fmt.Errorf("pipeline %q failed validation: %w", p.ID, err)
+	}
+	runID := uuid.New().String()
+	if _, err := e.registry.StartRunWithID(context.Background(), runID, p.ID, opts.ParentRunID, string(source), registry.RunKindPipeline); err != nil {
+		return "", fmt.Errorf("start pipeline run: %w", err)
+	}
+	r := &PipelineRunner{engine: e, spec: p, runID: runID}
+	go r.run(ctx)
+	return runID, nil
+}
+
+// run executes stages sequentially, threading each stage's output into the next
+// via ${input.*}, and short-circuits the pipeline on the first stage failure.
+func (r *PipelineRunner) run(ctx context.Context) {
+	e := r.engine
+	if r.spec.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, r.spec.Timeout)
+		defer cancel()
+	}
+
+	var upstream task.InputContext
+	var lastReturn interface{}
+	for i, st := range r.spec.Stages {
+		out, err := e.dispatchStage(ctx, st, upstream, r.runID)
+		if err != nil {
+			reason := fmt.Sprintf("stage %d (%s): %s", i, st.Task, err.Error())
+			e.log.Warn("pipeline stage failed; pipeline failed",
+				zap.String("pipeline", r.spec.ID), zap.Int("stage", i),
+				zap.String("task", st.Task), zap.Error(err))
+			r.finish(registry.StatusFailure, reason, nil)
+			return
+		}
+		upstream = out
+		lastReturn = out.Output
+	}
+	r.finish(registry.StatusSuccess, "", lastReturn)
+}
+
+// dispatchStage resolves the stage's overrides + ${input.*} references against
+// the upstream stage's output, fires the stage as a kind: Task child of the
+// pipeline run, and blocks until it reaches a terminal state. It returns the
+// stage's InputContext for the next stage.
+func (e *Engine) dispatchStage(ctx context.Context, st task.Stage, upstream task.InputContext, parentRunID string) (task.InputContext, error) {
+	ref, ok := e.registry.Get(st.Task) // Get filters to kind: Task — stages are always Task
+	if !ok {
+		return task.InputContext{}, fmt.Errorf("stage task %q not registered", st.Task)
+	}
+
+	dispatchSpec := ref
+	if st.Overrides != nil {
+		ovPtr := st.Overrides
+		if st.Overrides.Params != nil {
+			resolved, rerr := task.ResolveInputOutputList(st.Overrides.Params, upstream)
+			if rerr != nil {
+				return task.InputContext{}, fmt.Errorf("resolve input refs: %w", rerr)
+			}
+			ovCopy := *st.Overrides
+			ovCopy.Params = resolved
+			ovPtr = &ovCopy
+		}
+		merged := taskset.ApplyOverrides(ref, ovPtr)
+		if vErr := merged.Validate(); vErr != nil {
+			return task.InputContext{}, fmt.Errorf("overrides produce invalid spec: %w", vErr)
+		}
+		dispatchSpec = merged
+	}
+
+	runID, err := e.fireAsync(ctx, dispatchSpec, pkgruntime.RunOptions{ParentRunID: parentRunID}, registry.TriggerPipelineStage)
+	if err != nil {
+		return task.InputContext{}, fmt.Errorf("dispatch: %w", err)
+	}
+	res, werr := e.WaitRun(ctx, runID)
+	if werr != nil {
+		return task.InputContext{}, fmt.Errorf("wait: %w", werr)
+	}
+	if res.Status != registry.StatusSuccess {
+		return task.InputContext{}, fmt.Errorf("run %s ended with status %s", runID, res.Status)
+	}
+	return task.InputContext{Output: res.ReturnValue}, nil
+}
+
+// finish marks the pipeline's parent run terminal and records the terminal
+// stage's return value as the pipeline's own return (persisted to the run row,
+// so chain consumers and WaitRun observe it — mirrors how runTask persists).
+func (r *PipelineRunner) finish(status, reason string, ret interface{}) {
+	e := r.engine
+	finishCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if ret != nil {
+		if b, err := json.Marshal(ret); err == nil {
+			_ = e.registry.SetRunResult(finishCtx, r.runID, string(b), "", "")
+		}
+	}
+	if reason != "" {
+		_ = e.registry.FinishRunWithReason(finishCtx, r.runID, status, reason)
+	} else {
+		_ = e.registry.FinishRun(finishCtx, r.runID, status)
+	}
+}

--- a/pkg/trigger/pipeline_runner.go
+++ b/pkg/trigger/pipeline_runner.go
@@ -20,7 +20,8 @@ import (
 type PipelineRunner struct {
 	engine *Engine
 	spec   *task.PipelineTask
-	runID  string // the pipeline's own parent run ID
+	runID  string             // the pipeline's own parent run ID
+	cancel context.CancelFunc // cancels runCtx; invoked on finish + by KillRun
 }
 
 // firePipeline creates the pipeline's parent run row (kind=pipeline) and starts
@@ -40,8 +41,18 @@ func (e *Engine) firePipeline(ctx context.Context, p *task.PipelineTask, opts pk
 	if _, err := e.registry.StartRunWithID(context.Background(), runID, p.ID, opts.ParentRunID, string(source), registry.RunKindPipeline); err != nil {
 		return "", fmt.Errorf("start pipeline run: %w", err)
 	}
-	r := &PipelineRunner{engine: e, spec: p, runID: runID}
-	go r.run(ctx)
+	// Register the parent in the engine's run-lifecycle maps so it behaves like
+	// any managed run: WaitRun blocks on runDone until finish() (so a
+	// dicode.run_task targeting a pipeline gets the real result, not a racy nil),
+	// and KillRun(parentRunID) cancels runCtx — which the runner propagates to
+	// the in-flight stage. Trigger entrypoints pass a background context, so the
+	// async pipeline survives the trigger call returning.
+	runCtx, cancel := context.WithCancel(ctx)
+	e.runCancels.Store(runID, cancel)
+	e.runTriggerSource.Store(runID, source)
+	e.runDone.Store(runID, make(chan struct{}))
+	r := &PipelineRunner{engine: e, spec: p, runID: runID, cancel: cancel}
+	go r.run(runCtx)
 	return runID, nil
 }
 
@@ -108,6 +119,9 @@ func (e *Engine) dispatchStage(ctx context.Context, st task.Stage, upstream task
 	}
 	res, werr := e.WaitRun(ctx, runID)
 	if werr != nil {
+		// ctx cancelled (pipeline timeout or KillRun on the parent) — stop the
+		// orphaned stage subprocess rather than leaving it running detached.
+		e.KillRun(runID)
 		return task.InputContext{}, fmt.Errorf("wait: %w", werr)
 	}
 	if res.Status != registry.StatusSuccess {
@@ -133,7 +147,20 @@ func (r *PipelineRunner) finish(status, reason string, ret interface{}) {
 	} else {
 		_ = e.registry.FinishRun(finishCtx, r.runID, status)
 	}
+	// Tear down the run-lifecycle registrations now that the DB row is terminal.
+	// Close runDone AFTER the DB write so a WaitRun goroutine woken by the close
+	// reads the finalized row.
+	if v, ok := e.runDone.LoadAndDelete(r.runID); ok {
+		close(v.(chan struct{}))
+	}
 	// Pipeline-as-chain-source: fire downstream subscribers off the pipeline's
-	// overall outcome (a fresh background context — finishCtx is about to expire).
+	// overall outcome (fresh background context — finishCtx is about to expire).
+	// Done before dropping runTriggerSource, which FireChain's failure-path
+	// guards consult.
 	e.FireChain(context.Background(), r.spec.ID, r.runID, status, ret, nil)
+	e.runCancels.Delete(r.runID)
+	e.runTriggerSource.Delete(r.runID)
+	if r.cancel != nil {
+		r.cancel()
+	}
 }

--- a/pkg/trigger/pipeline_runner.go
+++ b/pkg/trigger/pipeline_runner.go
@@ -127,6 +127,10 @@ func (e *Engine) dispatchStage(ctx context.Context, st task.Stage, upstream task
 	if res.Status != registry.StatusSuccess {
 		return task.InputContext{}, fmt.Errorf("run %s ended with status %s", runID, res.Status)
 	}
+	// Only Output is threaded between stages in v1: PipelineTask.Validate rejects
+	// ${input.params.*} refs, so there is deliberately no Params snapshot here.
+	// Cross-stage param threading is a planned follow-up (mirrors the forward-compat
+	// note on the preflight dispatchPipelineStage path).
 	return task.InputContext{Output: res.ReturnValue}, nil
 }
 

--- a/pkg/trigger/pipeline_runner.go
+++ b/pkg/trigger/pipeline_runner.go
@@ -133,4 +133,7 @@ func (r *PipelineRunner) finish(status, reason string, ret interface{}) {
 	} else {
 		_ = e.registry.FinishRun(finishCtx, r.runID, status)
 	}
+	// Pipeline-as-chain-source: fire downstream subscribers off the pipeline's
+	// overall outcome (a fresh background context — finishCtx is about to expire).
+	e.FireChain(context.Background(), r.spec.ID, r.runID, status, ret, nil)
 }

--- a/pkg/trigger/pipeline_runner_test.go
+++ b/pkg/trigger/pipeline_runner_test.go
@@ -92,3 +92,116 @@ func TestPipelineRunnerSequential(t *testing.T) {
 		t.Errorf("pipeline return = %v, want \"hello\"", res.ReturnValue)
 	}
 }
+
+// findPipelineRun polls for a kind=pipeline run of taskID and returns it once it
+// reaches a terminal state (or fails the test on timeout).
+func findRun(t *testing.T, env *testEnv, taskID string, wantKind string, timeout time.Duration) *registry.Run {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		runs, _ := env.reg.ListRuns(context.Background(), taskID, 5)
+		for _, r := range runs {
+			if wantKind != "" && r.Kind != wantKind {
+				continue
+			}
+			if r.FinishedAt != nil {
+				return r
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("no terminal run for %q (kind=%q) within %v", taskID, wantKind, timeout)
+	return nil
+}
+
+// TestChainFiresPipeline asserts a pipeline with trigger.chain.from: <task> fires
+// when that upstream task completes successfully.
+func TestChainFiresPipeline(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+	env := newTestEnv(t)
+	dir := t.TempDir()
+
+	stage := writeTask(t, dir, "pstage", `export default async function main() { return "ok" }`, task.TriggerConfig{Manual: true})
+	upstream := writeTask(t, dir, "up", `export default async function main() { return "done" }`, task.TriggerConfig{Manual: true})
+	for _, s := range []*task.Spec{stage, upstream} {
+		if err := env.reg.Register(s); err != nil {
+			t.Fatal(err)
+		}
+		if err := env.engine.Register(s); err != nil {
+			t.Fatal(err)
+		}
+	}
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "chained-pipe", Name: "CP", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Chain: &task.ChainTrigger{From: "up", On: "success"}},
+		Stages:  []task.Stage{{Task: "pstage"}},
+	}
+	if err := env.reg.Register(pipe); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.engine.Register(pipe); err != nil {
+		t.Fatalf("register pipeline: %v", err)
+	}
+
+	if _, err := env.engine.FireManual(context.Background(), "up", nil); err != nil {
+		t.Fatalf("FireManual up: %v", err)
+	}
+
+	run := findRun(t, env, "chained-pipe", registry.RunKindPipeline, 30*time.Second)
+	if run.Status != registry.StatusSuccess {
+		t.Errorf("chained pipeline status = %q, want success", run.Status)
+	}
+	if run.TriggerSource != registry.TriggerChain {
+		t.Errorf("chained pipeline source = %q, want %q", run.TriggerSource, registry.TriggerChain)
+	}
+}
+
+// TestPipelineFiresChain asserts a downstream kind: Task chains from a pipeline's
+// overall outcome (pipeline-as-chain-source).
+func TestPipelineFiresChain(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+	env := newTestEnv(t)
+	dir := t.TempDir()
+
+	stage := writeTask(t, dir, "pstage2", `export default async function main() { return "ok" }`, task.TriggerConfig{Manual: true})
+	if err := env.reg.Register(stage); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.engine.Register(stage); err != nil {
+		t.Fatal(err)
+	}
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "src-pipe", Name: "SP", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Manual: true},
+		Stages:  []task.Stage{{Task: "pstage2"}},
+	}
+	if err := env.reg.Register(pipe); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.engine.Register(pipe); err != nil {
+		t.Fatalf("register pipeline: %v", err)
+	}
+	downstream := writeTask(t, dir, "after-pipe", `export default async function main() { return "after" }`,
+		task.TriggerConfig{Chain: &task.ChainTrigger{From: "src-pipe", On: "success"}})
+	if err := env.reg.Register(downstream); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.engine.Register(downstream); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := env.engine.FireManual(context.Background(), "src-pipe", nil); err != nil {
+		t.Fatalf("FireManual src-pipe: %v", err)
+	}
+
+	run := findRun(t, env, "after-pipe", registry.RunKindTask, 30*time.Second)
+	if run.TriggerSource != registry.TriggerChain {
+		t.Errorf("downstream source = %q, want %q (chained from pipeline outcome)", run.TriggerSource, registry.TriggerChain)
+	}
+}

--- a/pkg/trigger/pipeline_runner_test.go
+++ b/pkg/trigger/pipeline_runner_test.go
@@ -1,0 +1,94 @@
+package trigger
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// TestPipelineRunnerSequential fires a two-stage sequential pipeline and asserts
+// the parent run is kind=pipeline + success, both stages ran as pipeline-stage
+// children, and ${input.output} threaded stage-a's return into stage-b's param.
+func TestPipelineRunnerSequential(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+	env := newTestEnv(t)
+	dir := t.TempDir()
+
+	// stage-a returns a string; stage-b echoes its `content` param, which the
+	// pipeline wires to ${input.output} (stage-a's return).
+	stageA := writeTask(t, dir, "stage-a",
+		`export default async function main() { return "hello" }`,
+		task.TriggerConfig{Manual: true})
+	stageB := writeTask(t, dir, "stage-b",
+		`export default async function main({ params }) { return await params.get("content") }`,
+		task.TriggerConfig{Manual: true})
+	for _, s := range []*task.Spec{stageA, stageB} {
+		if err := env.reg.Register(s); err != nil {
+			t.Fatalf("reg.Register %s: %v", s.ID, err)
+		}
+		if err := env.engine.Register(s); err != nil {
+			t.Fatalf("eng.Register %s: %v", s.ID, err)
+		}
+	}
+
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "p", Name: "P", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Manual: true},
+		Stages: []task.Stage{
+			{Task: "stage-a"},
+			{Task: "stage-b", Overrides: &task.Overrides{
+				Params: task.ParamOverrides{{Name: "content", Default: "${input.output}"}}}},
+		},
+	}
+	if err := env.reg.Register(pipe); err != nil {
+		t.Fatalf("reg.Register pipe: %v", err)
+	}
+	if err := env.engine.Register(pipe); err != nil {
+		t.Fatalf("eng.Register pipe: %v", err)
+	}
+
+	parentRunID, err := env.engine.FireManual(context.Background(), "p", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+
+	parent := waitForTerminal(t, env.engine, parentRunID, 30*time.Second)
+	if parent.Kind != registry.RunKindPipeline {
+		t.Fatalf("parent kind = %q, want %q", parent.Kind, registry.RunKindPipeline)
+	}
+	if parent.Status != registry.StatusSuccess {
+		t.Fatalf("parent status = %q (reason=%q), want success", parent.Status, parent.FailureReason)
+	}
+
+	kids, err := env.reg.ListChildren(context.Background(), parentRunID, 10)
+	if err != nil {
+		t.Fatalf("ListChildren: %v", err)
+	}
+	if len(kids) != 2 {
+		t.Fatalf("want 2 stage children, got %d: %+v", len(kids), kids)
+	}
+	for _, c := range kids {
+		if c.TriggerSource != registry.TriggerPipelineStage {
+			t.Errorf("child %s source = %q, want %q", c.TaskID, c.TriggerSource, registry.TriggerPipelineStage)
+		}
+		if c.ParentRunID != parentRunID {
+			t.Errorf("child %s parent = %q, want %q", c.TaskID, c.ParentRunID, parentRunID)
+		}
+	}
+
+	// ${input.output} threading: the pipeline's own return value is stage-b's
+	// return, which echoes stage-a's "hello".
+	res, err := env.engine.WaitRun(context.Background(), parentRunID)
+	if err != nil {
+		t.Fatalf("WaitRun parent: %v", err)
+	}
+	if res.ReturnValue != "hello" {
+		t.Errorf("pipeline return = %v, want \"hello\"", res.ReturnValue)
+	}
+}

--- a/pkg/trigger/pipeline_runner_test.go
+++ b/pkg/trigger/pipeline_runner_test.go
@@ -114,6 +114,105 @@ func findRun(t *testing.T, env *testEnv, taskID string, wantKind string, timeout
 	return nil
 }
 
+// TestPipelineWaitRunBlocksUntilDone asserts WaitRun on a pipeline's parent run
+// blocks until the pipeline finishes and returns the terminal status + return
+// value — i.e. the parent is a managed run (runDone), so dicode.run_task on a
+// pipeline gets the real result rather than a racy "running"/nil.
+func TestPipelineWaitRunBlocksUntilDone(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+	env := newTestEnv(t)
+	dir := t.TempDir()
+	stage := writeTask(t, dir, "wstage", `export default async function main() { return "v" }`, task.TriggerConfig{Manual: true})
+	if err := env.reg.Register(stage); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.engine.Register(stage); err != nil {
+		t.Fatal(err)
+	}
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "wpipe", Name: "WP", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Manual: true},
+		Stages:  []task.Stage{{Task: "wstage"}},
+	}
+	if err := env.reg.Register(pipe); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.engine.Register(pipe); err != nil {
+		t.Fatalf("register pipeline: %v", err)
+	}
+
+	runID, err := env.engine.FireManual(context.Background(), "wpipe", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	res, err := env.engine.WaitRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("WaitRun: %v", err)
+	}
+	if res.Status != registry.StatusSuccess {
+		t.Fatalf("WaitRun status = %q, want success (WaitRun should block until terminal)", res.Status)
+	}
+	if res.ReturnValue != "v" {
+		t.Errorf("WaitRun return = %v, want \"v\"", res.ReturnValue)
+	}
+}
+
+// TestPipelineKillRunCancelsStage asserts KillRun on a pipeline's parent run
+// cancels the in-flight stage instead of leaving it running detached. The stage
+// sleeps 10s; a working kill makes the pipeline terminate well before that.
+func TestPipelineKillRunCancelsStage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+	env := newTestEnv(t)
+	dir := t.TempDir()
+	stage := writeTask(t, dir, "slowstage",
+		`export default async function main() { await new Promise(r => setTimeout(r, 10000)); return "late" }`,
+		task.TriggerConfig{Manual: true})
+	if err := env.reg.Register(stage); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.engine.Register(stage); err != nil {
+		t.Fatal(err)
+	}
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "killpipe", Name: "KP", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Manual: true},
+		Stages:  []task.Stage{{Task: "slowstage"}},
+	}
+	if err := env.reg.Register(pipe); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.engine.Register(pipe); err != nil {
+		t.Fatalf("register pipeline: %v", err)
+	}
+
+	runID, err := env.engine.FireManual(context.Background(), "killpipe", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	// Wait until the stage child run exists (pipeline is mid-stage).
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if kids, _ := env.reg.ListChildren(context.Background(), runID, 5); len(kids) > 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !env.engine.KillRun(runID) {
+		t.Fatal("KillRun returned false; pipeline parent run is not cancellable")
+	}
+	// If kill works, the pipeline fails fast (well under the stage's 10s sleep).
+	parent := waitForTerminal(t, env.engine, runID, 8*time.Second)
+	if parent.Status == registry.StatusSuccess {
+		t.Fatalf("killed pipeline ended success; expected failure")
+	}
+}
+
 // TestChainFiresPipeline asserts a pipeline with trigger.chain.from: <task> fires
 // when that upstream task completes successfully.
 func TestChainFiresPipeline(t *testing.T) {

--- a/pkg/trigger/registerpipeline.go
+++ b/pkg/trigger/registerpipeline.go
@@ -127,6 +127,14 @@ func (e *Engine) registerPipeline(p *task.PipelineTask) error {
 		e.log.Info("pipeline registered (disabled — no triggers scheduled)", zap.String("task", p.ID))
 		return nil
 	}
+	// Schedule cron/webhook triggers. Manual pipelines fire via FireManual and
+	// chain pipelines via FireChain (Task 16), so neither needs scheduling here.
+	if p.Trigger.Cron != "" {
+		e.registerPipelineCron(p)
+	}
+	if p.Trigger.Webhook != "" {
+		e.registerWebhookPath(p.ID, p.Trigger.Webhook)
+	}
 	e.log.Info("pipeline registered", zap.String("task", p.ID), zap.Int("stages", len(p.Stages)))
 	return nil
 }

--- a/pkg/trigger/registerpipeline_test.go
+++ b/pkg/trigger/registerpipeline_test.go
@@ -6,6 +6,66 @@ import (
 	"github.com/dicode/dicode/pkg/task"
 )
 
+// registerStageAndPipeline registers a trivial kind: Task stage plus the given
+// pipeline (which references it) through both the registry and the engine.
+func registerStageAndPipeline(t *testing.T, env *testEnv, pipe *task.PipelineTask) {
+	t.Helper()
+	stage := &task.Spec{ID: "s", Name: "S", Enabled: true,
+		Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}}
+	if err := env.reg.Register(stage); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.engine.Register(stage); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.reg.Register(pipe); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.engine.Register(pipe); err != nil {
+		t.Fatalf("register pipeline: %v", err)
+	}
+}
+
+// TestPipelineCronRegistered asserts a cron-triggered pipeline gets a cron entry
+// scheduled under its ID (so the scheduler will fire it).
+func TestPipelineCronRegistered(t *testing.T) {
+	env := newTestEnv(t)
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "p", Name: "P", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Cron: "0 0 * * *"},
+		Stages:  []task.Stage{{Task: "s"}},
+	}
+	registerStageAndPipeline(t, env, pipe)
+
+	env.engine.mu.Lock()
+	_, ok := env.engine.cronEntries["p"]
+	env.engine.mu.Unlock()
+	if !ok {
+		t.Fatal("no cron entry registered for cron-triggered pipeline")
+	}
+}
+
+// TestPipelineWebhookRegistered asserts a webhook-triggered pipeline claims its
+// path in the engine's webhook routing table.
+func TestPipelineWebhookRegistered(t *testing.T) {
+	env := newTestEnv(t)
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "wp", Name: "WP", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Webhook: "/hooks/pipe"},
+		Stages:  []task.Stage{{Task: "s"}},
+	}
+	registerStageAndPipeline(t, env, pipe)
+
+	env.engine.mu.Lock()
+	got := env.engine.webhooks["/hooks/pipe"]
+	env.engine.mu.Unlock()
+	if got != "wp" {
+		t.Fatalf("webhook path not claimed by pipeline: got %q, want wp", got)
+	}
+}
+
 func TestValidatePipelineRefs(t *testing.T) {
 	env := newTestEnv(t)
 	stage := &task.Spec{ID: "stage-a", Name: "A", Enabled: true,

--- a/pkg/webui/auth.go
+++ b/pkg/webui/auth.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/dicode/dicode/pkg/ipc"
+	"github.com/dicode/dicode/pkg/task"
 	"go.uber.org/zap"
 )
 
@@ -21,8 +22,21 @@ import (
 func (s *Server) webhookAuthGuard(w http.ResponseWriter, r *http.Request, next http.Handler) {
 	var requiresAuth bool
 	var bestLen = -1
-	for _, spec := range s.registry.All() {
-		wp := spec.Trigger.Webhook
+	// Consider every task kind: a kind: PipelineTask can also carry a webhook
+	// trigger with auth: true, and its protection must be enforced here just
+	// like a kind: Task's. Using AllKinded (not All) is what keeps a pipeline
+	// webhook from being silently public.
+	for _, k := range s.registry.AllKinded() {
+		var wp string
+		var auth bool
+		switch t := k.(type) {
+		case *task.Spec:
+			wp, auth = t.Trigger.Webhook, t.Trigger.WebhookAuth
+		case *task.PipelineTask:
+			wp, auth = t.Trigger.Webhook, t.Trigger.WebhookAuth
+		default:
+			continue
+		}
 		if wp == "" || !ipc.PathMatches(wp, r.URL.Path) {
 			continue
 		}
@@ -32,7 +46,7 @@ func (s *Server) webhookAuthGuard(w http.ResponseWriter, r *http.Request, next h
 		l := len(strings.TrimSuffix(wp, "/"))
 		if l > bestLen {
 			bestLen = l
-			requiresAuth = spec.Trigger.WebhookAuth
+			requiresAuth = auth
 		}
 	}
 

--- a/pkg/webui/auth_test.go
+++ b/pkg/webui/auth_test.go
@@ -570,6 +570,45 @@ func TestWebhookAuthGuard_LongestPrefixWins(t *testing.T) {
 	}
 }
 
+// TestWebhookAuthGuard_PipelineAuth guards against the auth bypass where a
+// kind: PipelineTask webhook with auth: true was silently public because the
+// guard only consulted registry.All() (kind: Task). A pipeline declaring
+// auth: true must require a session just like a kind: Task webhook.
+func TestWebhookAuthGuard_PipelineAuth(t *testing.T) {
+	srv := newAuthServer(t, "hunter2")
+
+	if err := srv.registry.Register(&task.PipelineTask{
+		ID:      "deploy-pipe",
+		Trigger: task.PipelineTrigger{Webhook: "/hooks/deploy", WebhookAuth: true},
+	}); err != nil {
+		t.Fatalf("register protected pipeline: %v", err)
+	}
+	if err := srv.registry.Register(&task.PipelineTask{
+		ID:      "public-pipe",
+		Trigger: task.PipelineTrigger{Webhook: "/hooks/public", WebhookAuth: false},
+	}); err != nil {
+		t.Fatalf("register public pipeline: %v", err)
+	}
+
+	h := srv.Handler()
+
+	// Protected pipeline webhook: rejected without a session.
+	req := httptest.NewRequest(http.MethodPost, "/hooks/deploy", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("POST /hooks/deploy (pipeline auth:true) without session: expected 401, got %d", w.Code)
+	}
+
+	// Public pipeline webhook: must NOT be turned into a protected one.
+	req = httptest.NewRequest(http.MethodPost, "/hooks/public", nil)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code == http.StatusUnauthorized {
+		t.Errorf("POST /hooks/public (pipeline auth:false): expected pass-through, got 401")
+	}
+}
+
 // TestWebhookAuthGuard_LongestPrefixWins_Inverse is the symmetric case:
 // the SHORT webhook is protected and the LONG one is public. Longest-prefix
 // must still win — i.e. a request to the long path must pass through


### PR DESCRIPTION
## Summary

PR3 of the **kind: PipelineTask** epic (successor to PR1 #339, PR2 #340). Makes registered pipelines actually run. A `PipelineRunner` creates the parent run (`kind=pipeline`), fires each stage sequentially as a `pipeline-stage` child linked to the parent, threads `${input.output}` between stages, short-circuits on the first failure, and records the terminal stage's return as the pipeline's own. All four trigger types route to it.

- **`pipeline-stage` trigger source** for stage runs (groups them under the parent in the WebUI).
- **`PipelineRunner`** + **`fireKinded`**: `FireManual`/`FireFromTask` resolve via `GetKinded` and route pipelines to `firePipeline`, plain tasks to `fireAsync`.
- **Cron/webhook**: unified through a shared `scheduleCron` primitive and `registerWebhookPath`; the webhook dispatcher routes a pipeline path to `handlePipelineWebhook` (HMAC via the shared `verifyWebhookSignatureSecret` core).
- **Chain (both directions)**: `FireChain` scans pipeline-kind tasks for a `trigger.chain.from` match and fires them; `PipelineRunner.finish` calls `FireChain` so downstream tasks can chain from a pipeline's outcome.
- **#341 mitigation**: `firePipeline` re-validates stage refs against the live registry before creating any run row, so manual/chain fires (which reach it via `GetKinded`, bypassing engine registration) never dispatch a pipeline whose stages are missing — closes the "engine-rejected pipeline silently never runs" gap from #340 review.

Maps to plan Tasks 13–17 (`docs/superpowers/plans/2026-05-18-pipeline-task-plan.md`).

### Deviations from the plan (deliberate)
- The pipeline's return value is persisted via `registry.SetRunResult` (DB column) instead of the plan's in-memory `runReturnValue.Store`, which would have leaked an entry that never gets TTL-cleaned (the parent run has no `startRun` cleanup).
- Cron/webhook registration was **unified** (shared `scheduleCron`/`registerWebhookPath`/`verifyWebhookSignatureSecret`) rather than cloning the kind: Task bodies, keeping the kind: Task path behavior-identical.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./...` green; `go test -race ./pkg/trigger/... ./pkg/registry/...` green
- [x] New tests: `TestPipelineRunnerSequential` (+`${input.output}` threading), `TestPipelineCronRegistered`, `TestPipelineWebhookRegistered`, `TestChainFiresPipeline`, `TestPipelineFiresChain`, `TestE2E_PipelineTask_RealDeno` (real Deno: buildin/template → write-local, asserts file output + pipeline-stage children)

Closes #341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)