### PR TITLE
refactor: extract shared cloneOrPull into internal/gitops (#195)

### DIFF
--- a/internal/gitops/clone.go
+++ b/internal/gitops/clone.go
@@ -1,0 +1,117 @@
+// Package gitops provides shared git clone/pull helpers used by both the
+// git source and the taskset loader.
+package gitops
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+)
+
+// CloneOrPull clones url@branch into dir if not present, otherwise pulls.
+// If a pull fails with a reclonable error (corrupted object DB, stuck
+// shallow clone, etc.) the directory is wiped and re-cloned from scratch.
+//
+// auth may be nil for public repos.
+//
+// Clones are full (no Depth limit) so that go-git's PullContext can
+// always compute a merge base when the remote advances. See #175.
+func CloneOrPull(ctx context.Context, dir, url, branch string, auth *http.BasicAuth) error {
+	if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+		if err := pullExisting(ctx, dir, branch, auth); err == nil {
+			return nil
+		} else if !IsReclonableError(err) {
+			return err
+		}
+		// Reclonable failure: wipe and fall through to the clone path.
+		if rmErr := os.RemoveAll(dir); rmErr != nil {
+			return fmt.Errorf("recover clone (remove): %w", rmErr)
+		}
+	}
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("mkdir: %w", err)
+	}
+	opts := &gogit.CloneOptions{
+		URL:           url,
+		ReferenceName: plumbing.NewBranchReferenceName(branch),
+		SingleBranch:  true,
+	}
+	if auth != nil {
+		opts.Auth = auth
+	}
+	if _, err := gogit.PlainCloneContext(ctx, dir, false, opts); err != nil {
+		return fmt.Errorf("clone: %w", err)
+	}
+	return nil
+}
+
+// pullExisting opens the repo at dir and pulls origin/branch. Returns
+// nil on success (including NoErrAlreadyUpToDate) or a wrapped pull
+// error that callers inspect with IsReclonableError.
+func pullExisting(ctx context.Context, dir, branch string, auth *http.BasicAuth) error {
+	repo, err := gogit.PlainOpen(dir)
+	if err != nil {
+		return fmt.Errorf("open repo: %w", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		return fmt.Errorf("worktree: %w", err)
+	}
+	opts := &gogit.PullOptions{
+		RemoteName:    "origin",
+		ReferenceName: plumbing.NewBranchReferenceName(branch),
+		Force:         true,
+	}
+	if auth != nil {
+		opts.Auth = auth
+	}
+	if err := wt.PullContext(ctx, opts); err != nil && err != gogit.NoErrAlreadyUpToDate {
+		return fmt.Errorf("pull: %w", err)
+	}
+	return nil
+}
+
+// IsReclonableError reports whether the local clone is in a state that
+// blowing-it-away-and-re-cloning fixes. These are the error shapes
+// observed in production: stuck-shallow reconcile failures, missing
+// objects/packfiles, dangling refs. Network errors and auth errors
+// are NOT reclonable — re-cloning would just fail the same way and
+// thrash the remote.
+func IsReclonableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	for _, sig := range []string{
+		"object not found",
+		"reference not found",
+		"packfile",
+		"invalid pkt-len",
+	} {
+		if strings.Contains(s, sig) {
+			return true
+		}
+	}
+	return false
+}
+
+// HTTPAuth returns HTTP basic-auth credentials derived from the named
+// environment variable, or nil if tokenEnv is empty or the variable is
+// unset.
+func HTTPAuth(tokenEnv string) *http.BasicAuth {
+	if tokenEnv == "" {
+		return nil
+	}
+	token := os.Getenv(tokenEnv)
+	if token == "" {
+		return nil
+	}
+	return &http.BasicAuth{Username: "git", Password: token}
+}

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -16,11 +16,11 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/dicode/dicode/internal/gitops"
 	"github.com/dicode/dicode/pkg/source"
 	"github.com/dicode/dicode/pkg/task"
 	gogit "github.com/go-git/go-git/v5"
 	gogitconfig "github.com/go-git/go-git/v5/config"
-	"github.com/go-git/go-git/v5/plumbing"
 	gogittransport "github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"go.uber.org/zap"
@@ -182,51 +182,7 @@ func (g *GitSource) cloneOrPull(ctx context.Context) error {
 // Returns nil on success or NoErrAlreadyUpToDate; any other error indicates
 // a failure the caller (cloneOrPull) may want to retry.
 func (g *GitSource) tryCloneOrPull(ctx context.Context) error {
-	auth := g.httpAuth()
-
-	// If the local dir already contains a repo, pull; otherwise clone.
-	if _, err := os.Stat(filepath.Join(g.localDir, ".git")); err == nil {
-		repo, err := gogit.PlainOpen(g.localDir)
-		if err != nil {
-			return fmt.Errorf("open repo: %w", err)
-		}
-		wt, err := repo.Worktree()
-		if err != nil {
-			return fmt.Errorf("worktree: %w", err)
-		}
-		opts := &gogit.PullOptions{
-			RemoteName:    "origin",
-			ReferenceName: plumbing.NewBranchReferenceName(g.branch),
-			Force:         true,
-		}
-		if auth != nil {
-			opts.Auth = auth
-		}
-		err = wt.PullContext(ctx, opts)
-		if err != nil && err != gogit.NoErrAlreadyUpToDate {
-			return fmt.Errorf("pull: %w", err)
-		}
-		return nil
-	}
-
-	// Clone.
-	if err := os.MkdirAll(g.localDir, 0755); err != nil {
-		return fmt.Errorf("mkdir: %w", err)
-	}
-	opts := &gogit.CloneOptions{
-		URL:           g.url,
-		ReferenceName: plumbing.NewBranchReferenceName(g.branch),
-		SingleBranch:  true,
-		Depth:         1,
-	}
-	if auth != nil {
-		opts.Auth = auth
-	}
-	_, err := gogit.PlainCloneContext(ctx, g.localDir, false, opts)
-	if err != nil {
-		return fmt.Errorf("clone: %w", err)
-	}
-	return nil
+	return gitops.CloneOrPull(ctx, g.localDir, g.url, g.branch, gitops.HTTPAuth(g.tokenEnv))
 }
 
 // isPermanentGitError reports whether err is a configuration-style failure
@@ -247,18 +203,6 @@ func isPermanentGitError(err error) bool {
 		return true
 	}
 	return false
-}
-
-// httpAuth returns HTTP basic-auth credentials if a token env var is set.
-func (g *GitSource) httpAuth() *http.BasicAuth {
-	if g.tokenEnv == "" {
-		return nil
-	}
-	token := os.Getenv(g.tokenEnv)
-	if token == "" {
-		return nil
-	}
-	return &http.BasicAuth{Username: "git", Password: token}
 }
 
 // syncAndEmit computes a diff against the previous snapshot and sends events.

--- a/pkg/taskset/git.go
+++ b/pkg/taskset/git.go
@@ -2,123 +2,21 @@ package taskset
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
 
-	gogit "github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/dicode/dicode/internal/gitops"
 )
 
 // cloneOrPull clones url@branch into dir if not present, otherwise pulls.
 // tokenEnv is the name of an env var holding an HTTP auth token; pass "" for public repos.
 //
-// If a pull fails with a reconcile-style error (e.g. the clone is a
-// leftover shallow from an older dicode version, or the object DB is
-// corrupted), the directory is wiped and re-cloned from scratch. This
-// keeps users upgrading from pre-#176 dicode builds from getting stuck
-// in a pull-fails-forever loop on their existing ~/.dicode/tasksets/
-// clones without having to manually delete the directory.
+// Delegates to internal/gitops.CloneOrPull which handles re-clone-on-corrupt
+// recovery (see #175, #176).
 func cloneOrPull(ctx context.Context, dir, url, branch, tokenEnv string) error {
-	auth := httpAuth(tokenEnv)
-
-	if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
-		if err := pullExisting(ctx, dir, branch, auth); err == nil {
-			return nil
-		} else if !isReclonableError(err) {
-			return err
-		}
-		// Reclonable failure: wipe and fall through to the clone path.
-		if rmErr := os.RemoveAll(dir); rmErr != nil {
-			return fmt.Errorf("recover clone (remove): %w", rmErr)
-		}
-	}
-
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("mkdir: %w", err)
-	}
-	// Full clone (no Depth). A shallow clone costs bandwidth once but
-	// fails PullContext with "object not found" the first time the remote
-	// advances past the shallow tip — go-git can't compute a merge base
-	// when the parent commits aren't in the local object DB. See #175.
-	opts := &gogit.CloneOptions{
-		URL:           url,
-		ReferenceName: plumbing.NewBranchReferenceName(branch),
-		SingleBranch:  true,
-	}
-	if auth != nil {
-		opts.Auth = auth
-	}
-	if _, err := gogit.PlainCloneContext(ctx, dir, false, opts); err != nil {
-		return fmt.Errorf("clone: %w", err)
-	}
-	return nil
-}
-
-// pullExisting opens the repo at dir and pulls origin/branch. Returns
-// nil on success (including NoErrAlreadyUpToDate) or a wrapped pull
-// error that callers inspect with isReclonableError.
-func pullExisting(ctx context.Context, dir, branch string, auth *http.BasicAuth) error {
-	repo, err := gogit.PlainOpen(dir)
-	if err != nil {
-		return fmt.Errorf("open repo: %w", err)
-	}
-	wt, err := repo.Worktree()
-	if err != nil {
-		return fmt.Errorf("worktree: %w", err)
-	}
-	opts := &gogit.PullOptions{
-		RemoteName:    "origin",
-		ReferenceName: plumbing.NewBranchReferenceName(branch),
-		Force:         true,
-	}
-	if auth != nil {
-		opts.Auth = auth
-	}
-	if err := wt.PullContext(ctx, opts); err != nil && err != gogit.NoErrAlreadyUpToDate {
-		return fmt.Errorf("pull: %w", err)
-	}
-	return nil
+	return gitops.CloneOrPull(ctx, dir, url, branch, gitops.HTTPAuth(tokenEnv))
 }
 
 // isReclonableError reports whether the local clone is in a state that
-// blowing-it-away-and-re-cloning fixes. These are the error shapes
-// observed in production: stuck-shallow reconcile failures, missing
-// objects/packfiles, dangling refs. Network errors and auth errors
-// are NOT reclonable — re-cloning would just fail the same way and
-// thrash the remote.
+// blowing-it-away-and-re-cloning fixes.
 func isReclonableError(err error) bool {
-	if err == nil {
-		return false
-	}
-	s := err.Error()
-	// Positive signals: references or objects that the remote has but
-	// the local object DB doesn't, which go-git surfaces as these
-	// phrases. Matching on substrings is permissive —
-	// we'd rather over-recover (cheap) than under-recover (breaks
-	// tasksets silently for the operator).
-	for _, sig := range []string{
-		"object not found",
-		"reference not found",
-		"packfile",
-		"invalid pkt-len",
-	} {
-		if strings.Contains(s, sig) {
-			return true
-		}
-	}
-	return false
-}
-
-func httpAuth(tokenEnv string) *http.BasicAuth {
-	if tokenEnv == "" {
-		return nil
-	}
-	token := os.Getenv(tokenEnv)
-	if token == "" {
-		return nil
-	}
-	return &http.BasicAuth{Username: "git", Password: token}
+	return gitops.IsReclonableError(err)
 }


### PR DESCRIPTION
## Summary
- **Epic #195, item 14**: Extract the duplicated git clone/pull + HTTP auth logic from `pkg/source/git` and `pkg/taskset` into a new `internal/gitops` package.
- The merged implementation takes the more robust version from `pkg/taskset` which includes re-clone-on-corrupt recovery (wipe-and-reclone when the local object DB is broken, fixing the #175/#176 upgrade path).
- Both call sites now delegate to `gitops.CloneOrPull` and `gitops.HTTPAuth`, reducing total LOC by ~49 lines (166 removed, 117 added).

### Files changed
- **`internal/gitops/clone.go`** (new) — shared `CloneOrPull`, `HTTPAuth`, `IsReclonableError`
- **`pkg/source/git/git.go`** — `tryCloneOrPull` now delegates to `gitops.CloneOrPull`; removed inline `httpAuth` method
- **`pkg/taskset/git.go`** — thin wrappers around `gitops.CloneOrPull` and `gitops.IsReclonableError`

## Test plan
- [x] `make build` compiles cleanly
- [x] `make lint` passes
- [x] `go test ./pkg/source/git/... -v` — all 12 tests pass (poll latency, sync, retry, auth errors, idempotent poll)
- [x] `go test ./pkg/taskset/... -v` — all tests pass (full history, corrupted clone recovery, reclonable error, pull-after-advance)
- [x] `make test` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)