### PR TITLE
fix(trigger): atomic FinishRunWithResult eliminates status/return_value race

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -211,6 +211,18 @@ func (r *Registry) FinishRunWithReason(ctx context.Context, runID, status, reaso
 	)
 }
 
+// FinishRunWithResult atomically updates the run status, finished_at,
+// return_value, and structured output columns in a single UPDATE.
+// This eliminates the race where a reader sees status=success but an
+// empty return_value because FinishRun and SetRunResult were separate writes.
+func (r *Registry) FinishRunWithResult(ctx context.Context, runID, status, returnValueJSON, outputContentType, outputContent string) error {
+	now := time.Now().UnixMilli()
+	return r.db.Exec(ctx,
+		`UPDATE runs SET status = ?, finished_at = ?, return_value = ?, output_content_type = ?, output_content = ? WHERE id = ?`,
+		status, now, returnValueJSON, outputContentType, outputContent, runID,
+	)
+}
+
 // SetLogHook registers a function called after each log entry is written.
 func (r *Registry) SetLogHook(fn func(runID, level, msg string, ts int64)) {
 	r.logMu.Lock()

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -441,3 +441,33 @@ func TestStartRunKind(t *testing.T) {
 		t.Fatalf("empty kind: got %q, want %q", run3.Kind, RunKindTask)
 	}
 }
+
+func TestFinishRunWithResult(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+
+	runID, err := r.StartRun(context.Background(), "task-1", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = r.FinishRunWithResult(context.Background(), runID, StatusSuccess,
+		`{"key":"value"}`, "text/html", "<b>hello</b>")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run, err := r.GetRun(context.Background(), runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != StatusSuccess {
+		t.Errorf("status = %q, want %q", run.Status, StatusSuccess)
+	}
+	if run.ReturnValue != `{"key":"value"}` {
+		t.Errorf("return_value = %q, want %q", run.ReturnValue, `{"key":"value"}`)
+	}
+	if run.FinishedAt == nil {
+		t.Error("finished_at should be set")
+	}
+}

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -242,7 +242,6 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	}
 
 	result := &RunResult{RunID: runID}
-	status := registry.StatusSuccess
 
 	defer func() {
 		// If the run failed before Deno started (secret missing, script not found,
@@ -253,9 +252,6 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		}
 		if logs, lerr := rt.registry.GetRunLogs(context.Background(), runID); lerr == nil {
 			result.Logs = logs
-		}
-		if ferr := rt.registry.FinishRun(context.Background(), runID, status); ferr != nil {
-			rt.log.Error("finish run", zap.String("run", runID), zap.Error(ferr))
 		}
 	}()
 
@@ -272,7 +268,6 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	} else {
 		resolvedRes, err = rt.envresolver().Resolve(ctx, spec)
 		if err != nil {
-			status = registry.StatusFailure
 			result.Error = err
 			return result, nil
 		}
@@ -282,7 +277,6 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 
 	taskPath := spec.ScriptPath()
 	if taskPath == "" {
-		status = registry.StatusFailure
 		result.Error = fmt.Errorf("script not found for task %s", spec.ID)
 		return result, nil
 	}
@@ -318,7 +312,6 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	}
 	socketPath, token, err := srv.Start(execCtx)
 	if err != nil {
-		status = registry.StatusFailure
 		result.Error = fmt.Errorf("start socket server: %w", err)
 		return result, nil
 	}
@@ -331,7 +324,6 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	// tasks/buildin/temp-cleanup builtin can correlate orphaned files with runs.
 	shimFile, err := os.CreateTemp("", "dicode-shim-"+runID+"__*.ts")
 	if err != nil {
-		status = registry.StatusFailure
 		result.Error = fmt.Errorf("create shim file: %w", err)
 		return result, nil
 	}
@@ -341,7 +333,6 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	}
 	if _, err := shimFile.WriteString(shimContent); err != nil {
 		shimFile.Close()
-		status = registry.StatusFailure
 		result.Error = fmt.Errorf("write shim: %w", err)
 		return result, nil
 	}
@@ -350,7 +341,6 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	// Write the wrapper that imports both and calls the user's exported main().
 	runnerFile, err := os.CreateTemp("", "dicode-runner-"+runID+"__*.ts")
 	if err != nil {
-		status = registry.StatusFailure
 		result.Error = fmt.Errorf("create runner file: %w", err)
 		return result, nil
 	}
@@ -383,7 +373,6 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		"}\n"
 	if _, err := runnerFile.WriteString(runner); err != nil {
 		runnerFile.Close()
-		status = registry.StatusFailure
 		result.Error = fmt.Errorf("write runner: %w", err)
 		return result, nil
 	}
@@ -400,25 +389,21 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		cmd.Stdout = io.Discard
 		cmd.Stderr = io.Discard
 		if err := cmd.Start(); err != nil {
-			status = registry.StatusFailure
 			result.Error = fmt.Errorf("start deno: %w", err)
 			return result, nil
 		}
 	} else {
 		stdout, err := cmd.StdoutPipe()
 		if err != nil {
-			status = registry.StatusFailure
 			result.Error = err
 			return result, nil
 		}
 		stderr, err := cmd.StderrPipe()
 		if err != nil {
-			status = registry.StatusFailure
 			result.Error = err
 			return result, nil
 		}
 		if err := cmd.Start(); err != nil {
-			status = registry.StatusFailure
 			result.Error = fmt.Errorf("start deno: %w", err)
 			return result, nil
 		}
@@ -471,11 +456,6 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		}
 		result.Output = srv.Output()
 		if exitErr != nil {
-			if execCtx.Err() != nil {
-				status = registry.StatusCancelled
-			} else {
-				status = registry.StatusFailure
-			}
 			result.Error = exitErr
 		}
 	}

--- a/pkg/runtime/deno/runtime_test.go
+++ b/pkg/runtime/deno/runtime_test.go
@@ -452,12 +452,8 @@ func TestRuntime_RunRecord(t *testing.T) {
 	if r.RunID == "" {
 		t.Fatal("no run ID")
 	}
-	run, err := e.reg.GetRun(context.Background(), r.RunID)
-	if err != nil {
-		t.Fatalf("GetRun: %v", err)
-	}
-	if run.Status != registry.StatusSuccess {
-		t.Errorf("expected success, got %s", run.Status)
+	if r.Error != nil {
+		t.Errorf("expected success, got error: %v", r.Error)
 	}
 }
 
@@ -491,13 +487,6 @@ func TestRuntime_ScriptError(t *testing.T) {
 	r := e.run(t, `throw new Error("boom")`, RunOptions{})
 	if r.Error == nil {
 		t.Fatal("expected error")
-	}
-	run, err := e.reg.GetRun(context.Background(), r.RunID)
-	if err != nil {
-		t.Fatalf("GetRun: %v", err)
-	}
-	if run.Status != registry.StatusFailure {
-		t.Errorf("expected failure, got %s", run.Status)
 	}
 }
 

--- a/pkg/runtime/docker/docker.go
+++ b/pkg/runtime/docker/docker.go
@@ -54,7 +54,6 @@ func New(r *registry.Registry, log *zap.Logger) *Runtime {
 
 // fail marks a run as failed and returns the result.
 func (rt *Runtime) fail(runID string, err error) (*RunResult, error) {
-	_ = rt.registry.FinishRun(context.Background(), runID, registry.StatusFailure)
 	return &RunResult{RunID: runID, Error: err}, nil
 }
 
@@ -80,7 +79,6 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		imageTag, err = rt.buildImage(ctx, dc, spec, runID)
 		if err != nil {
 			if ctx.Err() != nil {
-				_ = rt.registry.FinishRun(context.Background(), runID, registry.StatusCancelled)
 				return &RunResult{RunID: runID, Error: err}, nil
 			}
 			return rt.fail(runID, err)
@@ -92,7 +90,6 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		}
 		if err := rt.maybePull(ctx, dc, cfg.Image, pullPolicy, runID); err != nil {
 			if ctx.Err() != nil {
-				_ = rt.registry.FinishRun(context.Background(), runID, registry.StatusCancelled)
 				return &RunResult{RunID: runID, Error: err}, nil
 			}
 			return rt.fail(runID, err)
@@ -232,16 +229,9 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	<-logDone
 	closeLog() // no-op if the kill-watcher already closed it
 
-	finalStatus := registry.StatusSuccess
-	if ctx.Err() != nil {
-		finalStatus = registry.StatusCancelled
-	} else if result.Error != nil || exitCode != 0 {
-		finalStatus = registry.StatusFailure
-		if result.Error == nil {
-			result.Error = fmt.Errorf("container exited with code %d", exitCode)
-		}
+	if result.Error == nil && exitCode != 0 {
+		result.Error = fmt.Errorf("container exited with code %d", exitCode)
 	}
-	_ = rt.registry.FinishRun(context.Background(), runID, finalStatus)
 	return result, nil
 }
 

--- a/pkg/runtime/podman/runtime.go
+++ b/pkg/runtime/podman/runtime.go
@@ -95,13 +95,6 @@ type executor struct {
 func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
 	runID := opts.RunID
 	result := &pkgruntime.RunResult{RunID: runID}
-	status := registry.StatusSuccess
-
-	defer func() {
-		if ferr := e.reg.FinishRun(context.Background(), runID, status); ferr != nil {
-			e.log.Error("finish run", zap.String("run", runID), zap.Error(ferr))
-		}
-	}()
 
 	cfg := spec.Docker
 	containerName := "dicode-" + runID
@@ -112,11 +105,6 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 		var err error
 		imageTag, err = e.buildImage(ctx, spec, runID)
 		if err != nil {
-			if ctx.Err() != nil {
-				status = registry.StatusCancelled
-			} else {
-				status = registry.StatusFailure
-			}
 			result.Error = err
 			return result, nil
 		}
@@ -135,19 +123,16 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		status = registry.StatusFailure
 		result.Error = err
 		return result, nil
 	}
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		status = registry.StatusFailure
 		result.Error = err
 		return result, nil
 	}
 
 	if err := cmd.Start(); err != nil {
-		status = registry.StatusFailure
 		result.Error = fmt.Errorf("start podman: %w", err)
 		return result, nil
 	}
@@ -178,10 +163,8 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 
 	switch {
 	case ctx.Err() != nil:
-		status = registry.StatusCancelled
 		result.Error = ctx.Err()
 	case exitErr != nil:
-		status = registry.StatusFailure
 		result.Error = exitErr
 	}
 

--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -206,13 +206,6 @@ type executor struct {
 func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
 	runID := opts.RunID
 	result := &pkgruntime.RunResult{RunID: runID}
-	status := registry.StatusSuccess
-
-	defer func() {
-		if ferr := e.reg.FinishRun(context.Background(), runID, status); ferr != nil {
-			e.log.Error("finish run", zap.String("run", runID), zap.Error(ferr))
-		}
-	}()
 
 	// Resolve declared env permissions. When the trigger engine ran
 	// preflight (issue #235), it forwards the *Resolved here so we don't
@@ -228,7 +221,6 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	} else {
 		resolvedRes, err = envresolve.New(e.reg, e.secrets, e.providerRunner).Resolve(ctx, spec)
 		if err != nil {
-			status = registry.StatusFailure
 			result.Error = err
 			return result, nil
 		}
@@ -239,13 +231,11 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	// Read the user's task.py.
 	scriptPath := spec.ScriptPath()
 	if scriptPath == "" {
-		status = registry.StatusFailure
 		result.Error = fmt.Errorf("script not found for task %s", spec.ID)
 		return result, nil
 	}
 	scriptBytes, err := os.ReadFile(scriptPath) //nolint:gosec
 	if err != nil {
-		status = registry.StatusFailure
 		result.Error = fmt.Errorf("read script: %w", err)
 		return result, nil
 	}
@@ -277,7 +267,6 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	}
 	socketPath, token, err := srv.Start(execCtx)
 	if err != nil {
-		status = registry.StatusFailure
 		result.Error = fmt.Errorf("start socket server: %w", err)
 		return result, nil
 	}
@@ -286,14 +275,12 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	// Build the temporary wrapper file.
 	wrapped, err := buildWrapper(scriptBytes)
 	if err != nil {
-		status = registry.StatusFailure
 		result.Error = fmt.Errorf("build wrapper: %w", err)
 		return result, nil
 	}
 
 	tmpFile, err := os.CreateTemp("", "dicode-task-"+runID+"__*.py")
 	if err != nil {
-		status = registry.StatusFailure
 		result.Error = fmt.Errorf("create temp file: %w", err)
 		return result, nil
 	}
@@ -301,7 +288,6 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 
 	if _, err := tmpFile.WriteString(wrapped); err != nil {
 		tmpFile.Close()
-		status = registry.StatusFailure
 		result.Error = fmt.Errorf("write wrapper: %w", err)
 		return result, nil
 	}
@@ -312,13 +298,11 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		status = registry.StatusFailure
 		result.Error = err
 		return result, nil
 	}
 
 	if err := cmd.Start(); err != nil {
-		status = registry.StatusFailure
 		result.Error = fmt.Errorf("start uv: %w", err)
 		return result, nil
 	}
@@ -359,11 +343,6 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 			result.ChainInput = out.Data
 		}
 		if exitErr != nil {
-			if execCtx.Err() != nil {
-				status = registry.StatusCancelled
-			} else {
-				status = registry.StatusFailure
-			}
 			result.Error = exitErr
 		}
 	}

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -2364,7 +2364,17 @@ func (e *Engine) dispatch(ctx context.Context, spec *task.Spec, opts pkgruntime.
 		return registry.StatusFailure, &pkgruntime.RunResult{Error: err}
 	}
 
-	// Store return value and structured output if present.
+	// Compute final status from the result.
+	status := registry.StatusSuccess
+	if result.Error != nil {
+		if ctx.Err() != nil {
+			status = registry.StatusCancelled
+		} else {
+			status = registry.StatusFailure
+		}
+	}
+
+	// Marshal return value and determine persistence.
 	//
 	// `run_result.enabled: false` opts out of persisting the JSON-marshalled
 	// return value to `runs.return_value`. Structured output_content and
@@ -2376,49 +2386,33 @@ func (e *Engine) dispatch(ctx context.Context, spec *task.Spec, opts pkgruntime.
 	// stashed in runReturnValue so WaitRun can serve it to synchronous
 	// callers (dicode.run_task -> IPC reply). The entry is cleared by the
 	// startRun cleanup func once the run reaches a terminal state.
-	if result != nil && (result.ReturnValue != nil || result.OutputContent != "") {
-		retJSON := ""
-		if result.ReturnValue != nil {
-			if b, merr := json.Marshal(result.ReturnValue); merr == nil {
-				retJSON = string(b)
-			}
-		}
-		persistReturnValue := spec.RunResult.PersistReturnValue()
-		// When persistence is suppressed, stash the in-memory copy so
-		// WaitRun can still serve it to synchronous callers
-		// (dicode.run_task -> IPC reply). Done BEFORE the DB write
-		// (skipped below) so a WaitRun caller racing against the runDone
-		// close never observes an empty value: dispatch is called from
-		// runTask synchronously, the runDone channel is closed only by
-		// startRun's cleanup func which runs after runTask returns, and
-		// the cleanup defers the runReturnValue deletion to give
-		// post-close WaitRun goroutines time to scan the map.
-		//
-		// Common case (persistence enabled) takes no in-memory slot — the
-		// DB row carries the value as before.
-		persistedReturnJSON := retJSON
-		if !persistReturnValue {
-			persistedReturnJSON = ""
-			if retJSON != "" {
-				e.runReturnValue.Store(opts.RunID, retJSON)
-			}
-		}
-		// Skip the SetRunResult call entirely when nothing would be
-		// written (e.g. return-value persistence disabled AND no
-		// structured output) to avoid a needless UPDATE statement.
-		if persistedReturnJSON != "" || result.OutputContent != "" {
-			_ = e.registry.SetRunResult(context.Background(), opts.RunID, persistedReturnJSON, result.OutputContentType, result.OutputContent)
+	retJSON := ""
+	if result != nil && result.ReturnValue != nil {
+		if b, merr := json.Marshal(result.ReturnValue); merr == nil {
+			retJSON = string(b)
 		}
 	}
 
-	status := registry.StatusSuccess
-	if result.Error != nil {
-		if ctx.Err() != nil {
-			status = registry.StatusCancelled
-		} else {
-			status = registry.StatusFailure
+	persistedReturnJSON := retJSON
+	if persistReturnValue := spec.RunResult.PersistReturnValue(); !persistReturnValue {
+		persistedReturnJSON = ""
+		if retJSON != "" {
+			e.runReturnValue.Store(opts.RunID, retJSON)
 		}
 	}
+
+	outputContentType := ""
+	outputContent := ""
+	if result != nil {
+		outputContentType = result.OutputContentType
+		outputContent = result.OutputContent
+	}
+
+	// Atomic: set status + finished_at + return_value + output in one UPDATE.
+	// This eliminates the race where a reader polling for status != running
+	// could see the status flip before return_value was written.
+	_ = e.registry.FinishRunWithResult(context.Background(), opts.RunID, status,
+		persistedReturnJSON, outputContentType, outputContent)
 
 	e.FireChain(context.Background(), spec.ID, opts.RunID, status, result.ChainInput, opts.Params)
 	return status, result

--- a/pkg/trigger/engine_chain_params_test.go
+++ b/pkg/trigger/engine_chain_params_test.go
@@ -60,10 +60,7 @@ func TestFireChain_MergesParamsIntoInput(t *testing.T) {
 	}
 
 	// Decode the return value — the chain target echoed `input` back.
-	// Poll for return_value: the runtime's deferred FinishRun commits before
-	// the engine wrapper's SetRunResult, so a fast reader can see status=success
-	// with an empty ReturnValue.
-	returnValue := pollReturnValue(t, e.engine, got.ID, 5*time.Second)
+	returnValue := got.ReturnValue
 	var input map[string]any
 	if err := json.Unmarshal([]byte(returnValue), &input); err != nil {
 		t.Fatalf("unmarshal return value %q: %v", returnValue, err)
@@ -154,10 +151,7 @@ func TestFireChain_PerTaskFullyReplacesDefaults(t *testing.T) {
 	}
 
 	// Decode the return value — the chain target echoed `input` back.
-	// Poll for return_value: the runtime's deferred FinishRun commits before
-	// the engine wrapper's SetRunResult, so a fast reader can see status=success
-	// with an empty ReturnValue.
-	returnValue := pollReturnValue(t, e.engine, got.ID, 5*time.Second)
+	returnValue := got.ReturnValue
 	var input map[string]any
 	if err := json.Unmarshal([]byte(returnValue), &input); err != nil {
 		t.Fatalf("unmarshal return value %q: %v", returnValue, err)
@@ -328,7 +322,7 @@ func TestChainDispatch_ResolvesInputOutput(t *testing.T) {
 		t.Errorf("downstream status = %q, want success", got.Status)
 	}
 
-	returnValue := pollReturnValue(t, e.engine, got.ID, 5*time.Second)
+	returnValue := got.ReturnValue
 	var input map[string]any
 	if err := json.Unmarshal([]byte(returnValue), &input); err != nil {
 		t.Fatalf("unmarshal return value %q: %v", returnValue, err)
@@ -389,7 +383,7 @@ func TestChainDispatch_ResolvesInputParams(t *testing.T) {
 	if got.Status != "success" {
 		t.Errorf("downstream status = %q, want success", got.Status)
 	}
-	returnValue := pollReturnValue(t, e.engine, got.ID, 5*time.Second)
+	returnValue := got.ReturnValue
 	var input map[string]any
 	if err := json.Unmarshal([]byte(returnValue), &input); err != nil {
 		t.Fatalf("unmarshal return value: %v", err)
@@ -444,7 +438,7 @@ func TestOnFailureChainDispatch_ResolvesInputOutputField(t *testing.T) {
 	if got.Status != "success" {
 		t.Errorf("fallback status = %q, want success", got.Status)
 	}
-	returnValue := pollReturnValue(t, e.engine, got.ID, 5*time.Second)
+	returnValue := got.ReturnValue
 	var input map[string]any
 	if err := json.Unmarshal([]byte(returnValue), &input); err != nil {
 		t.Fatalf("unmarshal return value: %v", err)
@@ -519,7 +513,7 @@ func TestOnFailureChainDispatch_ResolvesInputOutput(t *testing.T) {
 		t.Errorf("fallback status = %q, want success", got.Status)
 	}
 
-	returnValue := pollReturnValue(t, e.engine, got.ID, 5*time.Second)
+	returnValue := got.ReturnValue
 	var input map[string]any
 	if err := json.Unmarshal([]byte(returnValue), &input); err != nil {
 		t.Fatalf("unmarshal return value %q: %v", returnValue, err)

--- a/pkg/trigger/engine_daemon_lifecycle_test.go
+++ b/pkg/trigger/engine_daemon_lifecycle_test.go
@@ -34,16 +34,13 @@ import (
 // One-shot tasks finish StatusSuccess synchronously; tasks marked via
 // markDaemon block until their run context is cancelled (KillRun path).
 type preflightExec struct {
-	reg *registry.Registry
-
 	mu     sync.Mutex
 	daemon map[string]chan struct{} // daemon taskID → block channel
 	runs   atomic.Int32             // count of executed runs (any task)
 }
 
-func newPreflightExec(reg *registry.Registry) *preflightExec {
+func newPreflightExec(_ *registry.Registry) *preflightExec {
 	return &preflightExec{
-		reg:    reg,
 		daemon: make(map[string]chan struct{}),
 	}
 }
@@ -59,7 +56,7 @@ func (p *preflightExec) markDaemon(taskID string) {
 	p.mu.Unlock()
 }
 
-func (p *preflightExec) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
+func (p *preflightExec) Execute(ctx context.Context, spec *task.Spec, _ pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
 	p.runs.Add(1)
 	p.mu.Lock()
 	daemonCh := p.daemon[spec.ID]
@@ -67,14 +64,10 @@ func (p *preflightExec) Execute(ctx context.Context, spec *task.Spec, opts pkgru
 
 	if daemonCh != nil {
 		// Long-running daemon: block until the run's context is cancelled
-		// (KillRun path). FinishRun(Success) before returning so onDaemon-
-		// RunFinished doesn't treat the daemon as crashed. Mirrors how a
-		// real daemon exits gracefully on shutdown.
+		// (KillRun path). Mirrors how a real daemon exits gracefully on shutdown.
 		<-ctx.Done()
-		_ = p.reg.FinishRun(context.Background(), opts.RunID, registry.StatusSuccess)
 		return &pkgruntime.RunResult{}, nil
 	}
-	_ = p.reg.FinishRun(context.Background(), opts.RunID, registry.StatusSuccess)
 	return &pkgruntime.RunResult{}, nil
 }
 

--- a/pkg/trigger/engine_failure_chain_test.go
+++ b/pkg/trigger/engine_failure_chain_test.go
@@ -31,35 +31,6 @@ func waitForRunOfTask(t *testing.T, e *Engine, taskID string, timeout time.Durat
 	return nil
 }
 
-// pollReturnValue waits for run.ReturnValue to be populated. The runtime's
-// deferred FinishRun commits status before the engine wrapper's SetRunResult
-// commits the return_value, so a fast reader can see status=success with an
-// empty ReturnValue. Tests that read return_value should call this after
-// waitForRunOfTask returns terminal status.
-//
-// Returns the populated value, or fails the test if it never lands within
-// the timeout. (Tasks that legitimately return undefined will fail-timeout
-// here — those tests should not call pollReturnValue.)
-func pollReturnValue(t *testing.T, e *Engine, runID string, timeout time.Duration) string {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	var lastErr error
-	for time.Now().Before(deadline) {
-		r, err := e.registry.GetRun(context.Background(), runID)
-		if err != nil {
-			lastErr = err
-		} else if r.ReturnValue != "" {
-			return r.ReturnValue
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	if lastErr != nil {
-		t.Fatalf("return_value never populated for run %s within %s; last GetRun error: %v", runID, timeout, lastErr)
-	}
-	t.Fatalf("return_value never populated for run %s within %s", runID, timeout)
-	return ""
-}
-
 // ptrSpec is a helper because task.Spec.OnFailureChain is *task.OnFailureChainSpec so
 // {task: ""} disables the default and nil uses the default.
 func ptrSpec(taskID string) *task.OnFailureChainSpec {

--- a/pkg/trigger/engine_per_edge_overrides_test.go
+++ b/pkg/trigger/engine_per_edge_overrides_test.go
@@ -124,7 +124,7 @@ params:
 	if got.Status != registry.StatusSuccess {
 		t.Errorf("downstream status = %q, want success", got.Status)
 	}
-	returnValue := pollReturnValue(t, e.engine, got.ID, 5*time.Second)
+	returnValue := got.ReturnValue
 	var mode string
 	if err := json.Unmarshal([]byte(returnValue), &mode); err != nil {
 		t.Fatalf("unmarshal return %q: %v", returnValue, err)

--- a/pkg/trigger/engine_preflight_env_chain_race_test.go
+++ b/pkg/trigger/engine_preflight_env_chain_race_test.go
@@ -19,19 +19,13 @@ import (
 // The on_failure_chain target dispatches through fireAsync, which hands the
 // run to its Executor; counting Execute calls per task ID lets the test
 // assert whether the on_failure_chain edge fired at all.
-//
-// FinishRun is called from the deferred path so the registry's run row
-// reaches a terminal state — without it WaitRun (and the engine's own
-// shutdown teardown) blocks.
 type chainTargetCountingExecutor struct {
-	reg   *registry.Registry
 	calls sync.Map // taskID -> *atomic.Int64
 }
 
 func (c *chainTargetCountingExecutor) Execute(_ context.Context, spec *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
 	v, _ := c.calls.LoadOrStore(spec.ID, &atomic.Int64{})
 	v.(*atomic.Int64).Add(1)
-	_ = c.reg.FinishRun(context.Background(), opts.RunID, registry.StatusSuccess)
 	return &pkgruntime.RunResult{RunID: opts.RunID}, nil
 }
 
@@ -71,7 +65,7 @@ func TestRunTask_PreflightEnvFailure_ChainDepthPreserved(t *testing.T) {
 	t.Cleanup(func() { d.Close() })
 	reg := registry.New(d)
 
-	exec := &chainTargetCountingExecutor{reg: reg}
+	exec := &chainTargetCountingExecutor{}
 	eng := New(reg, exec, zap.NewNop())
 	// Non-nil chain so preflightEnv does not short-circuit on
 	// `e.secrets == nil`. The empty chain is fine: the test path uses

--- a/pkg/trigger/engine_success_chain_params_test.go
+++ b/pkg/trigger/engine_success_chain_params_test.go
@@ -68,7 +68,7 @@ func TestFireChain_Success_ParamsMergedIntoInput(t *testing.T) {
 		t.Errorf("downstream status = %q, want success", got.Status)
 	}
 
-	returnValue := pollReturnValue(t, e.engine, got.ID, 5*time.Second)
+	returnValue := got.ReturnValue
 	var input map[string]any
 	if err := json.Unmarshal([]byte(returnValue), &input); err != nil {
 		t.Fatalf("unmarshal return value %q: %v", returnValue, err)
@@ -140,7 +140,7 @@ func TestFireChain_Success_NoParams_PreservesRawOutput(t *testing.T) {
 		t.Errorf("downstream status = %q, want success", got.Status)
 	}
 
-	returnValue := pollReturnValue(t, e.engine, got.ID, 5*time.Second)
+	returnValue := got.ReturnValue
 	// No wrapping: downstream sees the raw upstream output as a JSON string.
 	var input any
 	if err := json.Unmarshal([]byte(returnValue), &input); err != nil {

--- a/pkg/trigger/engine_test.go
+++ b/pkg/trigger/engine_test.go
@@ -903,13 +903,9 @@ func TestInjectDicodeSDK_NoHead(t *testing.T) {
 // instantExec is a mock Executor that completes immediately with success.
 // It avoids spawning real Deno subprocesses so the WaitRun channel tests
 // are fast and not sensitive to script format or Deno availability.
-// It calls FinishRun itself (mirroring what the real Deno executor does via defer).
-type instantExec struct {
-	reg *registry.Registry
-}
+type instantExec struct{}
 
-func (e instantExec) Execute(_ context.Context, _ *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
-	_ = e.reg.FinishRun(context.Background(), opts.RunID, registry.StatusSuccess)
+func (e instantExec) Execute(_ context.Context, _ *task.Spec, _ pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
 	return &pkgruntime.RunResult{ReturnValue: "done"}, nil
 }
 
@@ -923,7 +919,7 @@ func newFastEnv(t *testing.T) *testEnv {
 	}
 	t.Cleanup(func() { d.Close() })
 	reg := registry.New(d)
-	eng := New(reg, instantExec{reg: reg}, zap.NewNop())
+	eng := New(reg, instantExec{}, zap.NewNop())
 	return &testEnv{engine: eng, reg: reg}
 }
 

--- a/pkg/trigger/preflight_resolve_once_test.go
+++ b/pkg/trigger/preflight_resolve_once_test.go
@@ -35,14 +35,12 @@ func (f *fakeDenoRuntimeForChannel) SetSecretOutputChannel(c chan map[string]str
 // dispatches are recorded too — and the most recent opts.PreResolvedEnv is
 // captured so the test can verify the engine threaded it through.
 //
-// Real runtimes mark the run finished via their deferred reg.FinishRun; this
-// mock does the same so engine.Engine.WaitRun (used by the engine's own
-// ProviderRunner.Run method) sees a terminal status.
+// Real runtimes mark the run finished via FinishRunWithResult called by dispatch;
+// this mock just returns and lets dispatch handle it.
 type providerCountingExecutor struct {
 	providerID  string
 	providerVal map[string]string
 	denoRT      *fakeDenoRuntimeForChannel
-	reg         *registry.Registry
 
 	providerCalls           atomic.Int64
 	consumerCalls           atomic.Int64
@@ -50,12 +48,6 @@ type providerCountingExecutor struct {
 }
 
 func (p *providerCountingExecutor) Execute(_ context.Context, spec *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
-	defer func() {
-		// Match the runtime contract: the run record must reach a terminal
-		// state by the time the executor returns or WaitRun blocks forever.
-		_ = p.reg.FinishRun(context.Background(), opts.RunID, registry.StatusSuccess)
-	}()
-
 	if spec.ID == p.providerID {
 		p.providerCalls.Add(1)
 		// Mimic the IPC-server-side behaviour: when the provider task calls
@@ -104,7 +96,6 @@ func TestPreflight_ProviderFiresOnceAcrossPreflightAndDispatch(t *testing.T) {
 		providerID:  "doppler",
 		providerVal: map[string]string{"PG_URL": "postgres://x"},
 		denoRT:      denoRT,
-		reg:         reg,
 	}
 
 	eng := New(reg, exec, zap.NewNop())


### PR DESCRIPTION
## Summary

- **Root cause**: Runtime defers called `FinishRun` (setting `status=success`) before `dispatch` called `SetRunResult` (setting `return_value`). A reader polling for terminal status could see the flip before the return value was written — causing the flaky `TestEngine_RunResult_Default_PersistsValue` failure in CI.
- **Fix**: Added `Registry.FinishRunWithResult` that atomically sets `status`, `finished_at`, `return_value`, `output_content_type`, and `output_content` in a single UPDATE. Removed `FinishRun` from all 4 runtimes (deno, python, podman, docker); `dispatch` now calls `FinishRunWithResult` after `Execute` returns.
- **Cleanup**: Removed the `pollReturnValue` test workaround (existed solely because of this race) and updated mock executors to match the new contract.

## Test plan

- [x] `TestEngine_RunResult_Default_PersistsValue` passes reliably with `-race -count=5`
- [x] Full trigger test suite passes with `-race`
- [x] `make test-race` passes (all packages green)
- [x] `TestFinishRunWithResult` covers the new registry method
- [x] Deno runtime tests updated to check `result.Error` instead of `run.Status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)