### PR TITLE
fix(webui): sync SourceManager.cfg on raw config save

### DIFF
--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -776,6 +776,9 @@ func (s *Server) apiSaveConfigRaw(w http.ResponseWriter, r *http.Request) {
 	if newCfg, err := config.Load(s.cfgPath); err == nil {
 		s.cfgMu.Lock()
 		s.cfg = newCfg
+		if s.sourceMgr != nil {
+			s.sourceMgr.SetCfg(newCfg)
+		}
 		s.cfgMu.Unlock()
 	} else {
 		s.log.Warn("config reload after raw save failed", zap.Error(err))

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -29,6 +29,13 @@ import (
 
 func newTestServer(t *testing.T) (*Server, *registry.Registry) {
 	t.Helper()
+	return newTestServerWithSourceMgr(t, &config.Config{Server: config.ServerConfig{Port: 8080}}, "", nil)
+}
+
+// newTestServerWithSourceMgr creates a test Server with an optional SourceManager
+// and cfgPath. Pass nil sourceMgr and "" cfgPath for the default minimal setup.
+func newTestServerWithSourceMgr(t *testing.T, cfg *config.Config, cfgPath string, sourceMgr *SourceManager) (*Server, *registry.Registry) {
+	t.Helper()
 	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
 	if err != nil {
 		t.Fatalf("db: %v", err)
@@ -42,9 +49,12 @@ func newTestServer(t *testing.T) (*Server, *registry.Registry) {
 	}
 	eng := trigger.New(reg, rt, zap.NewNop())
 
-	srv, err := New(8080, reg, eng, &config.Config{Server: config.ServerConfig{Port: 8080}}, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
+	srv, err := New(8080, reg, eng, cfg, cfgPath, nil, nil, sourceMgr, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
 	if err != nil {
 		t.Fatalf("New server: %v", err)
+	}
+	if sourceMgr != nil {
+		sourceMgr.BindCfgMutex(&srv.cfgMu)
 	}
 	return srv, reg
 }

--- a/pkg/webui/sources.go
+++ b/pkg/webui/sources.go
@@ -72,6 +72,12 @@ func (m *SourceManager) BindCfgMutex(mu *sync.RWMutex) {
 	m.cfgMu = mu
 }
 
+// SetCfg replaces the config pointer. Must be called under cfgMu.Lock()
+// (the same mutex wired by BindCfgMutex).
+func (m *SourceManager) SetCfg(cfg *config.Config) {
+	m.cfg = cfg
+}
+
 // rLockCfg / rUnlockCfg let SourceManager methods uniformly acquire the
 // shared cfg lock; they're no-ops if cfgMu is nil (test setups).
 func (m *SourceManager) rLockCfg() {

--- a/pkg/webui/sources_test.go
+++ b/pkg/webui/sources_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -73,4 +75,66 @@ func TestApiSetDevMode_RejectsMalformedJson(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("got %d; want 400 BadRequest for malformed body. body=%s", w.Code, w.Body.String())
 	}
+}
+
+// TestApiSaveConfigRaw_SyncsSourceManagerCfg verifies that after a raw config
+// save via POST /api/config/raw, SourceManager.cfg is updated to the new
+// *config.Config pointer so that subsequent List() calls reflect the new sources.
+// This is the regression guard for issue #268.
+func TestApiSaveConfigRaw_SyncsSourceManagerCfg(t *testing.T) {
+	// Write initial dicode.yaml with one source entry.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+	initialYAML := "server:\n  port: 8080\nspec:\n  entries:\n    old-source:\n      ref:\n        path: /tmp/old\n"
+	if err := os.WriteFile(cfgPath, []byte(initialYAML), 0600); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+
+	// Build initial config and SourceManager from it.
+	initialCfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load initial config: %v", err)
+	}
+	sourceMgr := NewSourceManager(initialCfg, nil, dir, zap.NewNop())
+
+	// Build server with the SourceManager and the cfgPath so the handler can
+	// write and hot-reload the config.
+	srv, _ := newTestServerWithSourceMgr(t, initialCfg, cfgPath, sourceMgr)
+
+	// POST updated config that removes old-source and adds new-source.
+	updatedYAML := "server:\n  port: 8080\nspec:\n  entries:\n    new-source:\n      ref:\n        path: /tmp/new\n"
+	body := `{"content":` + string(mustJSON(t, updatedYAML)) + `}`
+	req := httptest.NewRequest(http.MethodPost, "/api/config/raw", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST /api/config/raw returned %d; body=%s", w.Code, w.Body.String())
+	}
+
+	// SourceManager.List() must now show new-source, not old-source.
+	sources := sourceMgr.List()
+	found := false
+	for _, s := range sources {
+		if s.Name == "new-source" {
+			found = true
+		}
+		if s.Name == "old-source" {
+			t.Errorf("SourceManager still lists old-source after raw config save; cfg was not synced")
+		}
+	}
+	if !found {
+		t.Errorf("SourceManager does not list new-source after raw config save; got %+v", sources)
+	}
+}
+
+// mustJSON marshals v as JSON, failing the test on error.
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	return b
 }


### PR DESCRIPTION
## Summary

- `apiSaveConfigRaw` replaces `s.cfg` with a new pointer, but `SourceManager.cfg` kept the old one — reads returned stale data until daemon restart
- Added `SourceManager.SetCfg()` method, called under the existing `cfgMu.Lock()` in `apiSaveConfigRaw`
- Only the full-replacement path (`POST /api/config/raw`) was affected; in-place mutations (add/remove source) were fine

Closes #268

## Test plan

- [x] New test `TestApiSaveConfigRaw_SyncsSourceManagerCfg` — writes config with `old-source`, POSTs YAML with `new-source`, verifies `SourceManager.List()` returns `new-source`
- [x] All webui tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)