### PR TITLE
feat(trigger): re-run propagation + daemon-terminal-stage lifetime (PR4/8)

### DIFF
--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -113,6 +113,14 @@ type Engine struct {
 	// driven restarts. See daemon_state.go for the coalescing rationale.
 	restartGates *restartGate
 
+	// livePipelines tracks PipelineRunners whose terminal daemon stage is
+	// currently running — i.e. the pipeline parent run is 'running' for the
+	// daemon's lifetime. Keyed by pipeline task ID. Guarded by livePipelineMu
+	// (separate from daemonMu so a lookup never blocks on a long daemon
+	// dispatch holding daemonMu).
+	livePipelineMu sync.Mutex
+	livePipelines  map[string]*PipelineRunner
+
 	defaultsOnFailureChain task.OnFailureChainSpec // from config.Defaults.OnFailureChain
 
 	db db.DB // optional — enables cron-job persistence and missed-run catchup
@@ -166,17 +174,18 @@ type PythonRuntimeAPI interface {
 // New creates a trigger Engine with a default Deno executor.
 func New(r *registry.Registry, defaultExec pkgruntime.Executor, log *zap.Logger) *Engine {
 	e := &Engine{
-		registry:     r,
-		executors:    make(map[task.Runtime]pkgruntime.Executor),
-		cron:         cron.New(),
-		log:          log,
-		cronEntries:  make(map[string]cron.EntryID),
-		webhooks:     make(map[string]string),
-		daemonRuns:   make(map[string]string),
-		daemonSpecs:  make(map[string]*task.Spec),
-		daemonStates: newDaemonStateMap(),
-		restartGates: newRestartGate(),
-		guards:       newChainGuards(),
+		registry:      r,
+		executors:     make(map[task.Runtime]pkgruntime.Executor),
+		cron:          cron.New(),
+		log:           log,
+		cronEntries:   make(map[string]cron.EntryID),
+		webhooks:      make(map[string]string),
+		daemonRuns:    make(map[string]string),
+		daemonSpecs:   make(map[string]*task.Spec),
+		daemonStates:  newDaemonStateMap(),
+		restartGates:  newRestartGate(),
+		livePipelines: make(map[string]*PipelineRunner),
+		guards:        newChainGuards(),
 	}
 	e.executors[task.RuntimeDeno] = defaultExec
 	return e

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -110,14 +110,19 @@ type Engine struct {
 	daemonStates *daemonStateMap
 
 	// restartGates is a per-daemon at-most-one-in-flight lock for prereq-
-	// driven restarts. See daemon_state.go for the coalescing rationale.
+	// driven restarts. See daemon_state.go for the coalescing rationale. Also
+	// reused by handlePipelineStageRerun, keyed by pipeline ID, so a flurry of
+	// mid-pipeline stage re-fires coalesces to at most one outstanding
+	// propagation per pipeline.
 	restartGates *restartGate
 
 	// livePipelines tracks PipelineRunners whose terminal daemon stage is
 	// currently running — i.e. the pipeline parent run is 'running' for the
-	// daemon's lifetime. Keyed by pipeline task ID. Guarded by livePipelineMu
-	// (separate from daemonMu so a lookup never blocks on a long daemon
-	// dispatch holding daemonMu).
+	// daemon's lifetime. Keyed by pipeline task ID. handlePipelineStageRerun
+	// consults this to find which live pipelines contain a just-completed stage
+	// task and need their descendants replayed + daemon restarted. Guarded by
+	// livePipelineMu (separate from daemonMu so a stage-rerun scan never blocks
+	// on a long daemon dispatch holding daemonMu).
 	livePipelineMu sync.Mutex
 	livePipelines  map[string]*PipelineRunner
 
@@ -1448,6 +1453,11 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 	// commit and tests for the rationale.
 	if runStatus == registry.StatusSuccess {
 		e.notifyPrereqCompletion(completedTaskID, output)
+		// PipelineTask analogue: when a task that is a stage of a *live*
+		// pipeline (terminal daemon stage running) re-fires successfully,
+		// replay the descendant stages with fresh ${input} and restart the
+		// terminal daemon so it picks up the freshly-rendered descendants.
+		e.handlePipelineStageRerun(completedTaskID, output)
 	}
 	// Shared resolver context for both the success-chain and
 	// on_failure_chain dispatch paths below. The full upstream return

--- a/pkg/trigger/pipeline_runner.go
+++ b/pkg/trigger/pipeline_runner.go
@@ -20,10 +20,11 @@ import (
 // fire.
 //
 // When the terminal stage is a daemon, the runner becomes "live" for the
-// daemon's lifetime: it registers itself in Engine.livePipelines and records
-// the terminal stage's position, the upstream context that fed it, and the
-// current daemon run ID under mu (mu guards them because a future mid-pipeline
-// re-fire path — PR4 Task 19 — reads them from another goroutine).
+// daemon's lifetime: it registers itself in Engine.livePipelines (so a
+// mid-pipeline stage re-fire — handlePipelineStageRerun — can find it) and
+// records the terminal stage's position, the upstream context that fed it, and
+// the current daemon run ID under mu. Those fields are read+written from both
+// the runner goroutine and the re-fire goroutine, hence the mutex.
 type PipelineRunner struct {
 	engine *Engine
 	spec   *task.PipelineTask
@@ -33,12 +34,21 @@ type PipelineRunner struct {
 
 	mu sync.Mutex
 	// live-daemon-terminal-stage state, set once the terminal daemon stage is
-	// fired. All guarded by mu.
+	// fired and read by handlePipelineStageRerun. All guarded by mu.
 	terminalIdx      int               // index of the terminal stage in spec.Stages
-	terminalStage    task.Stage        // the terminal daemon stage
+	terminalStage    task.Stage        // the terminal daemon stage (re-fired on restart)
 	terminalUpstream task.InputContext // the upstream ${input} that fed the terminal stage
 	daemonRunID      string            // current terminal daemon stage run ID
-	finished         bool              // set by finish()
+	finished         bool              // set by finish(); blocks late re-fires
+
+	// restart coordination between the terminal-daemon wait loop
+	// (runTerminalDaemon) and a mid-pipeline re-fire (propagatePipelineStageRerun).
+	// When a re-fire begins it sets restarting=true (under mu) BEFORE killing the
+	// current daemon run, so when the wait loop's WaitRun returns it knows the
+	// terminal was a deliberate restart (not a real exit) and blocks on
+	// restartDone until the new daemon run is published (or the restart aborts).
+	restarting  bool
+	restartDone chan struct{} // closed by the re-fire when it publishes the new run / aborts
 }
 
 // firePipeline creates the pipeline's parent run row (kind=pipeline) and starts
@@ -141,16 +151,18 @@ func (r *PipelineRunner) run(ctx context.Context) {
 }
 
 // runTerminalDaemon ties the pipeline's lifetime to a daemon terminal stage's
-// run. It registers the pipeline as "live", records the daemon run ID + the
-// upstream context that fed the terminal stage, then blocks on the daemon's
-// terminal state and finishes the pipeline with the daemon's *actual* status.
+// run. It registers the pipeline as "live" (so a mid-pipeline stage re-fire can
+// find it via handlePipelineStageRerun), records the daemon run ID + the
+// upstream context that fed the terminal stage (needed to replay descendants and
+// restart on re-fire), then blocks on the daemon's terminal state and finishes
+// the pipeline with the daemon's *actual* status.
 //
 // A KillRun on the pipeline parent (which cancels runCtx) is propagated to the
-// daemon stage run by the runCtx watcher below — the daemon's own run then
-// transitions to its cancelled terminal, which becomes the pipeline's.
+// daemon stage run by waitDaemonRun's runCtx watcher — the daemon's own run
+// then transitions to its cancelled terminal, which becomes the pipeline's.
 //
-// stageIdx/stage/upstream are recorded for the mid-pipeline re-fire path added
-// in PR4 Task 19.
+// stageIdx/stage are recorded so handlePipelineStageRerun knows where the
+// terminal stage sits and how to re-fire it.
 func (r *PipelineRunner) runTerminalDaemon(stageIdx int, stage task.Stage, upstream task.InputContext, daemonRunID string) {
 	e := r.engine
 	r.mu.Lock()
@@ -164,37 +176,87 @@ func (r *PipelineRunner) runTerminalDaemon(stageIdx int, stage task.Stage, upstr
 	defer e.unregisterLivePipeline(r.spec.ID, r)
 
 	// Propagate a pipeline-parent KillRun (runCtx cancellation) into the
-	// terminal daemon run so the daemon's own run reaches its cancelled
-	// terminal and that status flows up. Stop the watcher when we return.
+	// CURRENT terminal daemon run. The watcher re-reads daemonRunID under mu so
+	// it kills whichever run is live after a mid-pipeline restart swap. Stop it
+	// when the loop exits.
 	watchDone := make(chan struct{})
 	defer close(watchDone)
 	go func() {
 		select {
 		case <-r.runCtx.Done():
-			e.KillRun(daemonRunID)
+			r.mu.Lock()
+			cur := r.daemonRunID
+			r.mu.Unlock()
+			e.KillRun(cur)
 		case <-watchDone:
 		}
 	}()
 
-	// Block on the daemon run's terminal state with a background context so the
-	// daemon's lifetime — not the trigger call's context — governs when the
-	// pipeline finishes. Finish the pipeline with the daemon's *actual* status.
-	res, werr := e.WaitRun(context.Background(), daemonRunID)
-	status := res.Status
-	ret := res.ReturnValue
-	if werr != nil {
-		// WaitRun with a background context only errors on a pathological
-		// internal failure (never ctx cancellation). Surface it loudly and
-		// stop the orphaned daemon subprocess.
-		e.log.Error("pipeline terminal daemon wait failed",
-			zap.String("pipeline", r.spec.ID),
-			zap.String("daemon_run", daemonRunID),
-			zap.Error(werr))
-		e.KillRun(daemonRunID)
-		status = registry.StatusFailure
-		ret = nil
+	// Loop: wait on the current daemon run. When it terminates, either it was a
+	// deliberate mid-pipeline restart (restarting==true → wait for the new run
+	// and loop) or a real exit (→ finish the pipeline with the daemon's status).
+	for {
+		r.mu.Lock()
+		current := r.daemonRunID
+		r.mu.Unlock()
+
+		res, werr := e.WaitRun(context.Background(), current)
+		status := res.Status
+		ret := res.ReturnValue
+		if werr != nil {
+			// WaitRun with a background context only errors on a pathological
+			// internal failure (never ctx cancellation). Surface it loudly and
+			// stop the orphaned daemon subprocess.
+			e.log.Error("pipeline terminal daemon wait failed",
+				zap.String("pipeline", r.spec.ID),
+				zap.String("daemon_run", current),
+				zap.Error(werr))
+			e.KillRun(current)
+			status = registry.StatusFailure
+			ret = nil
+		}
+
+		// Decide whether this terminal was a deliberate mid-pipeline restart.
+		// The checks must be ordered to be robust regardless of how far the
+		// re-fire's handshake has progressed by the time we wake:
+		//
+		//  1. daemonRunID already advanced past `current` → the re-fire has
+		//     published the new run (and may have already cleared restarting);
+		//     loop and wait on the new run.
+		//  2. restarting==true but daemonRunID still == current → a re-fire is
+		//     in flight but hasn't published yet; block on restartDone, then
+		//     re-decide (it either published a new run or aborted).
+		//  3. otherwise → a real exit; finish the pipeline with this status.
+		//
+		// Checking daemonRunID before restarting closes the race where the
+		// re-fire completes the whole handshake (publish + clear restarting +
+		// close restartDone) before this goroutine is scheduled.
+		r.mu.Lock()
+		if r.daemonRunID != current {
+			r.mu.Unlock()
+			continue
+		}
+		if r.restarting {
+			done := r.restartDone
+			r.mu.Unlock()
+			<-done // closed by propagatePipelineStageRerun when the new run is published / restart aborted
+			r.mu.Lock()
+			if r.daemonRunID != current {
+				// Restart published a new run; wait on it.
+				r.mu.Unlock()
+				continue
+			}
+			// Restart aborted (descendant failed / shutting down): daemonRunID
+			// still points at the killed run. Finish with its terminal status.
+			r.mu.Unlock()
+			r.finish(status, "", ret)
+			return
+		}
+		r.mu.Unlock()
+
+		r.finish(status, "", ret)
+		return
 	}
-	r.finish(status, "", ret)
 }
 
 // fireStageRaw resolves the stage's overrides + ${input.*} references against
@@ -313,10 +375,11 @@ func (r *PipelineRunner) finish(status, reason string, ret interface{}) {
 	}
 }
 
-// registerLivePipeline records a runner whose terminal daemon stage is up.
-// Keyed by pipeline ID; the latest fire wins (a pipeline only has one live
-// daemon-terminal fire at a time). The mid-pipeline re-fire path (PR4 Task 19)
-// consumes this set.
+// registerLivePipeline records a runner whose terminal daemon stage is up, so
+// handlePipelineStageRerun can find it. Keyed by pipeline ID; the latest fire
+// wins (restart coalescing via restartGates ensures at most one in-flight
+// re-fire per pipeline, and a pipeline only has one live daemon-terminal fire
+// at a time).
 func (e *Engine) registerLivePipeline(r *PipelineRunner) {
 	e.livePipelineMu.Lock()
 	e.livePipelines[r.spec.ID] = r
@@ -333,4 +396,256 @@ func (e *Engine) unregisterLivePipeline(pipelineID string, r *PipelineRunner) {
 		delete(e.livePipelines, pipelineID)
 	}
 	e.livePipelineMu.Unlock()
+}
+
+// pipelineContainsStage reports whether the pipeline lists taskID as a stage.
+func pipelineContainsStage(p *task.PipelineTask, taskID string) bool {
+	for _, st := range p.Stages {
+		if st.Task == taskID {
+			return true
+		}
+	}
+	return false
+}
+
+// handlePipelineStageRerun is the post-success hook the engine calls from
+// FireChain when ANY kind: Task finishes with status=success. It is the
+// PipelineTask analogue of notifyPrereqCompletion → propagateBeforeRerun.
+//
+// For each registered kind: PipelineTask that (a) lists completedTaskID as a
+// stage and (b) is currently *live* (terminal daemon stage running, tracked in
+// livePipelines), it replays the stages AFTER the completed one with fresh
+// ${input} (seeded from the re-fired stage's output) and then restarts the
+// terminal daemon so it picks up the freshly-rendered descendants.
+//
+// Coalescing + shutdown/unregister handling mirror propagateBeforeRerun exactly:
+// restartGates.tryAcquire (keyed by pipeline ID) → defer release → bail on
+// shutdown / not-live → descendant loop with per-iteration re-checks → kill+wait
+// the old daemon run → re-fire the terminal daemon stage.
+func (e *Engine) handlePipelineStageRerun(completedTaskID string, output interface{}) {
+	for _, k := range e.registry.AllKinded() {
+		p, ok := k.(*task.PipelineTask)
+		if !ok {
+			continue
+		}
+		if !pipelineContainsStage(p, completedTaskID) {
+			continue
+		}
+		// Only live pipelines (terminal daemon stage running) are eligible.
+		// A re-fire of a stage in a pipeline that isn't currently running its
+		// terminal daemon has nothing to propagate to.
+		e.livePipelineMu.Lock()
+		runner := e.livePipelines[p.ID]
+		e.livePipelineMu.Unlock()
+		if runner == nil {
+			continue
+		}
+		e.propagatePipelineStageRerun(runner, completedTaskID, output)
+	}
+}
+
+// propagatePipelineStageRerun replays the descendants of a re-fired pipeline
+// stage and restarts the terminal daemon. Structurally mirrors
+// propagateBeforeRerun (daemon_state.go): coalesce via restartGates, bail on
+// shutdown / the pipeline no longer being live, replay descendants with fresh
+// ${input}, then kill+wait the old daemon run and re-fire the terminal stage.
+func (e *Engine) propagatePipelineStageRerun(runner *PipelineRunner, reranTaskID string, reranReturn interface{}) {
+	pipelineID := runner.spec.ID
+	if !e.restartGates.tryAcquire(pipelineID) {
+		// A propagation/restart is already queued or in flight; coalesce.
+		e.log.Debug("pipeline stage re-fire coalesced", zap.String("pipeline", pipelineID))
+		return
+	}
+	go func() {
+		defer e.restartGates.release(pipelineID)
+
+		// Find the re-fired stage's index in the pipeline's stages.
+		startIdx := -1
+		for i, st := range runner.spec.Stages {
+			if st.Task == reranTaskID {
+				startIdx = i
+				break
+			}
+		}
+		if startIdx < 0 {
+			// Defensive: handlePipelineStageRerun already verified membership.
+			return
+		}
+
+		// Bail if the engine is shutting down or the pipeline is no longer
+		// live (its terminal daemon already exited / the pipeline finished)
+		// between the liveness check and this goroutine being scheduled.
+		// Mirrors propagateBeforeRerun's canonical guard.
+		if e.isShuttingDown() {
+			e.log.Debug("pipeline stage re-fire skipped: engine shutting down",
+				zap.String("pipeline", pipelineID))
+			return
+		}
+		if !e.pipelineStillLive(pipelineID, runner) {
+			e.log.Debug("pipeline stage re-fire skipped: pipeline no longer live",
+				zap.String("pipeline", pipelineID))
+			return
+		}
+
+		runner.mu.Lock()
+		terminalIdx := runner.terminalIdx
+		terminalStage := runner.terminalStage
+		oldDaemonRunID := runner.daemonRunID
+		storedUpstream := runner.terminalUpstream
+		runner.mu.Unlock()
+
+		e.log.Info("pipeline mid-stage re-fire: propagating to descendants",
+			zap.String("pipeline", pipelineID),
+			zap.String("rerun", reranTaskID),
+			zap.Int("stage", startIdx),
+			// Non-terminal descendants replayed below [startIdx+1 .. terminalIdx-1];
+			// the terminal daemon stage is restarted separately.
+			zap.Int("replayed_descendants", terminalIdx-startIdx-1),
+		)
+
+		// Replay the NON-terminal descendants [startIdx+1 .. terminalIdx-1]
+		// with fresh ${input}, seeded from the re-fired stage's return value.
+		// The terminal stage itself is restarted separately below (it's the
+		// daemon). Use the engine's shutdown-cancellable context so an
+		// in-flight stage bails on Shutdown; the between-iteration guards only
+		// catch the gaps, not a stage already inside Execute.
+		stageCtx := e.getShutdownCtx()
+		if stageCtx == nil {
+			stageCtx = context.Background()
+		}
+		// upstream is what feeds the FIRST replayed descendant. When the
+		// re-fired stage is the terminal daemon stage itself (startIdx ==
+		// terminalIdx — an operator restarting the daemon's own task), there
+		// are no descendants to replay and the terminal stage keeps the
+		// upstream that originally fed it; re-seeding it with the daemon's own
+		// return would be wrong. Otherwise the first descendant is fed by the
+		// re-fired stage's fresh return value.
+		upstream := task.InputContext{Output: reranReturn}
+		if startIdx >= terminalIdx {
+			upstream = storedUpstream
+		}
+		for i := startIdx + 1; i < terminalIdx; i++ {
+			if e.isShuttingDown() {
+				e.log.Debug("pipeline stage re-fire aborted: engine shutting down",
+					zap.String("pipeline", pipelineID), zap.Int("stage", i))
+				return
+			}
+			if !e.pipelineStillLive(pipelineID, runner) {
+				e.log.Debug("pipeline stage re-fire aborted: pipeline no longer live",
+					zap.String("pipeline", pipelineID), zap.Int("stage", i))
+				return
+			}
+			out, err := e.dispatchStage(stageCtx, runner.spec.Stages[i], upstream, runner.runID)
+			if err != nil {
+				e.log.Warn("pipeline mid-stage re-fire: descendant stage failed; pipeline left on old daemon",
+					zap.String("pipeline", pipelineID), zap.Int("stage", i), zap.Error(err))
+				return
+			}
+			upstream = out
+		}
+
+		// Last guard before restarting the daemon: the pipeline could have
+		// finished (terminal daemon exited) or the engine started shutting
+		// down while we replayed descendants.
+		if e.isShuttingDown() {
+			e.log.Debug("pipeline stage re-fire restart skipped: engine shutting down",
+				zap.String("pipeline", pipelineID))
+			return
+		}
+		if !e.pipelineStillLive(pipelineID, runner) {
+			e.log.Debug("pipeline stage re-fire restart skipped: pipeline no longer live",
+				zap.String("pipeline", pipelineID))
+			return
+		}
+
+		// Enter the restart handshake. Setting restarting=true + a fresh
+		// restartDone BEFORE killing the old run tells the runner's wait loop
+		// that the imminent terminal of oldDaemonRunID is a deliberate restart,
+		// not a real exit — so it blocks on restartDone instead of finishing
+		// the pipeline. We MUST resolve the handshake (publish the new run or
+		// clear restarting) on every exit path from here, or the wait loop
+		// blocks forever; the deferred cleanup below guarantees that.
+		restartDone := make(chan struct{})
+		runner.mu.Lock()
+		runner.restarting = true
+		runner.restartDone = restartDone
+		runner.mu.Unlock()
+
+		published := false
+		defer func() {
+			// If we exit before publishing the new run (descendant of the
+			// restart phase failed), leave daemonRunID pointing at the old
+			// (now-killed) run and clear restarting; the wait loop detects the
+			// unchanged run ID and finishes the pipeline with the killed
+			// daemon's status. Closing restartDone unblocks it.
+			if !published {
+				runner.mu.Lock()
+				runner.restarting = false
+				runner.mu.Unlock()
+			}
+			close(restartDone)
+		}()
+
+		// Kill the current terminal daemon run and wait for it to drain.
+		// Mirrors propagateBeforeRerun: KillRun(old) + bounded WaitRun(old).
+		if oldDaemonRunID != "" {
+			e.KillRun(oldDaemonRunID)
+			waitCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			_, _ = e.WaitRun(waitCtx, oldDaemonRunID)
+			cancel()
+		}
+
+		// Re-fire the terminal daemon stage with the freshly-replayed upstream.
+		newRunID, isDaemon, ferr := e.fireStageRaw(stageCtx, terminalStage, upstream, runner.runID)
+		if ferr != nil {
+			e.log.Error("pipeline mid-stage re-fire: terminal daemon restart failed",
+				zap.String("pipeline", pipelineID), zap.Error(ferr))
+			return
+		}
+		if !isDaemon {
+			// Defensive: the terminal stage was a daemon when we registered as
+			// live; a registry mutation could in principle flip it. Stop the
+			// stray run rather than leaving it untracked, and let the wait loop
+			// finish the pipeline on the old (killed) daemon's status.
+			e.log.Warn("pipeline mid-stage re-fire: terminal stage no longer a daemon after restart; stopping stray run",
+				zap.String("pipeline", pipelineID))
+			e.KillRun(newRunID)
+			return
+		}
+
+		// Publish the new daemon run + upstream so the runner's wait loop
+		// re-waits on it. Clear restarting under the same lock so the loop sees
+		// a consistent snapshot. If the pipeline finished while we were
+		// restarting (e.g. an operator KillRun on the parent during the
+		// restart window), don't publish an untracked run — kill the fresh
+		// daemon so its subprocess doesn't leak.
+		runner.mu.Lock()
+		if runner.finished {
+			runner.mu.Unlock()
+			e.log.Debug("pipeline stage re-fire: pipeline finished during restart; stopping fresh daemon run",
+				zap.String("pipeline", pipelineID))
+			e.KillRun(newRunID)
+			return
+		}
+		runner.daemonRunID = newRunID
+		runner.terminalUpstream = upstream
+		runner.restarting = false
+		runner.mu.Unlock()
+		published = true
+	}()
+}
+
+// pipelineStillLive reports whether the given runner is still the live
+// registration for pipelineID AND has not yet finished. Used as the
+// propagation-loop guard (analogue of daemonRegistered for the daemon path).
+func (e *Engine) pipelineStillLive(pipelineID string, r *PipelineRunner) bool {
+	e.livePipelineMu.Lock()
+	cur := e.livePipelines[pipelineID]
+	e.livePipelineMu.Unlock()
+	if cur != r {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return !r.finished
 }

--- a/pkg/trigger/pipeline_runner.go
+++ b/pkg/trigger/pipeline_runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/dicode/dicode/pkg/registry"
@@ -16,12 +17,28 @@ import (
 
 // PipelineRunner orchestrates one fire of a kind: PipelineTask. It owns the
 // pipeline's parent run row and drives its stages sequentially. One runner per
-// fire; it holds no state beyond the in-flight pipeline.
+// fire.
+//
+// When the terminal stage is a daemon, the runner becomes "live" for the
+// daemon's lifetime: it registers itself in Engine.livePipelines and records
+// the terminal stage's position, the upstream context that fed it, and the
+// current daemon run ID under mu (mu guards them because a future mid-pipeline
+// re-fire path — PR4 Task 19 — reads them from another goroutine).
 type PipelineRunner struct {
 	engine *Engine
 	spec   *task.PipelineTask
 	runID  string             // the pipeline's own parent run ID
 	cancel context.CancelFunc // cancels runCtx; invoked on finish + by KillRun
+	runCtx context.Context    // the pipeline's lifecycle context (cancelled by KillRun/finish)
+
+	mu sync.Mutex
+	// live-daemon-terminal-stage state, set once the terminal daemon stage is
+	// fired. All guarded by mu.
+	terminalIdx      int               // index of the terminal stage in spec.Stages
+	terminalStage    task.Stage        // the terminal daemon stage
+	terminalUpstream task.InputContext // the upstream ${input} that fed the terminal stage
+	daemonRunID      string            // current terminal daemon stage run ID
+	finished         bool              // set by finish()
 }
 
 // firePipeline creates the pipeline's parent run row (kind=pipeline) and starts
@@ -51,7 +68,7 @@ func (e *Engine) firePipeline(ctx context.Context, p *task.PipelineTask, opts pk
 	e.runCancels.Store(runID, cancel)
 	e.runTriggerSource.Store(runID, source)
 	e.runDone.Store(runID, make(chan struct{}))
-	r := &PipelineRunner{engine: e, spec: p, runID: runID, cancel: cancel}
+	r := &PipelineRunner{engine: e, spec: p, runID: runID, cancel: cancel, runCtx: runCtx}
 	go r.run(runCtx)
 	return runID, nil
 }
@@ -69,6 +86,43 @@ func (r *PipelineRunner) run(ctx context.Context) {
 	var upstream task.InputContext
 	var lastReturn interface{}
 	for i, st := range r.spec.Stages {
+		isTerminal := i == len(r.spec.Stages)-1
+
+		// Terminal daemon stage: the pipeline's lifetime is the daemon's
+		// lifetime. Fire the daemon stage WITHOUT the wait-to-success gate,
+		// leave the pipeline 'running', then block on the daemon run's
+		// terminal state and finish the pipeline with the daemon's *actual*
+		// status (not a coerced failure). Daemon-ness is decided from the
+		// merged dispatch spec inside fireStageRaw — a stage trigger override
+		// could flip daemon either way.
+		if isTerminal {
+			runID, isDaemon, err := e.fireStageRaw(ctx, st, upstream, r.runID)
+			if err != nil {
+				reason := fmt.Sprintf("stage %d (%s): %s", i, st.Task, err.Error())
+				e.log.Warn("pipeline terminal stage dispatch failed; pipeline failed",
+					zap.String("pipeline", r.spec.ID), zap.Int("stage", i),
+					zap.String("task", st.Task), zap.Error(err))
+				r.finish(registry.StatusFailure, reason, nil)
+				return
+			}
+			if isDaemon {
+				r.runTerminalDaemon(i, st, upstream, runID)
+				return
+			}
+			// Terminal non-daemon stage: wait to terminal as usual.
+			out, werr := e.awaitStageSuccess(ctx, runID)
+			if werr != nil {
+				reason := fmt.Sprintf("stage %d (%s): %s", i, st.Task, werr.Error())
+				e.log.Warn("pipeline stage failed; pipeline failed",
+					zap.String("pipeline", r.spec.ID), zap.Int("stage", i),
+					zap.String("task", st.Task), zap.Error(werr))
+				r.finish(registry.StatusFailure, reason, nil)
+				return
+			}
+			r.finish(registry.StatusSuccess, "", out.Output)
+			return
+		}
+
 		out, err := e.dispatchStage(ctx, st, upstream, r.runID)
 		if err != nil {
 			reason := fmt.Sprintf("stage %d (%s): %s", i, st.Task, err.Error())
@@ -81,17 +135,82 @@ func (r *PipelineRunner) run(ctx context.Context) {
 		upstream = out
 		lastReturn = out.Output
 	}
+	// Reachable only for an empty-stages pipeline (Validate rejects that), but
+	// keep the success terminal for completeness.
 	r.finish(registry.StatusSuccess, "", lastReturn)
 }
 
-// dispatchStage resolves the stage's overrides + ${input.*} references against
-// the upstream stage's output, fires the stage as a kind: Task child of the
-// pipeline run, and blocks until it reaches a terminal state. It returns the
-// stage's InputContext for the next stage.
-func (e *Engine) dispatchStage(ctx context.Context, st task.Stage, upstream task.InputContext, parentRunID string) (task.InputContext, error) {
+// runTerminalDaemon ties the pipeline's lifetime to a daemon terminal stage's
+// run. It registers the pipeline as "live", records the daemon run ID + the
+// upstream context that fed the terminal stage, then blocks on the daemon's
+// terminal state and finishes the pipeline with the daemon's *actual* status.
+//
+// A KillRun on the pipeline parent (which cancels runCtx) is propagated to the
+// daemon stage run by the runCtx watcher below — the daemon's own run then
+// transitions to its cancelled terminal, which becomes the pipeline's.
+//
+// stageIdx/stage/upstream are recorded for the mid-pipeline re-fire path added
+// in PR4 Task 19.
+func (r *PipelineRunner) runTerminalDaemon(stageIdx int, stage task.Stage, upstream task.InputContext, daemonRunID string) {
+	e := r.engine
+	r.mu.Lock()
+	r.terminalIdx = stageIdx
+	r.terminalStage = stage
+	r.terminalUpstream = upstream
+	r.daemonRunID = daemonRunID
+	r.mu.Unlock()
+
+	e.registerLivePipeline(r)
+	defer e.unregisterLivePipeline(r.spec.ID, r)
+
+	// Propagate a pipeline-parent KillRun (runCtx cancellation) into the
+	// terminal daemon run so the daemon's own run reaches its cancelled
+	// terminal and that status flows up. Stop the watcher when we return.
+	watchDone := make(chan struct{})
+	defer close(watchDone)
+	go func() {
+		select {
+		case <-r.runCtx.Done():
+			e.KillRun(daemonRunID)
+		case <-watchDone:
+		}
+	}()
+
+	// Block on the daemon run's terminal state with a background context so the
+	// daemon's lifetime — not the trigger call's context — governs when the
+	// pipeline finishes. Finish the pipeline with the daemon's *actual* status.
+	res, werr := e.WaitRun(context.Background(), daemonRunID)
+	status := res.Status
+	ret := res.ReturnValue
+	if werr != nil {
+		// WaitRun with a background context only errors on a pathological
+		// internal failure (never ctx cancellation). Surface it loudly and
+		// stop the orphaned daemon subprocess.
+		e.log.Error("pipeline terminal daemon wait failed",
+			zap.String("pipeline", r.spec.ID),
+			zap.String("daemon_run", daemonRunID),
+			zap.Error(werr))
+		e.KillRun(daemonRunID)
+		status = registry.StatusFailure
+		ret = nil
+	}
+	r.finish(status, "", ret)
+}
+
+// fireStageRaw resolves the stage's overrides + ${input.*} references against
+// the upstream stage's output and fires the stage as a kind: Task child of the
+// pipeline run, returning the stage's run ID WITHOUT waiting for it to reach a
+// terminal state. It also reports whether the *merged* dispatch spec is a
+// daemon — a stage trigger override could flip daemon either way, so daemon-ness
+// is decided after applying overrides, not from the bare registry spec.
+//
+// dispatchStage = fireStageRaw + awaitStageSuccess; the terminal-daemon path in
+// run() uses fireStageRaw directly so it can leave the pipeline 'running' and
+// track the daemon run instead of gating on success.
+func (e *Engine) fireStageRaw(ctx context.Context, st task.Stage, upstream task.InputContext, parentRunID string) (string, bool, error) {
 	ref, ok := e.registry.Get(st.Task) // Get filters to kind: Task — stages are always Task
 	if !ok {
-		return task.InputContext{}, fmt.Errorf("stage task %q not registered", st.Task)
+		return "", false, fmt.Errorf("stage task %q not registered", st.Task)
 	}
 
 	dispatchSpec := ref
@@ -100,7 +219,7 @@ func (e *Engine) dispatchStage(ctx context.Context, st task.Stage, upstream task
 		if st.Overrides.Params != nil {
 			resolved, rerr := task.ResolveInputOutputList(st.Overrides.Params, upstream)
 			if rerr != nil {
-				return task.InputContext{}, fmt.Errorf("resolve input refs: %w", rerr)
+				return "", false, fmt.Errorf("resolve input refs: %w", rerr)
 			}
 			ovCopy := *st.Overrides
 			ovCopy.Params = resolved
@@ -108,15 +227,23 @@ func (e *Engine) dispatchStage(ctx context.Context, st task.Stage, upstream task
 		}
 		merged := taskset.ApplyOverrides(ref, ovPtr)
 		if vErr := merged.Validate(); vErr != nil {
-			return task.InputContext{}, fmt.Errorf("overrides produce invalid spec: %w", vErr)
+			return "", false, fmt.Errorf("overrides produce invalid spec: %w", vErr)
 		}
 		dispatchSpec = merged
 	}
 
 	runID, err := e.fireAsync(ctx, dispatchSpec, pkgruntime.RunOptions{ParentRunID: parentRunID}, registry.TriggerPipelineStage)
 	if err != nil {
-		return task.InputContext{}, fmt.Errorf("dispatch: %w", err)
+		return "", false, fmt.Errorf("dispatch: %w", err)
 	}
+	return runID, dispatchSpec.Trigger.Daemon, nil
+}
+
+// awaitStageSuccess blocks until the stage run reaches a terminal state and
+// returns its InputContext for the next stage. A non-success terminal (or a ctx
+// cancellation) is an error; on ctx cancellation it kills the orphaned stage
+// subprocess rather than leaving it running detached.
+func (e *Engine) awaitStageSuccess(ctx context.Context, runID string) (task.InputContext, error) {
 	res, werr := e.WaitRun(ctx, runID)
 	if werr != nil {
 		// ctx cancelled (pipeline timeout or KillRun on the parent) — stop the
@@ -134,11 +261,28 @@ func (e *Engine) dispatchStage(ctx context.Context, st task.Stage, upstream task
 	return task.InputContext{Output: res.ReturnValue}, nil
 }
 
+// dispatchStage resolves + fires a stage and blocks until it reaches a terminal
+// state, returning the stage's InputContext for the next stage. Used for
+// non-terminal stages (and as the success-gated composition of fireStageRaw +
+// awaitStageSuccess).
+func (e *Engine) dispatchStage(ctx context.Context, st task.Stage, upstream task.InputContext, parentRunID string) (task.InputContext, error) {
+	runID, _, err := e.fireStageRaw(ctx, st, upstream, parentRunID)
+	if err != nil {
+		return task.InputContext{}, err
+	}
+	return e.awaitStageSuccess(ctx, runID)
+}
+
 // finish marks the pipeline's parent run terminal and records the terminal
 // stage's return value as the pipeline's own return (persisted to the run row,
 // so chain consumers and WaitRun observe it — mirrors how runTask persists).
 func (r *PipelineRunner) finish(status, reason string, ret interface{}) {
 	e := r.engine
+	// Mark finished under mu so an in-flight handlePipelineStageRerun that has
+	// already passed its liveness check bails before touching a torn-down runner.
+	r.mu.Lock()
+	r.finished = true
+	r.mu.Unlock()
 	finishCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	if ret != nil {
@@ -167,4 +311,26 @@ func (r *PipelineRunner) finish(status, reason string, ret interface{}) {
 	if r.cancel != nil {
 		r.cancel()
 	}
+}
+
+// registerLivePipeline records a runner whose terminal daemon stage is up.
+// Keyed by pipeline ID; the latest fire wins (a pipeline only has one live
+// daemon-terminal fire at a time). The mid-pipeline re-fire path (PR4 Task 19)
+// consumes this set.
+func (e *Engine) registerLivePipeline(r *PipelineRunner) {
+	e.livePipelineMu.Lock()
+	e.livePipelines[r.spec.ID] = r
+	e.livePipelineMu.Unlock()
+}
+
+// unregisterLivePipeline removes a runner from the live set, but only if the
+// stored runner is still this one — a newer fire of the same pipeline ID may
+// have replaced it, and we must not clobber the newer registration when an old
+// runner's terminal daemon finally exits.
+func (e *Engine) unregisterLivePipeline(pipelineID string, r *PipelineRunner) {
+	e.livePipelineMu.Lock()
+	if e.livePipelines[pipelineID] == r {
+		delete(e.livePipelines, pipelineID)
+	}
+	e.livePipelineMu.Unlock()
 }

--- a/pkg/trigger/pipeline_runner_test.go
+++ b/pkg/trigger/pipeline_runner_test.go
@@ -93,6 +93,107 @@ func TestPipelineRunnerSequential(t *testing.T) {
 	}
 }
 
+// findStageChild polls a pipeline parent run's children for the named stage task
+// and returns it once observed in any state (or fails on timeout).
+func findStageChild(t *testing.T, env *testEnv, parentRunID, stageTaskID string, want string, timeout time.Duration) *registry.Run {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		kids, _ := env.reg.ListChildren(context.Background(), parentRunID, 20)
+		for _, c := range kids {
+			if c.TaskID != stageTaskID {
+				continue
+			}
+			if want == "" || c.Status == want {
+				return c
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("stage child %q (want status %q) not observed under %s", stageTaskID, want, timeout)
+	return nil
+}
+
+// TestPipelineDaemonTerminalStage asserts that a pipeline whose terminal stage
+// resolves to a trigger.daemon: true Task does NOT finish 'success' when the
+// daemon starts: it stays 'running' for the daemon's lifetime and finishes with
+// the daemon run's *actual* terminal status.
+//
+// Two behaviours are checked:
+//   - lifetime: while the daemon stage child is 'running', the pipeline parent
+//     is still 'running' (gated on the observable child-run state, not a sleep);
+//   - status fidelity: when the daemon run is killed (operator-style), the
+//     pipeline finishes with the daemon's terminal status ('cancelled'). The
+//     pre-Task-18 generic dispatchStage path would coerce any non-success
+//     terminal into a wrapped 'failure', so this distinguishes the new code.
+func TestPipelineDaemonTerminalStage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+	env := newTestEnv(t)
+	dir := t.TempDir()
+
+	stageA := writeTask(t, dir, "dts-a",
+		`export default async function main() { return "from-a" }`,
+		task.TriggerConfig{Manual: true})
+	// Terminal stage is a daemon: it stays up until killed. restart:never so a
+	// kill doesn't loop.
+	stageB := writeTask(t, dir, "dts-b",
+		`export default async function main() { while (true) { await new Promise(r => setTimeout(r, 200)); } }`,
+		task.TriggerConfig{Daemon: true, Restart: "never"})
+	for _, s := range []*task.Spec{stageA, stageB} {
+		if err := env.reg.Register(s); err != nil {
+			t.Fatalf("reg.Register %s: %v", s.ID, err)
+		}
+		if err := env.engine.Register(s); err != nil {
+			t.Fatalf("eng.Register %s: %v", s.ID, err)
+		}
+	}
+
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "dts-pipe", Name: "DTS", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Manual: true},
+		Stages:  []task.Stage{{Task: "dts-a"}, {Task: "dts-b"}},
+	}
+	if err := env.reg.Register(pipe); err != nil {
+		t.Fatalf("reg.Register pipe: %v", err)
+	}
+	if err := env.engine.Register(pipe); err != nil {
+		t.Fatalf("eng.Register pipe: %v", err)
+	}
+
+	parentRunID, err := env.engine.FireManual(context.Background(), "dts-pipe", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+
+	// Wait until the daemon terminal stage child run is up and 'running'.
+	daemonChild := findStageChild(t, env, parentRunID, "dts-b", registry.StatusRunning, 20*time.Second)
+
+	// While the daemon stage is running, the pipeline parent must NOT have
+	// finished — it tracks the daemon's lifetime.
+	parent, err := env.engine.registry.GetRun(context.Background(), parentRunID)
+	if err != nil {
+		t.Fatalf("GetRun parent: %v", err)
+	}
+	if parent.Status != registry.StatusRunning {
+		t.Fatalf("pipeline finished %q while daemon terminal stage still running; want 'running'", parent.Status)
+	}
+
+	// Kill the daemon stage run (operator-style). The pipeline must finish with
+	// the daemon run's *actual* terminal status (cancelled), not a coerced
+	// failure.
+	if !env.engine.KillRun(daemonChild.ID) {
+		t.Fatalf("KillRun(daemonChild) returned false; daemon stage run not cancellable")
+	}
+
+	final := waitForTerminal(t, env.engine, parentRunID, 20*time.Second)
+	if final.Status != registry.StatusCancelled {
+		t.Fatalf("pipeline final status = %q (reason=%q), want 'cancelled' (daemon run was killed)", final.Status, final.FailureReason)
+	}
+}
+
 // findPipelineRun polls for a kind=pipeline run of taskID and returns it once it
 // reaches a terminal state (or fails the test on timeout).
 func findRun(t *testing.T, env *testEnv, taskID string, wantKind string, timeout time.Duration) *registry.Run {

--- a/pkg/trigger/pipeline_runner_test.go
+++ b/pkg/trigger/pipeline_runner_test.go
@@ -405,3 +405,132 @@ func TestPipelineFiresChain(t *testing.T) {
 		t.Errorf("downstream source = %q, want %q (chained from pipeline outcome)", run.TriggerSource, registry.TriggerChain)
 	}
 }
+
+// countStageChildren returns how many of a pipeline parent run's children are
+// runs of stageTaskID.
+func countStageChildren(t *testing.T, env *testEnv, parentRunID, stageTaskID string) int {
+	t.Helper()
+	kids, _ := env.reg.ListChildren(context.Background(), parentRunID, 100)
+	n := 0
+	for _, c := range kids {
+		if c.TaskID == stageTaskID {
+			n++
+		}
+	}
+	return n
+}
+
+// TestPipelineStageRerun is the mid-pipeline stage re-fire propagation test
+// (Task 19). A 3-stage pipeline runs to its terminal daemon stage and stays
+// live. An operator then re-fires stage 0's underlying Task standalone. The
+// engine must replay the descendant stages [1..terminal] with fresh ${input}
+// and restart the terminal daemon — observed as: a SECOND run of the descendant
+// stage-1 task appears as a pipeline child, AND a SECOND run of the terminal
+// daemon stage appears (the restart).
+//
+// Determinism: every assertion gates on observable child-run counts going from
+// 1 to 2 (not sleeps). The daemon body blocks until killed, so the only way a
+// second daemon-stage child appears is the re-fire's kill+restart.
+func TestPipelineStageRerun(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+	env := newTestEnv(t)
+	dir := t.TempDir()
+
+	stage0 := writeTask(t, dir, "rr-0",
+		`export default async function main() { return "gen" }`,
+		task.TriggerConfig{Manual: true})
+	stage1 := writeTask(t, dir, "rr-1",
+		`export default async function main({ params }) { return await params.get("content") }`,
+		task.TriggerConfig{Manual: true})
+	// Terminal daemon stage blocks until killed; restart:never so a kill
+	// doesn't engage the daemon auto-restart path (this stage is a pipeline
+	// child, not a registered daemon, so that path is inert anyway).
+	stage2 := writeTask(t, dir, "rr-2",
+		`export default async function main() { while (true) { await new Promise(r => setTimeout(r, 200)); } }`,
+		task.TriggerConfig{Daemon: true, Restart: "never"})
+	for _, s := range []*task.Spec{stage0, stage1, stage2} {
+		if err := env.reg.Register(s); err != nil {
+			t.Fatalf("reg.Register %s: %v", s.ID, err)
+		}
+		if err := env.engine.Register(s); err != nil {
+			t.Fatalf("eng.Register %s: %v", s.ID, err)
+		}
+	}
+
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "rr-pipe", Name: "RR", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Manual: true},
+		Stages: []task.Stage{
+			{Task: "rr-0"},
+			{Task: "rr-1", Overrides: &task.Overrides{
+				Params: task.ParamOverrides{{Name: "content", Default: "${input.output}"}}}},
+			{Task: "rr-2"},
+		},
+	}
+	if err := env.reg.Register(pipe); err != nil {
+		t.Fatalf("reg.Register pipe: %v", err)
+	}
+	if err := env.engine.Register(pipe); err != nil {
+		t.Fatalf("eng.Register pipe: %v", err)
+	}
+
+	parentRunID, err := env.engine.FireManual(context.Background(), "rr-pipe", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+
+	// Wait until the terminal daemon stage is up: the pipeline is live.
+	findStageChild(t, env, parentRunID, "rr-2", registry.StatusRunning, 20*time.Second)
+	// Sanity: exactly one run each of the descendant + daemon stages so far.
+	if got := countStageChildren(t, env, parentRunID, "rr-1"); got != 1 {
+		t.Fatalf("before re-fire: rr-1 child count = %d, want 1", got)
+	}
+	if got := countStageChildren(t, env, parentRunID, "rr-2"); got != 1 {
+		t.Fatalf("before re-fire: rr-2 child count = %d, want 1", got)
+	}
+
+	// Operator re-fires stage 0's underlying Task standalone. On success its
+	// FireChain hook drives handlePipelineStageRerun → replay descendants +
+	// restart the terminal daemon.
+	if _, err := env.engine.FireManual(context.Background(), "rr-0", nil); err != nil {
+		t.Fatalf("FireManual rr-0 (re-fire): %v", err)
+	}
+
+	// Descendant stage-1 must re-run (a 2nd pipeline-child run appears).
+	waitUntil(t, 25*time.Second, func() bool {
+		return countStageChildren(t, env, parentRunID, "rr-1") >= 2
+	}, "descendant stage rr-1 was not re-run after stage-0 re-fire")
+
+	// Terminal daemon must restart (a 2nd daemon-stage child run appears, and
+	// it reaches 'running').
+	waitUntil(t, 25*time.Second, func() bool {
+		if countStageChildren(t, env, parentRunID, "rr-2") < 2 {
+			return false
+		}
+		// At least one rr-2 child should be 'running' (the restarted daemon).
+		kids, _ := env.reg.ListChildren(context.Background(), parentRunID, 100)
+		for _, c := range kids {
+			if c.TaskID == "rr-2" && c.Status == registry.StatusRunning {
+				return true
+			}
+		}
+		return false
+	}, "terminal daemon stage rr-2 did not restart after stage-0 re-fire")
+
+	// The pipeline parent must still be running across the restart (its
+	// lifetime tracks the restarted daemon, not the killed one).
+	parent, err := env.engine.registry.GetRun(context.Background(), parentRunID)
+	if err != nil {
+		t.Fatalf("GetRun parent: %v", err)
+	}
+	if parent.Status != registry.StatusRunning {
+		t.Fatalf("pipeline parent status = %q after restart, want 'running'", parent.Status)
+	}
+
+	// Cleanup: kill the pipeline so the daemon subprocess doesn't linger.
+	env.engine.KillRun(parentRunID)
+	waitForTerminal(t, env.engine, parentRunID, 15*time.Second)
+}


### PR DESCRIPTION
## Summary

PR4 of the `kind: PipelineTask` epic. Two tightly-coupled changes to `pkg/trigger`, each its own commit.

### Task 18 — daemon-terminal-stage lifetime
A `PipelineTask` whose **terminal** stage resolves to a `trigger.daemon: true` Task no longer finishes `success` when the daemon starts. It stays `running` for the daemon's lifetime and finishes with the daemon run's **actual** terminal status.

- Factored `fireStageRaw` (resolve + override + fire → returns the stage run ID and whether the **merged** dispatch spec is a daemon) and `awaitStageSuccess` (the wait-to-success gate) out of `dispatchStage`; `dispatchStage` is now their composition.
- Daemon-ness is decided from the merged dispatch spec, so a stage trigger override that flips `daemon` is honored.
- `runTerminalDaemon` registers the pipeline as live, blocks on the daemon run's terminal with a background context (the daemon's lifetime — not the trigger call's context — governs the pipeline), and finishes with the daemon's real status. A pipeline-parent `KillRun` is propagated to the daemon run via a `runCtx` watcher, so a killed daemon-terminal pipeline ends `cancelled` rather than a coerced `failure`.
- Added `Engine.livePipelines` (+ register/unregister helpers) — the live set Task 19 consumes.

### Task 19 — mid-pipeline stage re-fire propagation
The PipelineRunner analogue of `propagateBeforeRerun`. When an operator re-fires a stage's underlying `kind: Task` while a pipeline is live (terminal stage is a running daemon), the descendant stages are replayed with fresh `${input}` and the terminal daemon is restarted.

- `Engine.handlePipelineStageRerun(completedTaskID, output)` scans `registry.AllKinded()` for pipelines that (a) contain `completedTaskID` as a stage and (b) are currently live (`livePipelines`).
- `propagatePipelineStageRerun` mirrors `propagateBeforeRerun`: coalesce via `restartGates.tryAcquire` keyed by pipeline ID → defer `release` → bail on `isShuttingDown` / no-longer-live → replay non-terminal descendants with per-iteration shutdown+liveness re-checks → kill+wait the old daemon run → re-fire the terminal daemon stage.
- Wired from `FireChain` alongside `notifyPrereqCompletion`, guarded by `runStatus == StatusSuccess`.
- A restart handshake (`restarting` / `restartDone`) lets the runner's terminal-daemon wait loop re-wait on the freshly-fired daemon run instead of finishing the pipeline; the loop checks "daemonRunID advanced" before the `restarting` flag so it is robust regardless of handshake progress. An aborted restart (descendant failure / shutdown) finishes the pipeline on the killed daemon's status, and a pipeline killed mid-restart stops the fresh daemon rather than orphaning it.

## Test Plan

New tests (`pkg/trigger/pipeline_runner_test.go`):
- `TestPipelineDaemonTerminalStage` — pipeline stays `running` while the daemon terminal stage runs; killing the daemon run finishes the pipeline `cancelled` (status fidelity). Confirmed it fails on pre-Task-18 code (coerced `failure`).
- `TestPipelineStageRerun` — re-firing stage 0's task replays descendant stage 1 and restarts the terminal daemon (child-run counts 1→2); parent stays `running` across the restart. Confirmed it fails with the `FireChain` hook removed. Passes under `-race` (stressed 15x).

Verification from the worktree (all green):
- `go build ./...`
- `go vet ./...`
- `gofmt -l .` (clean)
- `go test ./pkg/trigger/... ./pkg/registry/... -timeout 240s`
- `go test -race ./pkg/trigger/... -timeout 360s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)