### PR TITLE
fix(trigger,daemon): pipeline daemon trigger fixes — restart orphan, webhook gateway, cold-start ordering

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -234,9 +234,10 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	// per daemon lifetime.
 	var bodyFullTextualWarned sync.Map
 	rec.OnRegister = func(k task.Kinded) {
-		// The webhook-gateway and footgun checks below only apply to kind: Task.
-		// Pipelines (kind: PipelineTask) register through the engine for routing
-		// but their trigger wiring lands in a later PR; skip the Spec-only logic.
+		// The footgun checks below only apply to kind: Task; the gateway-webhook
+		// route, however, applies to BOTH kind: Task and kind: PipelineTask —
+		// see registerGatewayWebhook (GAP 1: a pipeline's webhook 404'd because
+		// only kind: Task wired the daemon-level gateway route).
 		spec, isSpec := k.(*task.Spec)
 		// Override buildin/run-inputs-cleanup's retention_seconds default to
 		// match dicode.yaml's defaults.run_inputs.retention. This must happen
@@ -267,14 +268,14 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 				zap.Error(err))
 			return
 		}
+		// Wire the daemon-level gateway webhook route. Kind-aware: handles both
+		// kind: Task and kind: PipelineTask, so a pipeline's webhook trigger is
+		// reachable over HTTP (GAP 1). Recording the path under the task ID lets
+		// OnUnregister deregister it the same way for both kinds.
+		registerGatewayWebhook(gateway, webhookPaths, &webhookMu, webhookH, k)
+
 		if !isSpec {
 			return
-		}
-		if spec.Trigger.Webhook != "" {
-			gateway.Register(spec.Trigger.Webhook, webhookH)
-			webhookMu.Lock()
-			webhookPaths[spec.ID] = spec.Trigger.Webhook
-			webhookMu.Unlock()
 		}
 		if spec.Trigger.WebhookAuth && !cfg.Server.Auth {
 			log.Warn("task declares trigger.auth:true but server.auth is disabled — any password logs in",

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -272,6 +272,14 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 		// kind: Task and kind: PipelineTask, so a pipeline's webhook trigger is
 		// reachable over HTTP (GAP 1). Recording the path under the task ID lets
 		// OnUnregister deregister it the same way for both kinds.
+		//
+		// Cross-layer note: for a deferred webhook pipeline (cold start, stage not
+		// yet registered) eng.Register returned nil, so we claim the gateway route
+		// here even though the engine's webhooks map is not populated until the
+		// stage lands and retryDeferredPipelines schedules it. Until then a POST
+		// reaches the gateway, misses the engine's webhooks lookup, and 404s from
+		// the engine layer (correct "not ready" behaviour); the route starts
+		// routing once the stage arrives. The route is released on OnUnregister.
 		registerGatewayWebhook(gateway, webhookPaths, &webhookMu, webhookH, k)
 
 		if !isSpec {

--- a/pkg/daemon/webhook_register.go
+++ b/pkg/daemon/webhook_register.go
@@ -1,0 +1,52 @@
+package daemon
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/dicode/dicode/pkg/ipc"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// registerGatewayWebhook claims the daemon-level HTTP gateway route for a task
+// or pipeline that declares a webhook trigger, recording the path under the
+// task ID so OnUnregister can deregister it later.
+//
+// This is kind-aware: both kind: Task (*task.Spec) and kind: PipelineTask
+// (*task.PipelineTask) can carry a webhook trigger. The engine already wires
+// the routing side for both (registerWebhook/registerWebhookPath populate the
+// engine's internal webhooks map, and WebhookHandler dispatches pipelines via
+// GetKinded → handlePipelineWebhook). What was missing for pipelines was THIS:
+// the daemon-level gateway.Register that puts the path on the HTTP surface so a
+// POST actually reaches webhookH. Without it, a pipeline's webhook returned 404
+// before the handler ran (GAP 1).
+//
+// webhookH is the same gateway handler used for kind: Task — it routes into the
+// engine's WebhookHandler, which resolves the kind and fires the right path.
+//
+// No-op for kinds with no webhook trigger (manual/cron/chain), and for unknown
+// kinds.
+func registerGatewayWebhook(
+	gateway *ipc.Gateway,
+	webhookPaths map[string]string,
+	webhookMu *sync.Mutex,
+	webhookH http.Handler,
+	k task.Kinded,
+) {
+	var id, path string
+	switch v := k.(type) {
+	case *task.Spec:
+		id, path = v.ID, v.Trigger.Webhook
+	case *task.PipelineTask:
+		id, path = v.ID, v.Trigger.Webhook
+	default:
+		return
+	}
+	if path == "" {
+		return
+	}
+	gateway.Register(path, webhookH)
+	webhookMu.Lock()
+	webhookPaths[id] = path
+	webhookMu.Unlock()
+}

--- a/pkg/daemon/webhook_register_test.go
+++ b/pkg/daemon/webhook_register_test.go
@@ -1,0 +1,153 @@
+package daemon
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/ipc"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// TestRegisterGatewayWebhook_Pipeline is the regression test for GAP 1: a
+// kind: PipelineTask with trigger.webhook must get its gateway route wired so
+// POST /hooks/<path> reaches the engine WebhookHandler instead of 404ing.
+// Before the fix, OnRegister returned early for non-*task.Spec kinds and never
+// called gateway.Register for pipelines.
+func TestRegisterGatewayWebhook_Pipeline(t *testing.T) {
+	gateway := ipc.NewGateway()
+	var webhookMu sync.Mutex
+	webhookPaths := make(map[string]string)
+
+	hit := false
+	webhookH := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "p", Name: "P", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Webhook: "/hooks/pipe"},
+		Stages:  []task.Stage{{Task: "s"}},
+	}
+
+	registerGatewayWebhook(gateway, webhookPaths, &webhookMu, webhookH, pipe)
+
+	// The gateway must now route a POST for the pipeline's webhook path.
+	w := httptest.NewRecorder()
+	gateway.ServeHTTP(w, httptest.NewRequest("POST", "/hooks/pipe", nil))
+	if w.Code != http.StatusOK || !hit {
+		t.Fatalf("pipeline webhook not routed by gateway: code=%d hit=%v", w.Code, hit)
+	}
+
+	// And the path must be recorded under the pipeline ID so OnUnregister
+	// cleanup deregisters it.
+	webhookMu.Lock()
+	got := webhookPaths["p"]
+	webhookMu.Unlock()
+	if got != "/hooks/pipe" {
+		t.Fatalf("webhookPaths[p] = %q, want /hooks/pipe", got)
+	}
+}
+
+// TestRegisterGatewayWebhook_Task confirms the kind: Task path still wires the
+// gateway route (no regression to the original behaviour).
+func TestRegisterGatewayWebhook_Task(t *testing.T) {
+	gateway := ipc.NewGateway()
+	var webhookMu sync.Mutex
+	webhookPaths := make(map[string]string)
+
+	hit := false
+	webhookH := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	spec := &task.Spec{
+		ID: "t", Name: "T", Enabled: true, Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Webhook: "/hooks/task"},
+	}
+
+	registerGatewayWebhook(gateway, webhookPaths, &webhookMu, webhookH, spec)
+
+	w := httptest.NewRecorder()
+	gateway.ServeHTTP(w, httptest.NewRequest("POST", "/hooks/task", nil))
+	if w.Code != http.StatusOK || !hit {
+		t.Fatalf("task webhook not routed by gateway: code=%d hit=%v", w.Code, hit)
+	}
+
+	webhookMu.Lock()
+	got := webhookPaths["t"]
+	webhookMu.Unlock()
+	if got != "/hooks/task" {
+		t.Fatalf("webhookPaths[t] = %q, want /hooks/task", got)
+	}
+}
+
+// TestRegisterGatewayWebhook_PipelineUnregisterCleanup confirms the OnUnregister
+// cleanup contract: because registerGatewayWebhook records the pipeline path
+// under its task ID, the same generic cleanup the daemon runs for kind: Task
+// (look up webhookPaths[id] → gateway.Unregister) deregisters the pipeline's
+// route. This guards against a pipeline webhook lingering after removal.
+func TestRegisterGatewayWebhook_PipelineUnregisterCleanup(t *testing.T) {
+	gateway := ipc.NewGateway()
+	var webhookMu sync.Mutex
+	webhookPaths := make(map[string]string)
+	webhookH := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "p", Name: "P", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Webhook: "/hooks/pipe"},
+		Stages:  []task.Stage{{Task: "s"}},
+	}
+	registerGatewayWebhook(gateway, webhookPaths, &webhookMu, webhookH, pipe)
+
+	// Mirror the daemon's OnUnregister cleanup (kind-agnostic, keyed by id).
+	webhookMu.Lock()
+	path := webhookPaths["p"]
+	delete(webhookPaths, "p")
+	webhookMu.Unlock()
+	if path != "" {
+		gateway.Unregister(path)
+	}
+
+	w := httptest.NewRecorder()
+	gateway.ServeHTTP(w, httptest.NewRequest("POST", "/hooks/pipe", nil))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("pipeline webhook route not cleaned up: got %d, want 404", w.Code)
+	}
+}
+
+// TestRegisterGatewayWebhook_NoWebhook ensures a pipeline/task without a webhook
+// trigger claims no gateway route (so manual/cron-only specs aren't routed).
+func TestRegisterGatewayWebhook_NoWebhook(t *testing.T) {
+	gateway := ipc.NewGateway()
+	var webhookMu sync.Mutex
+	webhookPaths := make(map[string]string)
+	webhookH := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "cron-pipe", Name: "CP", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Cron: "0 0 * * *"},
+		Stages:  []task.Stage{{Task: "s"}},
+	}
+	registerGatewayWebhook(gateway, webhookPaths, &webhookMu, webhookH, pipe)
+
+	webhookMu.Lock()
+	_, recorded := webhookPaths["cron-pipe"]
+	webhookMu.Unlock()
+	if recorded {
+		t.Fatal("cron-only pipeline must not claim a gateway webhook path")
+	}
+	w := httptest.NewRecorder()
+	gateway.ServeHTTP(w, httptest.NewRequest("POST", "/hooks/pipe", nil))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unregistered path, got %d", w.Code)
+	}
+}

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -73,6 +73,19 @@ type Engine struct {
 	// don't race today; this is defense-in-depth for future callers.
 	registerMu sync.Mutex
 
+	// deferredPipelines holds kind: PipelineTask registrations that were
+	// rejected because a stage task was not yet in the registry — the
+	// cold-start ordering case where the reconciler registers a pipeline
+	// before its stages (#341). Such a pipeline is kept here (keyed by ID)
+	// instead of erroring; when a kind: Task later registers successfully,
+	// Register replays the deferred set, so a pipeline self-heals once its
+	// stages exist — without needing a file change to trigger re-reconcile.
+	// Guarded by registerMu (same lock that serialises the whole Register
+	// path), so retries can't race a concurrent registration. Entries are
+	// dropped on success and on Unregister(id) so a removed/superseded
+	// pipeline is never resurrected.
+	deferredPipelines map[string]*task.PipelineTask
+
 	runCancels       sync.Map // runID → context.CancelFunc
 	runDone          sync.Map // runID (string) → chan struct{}, closed when the run reaches a terminal state
 	runTriggerSource sync.Map // runID (string) → triggerSource (registry.TriggerSource)
@@ -179,18 +192,19 @@ type PythonRuntimeAPI interface {
 // New creates a trigger Engine with a default Deno executor.
 func New(r *registry.Registry, defaultExec pkgruntime.Executor, log *zap.Logger) *Engine {
 	e := &Engine{
-		registry:      r,
-		executors:     make(map[task.Runtime]pkgruntime.Executor),
-		cron:          cron.New(),
-		log:           log,
-		cronEntries:   make(map[string]cron.EntryID),
-		webhooks:      make(map[string]string),
-		daemonRuns:    make(map[string]string),
-		daemonSpecs:   make(map[string]*task.Spec),
-		daemonStates:  newDaemonStateMap(),
-		restartGates:  newRestartGate(),
-		livePipelines: make(map[string]*PipelineRunner),
-		guards:        newChainGuards(),
+		registry:          r,
+		executors:         make(map[task.Runtime]pkgruntime.Executor),
+		cron:              cron.New(),
+		log:               log,
+		cronEntries:       make(map[string]cron.EntryID),
+		webhooks:          make(map[string]string),
+		daemonRuns:        make(map[string]string),
+		daemonSpecs:       make(map[string]*task.Spec),
+		daemonStates:      newDaemonStateMap(),
+		restartGates:      newRestartGate(),
+		livePipelines:     make(map[string]*PipelineRunner),
+		deferredPipelines: make(map[string]*task.PipelineTask),
+		guards:            newChainGuards(),
 	}
 	e.executors[task.RuntimeDeno] = defaultExec
 	return e
@@ -375,7 +389,13 @@ func (e *Engine) Register(k task.Kinded) error {
 			return err
 		}
 
-		e.Unregister(s.ID)
+		// We already hold registerMu, so use the non-locking teardown and drop
+		// any deferred-pipeline entry for this ID inline (registerMu guards it).
+		// In practice a Spec ID won't be in deferredPipelines (that map only
+		// holds pipelines), but the delete is a cheap no-op safeguard if a
+		// pipeline is ever replaced in-place by a Task of the same ID.
+		delete(e.deferredPipelines, s.ID)
+		e.unregisterTriggers(s.ID)
 
 		// Disabled tasks are kept in the registry for API visibility but must not
 		// be scheduled, spawned as daemons, or registered as webhook endpoints.
@@ -401,6 +421,12 @@ func (e *Engine) Register(k task.Kinded) error {
 			zap.String("trigger", string(triggerSource(s))),
 			zap.String("runtime", string(s.Runtime)),
 		)
+		// A kind: Task just landed — it may be the stage a deferred pipeline was
+		// waiting on (cold-start ordering, #341). Retry the deferred set so such
+		// a pipeline schedules itself without needing a file change. Runs under
+		// registerMu (held for the whole Register path), which also guards
+		// deferredPipelines.
+		e.retryDeferredPipelines()
 		return nil
 	default:
 		return fmt.Errorf("engine: unsupported task kind %q", k.KindOf())
@@ -596,8 +622,26 @@ func (e *Engine) detectBeforeCycle(spec *task.Spec) string {
 	return ""
 }
 
-// Unregister removes all trigger registrations for a task ID.
+// Unregister removes all trigger registrations for a task ID and drops any
+// deferred-pipeline entry for it, so a pipeline that was parked waiting for its
+// stages (cold-start ordering, #341) is never resurrected after removal.
+//
+// This is the public entry point used by the reconciler's OnUnregister. It must
+// NOT be called while holding registerMu; the internal Register path uses
+// unregisterTriggers instead (it already holds registerMu and drops the
+// deferred entry inline).
 func (e *Engine) Unregister(id string) {
+	e.registerMu.Lock()
+	delete(e.deferredPipelines, id)
+	e.registerMu.Unlock()
+	e.unregisterTriggers(id)
+}
+
+// unregisterTriggers removes all trigger registrations (cron, webhook, daemon)
+// for a task ID. Split out from Unregister so the Register path can reuse it
+// while already holding registerMu without deadlocking on a re-entrant lock.
+// Does NOT touch deferredPipelines (the caller handles that under registerMu).
+func (e *Engine) unregisterTriggers(id string) {
 	e.mu.Lock()
 	hadCron := false
 	if entryID, ok := e.cronEntries[id]; ok {

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -2467,7 +2467,9 @@ func (e *Engine) runTask(runCtx context.Context, spec *task.Spec, opts pkgruntim
 	// when the stage task ALSO happens to be a registered standalone daemon,
 	// flip that standalone daemon's global DaemonState and possibly schedule an
 	// unintended startDaemon on a mid-pipeline restart's KillRun (#344, LOW
-	// security). Suppress the hook for pipeline-stage runs.
+	// security). Suppress the hook for pipeline-stage runs. This gate depends on
+	// fireStageRaw always dispatching pipeline stages with TriggerPipelineStage
+	// (see the INVARIANT note at pipeline_runner.go:fireStageRaw's fireAsync).
 	if spec.Trigger.Daemon && source != registry.TriggerPipelineStage {
 		e.onDaemonRunFinished(spec, opts.RunID)
 	}

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -2457,7 +2457,18 @@ func (e *Engine) runTask(runCtx context.Context, spec *task.Spec, opts pkgruntim
 		h(spec.ID, opts.RunID, status, string(source), elapsed.Milliseconds())
 	}
 
-	if spec.Trigger.Daemon {
+	// Drive the standalone-daemon lifecycle (restart-policy decision,
+	// DaemonState transition) only for runs that the engine actually manages as
+	// standalone daemons. A pipeline's terminal stage is dispatched as a
+	// daemon-kind run too (source=pipeline-stage), but it is owned by the
+	// PipelineRunner, not the standalone-daemon machinery: its lifetime,
+	// restarts, and DaemonState are not tracked in daemonRuns/daemonStates.
+	// Routing a pipeline-stage daemon run through onDaemonRunFinished would,
+	// when the stage task ALSO happens to be a registered standalone daemon,
+	// flip that standalone daemon's global DaemonState and possibly schedule an
+	// unintended startDaemon on a mid-pipeline restart's KillRun (#344, LOW
+	// security). Suppress the hook for pipeline-stage runs.
+	if spec.Trigger.Daemon && source != registry.TriggerPipelineStage {
 		e.onDaemonRunFinished(spec, opts.RunID)
 	}
 

--- a/pkg/trigger/pipeline_runner.go
+++ b/pkg/trigger/pipeline_runner.go
@@ -296,6 +296,12 @@ func (e *Engine) fireStageRaw(ctx context.Context, st task.Stage, upstream task.
 		dispatchSpec = merged
 	}
 
+	// INVARIANT: the registry.TriggerPipelineStage source here is load-bearing,
+	// not cosmetic. runTask keys off it (engine.go:onDaemonRunFinished gate) to
+	// skip the standalone-daemon onDaemonRunFinished lifecycle hook for pipeline
+	// stages — pipeline-owned daemon runs must not flip global DaemonState or
+	// schedule restarts (#344). Any future stage-dispatch path MUST fire with
+	// this source, or daemon-lifecycle suppression silently stops protecting.
 	runID, err := e.fireAsync(ctx, dispatchSpec, pkgruntime.RunOptions{ParentRunID: parentRunID}, registry.TriggerPipelineStage)
 	if err != nil {
 		return "", false, fmt.Errorf("dispatch: %w", err)

--- a/pkg/trigger/pipeline_runner.go
+++ b/pkg/trigger/pipeline_runner.go
@@ -204,9 +204,11 @@ func (r *PipelineRunner) runTerminalDaemon(stageIdx int, stage task.Stage, upstr
 		status := res.Status
 		ret := res.ReturnValue
 		if werr != nil {
-			// WaitRun with a background context only errors on a pathological
-			// internal failure (never ctx cancellation). Surface it loudly and
-			// stop the orphaned daemon subprocess.
+			// With a background context WaitRun never errors on cancellation; it
+			// errors only on a DB read failure or a missing run row
+			// (ErrRunNotFound). Either way the run's terminal status is
+			// unrecoverable here — surface it loudly and stop the (possibly still
+			// live) daemon subprocess rather than leaving it orphaned.
 			e.log.Error("pipeline terminal daemon wait failed",
 				zap.String("pipeline", r.spec.ID),
 				zap.String("daemon_run", current),
@@ -398,6 +400,14 @@ func (e *Engine) unregisterLivePipeline(pipelineID string, r *PipelineRunner) {
 	e.livePipelineMu.Unlock()
 }
 
+// pipelineRestartGateKey namespaces a pipeline ID for use as a restartGates
+// key. restartGates is shared with the standalone-daemon restart path, which
+// keys it by daemon task ID; the prefix prevents a pipeline whose ID equals a
+// daemon task ID from cross-coalescing with that daemon's gate (#344).
+func pipelineRestartGateKey(pipelineID string) string {
+	return "pipeline:" + pipelineID
+}
+
 // pipelineContainsStage reports whether the pipeline lists taskID as a stage.
 func pipelineContainsStage(p *task.PipelineTask, taskID string) bool {
 	for _, st := range p.Stages {
@@ -451,13 +461,18 @@ func (e *Engine) handlePipelineStageRerun(completedTaskID string, output interfa
 // ${input}, then kill+wait the old daemon run and re-fire the terminal stage.
 func (e *Engine) propagatePipelineStageRerun(runner *PipelineRunner, reranTaskID string, reranReturn interface{}) {
 	pipelineID := runner.spec.ID
-	if !e.restartGates.tryAcquire(pipelineID) {
+	// restartGates is shared with the standalone-daemon restart path
+	// (propagateBeforeRerun), which keys it by daemon TASK ID. Namespace the
+	// pipeline key so a pipeline whose ID happens to equal a daemon task ID
+	// can't cross-coalesce with that daemon's restart gate (#344, LOW).
+	gateKey := pipelineRestartGateKey(pipelineID)
+	if !e.restartGates.tryAcquire(gateKey) {
 		// A propagation/restart is already queued or in flight; coalesce.
 		e.log.Debug("pipeline stage re-fire coalesced", zap.String("pipeline", pipelineID))
 		return
 	}
 	go func() {
-		defer e.restartGates.release(pipelineID)
+		defer e.restartGates.release(gateKey)
 
 		// Find the re-fired stage's index in the pipeline's stages.
 		startIdx := -1
@@ -615,14 +630,37 @@ func (e *Engine) propagatePipelineStageRerun(runner *PipelineRunner, reranTaskID
 
 		// Publish the new daemon run + upstream so the runner's wait loop
 		// re-waits on it. Clear restarting under the same lock so the loop sees
-		// a consistent snapshot. If the pipeline finished while we were
-		// restarting (e.g. an operator KillRun on the parent during the
-		// restart window), don't publish an untracked run — kill the fresh
-		// daemon so its subprocess doesn't leak.
+		// a consistent snapshot.
+		//
+		// Two abort conditions, checked under the SAME mutex as the publish so
+		// there's no TOCTOU between "is the pipeline still alive?" and "adopt the
+		// fresh run":
+		//
+		//   - runner.finished: the pipeline already finished (its terminal-daemon
+		//     wait loop ran finish()) while we were restarting.
+		//   - runner.runCtx.Err() != nil: the pipeline parent was KillRun'd /
+		//     cancelled while we were restarting. The single-shot runCtx watcher
+		//     in runTerminalDaemon may have already fired on the now-dead OLD run
+		//     (it's spent), so adopting the fresh run here would leave it with
+		//     nothing to kill it → leaked daemon subprocess + pipeline wedged
+		//     'running' (#344, HIGH). Refuse to adopt: kill the fresh daemon and
+		//     leave daemonRunID pointing at the killed old run so the wait loop's
+		//     "restart aborted" branch finishes the pipeline with the old run's
+		//     terminal status (cancelled).
+		//
+		// The deferred cleanup (published==false) clears restarting + closes
+		// restartDone on either abort, unblocking the wait loop.
 		runner.mu.Lock()
 		if runner.finished {
 			runner.mu.Unlock()
 			e.log.Debug("pipeline stage re-fire: pipeline finished during restart; stopping fresh daemon run",
+				zap.String("pipeline", pipelineID))
+			e.KillRun(newRunID)
+			return
+		}
+		if runner.runCtx.Err() != nil {
+			runner.mu.Unlock()
+			e.log.Debug("pipeline stage re-fire: pipeline cancelled during restart; stopping fresh daemon run",
 				zap.String("pipeline", pipelineID))
 			e.KillRun(newRunID)
 			return

--- a/pkg/trigger/pipeline_runner_test.go
+++ b/pkg/trigger/pipeline_runner_test.go
@@ -2,6 +2,8 @@ package trigger
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -532,5 +534,242 @@ func TestPipelineStageRerun(t *testing.T) {
 
 	// Cleanup: kill the pipeline so the daemon subprocess doesn't linger.
 	env.engine.KillRun(parentRunID)
+	waitForTerminal(t, env.engine, parentRunID, 15*time.Second)
+}
+
+// TestPipelineParentKillDuringRestart covers the parent-kill-mid-restart window
+// that TestPipelineStageRerun misses (#344, HIGH). A live pipeline with a daemon
+// terminal stage is restarted by a mid-pipeline stage re-fire; the operator
+// KillRun's the pipeline PARENT while the restart handshake is in flight — old
+// daemon run already killed, the freshly-fired daemon run not yet published to
+// the runner's wait loop.
+//
+// Determinism: the runStartedHook fires synchronously inside fireStageRaw, so
+// when it observes the 2nd start of the terminal daemon task (the restart's new
+// run), propagatePipelineStageRerun is still blocked inside fireStageRaw and has
+// NOT reached its publish critical section. KillRun(parent) from the hook lands
+// runCtx cancellation squarely in the mid-restart window. The publish path must
+// then refuse to adopt the fresh daemon (runCtx cancelled), kill it, and let the
+// pipeline finish 'cancelled'.
+//
+// Invariants asserted after the parent kill:
+//
+//	(a) no daemon-stage child run remains 'running' (no orphaned subprocess);
+//	(b) the pipeline parent ends non-'running' (cancelled).
+func TestPipelineParentKillDuringRestart(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+	env := newTestEnv(t)
+	dir := t.TempDir()
+
+	stage0 := writeTask(t, dir, "pk-0",
+		`export default async function main() { return "gen" }`,
+		task.TriggerConfig{Manual: true})
+	stage1 := writeTask(t, dir, "pk-1",
+		`export default async function main({ params }) { return await params.get("content") }`,
+		task.TriggerConfig{Manual: true})
+	// Terminal daemon stage blocks until killed; restart:never so a kill
+	// doesn't engage the daemon auto-restart path.
+	stage2 := writeTask(t, dir, "pk-2",
+		`export default async function main() { while (true) { await new Promise(r => setTimeout(r, 200)); } }`,
+		task.TriggerConfig{Daemon: true, Restart: "never"})
+	for _, s := range []*task.Spec{stage0, stage1, stage2} {
+		if err := env.reg.Register(s); err != nil {
+			t.Fatalf("reg.Register %s: %v", s.ID, err)
+		}
+		if err := env.engine.Register(s); err != nil {
+			t.Fatalf("eng.Register %s: %v", s.ID, err)
+		}
+	}
+
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "pk-pipe", Name: "PK", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Manual: true},
+		Stages: []task.Stage{
+			{Task: "pk-0"},
+			{Task: "pk-1", Overrides: &task.Overrides{
+				Params: task.ParamOverrides{{Name: "content", Default: "${input.output}"}}}},
+			{Task: "pk-2"},
+		},
+	}
+	if err := env.reg.Register(pipe); err != nil {
+		t.Fatalf("reg.Register pipe: %v", err)
+	}
+	if err := env.engine.Register(pipe); err != nil {
+		t.Fatalf("eng.Register pipe: %v", err)
+	}
+
+	parentRunID, err := env.engine.FireManual(context.Background(), "pk-pipe", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+
+	// Install the kill-during-restart trap: on the 2nd start of the terminal
+	// daemon task (= the restart's freshly-fired run), KillRun the pipeline
+	// parent. The hook runs synchronously inside fireStageRaw, before the
+	// runner's wait loop can adopt the new run — i.e. inside the restart window.
+	var daemonStarts int32
+	killed := make(chan struct{})
+	var killOnce sync.Once
+	env.engine.SetRunStartedHook(func(taskID, runID, triggerSource string) {
+		if taskID != "pk-2" {
+			return
+		}
+		if atomic.AddInt32(&daemonStarts, 1) == 2 {
+			env.engine.KillRun(parentRunID)
+			killOnce.Do(func() { close(killed) })
+		}
+	})
+
+	// Wait until the terminal daemon stage is up: the pipeline is live.
+	findStageChild(t, env, parentRunID, "pk-2", registry.StatusRunning, 20*time.Second)
+
+	// Operator re-fires stage 0 standalone → handlePipelineStageRerun replays
+	// descendants + restarts the terminal daemon. The restart's new run start
+	// trips the hook above, which KillRun's the parent mid-restart.
+	if _, err := env.engine.FireManual(context.Background(), "pk-0", nil); err != nil {
+		t.Fatalf("FireManual pk-0 (re-fire): %v", err)
+	}
+
+	// The hook must fire (the restart must reach the new-run-start point).
+	select {
+	case <-killed:
+	case <-time.After(25 * time.Second):
+		t.Fatal("restart never reached the new-daemon-run start; window not exercised")
+	}
+
+	// (b) The pipeline parent must end non-'running' (cancelled), not wedge.
+	final := waitForTerminal(t, env.engine, parentRunID, 20*time.Second)
+	if final.Status == registry.StatusRunning {
+		t.Fatalf("pipeline parent wedged 'running' after parent KillRun during restart")
+	}
+	if final.Status != registry.StatusCancelled {
+		t.Fatalf("pipeline final status = %q (reason=%q), want 'cancelled'", final.Status, final.FailureReason)
+	}
+
+	// (a) No daemon-stage child run may remain 'running' — neither the killed
+	// old run nor the freshly-fired-but-unadopted new run. Poll: the new run's
+	// kill is async (KillRun cancels its ctx; the run drains to a terminal).
+	waitUntil(t, 20*time.Second, func() bool {
+		kids, _ := env.reg.ListChildren(context.Background(), parentRunID, 100)
+		for _, c := range kids {
+			if c.TaskID == "pk-2" && c.Status == registry.StatusRunning {
+				return false
+			}
+		}
+		return true
+	}, "a terminal daemon stage child remained 'running' after parent KillRun during restart")
+}
+
+// TestPipelineStageDaemonDoesNotFlipStandaloneDaemonState covers the
+// daemon-state cross-contamination bug (#344, LOW security): a task that is BOTH
+// a registered standalone daemon AND a pipeline's terminal stage. Killing the
+// pipeline-stage run (as a mid-pipeline restart does) must NOT route through the
+// standalone-daemon lifecycle hook (onDaemonRunFinished) and flip the standalone
+// daemon's global DaemonState.
+//
+// Setup: register daemon task "shared" — registration auto-starts it standalone
+// (DaemonState→Running, its own standalone run). Then fire a pipeline whose
+// terminal stage is "shared"; that dispatches a SEPARATE pipeline-stage run of
+// the same task. KillRun the pipeline-stage run. With the bug,
+// onDaemonRunFinished(shared, pipelineStageRunID) fires and flips
+// DaemonState(shared) to Stopped/Crashed even though the standalone daemon run
+// is untouched. The fix suppresses the hook for pipeline-stage runs, so the
+// standalone daemon's state stays Running.
+func TestPipelineStageDaemonDoesNotFlipStandaloneDaemonState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+	env := newTestEnv(t)
+	dir := t.TempDir()
+
+	// "shared" is a daemon that loops forever; restart:never so a kill doesn't
+	// auto-restart it.
+	shared := writeTask(t, dir, "shared",
+		`export default async function main() { while (true) { await new Promise(r => setTimeout(r, 200)); } }`,
+		task.TriggerConfig{Daemon: true, Restart: "never"})
+	if err := env.reg.Register(shared); err != nil {
+		t.Fatalf("reg.Register shared: %v", err)
+	}
+	if err := env.engine.Register(shared); err != nil {
+		t.Fatalf("eng.Register shared: %v", err)
+	}
+
+	// Registration auto-starts the STANDALONE daemon. Wait until it's Running.
+	waitUntil(t, 20*time.Second, func() bool {
+		return env.engine.DaemonState("shared") == DaemonRunning
+	}, "standalone daemon 'shared' did not reach DaemonRunning after registration")
+
+	// Record the standalone daemon's own run ID so we can tell it apart from the
+	// pipeline-stage run of the same task.
+	env.engine.daemonMu.Lock()
+	standaloneRunID := env.engine.daemonRuns["shared"]
+	env.engine.daemonMu.Unlock()
+	if standaloneRunID == "" {
+		t.Fatalf("no standalone daemon run recorded for 'shared'")
+	}
+
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "sd-pipe", Name: "SD", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Manual: true},
+		Stages:  []task.Stage{{Task: "shared"}},
+	}
+	if err := env.reg.Register(pipe); err != nil {
+		t.Fatalf("reg.Register pipe: %v", err)
+	}
+	if err := env.engine.Register(pipe); err != nil {
+		t.Fatalf("eng.Register pipe: %v", err)
+	}
+
+	parentRunID, err := env.engine.FireManual(context.Background(), "sd-pipe", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+
+	// Find the pipeline-stage run of "shared" (a child of the pipeline parent,
+	// distinct from the standalone run) once it's running.
+	stageChild := findStageChild(t, env, parentRunID, "shared", registry.StatusRunning, 20*time.Second)
+	if stageChild.ID == standaloneRunID {
+		t.Fatalf("pipeline-stage run ID collided with standalone run ID %s", standaloneRunID)
+	}
+
+	// Kill the PIPELINE-STAGE run (this is what a mid-pipeline restart does to
+	// the old terminal-daemon stage run). It must not disturb the standalone
+	// daemon's lifecycle/state.
+	if !env.engine.KillRun(stageChild.ID) {
+		t.Fatalf("KillRun(stageChild) returned false")
+	}
+
+	// Wait for the pipeline-stage run to actually terminate, so the
+	// onDaemonRunFinished hook (if it were going to fire) would have fired.
+	if _, werr := env.engine.WaitRun(context.Background(), stageChild.ID); werr != nil {
+		t.Fatalf("WaitRun(stageChild): %v", werr)
+	}
+
+	// The standalone daemon must remain Running: its state was NOT flipped by
+	// the pipeline-stage run finishing. Poll briefly to give any spurious async
+	// hook a chance to mis-fire (it must not).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := env.engine.DaemonState("shared"); got != DaemonRunning {
+			t.Fatalf("standalone daemon 'shared' state flipped to %q after pipeline-stage run killed; want still %q", got, DaemonRunning)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	// And its standalone run row must be untouched (still the same run, not
+	// removed from daemonRuns).
+	env.engine.daemonMu.Lock()
+	stillTracked := env.engine.daemonRuns["shared"]
+	env.engine.daemonMu.Unlock()
+	if stillTracked != standaloneRunID {
+		t.Fatalf("standalone daemon run tracking changed: %q != %q", stillTracked, standaloneRunID)
+	}
+
+	// Cleanup: stop the standalone daemon subprocess.
+	env.engine.KillRun(standaloneRunID)
+	// And drain the pipeline (its terminal stage was killed → pipeline finishes).
 	waitForTerminal(t, env.engine, parentRunID, 15*time.Second)
 }

--- a/pkg/trigger/registerpipeline.go
+++ b/pkg/trigger/registerpipeline.go
@@ -135,11 +135,28 @@ func (e *Engine) detectPipelineCycle(p *task.PipelineTask) string {
 // validation failure (bad subtype, invalid overrides, cycle) still returns an
 // error so the operator sees the misconfiguration.
 //
+// A disabled pipeline is short-circuited before the registry-ref check: it
+// schedules nothing regardless of its stages, so it is never deferred (and a
+// stale deferred entry is dropped if an enabled pipeline is re-registered
+// disabled).
+//
 // NOTE: registerPipeline must be called with e.registerMu already held (Engine.Register does this),
 // which is also what guards deferredPipelines.
 func (e *Engine) registerPipeline(p *task.PipelineTask) error {
 	if err := p.Validate(); err != nil {
 		return err
+	}
+	// Short-circuit a disabled pipeline before the registry-ref check: it
+	// schedules no triggers regardless of whether its stages ever arrive, so
+	// deferring it on a missing stage is pointless churn (it would sit in
+	// deferredPipelines and re-validate on every kind: Task registration, only
+	// to hit the disabled early-return below each time). Drop any stale deferred
+	// entry too — a pipeline deferred while enabled and re-registered disabled
+	// must not linger in the set and get retried.
+	if !p.Enabled {
+		delete(e.deferredPipelines, p.ID)
+		e.log.Info("pipeline registered (disabled — no triggers scheduled)", zap.String("task", p.ID))
+		return nil
 	}
 	if err := e.validatePipelineRefs(p); err != nil {
 		if errors.Is(err, errPipelineStageMissing) {
@@ -158,12 +175,8 @@ func (e *Engine) registerPipeline(p *task.PipelineTask) error {
 	}
 	// Validated cleanly — it must not linger in the deferred set (e.g. a
 	// previously-deferred pipeline whose stages have now arrived, or a
-	// re-registration after an edit).
+	// re-registration after an edit). Disabled pipelines already returned above.
 	delete(e.deferredPipelines, p.ID)
-	if !p.Enabled {
-		e.log.Info("pipeline registered (disabled — no triggers scheduled)", zap.String("task", p.ID))
-		return nil
-	}
 	// Schedule cron/webhook triggers. Manual pipelines fire via FireManual and
 	// chain pipelines via FireChain (Task 16), so neither needs scheduling here.
 	if p.Trigger.Cron != "" {

--- a/pkg/trigger/registerpipeline.go
+++ b/pkg/trigger/registerpipeline.go
@@ -1,6 +1,7 @@
 package trigger
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -8,6 +9,14 @@ import (
 	"github.com/dicode/dicode/pkg/taskset"
 	"go.uber.org/zap"
 )
+
+// errPipelineStageMissing marks a pipeline-ref validation failure caused solely
+// by a stage task not yet being present in the registry (the cold-start
+// ordering case, #341). registerPipeline wraps the per-stage error with this
+// sentinel so Register can distinguish "defer and retry once the stage lands"
+// from genuine, non-transient validation failures (bad subtype, invalid
+// overrides, cycle) which must still surface as errors.
+var errPipelineStageMissing = errors.New("pipeline stage task not yet registered")
 
 // validatePipelineRefs runs the registry-aware checks for a PipelineTask:
 // every stage task exists, is kind: Task (not a pipeline — v1 rule), each
@@ -17,7 +26,10 @@ func (e *Engine) validatePipelineRefs(p *task.PipelineTask) error {
 	for i, st := range p.Stages {
 		k, ok := e.registry.GetKinded(st.Task)
 		if !ok {
-			return fmt.Errorf("pipeline.stages[%d]: task %q not found in registry", i, st.Task)
+			// Wrap with the sentinel so registerPipeline can defer-and-retry
+			// rather than permanently reject — the stage may simply not have
+			// been reconciled yet (cold-start ordering, #341).
+			return fmt.Errorf("pipeline.stages[%d]: task %q not found in registry: %w", i, st.Task, errPipelineStageMissing)
 		}
 		ref, ok := k.(*task.Spec)
 		if !ok {
@@ -112,17 +124,42 @@ func (e *Engine) detectPipelineCycle(p *task.PipelineTask) string {
 	return dfs(p.ID)
 }
 
-// registerPipeline validates a PipelineTask against the registry. Trigger
-// scheduling (cron/webhook) and execution wiring land in a later PR; manual
-// pipelines need no scheduling here.
-// NOTE: registerPipeline must be called with e.registerMu already held (Engine.Register does this).
+// registerPipeline validates a PipelineTask against the registry and schedules
+// its cron/webhook triggers. Manual pipelines fire via FireManual and chain
+// pipelines via FireChain, so neither needs scheduling here.
+//
+// Cold-start ordering (#341): if validation fails ONLY because a stage task is
+// not yet registered (errPipelineStageMissing), the pipeline is recorded in
+// deferredPipelines and registerPipeline returns nil — it will be retried when
+// a kind: Task later registers (see retryDeferredPipelines). Any other
+// validation failure (bad subtype, invalid overrides, cycle) still returns an
+// error so the operator sees the misconfiguration.
+//
+// NOTE: registerPipeline must be called with e.registerMu already held (Engine.Register does this),
+// which is also what guards deferredPipelines.
 func (e *Engine) registerPipeline(p *task.PipelineTask) error {
 	if err := p.Validate(); err != nil {
 		return err
 	}
 	if err := e.validatePipelineRefs(p); err != nil {
+		if errors.Is(err, errPipelineStageMissing) {
+			// Defer: keep the pipeline so a later kind: Task registration can
+			// heal it without a file change. Logged once at INFO (not WARN) so
+			// reconcile cycles don't spam — a permanently-deferred pipeline is
+			// the bug, a transiently-deferred one is expected at cold start.
+			if _, already := e.deferredPipelines[p.ID]; !already {
+				e.log.Info("pipeline waiting for stage tasks to register — will retry",
+					zap.String("task", p.ID), zap.Error(err))
+			}
+			e.deferredPipelines[p.ID] = p
+			return nil
+		}
 		return err
 	}
+	// Validated cleanly — it must not linger in the deferred set (e.g. a
+	// previously-deferred pipeline whose stages have now arrived, or a
+	// re-registration after an edit).
+	delete(e.deferredPipelines, p.ID)
 	if !p.Enabled {
 		e.log.Info("pipeline registered (disabled — no triggers scheduled)", zap.String("task", p.ID))
 		return nil
@@ -137,4 +174,44 @@ func (e *Engine) registerPipeline(p *task.PipelineTask) error {
 	}
 	e.log.Info("pipeline registered", zap.String("task", p.ID), zap.Int("stages", len(p.Stages)))
 	return nil
+}
+
+// retryDeferredPipelines re-attempts registration of every pipeline currently
+// parked in deferredPipelines. Called after a kind: Task registers
+// successfully — the newly-arrived stage may be exactly the one a deferred
+// pipeline was waiting for. Each retry runs registerPipeline, which removes the
+// pipeline from the set on success (it schedules cron/webhook) and leaves it
+// parked if a stage is still missing. A genuinely-broken pipeline that now
+// fails for a NON-missing-stage reason (e.g. an override that becomes invalid
+// once its stage exists) is dropped from the deferred set and surfaces a WARN —
+// it will never schedule but also won't be retried forever.
+//
+// MUST be called with e.registerMu held (Register holds it across the whole
+// path); deferredPipelines is guarded by registerMu.
+func (e *Engine) retryDeferredPipelines() {
+	if len(e.deferredPipelines) == 0 {
+		return
+	}
+	// Snapshot the IDs so we can mutate the map inside the loop (registerPipeline
+	// deletes on success). Order is irrelevant: each pipeline validates against
+	// the full registry independently.
+	pending := make([]*task.PipelineTask, 0, len(e.deferredPipelines))
+	for _, p := range e.deferredPipelines {
+		pending = append(pending, p)
+	}
+	for _, p := range pending {
+		// A pipeline may have been unregistered/superseded between defer and
+		// retry; skip if it's no longer the parked entry for this ID.
+		if e.deferredPipelines[p.ID] != p {
+			continue
+		}
+		if err := e.registerPipeline(p); err != nil {
+			// registerPipeline returns nil for the still-missing-stage case
+			// (re-defers). A non-nil error here means the pipeline is genuinely
+			// invalid now that its stage exists — stop retrying it.
+			delete(e.deferredPipelines, p.ID)
+			e.log.Warn("deferred pipeline failed to register after stage arrived — fix the spec to re-enable",
+				zap.String("task", p.ID), zap.Error(err))
+		}
+	}
 }

--- a/pkg/trigger/registerpipeline_test.go
+++ b/pkg/trigger/registerpipeline_test.go
@@ -160,6 +160,162 @@ func TestRegisterPipelineValidates(t *testing.T) {
 	}
 }
 
+// TestColdStartDeferredPipeline is the regression test for GAP 2 (#341): on a
+// fresh daemon the reconciler can register a pipeline BEFORE its stage tasks.
+// registerPipeline → validatePipelineRefs then fails ("stage task not found"),
+// and nothing retried — so the pipeline's cron/webhook never got scheduled
+// until its file changed. The fix records such pipelines in deferredPipelines
+// and retries them when a kind: Task is later registered successfully.
+func TestColdStartDeferredPipeline(t *testing.T) {
+	env := newTestEnv(t)
+
+	// 1. Register the pipeline FIRST — its stage "s" is not yet registered.
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "p", Name: "P", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Cron: "0 0 * * *"},
+		Stages:  []task.Stage{{Task: "s"}},
+	}
+	if err := env.reg.Register(pipe); err != nil {
+		t.Fatalf("registry.Register(pipe): %v", err)
+	}
+	// Register must NOT return a fatal error — the pipeline is deferred.
+	if err := env.engine.Register(pipe); err != nil {
+		t.Fatalf("Register(pipe) before stage should defer, not error: %v", err)
+	}
+	// It must NOT be scheduled yet (no cron entry).
+	env.engine.mu.Lock()
+	_, scheduled := env.engine.cronEntries["p"]
+	env.engine.mu.Unlock()
+	if scheduled {
+		t.Fatal("pipeline should not be scheduled before its stage exists")
+	}
+	// It must be recorded as deferred.
+	env.engine.registerMu.Lock()
+	_, deferred := env.engine.deferredPipelines["p"]
+	env.engine.registerMu.Unlock()
+	if !deferred {
+		t.Fatal("pipeline with missing stage should be recorded as deferred")
+	}
+
+	// 2. Now register the stage task — WITHOUT re-submitting the pipeline.
+	stage := &task.Spec{ID: "s", Name: "S", Enabled: true,
+		Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}}
+	if err := env.reg.Register(stage); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.engine.Register(stage); err != nil {
+		t.Fatalf("Register(stage): %v", err)
+	}
+
+	// 3. The pipeline must now be scheduled (cron entry appears) and dropped
+	// from the deferred set.
+	env.engine.mu.Lock()
+	_, scheduled = env.engine.cronEntries["p"]
+	env.engine.mu.Unlock()
+	if !scheduled {
+		t.Fatal("pipeline was not scheduled after its stage registered (deferred-retry failed)")
+	}
+	env.engine.registerMu.Lock()
+	_, stillDeferred := env.engine.deferredPipelines["p"]
+	env.engine.registerMu.Unlock()
+	if stillDeferred {
+		t.Fatal("pipeline should be removed from deferred set once it schedules")
+	}
+}
+
+// TestColdStartDeferredPipeline_GenuinelyMissingStaysUnscheduled confirms a
+// pipeline whose stage is never registered stays unscheduled forever — no
+// crash, no infinite retry, just a permanently-deferred entry that never
+// schedules. Registering an UNRELATED stage triggers a retry attempt that must
+// fail cleanly and leave the pipeline deferred.
+func TestColdStartDeferredPipeline_GenuinelyMissingStaysUnscheduled(t *testing.T) {
+	env := newTestEnv(t)
+
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "p", Name: "P", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Cron: "0 0 * * *"},
+		Stages:  []task.Stage{{Task: "never-exists"}},
+	}
+	if err := env.reg.Register(pipe); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.engine.Register(pipe); err != nil {
+		t.Fatalf("Register(pipe) should defer, not error: %v", err)
+	}
+
+	// Register an unrelated stage — triggers a retry that must fail cleanly.
+	other := &task.Spec{ID: "other", Name: "Other", Enabled: true,
+		Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}}
+	if err := env.reg.Register(other); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.engine.Register(other); err != nil {
+		t.Fatalf("Register(other): %v", err)
+	}
+
+	env.engine.mu.Lock()
+	_, scheduled := env.engine.cronEntries["p"]
+	env.engine.mu.Unlock()
+	if scheduled {
+		t.Fatal("pipeline with a genuinely-missing stage must never schedule")
+	}
+	env.engine.registerMu.Lock()
+	_, deferred := env.engine.deferredPipelines["p"]
+	env.engine.registerMu.Unlock()
+	if !deferred {
+		t.Fatal("genuinely-missing pipeline should remain deferred")
+	}
+}
+
+// TestColdStartDeferredPipeline_DroppedOnUnregister confirms a deferred
+// pipeline that is later unregistered is removed from the deferred set, so a
+// subsequent stage registration does not resurrect a stale pipeline.
+func TestColdStartDeferredPipeline_DroppedOnUnregister(t *testing.T) {
+	env := newTestEnv(t)
+
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "p", Name: "P", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Cron: "0 0 * * *"},
+		Stages:  []task.Stage{{Task: "s"}},
+	}
+	if err := env.reg.Register(pipe); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.engine.Register(pipe); err != nil {
+		t.Fatalf("Register(pipe): %v", err)
+	}
+
+	// Unregister the deferred pipeline (e.g. its file was removed).
+	env.reg.Unregister("p")
+	env.engine.Unregister("p")
+
+	env.engine.registerMu.Lock()
+	_, deferred := env.engine.deferredPipelines["p"]
+	env.engine.registerMu.Unlock()
+	if deferred {
+		t.Fatal("unregistered pipeline must be dropped from the deferred set")
+	}
+
+	// Now register the stage — the dropped pipeline must NOT come back.
+	stage := &task.Spec{ID: "s", Name: "S", Enabled: true,
+		Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}}
+	if err := env.reg.Register(stage); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.engine.Register(stage); err != nil {
+		t.Fatal(err)
+	}
+	env.engine.mu.Lock()
+	_, scheduled := env.engine.cronEntries["p"]
+	env.engine.mu.Unlock()
+	if scheduled {
+		t.Fatal("dropped pipeline must not be resurrected by a later stage registration")
+	}
+}
+
 func TestEngineRegisterRoutesByKind(t *testing.T) {
 	env := newTestEnv(t)
 	stage := &task.Spec{ID: "s", Name: "S", Enabled: true,

--- a/pkg/trigger/registerpipeline_test.go
+++ b/pkg/trigger/registerpipeline_test.go
@@ -224,6 +224,140 @@ func TestColdStartDeferredPipeline(t *testing.T) {
 	}
 }
 
+// TestColdStartDeferredPipeline_Webhook is the webhook analogue of
+// TestColdStartDeferredPipeline and locks in the cross-layer behaviour the
+// daemon comment describes: a webhook-triggered pipeline registered before its
+// stage is deferred and does NOT claim its path in the engine's webhooks map.
+// At the daemon layer the gateway route is still claimed at defer time, so a
+// POST reaches the engine but misses this lookup and 404s — the engine
+// webhooks[path] entry only appears once the stage lands and the deferred
+// pipeline is retried/scheduled. We assert against the engine routing table
+// directly (no full daemon+gateway harness needed: the engine map is the
+// authority for whether the path actually routes).
+func TestColdStartDeferredPipeline_Webhook(t *testing.T) {
+	env := newTestEnv(t)
+
+	const path = "/hooks/pipe"
+
+	// 1. Register the webhook pipeline FIRST — its stage "s" is absent.
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "wp", Name: "WP", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Webhook: path},
+		Stages:  []task.Stage{{Task: "s"}},
+	}
+	if err := env.reg.Register(pipe); err != nil {
+		t.Fatalf("registry.Register(pipe): %v", err)
+	}
+	if err := env.engine.Register(pipe); err != nil {
+		t.Fatalf("Register(pipe) before stage should defer, not error: %v", err)
+	}
+	// The webhook path must NOT be routable yet (engine webhooks map has no
+	// entry — a POST would 404 from the engine layer).
+	env.engine.mu.Lock()
+	_, routed := env.engine.webhooks[path]
+	env.engine.mu.Unlock()
+	if routed {
+		t.Fatal("webhook path must not be in the engine routing table while the pipeline is deferred")
+	}
+	// And it must be recorded as deferred.
+	env.engine.registerMu.Lock()
+	_, deferred := env.engine.deferredPipelines["wp"]
+	env.engine.registerMu.Unlock()
+	if !deferred {
+		t.Fatal("webhook pipeline with missing stage should be recorded as deferred")
+	}
+
+	// 2. Register the stage — WITHOUT re-submitting the pipeline.
+	stage := &task.Spec{ID: "s", Name: "S", Enabled: true,
+		Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}}
+	if err := env.reg.Register(stage); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.engine.Register(stage); err != nil {
+		t.Fatalf("Register(stage): %v", err)
+	}
+
+	// 3. The webhook path is now claimed by the pipeline (routable) and the
+	// pipeline is dropped from the deferred set.
+	env.engine.mu.Lock()
+	got := env.engine.webhooks[path]
+	env.engine.mu.Unlock()
+	if got != "wp" {
+		t.Fatalf("webhook path not routed to pipeline after stage registered: got %q, want wp", got)
+	}
+	env.engine.registerMu.Lock()
+	_, stillDeferred := env.engine.deferredPipelines["wp"]
+	env.engine.registerMu.Unlock()
+	if stillDeferred {
+		t.Fatal("webhook pipeline should be removed from the deferred set once it schedules")
+	}
+}
+
+// TestColdStartDeferredPipeline_DisabledNotDeferred confirms a disabled pipeline
+// with a missing stage is NOT parked in deferredPipelines — it schedules nothing
+// regardless of its stages, so deferring/retrying it would be pointless churn.
+// It also confirms that a pipeline deferred while enabled is dropped from the
+// deferred set when re-registered disabled.
+func TestColdStartDeferredPipeline_DisabledNotDeferred(t *testing.T) {
+	env := newTestEnv(t)
+
+	// A disabled pipeline whose stage is absent must register cleanly without
+	// being deferred.
+	disabled := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "p", Name: "P", Subtype: "sequential", Enabled: false,
+		Trigger: task.PipelineTrigger{Cron: "0 0 * * *"},
+		Stages:  []task.Stage{{Task: "s"}},
+	}
+	if err := env.reg.Register(disabled); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.engine.Register(disabled); err != nil {
+		t.Fatalf("Register(disabled pipeline) should succeed, got: %v", err)
+	}
+	env.engine.registerMu.Lock()
+	_, deferred := env.engine.deferredPipelines["p"]
+	env.engine.registerMu.Unlock()
+	if deferred {
+		t.Fatal("disabled pipeline with a missing stage must not be deferred")
+	}
+	env.engine.mu.Lock()
+	_, scheduled := env.engine.cronEntries["p"]
+	env.engine.mu.Unlock()
+	if scheduled {
+		t.Fatal("disabled pipeline must not schedule a cron entry")
+	}
+
+	// Now flip the same pipeline enabled (still missing its stage) so it becomes
+	// deferred, then re-register it disabled — it must be dropped from the set.
+	enabled := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "p", Name: "P", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Cron: "0 0 * * *"},
+		Stages:  []task.Stage{{Task: "s"}},
+	}
+	if err := env.engine.Register(enabled); err != nil {
+		t.Fatalf("Register(enabled pipeline) should defer, not error: %v", err)
+	}
+	env.engine.registerMu.Lock()
+	_, deferred = env.engine.deferredPipelines["p"]
+	env.engine.registerMu.Unlock()
+	if !deferred {
+		t.Fatal("enabled pipeline with a missing stage should be deferred")
+	}
+
+	if err := env.engine.Register(disabled); err != nil {
+		t.Fatalf("re-Register(disabled pipeline) should succeed, got: %v", err)
+	}
+	env.engine.registerMu.Lock()
+	_, deferred = env.engine.deferredPipelines["p"]
+	env.engine.registerMu.Unlock()
+	if deferred {
+		t.Fatal("pipeline re-registered disabled must be dropped from the deferred set")
+	}
+}
+
 // TestColdStartDeferredPipeline_GenuinelyMissingStaysUnscheduled confirms a
 // pipeline whose stage is never registered stays unscheduled forever — no
 // crash, no infinite retry, just a permanently-deferred entry that never


### PR DESCRIPTION
Fast-follow daemon-fix PR for the `kind: PipelineTask` epic. Originally fixed the daemon-restart orphan bug found by code + security review of the daemon-terminal-stage / mid-pipeline-rerun code (closes #344). A subsequent **live daemon smoke test** (cron/manual/chain pipelines verified end-to-end) surfaced two further daemon/trigger gaps that diff-only review had missed; both are now folded in here.

## Scope

This PR now:
1. **fixes the daemon-restart orphan** — a parent `KillRun` mid-daemon-restart no longer orphans the daemon or wedges the pipeline `running` (original; **Closes #344**).
2. **wires pipeline webhook triggers through the daemon gateway** — `kind: PipelineTask` with `trigger.webhook` no longer 404s (smoke-test gap 1).
3. **completes the #341 cold-start ordering gap** — engine-rejected pipelines self-heal once their stage tasks register, without a file change (smoke-test gap 2; **Completes #341**).

---

## Bug 1 (original) — parent KillRun mid-daemon-restart orphaned the daemon + wedged the pipeline `running`
The runCtx kill watcher in `runTerminalDaemon` is single-shot (one `select` set up before the wait loop). If an operator `KillRun`s the pipeline parent while the wait loop is blocked on `restartDone` (old daemon run already killed, new one not yet published), the watcher fires on the dead old run and is spent. The restart publish path checked only `runner.finished` (still false), adopted the freshly-fired daemon, and the loop `WaitRun`'d it with `context.Background()` — nothing left to kill it → leaked daemon subprocess + pipeline stuck `running`.

**Fix:** in the publish critical section, also gate on `runner.runCtx.Err() != nil`, symmetric with the existing `runner.finished` guard and under the **same `runner.mu`** as the publish (no TOCTOU). When the pipeline was cancelled, the publish refuses to adopt the fresh run, `KillRun`s it, and returns. The deferred cleanup (`published == false`) clears `restarting` and closes `restartDone`; the wait loop wakes, sees `daemonRunID` unchanged (still the killed old run), and takes its **restart-aborted** branch → `finish(cancelled)`.

(Plus the originally-bundled lower-severity fixes: `restartGates` key collision namespaced with a `pipeline:` prefix; pipeline-stage daemon runs no longer flip a same-named standalone daemon's `DaemonState`, gated on `source == registry.TriggerPipelineStage`; comment polish on the `WaitRun` error contract.)

## Bug 2 (smoke test) — pipeline webhook triggers 404'd in the daemon
A `kind: PipelineTask` with `trigger.webhook` registered in the engine but `POST /hooks/<path>` returned 404. Root cause: `pkg/daemon/daemon.go`'s `rec.OnRegister` returned early for any non-`*task.Spec` kind **before** calling `gateway.Register`. So a pipeline's webhook path was added to the engine's internal routing table (and `WebhookHandler`/`handlePipelineWebhook` could dispatch it), but the daemon-level `ipc.Gateway` route was never registered — the request 404'd before reaching the handler.

**Fix:** extract a kind-aware `registerGatewayWebhook` helper that claims the gateway route for **both** `*task.Spec` and `*task.PipelineTask` carrying a webhook trigger, recording the path under the task ID so the existing (kind-agnostic) `OnUnregister` cleanup deregisters it for both kinds. Auth is unchanged (`webhookAuthGuard` is already kind-aware from #342; `handlePipelineWebhook` enforces HMAC). Cron is unchanged (the engine's `registerPipelineCron` already handled it — which is why cron worked in the smoke test).

## Bug 3 (smoke test) — cold-start registration ordering (#341 not actually closed)
On a fresh daemon the reconciler can register a pipeline **before** its stage tasks. `Engine.Register` → `registerPipeline` → `validatePipelineRefs` then rejected it ("stage task not found"), the daemon WARNed, and **nothing retried** — so the pipeline's cron/webhook was never scheduled until its file changed. PR3's fire-time `validatePipelineRefs` gate only covered manual/chain fires (via `GetKinded`), not registration-time scheduling, so #341's root issue persisted for cron/webhook pipelines (#341 was closed prematurely by PR3).

**Fix:** when `validatePipelineRefs` fails **only** because a stage task isn't in the registry yet (new `errPipelineStageMissing` sentinel), record the pipeline in a `deferredPipelines` set (guarded by `registerMu`) and return nil instead of erroring. When a `kind: Task` later registers successfully, `Register` replays the deferred set (`retryDeferredPipelines`), so a pipeline schedules itself once its stages exist — no file change needed. Other validation failures (bad subtype, invalid overrides, cycle) still surface as errors.

**Locking:** `deferredPipelines` is guarded by `registerMu`, which already serialises the whole `Register` path; `registerPipeline`/`retryDeferredPipelines` run under it. `Unregister` is split into the public `Unregister` (drops the deferred entry under `registerMu`, then tears down triggers) and an internal `unregisterTriggers` the `Register` path reuses while already holding `registerMu` — avoiding a re-entrant deadlock. A deferred pipeline that is later unregistered/superseded is dropped from the set so it is never resurrected. Transiently-deferred pipelines log once at INFO (no WARN spam on every reconcile); only a pipeline that genuinely fails after its stage arrives logs WARN.

---

## Test Plan

**Bug 1 (original)** — `pkg/trigger/pipeline_runner_test.go`:
- `TestPipelineParentKillDuringRestart` (HIGH) — fires a 3-stage pipeline with a daemon terminal stage, re-fires stage 0 to put the restart handshake in flight, and uses `runStartedHook` (fires synchronously inside `fireStageRaw`, before the new run is published) to `KillRun` the parent squarely in the mid-restart window. Asserts no daemon-stage child stays `running` and the parent ends `cancelled`. Red before the runCtx fix, green after.
- `TestPipelineStageDaemonDoesNotFlipStandaloneDaemonState` (security) — registers a task as both a standalone daemon and a pipeline terminal stage, kills the pipeline-stage run, asserts the standalone daemon's `DaemonState` stays `Running`. Red before the source-gate fix, green after.

**Bug 2 (webhook gateway)** — `pkg/daemon/webhook_register_test.go`:
- `TestRegisterGatewayWebhook_Pipeline` — after registering a pipeline with a webhook trigger, a `POST` to its path is routed by the gateway (200, handler hit) and the path is recorded under the pipeline ID. (Red before the fix: helper didn't exist / pipeline never registered.)
- `TestRegisterGatewayWebhook_Task` — kind: Task webhook still routes (no regression).
- `TestRegisterGatewayWebhook_PipelineUnregisterCleanup` — the kind-agnostic OnUnregister cleanup (look up `webhookPaths[id]` → `gateway.Unregister`) removes the pipeline route (404 after).
- `TestRegisterGatewayWebhook_NoWebhook` — a cron-only pipeline claims no gateway route.

**Bug 3 (cold-start ordering)** — `pkg/trigger/registerpipeline_test.go`:
- `TestColdStartDeferredPipeline` — register a cron pipeline whose stage is **not** yet registered → asserts it is NOT scheduled (no cron entry), `Register` does not error, and it is recorded as deferred; then register the stage task **without re-submitting the pipeline** → asserts a cron entry now appears and the pipeline is dropped from the deferred set. Red before the fix (no `deferredPipelines`), green after.
- `TestColdStartDeferredPipeline_GenuinelyMissingStaysUnscheduled` — a pipeline whose stage is never registered stays deferred/unscheduled even when an unrelated stage triggers a retry (no crash, no infinite retry).
- `TestColdStartDeferredPipeline_DroppedOnUnregister` — a deferred pipeline that is later unregistered is dropped from the set; a subsequent stage registration does not resurrect it.

Commands (all clean):

```
go -C <wt> build ./...
go -C <wt> vet ./pkg/trigger/... ./pkg/daemon/... ./pkg/registry/... ./pkg/webui/...
gofmt -l <wt>/pkg/trigger <wt>/pkg/daemon          # no output
go -C <wt> test ./pkg/trigger/... ./pkg/daemon/... ./pkg/registry/... ./pkg/webui/... -p 2 -timeout 240s
go -C <wt> test -race ./pkg/trigger/... ./pkg/daemon/... -p 2 -timeout 360s
```

-race stress (15×, clean): `TestColdStartDeferredPipeline*`, `TestRegisterGatewayWebhook*`, plus the original `TestPipelineParentKillDuringRestart`, `TestPipelineStageRerun`, `TestPipelineStageDaemonDoesNotFlipStandaloneDaemonState`, `TestPipelineDaemonTerminalStage`, `TestPipelineKillRunCancelsStage`, and the existing `TestPipelineCronRegistered` / `TestPipelineWebhookRegistered` / `TestEngineRegisterRoutesByKind`.

Closes #344
Completes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)
