### PR TITLE
feat(taskset): path templating variables in ref entries — REPO_DIR, TASKSET_DIR

### DIFF
--- a/pkg/taskset/resolver.go
+++ b/pkg/taskset/resolver.go
@@ -7,11 +7,22 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/dicode/dicode/pkg/task"
 	"go.uber.org/zap"
+)
+
+// Ref path template variables expanded before path resolution.
+const (
+	// VarRepoDir expands to the root of the source (git clone dir or local source root).
+	VarRepoDir = "REPO_DIR"
+	// VarTaskSetRefDir expands to the directory containing the current taskset.yaml.
+	// Named differently from task.VarTaskSetDir to avoid confusion: VarTaskSetDir
+	// is expanded inside task.yaml specs; VarTaskSetRefDir is expanded in ref paths.
+	VarTaskSetRefDir = "TASKSET_DIR"
 )
 
 // repoKey is the deduplication key for a git repository clone.
@@ -78,7 +89,7 @@ func (r *Resolver) DevMode() bool {
 // root taskset.yaml path, so source loaders don't need to. The map is
 // treated as read-only; the resolver never mutates or retains it.
 func (r *Resolver) Resolve(ctx context.Context, namespace string, tsRef *Ref, configDefaults *Defaults, parentOverrides *Overrides, extraVars map[string]string) ([]*ResolvedTask, error) {
-	tsPath, err := r.resolveRef(ctx, tsRef, "")
+	tsPath, err := r.resolveRef(ctx, tsRef, "", nil)
 	if err != nil {
 		return nil, fmt.Errorf("resolve ref for namespace %q: %w", namespace, err)
 	}
@@ -87,6 +98,11 @@ func (r *Resolver) Resolve(ctx context.Context, namespace string, tsRef *Ref, co
 	if err != nil {
 		return nil, err
 	}
+
+	// Compute the repo-root directory for ref path template expansion.
+	// For local sources this is the directory containing the root taskset.yaml;
+	// for git sources it would be the clone directory (already resolved above).
+	repoDir := filepath.Dir(tsPath)
 
 	// At the TOP-level Resolve only, inject TASK_SET_DIR from the resolved
 	// root taskset path. Nested resolveNestedRef calls receive this same
@@ -99,7 +115,7 @@ func (r *Resolver) Resolve(ctx context.Context, namespace string, tsRef *Ref, co
 	// ${TASK_SET_DIR} in task.yaml paths.
 	rootVars := withTaskSetDir(extraVars, tsPath)
 
-	return r.resolveBody(ctx, namespace, tsPath, ts, configDefaults, parentOverrides, rootVars)
+	return r.resolveBody(ctx, namespace, tsPath, ts, configDefaults, parentOverrides, rootVars, repoDir)
 }
 
 // withTaskSetDir returns a copy of base with VarTaskSetDir set to
@@ -124,6 +140,7 @@ func (r *Resolver) resolveBody(
 	configDefaults *Defaults,
 	parentOverrides *Overrides,
 	extraVars map[string]string,
+	repoDir string,
 ) ([]*ResolvedTask, error) {
 	// Deprecation warnings for removed precedence levels.
 	if defaultsNonEmpty(configDefaults) {
@@ -190,7 +207,13 @@ func (r *Resolver) resolveBody(
 			ref = ref.DevRef
 		}
 
-		localPath, err := r.resolveRef(ctx, ref, tsPath)
+		// Build ref path template variables for ${REPO_DIR} / ${TASKSET_DIR}.
+		refVars := map[string]string{
+			VarRepoDir:       repoDir,
+			VarTaskSetRefDir: filepath.Dir(tsPath),
+		}
+
+		localPath, err := r.resolveRef(ctx, ref, tsPath, refVars)
 		if err != nil {
 			r.log.Warn("taskset: failed to resolve ref",
 				zap.String("entry", fullID), zap.Error(err))
@@ -297,7 +320,7 @@ func (r *Resolver) resolveBody(
 			if parentEntryOverride != nil {
 				nestedOverrides = mergeOverrides(parentEntryOverride, nestedOverrides)
 			}
-			nested, err := r.resolveNestedRef(ctx, fullID, localPath, nestedOverrides, extraVars)
+			nested, err := r.resolveNestedRef(ctx, fullID, localPath, nestedOverrides, extraVars, repoDir)
 			if err != nil {
 				r.log.Warn("taskset: failed to resolve nested taskset",
 					zap.String("entry", fullID), zap.Error(err))
@@ -321,27 +344,32 @@ func (r *Resolver) resolveBody(
 	return results, nil
 }
 
-func (r *Resolver) resolveNestedRef(ctx context.Context, namespace, tsPath string, overrides *Overrides, extraVars map[string]string) ([]*ResolvedTask, error) {
+func (r *Resolver) resolveNestedRef(ctx context.Context, namespace, tsPath string, overrides *Overrides, extraVars map[string]string, repoDir string) ([]*ResolvedTask, error) {
 	ts, err := LoadTaskSet(tsPath)
 	if err != nil {
 		return nil, err
 	}
 	// Pass nil for configDefaults: deprecation warnings are emitted once at the
 	// public Resolve entry point; nested sets do not re-emit them.
-	return r.resolveBody(ctx, namespace, tsPath, ts, nil, overrides, extraVars)
+	return r.resolveBody(ctx, namespace, tsPath, ts, nil, overrides, extraVars, repoDir)
 }
 
 // resolveRef returns the absolute local path to the yaml file pointed to by ref.
 // For git refs this may trigger a clone or pull.
 // parentTSPath is the absolute path of the parent taskset.yaml — used to resolve
 // relative paths in local refs against the parent's directory.
-func (r *Resolver) resolveRef(ctx context.Context, ref *Ref, parentTSPath string) (string, error) {
+// refVars holds template variables (REPO_DIR, TASKSET_DIR) to expand in the
+// ref's Path field before resolution. Pass nil when no expansion is needed
+// (e.g. the root Resolve call before repoDir is known).
+func (r *Resolver) resolveRef(ctx context.Context, ref *Ref, parentTSPath string, refVars map[string]string) (string, error) {
+	path := expandRefPath(ref.Path, refVars)
+
 	var resolved string
 	if !ref.IsGit() {
-		if !filepath.IsAbs(ref.Path) {
-			resolved = filepath.Join(filepath.Dir(parentTSPath), ref.Path)
+		if !filepath.IsAbs(path) {
+			resolved = filepath.Join(filepath.Dir(parentTSPath), path)
 		} else {
-			resolved = ref.Path
+			resolved = path
 		}
 	} else {
 		branch := ref.effectiveBranch()
@@ -349,9 +377,23 @@ func (r *Resolver) resolveRef(ctx context.Context, ref *Ref, parentTSPath string
 		if err != nil {
 			return "", err
 		}
-		resolved = filepath.Join(localDir, ref.Path)
+		resolved = filepath.Join(localDir, path)
 	}
 	return resolveYAMLPath(resolved), nil
+}
+
+// expandRefPath replaces ${REPO_DIR} and ${TASKSET_DIR} placeholders in a ref
+// path with the corresponding values from vars. Unknown or absent variables are
+// left as-is. Returns the path unchanged when vars is nil or the path contains
+// no placeholders.
+func expandRefPath(path string, vars map[string]string) string {
+	if len(vars) == 0 || !strings.Contains(path, "${") {
+		return path
+	}
+	for k, v := range vars {
+		path = strings.ReplaceAll(path, "${"+k+"}", v)
+	}
+	return path
 }
 
 // resolveYAMLPath returns path unchanged if it is already a file.

--- a/pkg/taskset/resolver_test.go
+++ b/pkg/taskset/resolver_test.go
@@ -958,3 +958,144 @@ spec:
 		t.Errorf("task without enabled override should default to Enabled=true")
 	}
 }
+
+// ── expandRefPath ────────────────────────────────────────────────────────────
+
+func TestExpandRefPath_NoVars(t *testing.T) {
+	// Path without variables is returned unchanged.
+	got := expandRefPath("./deploy/task.yaml", nil)
+	if got != "./deploy/task.yaml" {
+		t.Errorf("got %q, want unchanged", got)
+	}
+}
+
+func TestExpandRefPath_RepoDir(t *testing.T) {
+	vars := map[string]string{VarRepoDir: "/home/repo", VarTaskSetRefDir: "/home/repo/sets"}
+	got := expandRefPath("${REPO_DIR}/tasks/deploy", vars)
+	if got != "/home/repo/tasks/deploy" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExpandRefPath_TaskSetDir(t *testing.T) {
+	vars := map[string]string{VarRepoDir: "/home/repo", VarTaskSetRefDir: "/home/repo/sets"}
+	got := expandRefPath("${TASKSET_DIR}/../shared", vars)
+	if got != "/home/repo/sets/../shared" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExpandRefPath_BothVars(t *testing.T) {
+	vars := map[string]string{VarRepoDir: "/root", VarTaskSetRefDir: "/root/sub"}
+	got := expandRefPath("${REPO_DIR}/a/${TASKSET_DIR}/b", vars)
+	if got != "/root/a//root/sub/b" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExpandRefPath_UnknownVar(t *testing.T) {
+	vars := map[string]string{VarRepoDir: "/root"}
+	got := expandRefPath("${UNKNOWN}/foo", vars)
+	if got != "${UNKNOWN}/foo" {
+		t.Errorf("unknown var should be left as-is: got %q", got)
+	}
+}
+
+// ── Resolver ref path templating integration ─────────────────────────────────
+
+func TestResolver_RefPathRepoDirExpansion(t *testing.T) {
+	// ${REPO_DIR} in a ref path expands to the root taskset.yaml directory.
+	repoDir := t.TempDir()
+	taskDir := writeTaskDir(t, repoDir, "deploy")
+
+	tsContent := `
+apiVersion: dicode/v1
+kind: TaskSet
+metadata:
+  name: infra
+spec:
+  entries:
+    deploy:
+      ref:
+        path: ${REPO_DIR}/deploy
+`
+	tsPath := writeTaskSetFile(t, repoDir, "taskset.yaml", tsContent)
+
+	r := newResolver(t)
+	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	if results[0].ID != "infra/deploy" {
+		t.Errorf("ID: got %q", results[0].ID)
+	}
+	// TaskDir should point at the actual task directory.
+	if results[0].TaskDir != taskDir {
+		t.Errorf("TaskDir: got %q, want %q", results[0].TaskDir, taskDir)
+	}
+}
+
+func TestResolver_RefPathTaskSetDirExpansion(t *testing.T) {
+	// ${TASKSET_DIR} in a ref path expands to the directory of the current
+	// taskset.yaml, which for the root taskset is the same as REPO_DIR.
+	repoDir := t.TempDir()
+	taskDir := writeTaskDir(t, repoDir, "deploy")
+
+	tsContent := `
+apiVersion: dicode/v1
+kind: TaskSet
+metadata:
+  name: infra
+spec:
+  entries:
+    deploy:
+      ref:
+        path: ${TASKSET_DIR}/deploy
+`
+	tsPath := writeTaskSetFile(t, repoDir, "taskset.yaml", tsContent)
+
+	r := newResolver(t)
+	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	if results[0].TaskDir != taskDir {
+		t.Errorf("TaskDir: got %q, want %q", results[0].TaskDir, taskDir)
+	}
+}
+
+func TestResolver_RefPathWithoutVarsUnchanged(t *testing.T) {
+	// Regression: ref paths without template variables must still work.
+	repoDir := t.TempDir()
+	taskDir := writeTaskDir(t, repoDir, "deploy")
+
+	tsContent := `
+apiVersion: dicode/v1
+kind: TaskSet
+metadata:
+  name: infra
+spec:
+  entries:
+    deploy:
+      ref:
+        path: ` + filepath.Join(taskDir, "task.yaml") + `
+`
+	tsPath := writeTaskSetFile(t, repoDir, "taskset.yaml", tsContent)
+	r := newResolver(t)
+	results, err := r.Resolve(context.Background(), "infra", &Ref{Path: tsPath}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	if results[0].ID != "infra/deploy" {
+		t.Errorf("ID: got %q", results[0].ID)
+	}
+}


### PR DESCRIPTION
## Summary

- Added `${REPO_DIR}` and `${TASKSET_DIR}` template variable expansion in taskset ref paths
- `REPO_DIR` = root source directory (stays fixed across nested tasksets)
- `TASKSET_DIR` = directory of the current taskset.yaml (changes per nesting level)
- Simple `strings.ReplaceAll` expansion — no template engine needed
- Paths without variables work unchanged (regression tested)

Closes #61

## Test plan

- [x] `TestExpandRefPath_*` — 5 unit tests (no vars, REPO_DIR, TASKSET_DIR, both, unknown)
- [x] `TestResolver_RefPath*Expansion` — 2 end-to-end tests with real taskset resolution
- [x] `TestResolver_RefPathWithoutVarsUnchanged` — regression test
- [x] All 96 taskset tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)