### PR TITLE
feat(webui): surface pipelines + stages in the WebUI (PR5/8)

### DIFF
--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -1385,12 +1385,20 @@ func (s *Server) apiListTasks(w http.ResponseWriter, r *http.Request) {
 				LastRunStatus: lastRunStatus,
 			})
 		default:
-			// Unknown kind — surface it rather than dropping it silently.
+			// Forward-compat safety net: the registry only ever holds
+			// *task.Spec / *task.PipelineTask today, so this branch is
+			// effectively unreachable. We surface an unknown kind rather than
+			// dropping it silently. PipelineListItem is reused only because its
+			// field set matches what the list view reads; the kind it carries
+			// is whatever KindOf() returns, which the JS badge won't recognize.
+			// Give it a parity TriggerLabel ("—") so the list renders sanely
+			// instead of falling back to a misleading "manual".
 			items = append(items, PipelineListItem{
 				ID:            k.TaskID(),
 				Name:          k.TaskID(),
 				Enabled:       k.IsEnabled(),
 				Kind:          k.KindOf(),
+				TriggerLabel:  "—",
 				LastRunID:     lastRunID,
 				LastRunStatus: lastRunStatus,
 			})

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -1328,27 +1328,73 @@ func (s *Server) apiGetConfig(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, configResponse{Config: s.cfg, RelayHookBaseURL: relayHookBaseURL})
 }
 
-// TaskListItem is the shape returned by GET /api/tasks.
+// TaskListItem is the shape returned by GET /api/tasks for a kind: Task
+// entry. It embeds the spec (the WebUI relies on the flat Spec fields) and
+// additively surfaces the task `kind` so the list view can badge pipelines.
 type TaskListItem struct {
 	*task.Spec
+	// Kind is the task kind discriminator (task.KindTask). Always set so the
+	// UI can distinguish tasks from pipelines without inspecting other fields.
+	Kind          string `json:"kind"`
+	TriggerLabel  string `json:"trigger_label"`
+	LastRunID     string `json:"last_run_id,omitempty"`
+	LastRunStatus string `json:"last_run_status,omitempty"`
+}
+
+// PipelineListItem is the shape returned by GET /api/tasks for a kind:
+// PipelineTask entry. It deliberately mirrors the kind: Task fields the list
+// view reads (id/name/enabled/kind/trigger_label/last_run_*) without embedding
+// *task.Spec, since a PipelineTask is a peer of Spec, not a Spec.
+type PipelineListItem struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Enabled       bool   `json:"enabled"`
+	Kind          string `json:"kind"`
 	TriggerLabel  string `json:"trigger_label"`
 	LastRunID     string `json:"last_run_id,omitempty"`
 	LastRunStatus string `json:"last_run_status,omitempty"`
 }
 
 func (s *Server) apiListTasks(w http.ResponseWriter, r *http.Request) {
-	specs := s.registry.All()
-	items := make([]TaskListItem, len(specs))
-	for i, spec := range specs {
-		item := TaskListItem{
-			Spec:         spec,
-			TriggerLabel: triggerLabel(spec.Trigger),
+	kinded := s.registry.AllKinded()
+	items := make([]any, 0, len(kinded))
+	for _, k := range kinded {
+		// Last-run lookup is identical across kinds.
+		var lastRunID, lastRunStatus string
+		if runs, err := s.registry.ListRuns(r.Context(), k.TaskID(), 1); err == nil && len(runs) > 0 {
+			lastRunID = runs[0].ID
+			lastRunStatus = runs[0].Status
 		}
-		if runs, err := s.registry.ListRuns(r.Context(), spec.ID, 1); err == nil && len(runs) > 0 {
-			item.LastRunID = runs[0].ID
-			item.LastRunStatus = runs[0].Status
+		switch v := k.(type) {
+		case *task.Spec:
+			items = append(items, TaskListItem{
+				Spec:          v,
+				Kind:          task.KindTask,
+				TriggerLabel:  triggerLabel(v.Trigger),
+				LastRunID:     lastRunID,
+				LastRunStatus: lastRunStatus,
+			})
+		case *task.PipelineTask:
+			items = append(items, PipelineListItem{
+				ID:            v.ID,
+				Name:          v.Name,
+				Enabled:       v.Enabled,
+				Kind:          task.KindPipelineTask,
+				TriggerLabel:  pipelineTriggerLabel(v),
+				LastRunID:     lastRunID,
+				LastRunStatus: lastRunStatus,
+			})
+		default:
+			// Unknown kind — surface it rather than dropping it silently.
+			items = append(items, PipelineListItem{
+				ID:            k.TaskID(),
+				Name:          k.TaskID(),
+				Enabled:       k.IsEnabled(),
+				Kind:          k.KindOf(),
+				LastRunID:     lastRunID,
+				LastRunStatus: lastRunStatus,
+			})
 		}
-		items[i] = item
 	}
 	jsonOK(w, items)
 }
@@ -2440,6 +2486,26 @@ func triggerLabel(tc task.TriggerConfig) string {
 		return "daemon (restart: " + restart + ")"
 	}
 	return "—"
+}
+
+// pipelineTriggerLabel renders a human-readable trigger summary for a
+// kind: PipelineTask. A pipeline's PipelineTrigger has no Daemon shape — a
+// pipeline is daemon-shaped iff its terminal stage is a daemon Task, which
+// the detail view surfaces separately via DaemonState.
+func pipelineTriggerLabel(p *task.PipelineTask) string {
+	tc := p.Trigger
+	switch {
+	case tc.Cron != "":
+		return "cron: " + tc.Cron
+	case tc.Webhook != "":
+		return "webhook: " + tc.Webhook
+	case tc.Chain != nil:
+		return "chain: " + tc.Chain.From
+	case tc.Manual:
+		return "manual"
+	default:
+		return "—"
+	}
 }
 
 func fmtTime(t time.Time) string {

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -1417,10 +1417,29 @@ type TaskDetail struct {
 	DaemonState string `json:"daemon_state,omitempty"`
 }
 
+// PipelineDetail is the shape returned by GET /api/tasks/{id} for a kind:
+// PipelineTask. It embeds the pipeline spec (kind, name, stages, …) and adds
+// a trigger label plus — when the terminal stage resolves to a daemon Task —
+// that stage's daemon lifecycle phase, mirroring the kind: Task detail's
+// daemon_state contract.
+type PipelineDetail struct {
+	*task.PipelineTask
+	TriggerLabel string `json:"trigger_label"`
+	DaemonState  string `json:"daemon_state,omitempty"`
+}
+
 func (s *Server) apiGetTask(w http.ResponseWriter, r *http.Request) {
 	id := taskIDParam(r)
 	spec, ok := s.registry.Get(id)
 	if !ok {
+		// Not a kind: Task — it may be a kind: PipelineTask. A PipelineTask is
+		// a peer of Spec (not a Spec), so it needs its own detail shape.
+		if k, kok := s.registry.GetKinded(id); kok {
+			if p, pok := k.(*task.PipelineTask); pok {
+				s.writePipelineDetail(w, p)
+				return
+			}
+		}
 		jsonErr(w, "task not found", http.StatusNotFound)
 		return
 	}
@@ -1465,6 +1484,26 @@ func (s *Server) apiGetTask(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	jsonOK(w, detail)
+}
+
+// writePipelineDetail renders the GET /api/tasks/{id} response for a kind:
+// PipelineTask. It surfaces the pipeline's stages and, when the terminal
+// stage resolves to a daemon Task, that stage's daemon lifecycle phase — a
+// pipeline is daemon-shaped iff its terminal stage is a daemon, so operators
+// see the same lifecycle badge they'd see on the bare daemon task.
+func (s *Server) writePipelineDetail(w http.ResponseWriter, p *task.PipelineTask) {
+	detail := PipelineDetail{
+		PipelineTask: p,
+		TriggerLabel: pipelineTriggerLabel(p),
+	}
+	if len(p.Stages) > 0 {
+		terminalID := p.Stages[len(p.Stages)-1].Task
+		// Only a kind: Task with trigger.daemon: true has a daemon lifecycle.
+		if termSpec, ok := s.registry.Get(terminalID); ok && termSpec.Trigger.Daemon {
+			detail.DaemonState = string(s.engine.DaemonState(terminalID))
+		}
+	}
 	jsonOK(w, detail)
 }
 

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -243,6 +243,140 @@ func TestAPI_GetTask_NonDaemonOmitsDaemonState(t *testing.T) {
 	}
 }
 
+// TestAPI_GetTask_Pipeline verifies that GET /api/tasks/{id} resolves a
+// kind: PipelineTask, returns 200, and surfaces its kind + stages so the
+// detail view can render the pipeline shape.
+func TestAPI_GetTask_Pipeline(t *testing.T) {
+	srv, reg := newTestServer(t)
+	registerTask(t, reg, "stage-a", `return 1`)
+	registerTask(t, reg, "stage-b", `return 2`)
+	if err := reg.Register(&task.PipelineTask{
+		APIVersion: "dicode/v1",
+		Kind:       task.KindPipelineTask,
+		ID:         "my-pipeline",
+		Name:       "My Pipeline",
+		Subtype:    "sequential",
+		Enabled:    true,
+		Stages:     []task.Stage{{Task: "stage-a"}, {Task: "stage-b"}},
+	}); err != nil {
+		t.Fatalf("register pipeline: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks/my-pipeline", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+
+	var detail map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if detail["kind"] != task.KindPipelineTask {
+		t.Errorf("kind = %v, want %q", detail["kind"], task.KindPipelineTask)
+	}
+	stages, ok := detail["stages"].([]any)
+	if !ok {
+		t.Fatalf("stages missing or not an array: %v", detail["stages"])
+	}
+	if len(stages) != 2 {
+		t.Fatalf("expected 2 stages, got %d: %v", len(stages), stages)
+	}
+}
+
+// TestAPI_GetTask_PipelineTerminalDaemonState verifies that GET
+// /api/tasks/{id} for a pipeline whose terminal stage resolves to a daemon
+// Task surfaces that stage's daemon lifecycle phase. The default for an
+// unfired daemon is "stopped".
+func TestAPI_GetTask_PipelineTerminalDaemonState(t *testing.T) {
+	srv, reg := newTestServer(t)
+	registerTask(t, reg, "build-step", `return 1`)
+
+	// Terminal stage is a daemon task.
+	dir := t.TempDir()
+	td := filepath.Join(dir, "serve-step")
+	_ = os.MkdirAll(td, 0755)
+	_ = os.WriteFile(filepath.Join(td, "task.yaml"),
+		[]byte("name: serve-step\nruntime: docker\ntrigger:\n  daemon: true\ndocker: { image: alpine }\n"), 0644)
+	if err := reg.Register(&task.Spec{
+		ID:      "serve-step",
+		Name:    "serve-step",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{Daemon: true, Restart: "never"},
+		Enabled: true,
+		TaskDir: td,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.Register(&task.PipelineTask{
+		APIVersion: "dicode/v1",
+		Kind:       task.KindPipelineTask,
+		ID:         "daemon-pipeline",
+		Name:       "Daemon Pipeline",
+		Subtype:    "sequential",
+		Enabled:    true,
+		Stages:     []task.Stage{{Task: "build-step"}, {Task: "serve-step"}},
+	}); err != nil {
+		t.Fatalf("register pipeline: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks/daemon-pipeline", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+
+	var detail map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got, ok := detail["daemon_state"]
+	if !ok {
+		t.Fatalf("daemon_state missing for daemon-terminal pipeline: %v", detail)
+	}
+	if got != "stopped" {
+		t.Errorf("daemon_state = %v, want \"stopped\"", got)
+	}
+}
+
+// TestAPI_GetTask_PipelineNonDaemonTerminalOmitsState verifies that a
+// pipeline whose terminal stage is NOT a daemon omits daemon_state, so the
+// UI doesn't render a misleading "stopped" badge on plain pipelines.
+func TestAPI_GetTask_PipelineNonDaemonTerminalOmitsState(t *testing.T) {
+	srv, reg := newTestServer(t)
+	registerTask(t, reg, "step-1", `return 1`)
+	registerTask(t, reg, "step-2", `return 2`)
+	if err := reg.Register(&task.PipelineTask{
+		APIVersion: "dicode/v1",
+		Kind:       task.KindPipelineTask,
+		ID:         "plain-pipeline",
+		Name:       "Plain Pipeline",
+		Subtype:    "sequential",
+		Enabled:    true,
+		Stages:     []task.Stage{{Task: "step-1"}, {Task: "step-2"}},
+	}); err != nil {
+		t.Fatalf("register pipeline: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks/plain-pipeline", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+
+	var detail map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got, ok := detail["daemon_state"]; ok && got != "" {
+		t.Errorf("daemon_state should be omitted for non-daemon pipeline, got %q", got)
+	}
+}
+
 func TestAPI_GetTask_NotFound(t *testing.T) {
 	srv, _ := newTestServer(t)
 

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -156,6 +156,57 @@ func TestAPI_ListTasks_IncludesPipelineKind(t *testing.T) {
 	}
 }
 
+// fakeKinded is a task.Kinded implementation that is neither *task.Spec nor
+// *task.PipelineTask, used to exercise apiListTasks's forward-compat default
+// branch (effectively unreachable in production today).
+type fakeKinded struct{ id string }
+
+func (f *fakeKinded) KindOf() string         { return "FutureKind" }
+func (f *fakeKinded) TaskID() string         { return f.id }
+func (f *fakeKinded) SetTaskID(s string)     { f.id = s }
+func (f *fakeKinded) IsEnabled() bool        { return true }
+func (f *fakeKinded) SetEnabled(bool)        {}
+func (f *fakeKinded) LoadWarnings() []string { return nil }
+func (f *fakeKinded) Validate() error        { return nil }
+
+// TestAPI_ListTasks_UnknownKind verifies that an unrecognized task kind hits
+// apiListTasks's default branch and serializes with a parity "—" trigger
+// label (rather than an empty string that the JS list would mask as "manual").
+func TestAPI_ListTasks_UnknownKind(t *testing.T) {
+	srv, reg := newTestServer(t)
+	if err := reg.Register(&fakeKinded{id: "mystery"}); err != nil {
+		t.Fatalf("register fakeKinded: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+
+	var items []map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&items); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var found map[string]any
+	for _, it := range items {
+		if it["id"] == "mystery" {
+			found = it
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("unknown-kind task dropped from list: %v", items)
+	}
+	if found["kind"] != "FutureKind" {
+		t.Errorf("kind = %v, want %q", found["kind"], "FutureKind")
+	}
+	if found["trigger_label"] != "—" {
+		t.Errorf("trigger_label = %v, want %q (parity placeholder)", found["trigger_label"], "—")
+	}
+}
+
 func TestAPI_GetTask(t *testing.T) {
 	srv, reg := newTestServer(t)
 	registerTask(t, reg, "my-task", `return 1`)
@@ -282,6 +333,17 @@ func TestAPI_GetTask_Pipeline(t *testing.T) {
 	}
 	if len(stages) != 2 {
 		t.Fatalf("expected 2 stages, got %d: %v", len(stages), stages)
+	}
+	// The WebUI's _renderStages reads each stage's task ID and overrides
+	// indicator. task.Stage has no JSON tags, so the fields serialize with Go
+	// field-name casing ("Task"/"Overrides"); assert that contract so a future
+	// tag change can't silently break the stages list rendering.
+	s0, ok := stages[0].(map[string]any)
+	if !ok {
+		t.Fatalf("stage[0] not an object: %v", stages[0])
+	}
+	if s0["Task"] != "stage-a" {
+		t.Errorf("stage[0].Task = %v, want %q", s0["Task"], "stage-a")
 	}
 }
 

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -90,6 +90,72 @@ func TestAPI_ListTasks(t *testing.T) {
 	}
 }
 
+// TestAPI_ListTasks_IncludesPipelineKind verifies that GET /api/tasks
+// surfaces kind: PipelineTask entries (via registry.AllKinded()) alongside
+// kind: Task entries, and that each list item carries a "kind" indicator so
+// the WebUI can badge pipelines. The kind: Task JSON shape must stay intact.
+func TestAPI_ListTasks_IncludesPipelineKind(t *testing.T) {
+	srv, reg := newTestServer(t)
+	registerTask(t, reg, "plain-task", `return 1`)
+	if err := reg.Register(&task.PipelineTask{
+		APIVersion: "dicode/v1",
+		Kind:       task.KindPipelineTask,
+		ID:         "my-pipeline",
+		Name:       "My Pipeline",
+		Subtype:    "sequential",
+		Enabled:    true,
+		Stages:     []task.Stage{{Task: "plain-task"}},
+	}); err != nil {
+		t.Fatalf("register pipeline: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+
+	var items []map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&items); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	byID := map[string]map[string]any{}
+	for _, it := range items {
+		id, _ := it["id"].(string)
+		byID[id] = it
+	}
+	if len(byID) != 2 {
+		t.Fatalf("expected 2 list items (task + pipeline), got %d: %v", len(byID), items)
+	}
+
+	plain, ok := byID["plain-task"]
+	if !ok {
+		t.Fatalf("plain-task missing from list: %v", items)
+	}
+	if plain["kind"] != task.KindTask {
+		t.Errorf("plain-task kind = %v, want %q", plain["kind"], task.KindTask)
+	}
+	// kind: Task JSON shape must remain intact (name + trigger_label present).
+	if plain["name"] != "plain-task" {
+		t.Errorf("plain-task name = %v, want plain-task", plain["name"])
+	}
+	if _, ok := plain["trigger_label"]; !ok {
+		t.Errorf("plain-task missing trigger_label: %v", plain)
+	}
+
+	pipe, ok := byID["my-pipeline"]
+	if !ok {
+		t.Fatalf("my-pipeline missing from list: %v", items)
+	}
+	if pipe["kind"] != task.KindPipelineTask {
+		t.Errorf("my-pipeline kind = %v, want %q", pipe["kind"], task.KindPipelineTask)
+	}
+	if pipe["name"] != "My Pipeline" {
+		t.Errorf("my-pipeline name = %v, want My Pipeline", pipe["name"])
+	}
+}
+
 func TestAPI_GetTask(t *testing.T) {
 	srv, reg := newTestServer(t)
 	registerTask(t, reg, "my-task", `return 1`)
@@ -238,6 +304,37 @@ func TestAPI_ListRuns(t *testing.T) {
 	_ = json.NewDecoder(w2.Body).Decode(&runs)
 	if len(runs) == 0 {
 		t.Error("expected at least one run")
+	}
+}
+
+// TestAPI_ListRuns_IncludesKind verifies that GET /api/tasks/{id}/runs
+// surfaces the per-run kind ("task" or "pipeline") so the WebUI can badge
+// pipeline runs. registry.Run has no JSON tags, so the field serializes as
+// the Go field name "Kind".
+func TestAPI_ListRuns_IncludesKind(t *testing.T) {
+	srv, reg := newTestServer(t)
+	ctx := context.Background()
+
+	if _, err := reg.StartRunWithID(ctx, "pipe-run-1", "my-pipeline", "", "", registry.RunKindPipeline); err != nil {
+		t.Fatalf("StartRunWithID pipeline: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks/my-pipeline/runs", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body)
+	}
+
+	var runs []map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&runs); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d: %v", len(runs), runs)
+	}
+	if runs[0]["Kind"] != registry.RunKindPipeline {
+		t.Errorf("run Kind = %v, want %q", runs[0]["Kind"], registry.RunKindPipeline)
 	}
 }
 

--- a/tasks/buildin/webui/app/components/dc-task-detail.js
+++ b/tasks/buildin/webui/app/components/dc-task-detail.js
@@ -27,7 +27,7 @@ class DcTaskDetail extends LitElement {
     _aiStatus:        { state: true },
     _aiSessionId:     { state: true },
     _currentFile:     { state: true },
-    _showPrereqs:     { state: true },
+    _showStages:      { state: true },
     _expanded:        { state: true }, // Set<runID> — top-level rows with children currently expanded
     _children:        { state: true }, // Map<parentRunID, Run[]> — lazily-fetched child rows
   };
@@ -38,7 +38,7 @@ class DcTaskDetail extends LitElement {
     this._triggerOpen = false; this._triggerType = 'manual';
     this._editorOpen = false; this._editorStatus = ''; this._currentFile = null;
     this._aiOpen = false; this._aiHistory = []; this._aiStatus = ''; this._aiSessionId = '';
-    this._showPrereqs = false;
+    this._showStages = false;
     this._expanded = new Set();
     this._children = new Map();
     this._editor = null;
@@ -242,9 +242,9 @@ class DcTaskDetail extends LitElement {
   // The flat list of runs returned by /api/tasks/{id}/runs is collapsed by
   // two rules so the user sees one row per logical event:
   //
-  //   1. Hide rows whose ParentRunID is set — those are sub-runs (a prereq
-  //      run from `if_missing`, or a sub-task fired via dicode.run_task).
-  //      A toggle restores the flat view for debugging.
+  //   1. Hide rows whose ParentRunID is set — those are stage runs (a
+  //      pipeline stage, or a sub-task fired via dicode.run_task). A toggle
+  //      restores the flat view for debugging.
   //   2. Collapse consecutive top-level rows with the same non-empty Group
   //      into one row ("N runs in this session, last 3m ago"). Tasks tag
   //      themselves via dicode.set_group() — see the ai-agent buildin (#112).
@@ -254,7 +254,7 @@ class DcTaskDetail extends LitElement {
   //   { kind: 'group',  runs: [...] }      — collapse of consecutive same-group runs
   _buildRunItems() {
     const all = this._runs || [];
-    if (this._showPrereqs) return all.map(run => ({ kind: 'single', run }));
+    if (this._showStages) return all.map(run => ({ kind: 'single', run }));
 
     const top = all.filter(r => !(r.ParentRunID || r.parent_run_id));
     const items = [];
@@ -308,14 +308,20 @@ class DcTaskDetail extends LitElement {
     const expanded = this._expanded.has(r.ID);
     const kids = this._children.get(r.ID) || [];
     const showExpand = !expandedKid; // sub-rows don't recurse further by default
+    // registry.Run has no JSON tags, so the kind serializes as `Kind`
+    // ("task" | "pipeline"); badge pipeline parents so operators can tell a
+    // pipeline run (whose stage children expand below) from a plain task run.
+    const isPipeline = (r.Kind || r.kind) === 'pipeline';
     return html`
       <tr>
         <td style=${padding}>
           ${showExpand ? html`<button class="btn btn-sm secondary"
             style="padding:0 .35rem;margin-right:.35rem;font-family:monospace"
-            title="Show child runs"
+            title="Show stage runs"
             @click=${() => this._toggleExpand(r.ID)}>${expanded ? '▾' : '▸'}</button>` : ''}
           <a href="runs/${r.ID}">${r.ID.slice(0,8)}</a>
+          ${isPipeline ? html`<span class="badge" title="Pipeline run"
+            style="margin-left:.5rem;font-size:0.7rem;background:rgba(137, 220, 235, .15);color:var(--sky)">pipeline</span>` : ''}
           ${hint ? html`<span class="meta" style="margin-left:.5rem">${hint}</span>` : ''}
         </td>
         <td><span class="badge badge-${r.Status}">${r.Status}</span></td>
@@ -508,9 +514,9 @@ class DcTaskDetail extends LitElement {
         <h2 style="margin:0">Recent runs</h2>
         <label class="meta" style="margin-left:auto;cursor:pointer">
           <input type="checkbox"
-            .checked=${this._showPrereqs}
-            @change=${e => { this._showPrereqs = e.target.checked; }}>
-          Show prereq runs
+            .checked=${this._showStages}
+            @change=${e => { this._showStages = e.target.checked; }}>
+          Show stages
         </label>
       </div>
       <table>

--- a/tasks/buildin/webui/app/components/dc-task-detail.js
+++ b/tasks/buildin/webui/app/components/dc-task-detail.js
@@ -393,6 +393,40 @@ class DcTaskDetail extends LitElement {
       >${s.text}</span>`;
   }
 
+  // Renders the ordered stages of a kind: PipelineTask. The PipelineDetail
+  // payload embeds *task.PipelineTask, whose Stage struct has NO JSON tags, so
+  // each element serializes with Go field-name casing (`Task`, `Overrides`);
+  // we read both casings defensively. Stage task IDs are operator-controlled
+  // and therefore rendered via lit `html` text bindings (auto-escaped), never
+  // unsafeHTML. The terminal-stage daemon_state badge already renders in the
+  // trigger card above, so it isn't duplicated here.
+  _renderStages(task) {
+    const stages = task.stages || task.Stages || [];
+    if (!stages.length) {
+      return html`
+        <div class="card" style="margin-bottom:var(--space-md)">
+          <h2 style="margin:0 0 0.5rem">Stages</h2>
+          <p class="meta" style="margin:0">This pipeline has no stages.</p>
+        </div>`;
+    }
+    return html`
+      <div class="card" style="margin-bottom:var(--space-md)">
+        <h2 style="margin:0 0 0.75rem">Stages</h2>
+        <ol style="margin:0;padding-left:1.5rem;display:flex;flex-direction:column;gap:0.4rem">
+          ${stages.map(s => {
+            const id = s.Task || s.task || '(unknown)';
+            const hasOverrides = !!(s.Overrides || s.overrides);
+            return html`
+              <li>
+                <a href="tasks/${encodeURIComponent(id)}" style="font-family:monospace">${id}</a>
+                ${hasOverrides ? html`<span class="badge" title="This stage applies overrides"
+                  style="margin-left:.5rem;font-size:0.7rem;background:rgba(249, 226, 175, .15);color:var(--yellow)">overrides</span>` : ''}
+              </li>`;
+          })}
+        </ol>
+      </div>`;
+  }
+
   _triggerFields() {
     const t = this._task?.trigger || this._task?.Trigger || {};
     const type = this._triggerType;
@@ -437,12 +471,20 @@ class DcTaskDetail extends LitElement {
     const task = this._task;
     const scriptFile = task.script_file || 'task.ts';
     const testFile   = task.test_file   || scriptFile.replace(/\.(ts|js)$/, '.test.$1');
+    // A kind: PipelineTask has only a task.yaml — no script/test file — so the
+    // code editor (Edit-code button + Monaco tab) is meaningless and would
+    // 404 on save/load. Gate it on the presence of a script_file (kind: Task
+    // detail always sets one; PipelineDetail never does) and double-guard on
+    // the task kind so a future PipelineDetail field can't accidentally re-open
+    // the affordance.
+    const isPipeline = task.kind === 'PipelineTask';
+    const hasEditor  = !isPipeline && !!task.script_file;
 
     return html`
       <div style="display:flex;align-items:center;gap:0.75rem;margin-bottom:var(--space-sm)">
         <h1 style="margin:0">${task.name}</h1>
         <button class="btn" @click=${() => this._run()}>&#9654; Run now</button>
-        <button class="btn" style="background:var(--muted)" @click=${() => this._openEditor()}>&#9998; Edit code</button>
+        ${hasEditor ? html`<button class="btn" style="background:var(--muted)" @click=${() => this._openEditor()}>&#9998; Edit code</button>` : ''}
       </div>
       ${task.description ? html`<div class="task-desc">${unsafeHTML(marked.parse(task.description))}</div>` : ''}
 
@@ -452,6 +494,8 @@ class DcTaskDetail extends LitElement {
         <button class="btn btn-sm" style="background:var(--muted);margin-left:auto"
           @click=${() => { this._triggerOpen = !this._triggerOpen; }}>&#9998; Edit trigger</button>
       </div>
+
+      ${isPipeline ? this._renderStages(task) : ''}
 
       ${this._triggerOpen ? html`
         <div class="card" style="margin-bottom:var(--space-md)">
@@ -468,7 +512,7 @@ class DcTaskDetail extends LitElement {
           </div>
         </div>` : ''}
 
-      ${this._editorOpen ? html`
+      ${this._editorOpen && hasEditor ? html`
         <div class="card" style="margin-top:1.5rem;padding:0.75rem">
           <div style="display:flex;align-items:center;gap:var(--space-sm);margin-bottom:var(--space-sm);flex-wrap:wrap">
             <button class="btn btn-sm" @click=${() => this._loadEditorFile(scriptFile)}>${scriptFile}</button>


### PR DESCRIPTION
## Summary

PR5 of the `kind: PipelineTask` epic — surfaces pipelines and their stage children in the WebUI. Intentionally small and additive; the kind: Task JSON shape the existing tests and frontend rely on is unchanged.

- **Task 20 — API surfaces `kind`:** `GET /api/tasks` now iterates `registry.AllKinded()` so kind: PipelineTask entries appear alongside kind: Task entries, each carrying a `kind` discriminator. Since `*task.PipelineTask` is a peer of `*task.Spec` (not a Spec), the handler type-switches and builds a dedicated `PipelineListItem` rather than reusing the embedded-Spec `TaskListItem` — avoiding a JSON tag collision that would otherwise shadow the kind: Task `name`/`id`/`enabled` fields. The per-run `kind` already serializes via `registry.Run.Kind`.
- **Task 21 — relabel prereqs→stages:** Renamed the `_showPrereqs` toggle to `_showStages` ("Show stages") in `dc-task-detail.js`. The existing `!parent_run_id` filter and lazy `/api/runs?parent=` child fetch already collapse pipeline stage children under their parent. Added a `pipeline` badge for runs whose `Kind === 'pipeline'`.
- **Task 22 — daemon-state on pipeline terminal stage:** `GET /api/tasks/{id}` resolves a kind: PipelineTask via `GetKinded` and returns a `PipelineDetail` (kind, stages, trigger label). When the terminal stage (`Stages[len-1].Task`) resolves to a daemon Task, it surfaces that stage's `engine.DaemonState` — a pipeline is daemon-shaped iff its terminal stage is a daemon. Non-daemon terminal stages omit `daemon_state`.

## Test Plan

New tests in `pkg/webui/server_test.go` (all green):
- `TestAPI_ListTasks_IncludesPipelineKind` — pipeline appears in the list with its kind; kind: Task shape intact.
- `TestAPI_ListRuns_IncludesKind` — per-run `Kind` serialized in `/api/tasks/{id}/runs`.
- `TestAPI_GetTask_Pipeline` — pipeline detail returns 200 with kind + stages.
- `TestAPI_GetTask_PipelineTerminalDaemonState` — daemon terminal stage surfaces `daemon_state`.
- `TestAPI_GetTask_PipelineNonDaemonTerminalOmitsState` — non-daemon terminal stage omits `daemon_state`.

Verification (from the worktree):
- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt -l <worktree>` — clean
- `go test ./... -timeout 300s` — all packages ok, exit 0, 0 failures
- JS: no JS test/lint/build setup in the webui dir (no `package.json`); validated `dc-task-detail.js` with `node --check` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)