### PR TITLE
fix(webui,taskset): hardening follow-ups — redact RefAuth secrets + source API tests

### DIFF
--- a/pkg/taskset/spec.go
+++ b/pkg/taskset/spec.go
@@ -26,8 +26,8 @@ type Ref struct {
 
 // RefAuth holds optional credentials for a git ref.
 type RefAuth struct {
-	TokenEnv string `yaml:"token_env,omitempty"`
-	SSHKey   string `yaml:"ssh_key,omitempty"`
+	TokenEnv string `yaml:"token_env,omitempty" json:"-"`
+	SSHKey   string `yaml:"ssh_key,omitempty" json:"-"`
 }
 
 // IsGit reports whether this is a git ref (URL is non-empty).

--- a/pkg/webui/sources_test.go
+++ b/pkg/webui/sources_test.go
@@ -138,3 +138,137 @@ func mustJSON(t *testing.T, v any) []byte {
 	}
 	return b
 }
+
+// ---------------------------------------------------------------------------
+// HTTP-level tests for apiAddSource / apiRemoveSource (#263)
+// ---------------------------------------------------------------------------
+
+// TestApiAddSource_LocalPath adds a local-path source via POST and verifies
+// it appears in the server config.
+func TestApiAddSource_LocalPath(t *testing.T) {
+	srv, _ := newTestServerWithConfigPath(t)
+
+	body := `{"name":"my-local","path":"/tmp/tasks"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/sources", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST /api/settings/sources returned %d; body=%s", w.Code, w.Body.String())
+	}
+
+	srv.cfgMu.RLock()
+	entry := srv.cfg.Spec.Entries["my-local"]
+	srv.cfgMu.RUnlock()
+	if entry == nil || entry.Ref == nil {
+		t.Fatal("expected my-local entry in config after add")
+	}
+	if entry.Ref.Path != "/tmp/tasks" {
+		t.Errorf("path = %q, want /tmp/tasks", entry.Ref.Path)
+	}
+}
+
+// TestApiAddSource_GitURL adds a git source and verifies branch + URL appear.
+func TestApiAddSource_GitURL(t *testing.T) {
+	srv, _ := newTestServerWithConfigPath(t)
+
+	body := `{"name":"my-git","url":"https://github.com/example/repo.git","branch":"develop"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/sources", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST /api/settings/sources returned %d; body=%s", w.Code, w.Body.String())
+	}
+
+	srv.cfgMu.RLock()
+	entry := srv.cfg.Spec.Entries["my-git"]
+	srv.cfgMu.RUnlock()
+	if entry == nil || entry.Ref == nil {
+		t.Fatal("expected my-git entry in config after add")
+	}
+	if entry.Ref.URL != "https://github.com/example/repo.git" {
+		t.Errorf("url = %q, want https://github.com/example/repo.git", entry.Ref.URL)
+	}
+	if entry.Ref.Branch != "develop" {
+		t.Errorf("branch = %q, want develop", entry.Ref.Branch)
+	}
+}
+
+// TestApiAddSource_MissingName verifies that a missing name returns 400.
+func TestApiAddSource_MissingName(t *testing.T) {
+	srv, _ := newTestServerWithConfigPath(t)
+
+	body := `{"path":"/tmp/tasks"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/sources", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("got %d; want 400 for missing name", w.Code)
+	}
+}
+
+// TestApiAddSource_MissingURLAndPath verifies that omitting both url and path
+// returns 400.
+func TestApiAddSource_MissingURLAndPath(t *testing.T) {
+	srv, _ := newTestServerWithConfigPath(t)
+
+	body := `{"name":"empty"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/sources", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("got %d; want 400 for missing url and path", w.Code)
+	}
+}
+
+// TestApiRemoveSource_HappyPath adds then removes a source, verifying it
+// disappears from the config.
+func TestApiRemoveSource_HappyPath(t *testing.T) {
+	srv, _ := newTestServerWithConfigPath(t)
+
+	// Add a source first.
+	addBody := `{"name":"ephemeral","path":"/tmp/eph"}`
+	addReq := httptest.NewRequest(http.MethodPost, "/api/settings/sources", strings.NewReader(addBody))
+	addReq.Header.Set("Content-Type", "application/json")
+	addW := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(addW, addReq)
+	if addW.Code != http.StatusOK {
+		t.Fatalf("add returned %d; body=%s", addW.Code, addW.Body.String())
+	}
+
+	// Remove it.
+	delReq := httptest.NewRequest(http.MethodDelete, "/api/settings/sources/ephemeral", nil)
+	delW := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(delW, delReq)
+	if delW.Code != http.StatusOK {
+		t.Fatalf("delete returned %d; body=%s", delW.Code, delW.Body.String())
+	}
+
+	srv.cfgMu.RLock()
+	entry := srv.cfg.Spec.Entries["ephemeral"]
+	srv.cfgMu.RUnlock()
+	if entry != nil {
+		t.Error("expected ephemeral to be removed from config, but it still exists")
+	}
+}
+
+// TestApiRemoveSource_NotFound verifies that removing a non-existent source
+// returns 404.
+func TestApiRemoveSource_NotFound(t *testing.T) {
+	srv, _ := newTestServerWithConfigPath(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/settings/sources/does-not-exist", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("got %d; want 404 for non-existent source", w.Code)
+	}
+}


### PR DESCRIPTION
## Summary

- **RefAuth JSON redaction**: Added `json:"-"` to `TokenEnv` and `SSHKey` fields so GET /api/config no longer leaks sensitive source credentials
- **Source API tests**: Added 6 HTTP-level tests for `apiAddSource` and `apiRemoveSource` (local path, git URL, missing name, missing URL+path, happy delete, 404 delete)
- Item 2 (persistConfig atomicity) was already fixed in a prior PR

Closes #263

## Test plan

- [x] `TestApiAddSource_*` — 4 tests covering valid and invalid inputs
- [x] `TestApiRemoveSource_*` — 2 tests covering happy path and 404
- [x] All webui and taskset tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)