### PR TITLE
refactor: unify uv/deno binary installer into internal/installer (#195)

### DIFF
--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -60,11 +60,16 @@ type Spec struct {
 // to the given Spec. If the binary already exists at CachePath it is returned
 // immediately without any network access.
 func EnsureBinary(s Spec) (string, error) {
-	if _, err := os.Stat(s.CachePath); err == nil {
-		return s.CachePath, nil
+	// filepath.Clean prevents path traversal — CodeQL flags the raw user-facing
+	// Spec fields as tainted, but callers (pkg/deno, pkg/uv) construct them
+	// from hardcoded version strings. Clean is defence-in-depth.
+	cachePath := filepath.Clean(s.CachePath)
+
+	if _, err := os.Stat(cachePath); err == nil {
+		return cachePath, nil
 	}
 
-	if err := os.MkdirAll(filepath.Dir(s.CachePath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0755); err != nil {
 		return "", fmt.Errorf("create cache dir: %w", err)
 	}
 
@@ -97,7 +102,7 @@ func EnsureBinary(s Spec) (string, error) {
 
 	// Write to a temp file in the same directory, then rename atomically.
 	// This prevents concurrent downloaders from corrupting the binary.
-	tmp, err := os.CreateTemp(filepath.Dir(s.CachePath), "installer-*.tmp")
+	tmp, err := os.CreateTemp(filepath.Dir(cachePath), "installer-*.tmp")
 	if err != nil {
 		return "", fmt.Errorf("create temp file: %w", err)
 	}
@@ -115,12 +120,12 @@ func EnsureBinary(s Spec) (string, error) {
 		_ = os.Remove(tmpPath)
 		return "", fmt.Errorf("chmod binary: %w", err)
 	}
-	if err := os.Rename(tmpPath, s.CachePath); err != nil {
+	if err := os.Rename(tmpPath, cachePath); err != nil {
 		_ = os.Remove(tmpPath)
 		return "", fmt.Errorf("install binary: %w", err)
 	}
 
-	return s.CachePath, nil
+	return cachePath, nil
 }
 
 // PlatformName returns the canonical platform triple for the current OS/arch

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -1,0 +1,226 @@
+// Package installer provides shared logic for downloading, verifying, and
+// caching pinned binary releases from GitHub. It is used by the deno and uv
+// packages to avoid duplicating the download/verify/extract/cache pipeline.
+package installer
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// ArchiveFormat describes the archive type to download and extract.
+type ArchiveFormat int
+
+const (
+	// FormatZip is a .zip archive (used by deno on all platforms, uv on Windows).
+	FormatZip ArchiveFormat = iota
+	// FormatTarGz is a .tar.gz archive (used by uv on non-Windows).
+	FormatTarGz
+)
+
+// ExtractMode controls how the binary is located inside the archive.
+type ExtractMode int
+
+const (
+	// MatchExact requires the archive entry name to equal the binary name exactly.
+	MatchExact ExtractMode = iota
+	// MatchBaseName matches on filepath.Base(entry) == binary name,
+	// allowing the binary to be inside a subdirectory.
+	MatchBaseName
+)
+
+// Spec describes everything needed to download, verify, and cache a binary.
+type Spec struct {
+	// ArchiveURL is the URL of the archive to download.
+	ArchiveURL string
+	// ChecksumURL is the URL of the SHA-256 checksum file.
+	ChecksumURL string
+	// BinName is the name of the binary to extract (e.g. "deno", "uv.exe").
+	BinName string
+	// CachePath is the final filesystem path where the binary will be stored.
+	CachePath string
+	// Format is the archive format (zip or tar.gz).
+	Format ArchiveFormat
+	// Extract controls how the binary is located in the archive.
+	Extract ExtractMode
+}
+
+// EnsureBinary downloads, verifies, extracts, and caches a binary according
+// to the given Spec. If the binary already exists at CachePath it is returned
+// immediately without any network access.
+func EnsureBinary(s Spec) (string, error) {
+	if _, err := os.Stat(s.CachePath); err == nil {
+		return s.CachePath, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(s.CachePath), 0755); err != nil {
+		return "", fmt.Errorf("create cache dir: %w", err)
+	}
+
+	archiveData, err := DownloadBytes(s.ArchiveURL)
+	if err != nil {
+		return "", fmt.Errorf("download archive: %w", err)
+	}
+
+	checksumData, err := DownloadBytes(s.ChecksumURL)
+	if err != nil {
+		return "", fmt.Errorf("download checksum: %w", err)
+	}
+
+	if err := VerifyChecksum(archiveData, string(checksumData)); err != nil {
+		return "", fmt.Errorf("checksum verification failed: %w", err)
+	}
+
+	var binData []byte
+	switch s.Format {
+	case FormatZip:
+		binData, err = ExtractFromZip(archiveData, s.BinName, s.Extract)
+	case FormatTarGz:
+		binData, err = ExtractFromTarGz(archiveData, s.BinName)
+	default:
+		return "", fmt.Errorf("unsupported archive format: %d", s.Format)
+	}
+	if err != nil {
+		return "", fmt.Errorf("extract binary: %w", err)
+	}
+
+	// Write to a temp file in the same directory, then rename atomically.
+	// This prevents concurrent downloaders from corrupting the binary.
+	tmp, err := os.CreateTemp(filepath.Dir(s.CachePath), "installer-*.tmp")
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(binData); err != nil {
+		tmp.Close()
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("write binary: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Chmod(tmpPath, 0755); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("chmod binary: %w", err)
+	}
+	if err := os.Rename(tmpPath, s.CachePath); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("install binary: %w", err)
+	}
+
+	return s.CachePath, nil
+}
+
+// PlatformName returns the canonical platform triple for the current OS/arch
+// combination (e.g. "x86_64-unknown-linux-gnu"). Both deno and uv use the
+// same set of platform strings.
+func PlatformName() (string, error) {
+	type entry struct{ goos, goarch, name string }
+	platforms := []entry{
+		{"linux", "amd64", "x86_64-unknown-linux-gnu"},
+		{"linux", "arm64", "aarch64-unknown-linux-gnu"},
+		{"darwin", "amd64", "x86_64-apple-darwin"},
+		{"darwin", "arm64", "aarch64-apple-darwin"},
+		{"windows", "amd64", "x86_64-pc-windows-msvc"},
+	}
+	for _, p := range platforms {
+		if p.goos == runtime.GOOS && p.goarch == runtime.GOARCH {
+			return p.name, nil
+		}
+	}
+	return "", fmt.Errorf("unsupported platform %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+// DownloadBytes fetches the contents of the given URL into memory.
+func DownloadBytes(url string) ([]byte, error) {
+	resp, err := http.Get(url) //nolint:gosec
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d fetching %s", resp.StatusCode, url)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// VerifyChecksum checks the SHA-256 of data against a checksum file line
+// in the format "<hex>  <filename>" (standard sha256sum output).
+func VerifyChecksum(data []byte, checksumLine string) error {
+	fields := strings.Fields(checksumLine)
+	if len(fields) == 0 {
+		return fmt.Errorf("empty checksum file")
+	}
+	expected := strings.ToLower(fields[0])
+	h := sha256.Sum256(data)
+	got := hex.EncodeToString(h[:])
+	if got != expected {
+		return fmt.Errorf("expected %s got %s", expected, got)
+	}
+	return nil
+}
+
+// ExtractFromZip extracts a file from a zip archive. When mode is MatchExact,
+// the entry name must equal binName exactly. When mode is MatchBaseName,
+// filepath.Base(entry) is compared instead.
+func ExtractFromZip(zipData []byte, binName string, mode ExtractMode) ([]byte, error) {
+	r, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range r.File {
+		match := false
+		switch mode {
+		case MatchExact:
+			match = f.Name == binName
+		case MatchBaseName:
+			match = filepath.Base(f.Name) == binName
+		}
+		if match {
+			rc, err := f.Open()
+			if err != nil {
+				return nil, err
+			}
+			defer rc.Close()
+			return io.ReadAll(rc)
+		}
+	}
+	return nil, fmt.Errorf("file %q not found in zip", binName)
+}
+
+// ExtractFromTarGz finds the first entry whose base name matches binName
+// inside a .tar.gz archive and returns its content.
+func ExtractFromTarGz(data []byte, binName string) ([]byte, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("open gzip: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if filepath.Base(hdr.Name) == binName && hdr.Typeflag == tar.TypeReg {
+			return io.ReadAll(tr)
+		}
+	}
+	return nil, fmt.Errorf("file %q not found in tar archive", binName)
+}

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -50,6 +50,10 @@ type Spec struct {
 	BinName string
 	// CachePath is the final filesystem path where the binary will be stored.
 	CachePath string
+	// CacheBase is the root directory that CachePath must reside under.
+	// Used to prevent path-traversal attacks. Defaults to ~/.cache/dicode
+	// when empty.
+	CacheBase string
 	// Format is the archive format (zip or tar.gz).
 	Format ArchiveFormat
 	// Extract controls how the binary is located in the archive.
@@ -60,10 +64,21 @@ type Spec struct {
 // to the given Spec. If the binary already exists at CachePath it is returned
 // immediately without any network access.
 func EnsureBinary(s Spec) (string, error) {
-	// filepath.Clean prevents path traversal — CodeQL flags the raw user-facing
-	// Spec fields as tainted, but callers (pkg/deno, pkg/uv) construct them
-	// from hardcoded version strings. Clean is defence-in-depth.
+	// Validate CachePath against traversal. Callers (pkg/deno, pkg/uv) build
+	// it from hardcoded segments + a version string; Clean+HasPrefix is
+	// defence-in-depth so a rogue version can't escape the cache tree.
 	cachePath := filepath.Clean(s.CachePath)
+	cacheBase := s.CacheBase
+	if cacheBase == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home dir: %w", err)
+		}
+		cacheBase = filepath.Join(home, ".cache", "dicode")
+	}
+	if !strings.HasPrefix(cachePath, filepath.Clean(cacheBase)+string(filepath.Separator)) {
+		return "", fmt.Errorf("cache path %q escapes base %q", cachePath, cacheBase)
+	}
 
 	if _, err := os.Stat(cachePath); err == nil {
 		return cachePath, nil

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -1,0 +1,280 @@
+package installer
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPlatformName(t *testing.T) {
+	name, err := PlatformName()
+	if err != nil {
+		t.Skipf("unsupported platform: %v", err)
+	}
+	if name == "" {
+		t.Error("expected non-empty platform name")
+	}
+}
+
+func TestVerifyChecksum_Valid(t *testing.T) {
+	data := []byte("hello installer")
+	h := sha256.Sum256(data)
+	line := hex.EncodeToString(h[:]) + "  archive.zip"
+	if err := VerifyChecksum(data, line); err != nil {
+		t.Errorf("expected valid checksum, got: %v", err)
+	}
+}
+
+func TestVerifyChecksum_Invalid(t *testing.T) {
+	data := []byte("hello installer")
+	line := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef  archive.zip"
+	if err := VerifyChecksum(data, line); err == nil {
+		t.Error("expected checksum mismatch error")
+	}
+}
+
+func TestVerifyChecksum_Empty(t *testing.T) {
+	if err := VerifyChecksum([]byte("data"), ""); err == nil {
+		t.Error("expected error for empty checksum line")
+	}
+}
+
+func TestExtractFromZip_Exact(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create("mybinary")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []byte("fake-binary-content")
+	w.Write(want) //nolint:errcheck
+	zw.Close()
+
+	got, err := ExtractFromZip(buf.Bytes(), "mybinary", MatchExact)
+	if err != nil {
+		t.Fatalf("ExtractFromZip: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExtractFromZip_BaseName(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create("subdir/mybinary")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []byte("nested-binary")
+	w.Write(want) //nolint:errcheck
+	zw.Close()
+
+	got, err := ExtractFromZip(buf.Bytes(), "mybinary", MatchBaseName)
+	if err != nil {
+		t.Fatalf("ExtractFromZip: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExtractFromZip_Missing(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	zw.Close()
+
+	_, err := ExtractFromZip(buf.Bytes(), "mybinary", MatchExact)
+	if err == nil {
+		t.Error("expected error for missing file in zip")
+	}
+}
+
+func TestExtractFromTarGz(t *testing.T) {
+	want := []byte("fake-uv-binary")
+	data := buildTarGz(t, "uv-platform/uv", want)
+
+	got, err := ExtractFromTarGz(data, "uv")
+	if err != nil {
+		t.Fatalf("ExtractFromTarGz: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExtractFromTarGz_Missing(t *testing.T) {
+	data := buildTarGz(t, "other-file", []byte("content"))
+
+	_, err := ExtractFromTarGz(data, "uv")
+	if err == nil {
+		t.Error("expected error for missing file in tar.gz")
+	}
+}
+
+func TestEnsureBinary_Cached(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "mybinary")
+	if err := os.WriteFile(cachePath, []byte("cached"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := EnsureBinary(Spec{CachePath: cachePath})
+	if err != nil {
+		t.Fatalf("EnsureBinary: %v", err)
+	}
+	if got != cachePath {
+		t.Errorf("expected %s, got %s", cachePath, got)
+	}
+}
+
+func TestEnsureBinary_DownloadZip(t *testing.T) {
+	binContent := []byte("#!/bin/sh\necho hello")
+	var zipBuf bytes.Buffer
+	zw := zip.NewWriter(&zipBuf)
+	w, _ := zw.Create("mybinary")
+	w.Write(binContent) //nolint:errcheck
+	zw.Close()
+	zipData := zipBuf.Bytes()
+
+	h := sha256.Sum256(zipData)
+	checksum := hex.EncodeToString(h[:]) + "  archive.zip\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/checksum" {
+			w.Write([]byte(checksum)) //nolint:errcheck
+		} else {
+			w.Write(zipData) //nolint:errcheck
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "v1", "mybinary")
+
+	got, err := EnsureBinary(Spec{
+		ArchiveURL:  srv.URL + "/archive",
+		ChecksumURL: srv.URL + "/checksum",
+		BinName:     "mybinary",
+		CachePath:   cachePath,
+		Format:      FormatZip,
+		Extract:     MatchExact,
+	})
+	if err != nil {
+		t.Fatalf("EnsureBinary: %v", err)
+	}
+	if got != cachePath {
+		t.Errorf("expected %s, got %s", cachePath, got)
+	}
+
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(binContent) {
+		t.Errorf("binary content mismatch: got %q", data)
+	}
+}
+
+func TestEnsureBinary_DownloadTarGz(t *testing.T) {
+	binContent := []byte("#!/bin/sh\necho uv")
+	tarGzData := buildTarGz(t, "uv-platform/uv", binContent)
+
+	h := sha256.Sum256(tarGzData)
+	checksum := hex.EncodeToString(h[:]) + "  archive.tar.gz\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/checksum" {
+			w.Write([]byte(checksum)) //nolint:errcheck
+		} else {
+			w.Write(tarGzData) //nolint:errcheck
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "v1", "uv")
+
+	got, err := EnsureBinary(Spec{
+		ArchiveURL:  srv.URL + "/archive",
+		ChecksumURL: srv.URL + "/checksum",
+		BinName:     "uv",
+		CachePath:   cachePath,
+		Format:      FormatTarGz,
+		Extract:     MatchBaseName,
+	})
+	if err != nil {
+		t.Fatalf("EnsureBinary: %v", err)
+	}
+	if got != cachePath {
+		t.Errorf("expected %s, got %s", cachePath, got)
+	}
+
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(binContent) {
+		t.Errorf("binary content mismatch: got %q", data)
+	}
+}
+
+func TestEnsureBinary_ChecksumMismatch(t *testing.T) {
+	var zipBuf bytes.Buffer
+	zw := zip.NewWriter(&zipBuf)
+	w, _ := zw.Create("mybinary")
+	w.Write([]byte("content")) //nolint:errcheck
+	zw.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/checksum" {
+			w.Write([]byte("deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef  archive.zip\n")) //nolint:errcheck
+		} else {
+			w.Write(zipBuf.Bytes()) //nolint:errcheck
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	_, err := EnsureBinary(Spec{
+		ArchiveURL:  srv.URL + "/archive",
+		ChecksumURL: srv.URL + "/checksum",
+		BinName:     "mybinary",
+		CachePath:   filepath.Join(dir, "mybinary"),
+		Format:      FormatZip,
+		Extract:     MatchExact,
+	})
+	if err == nil {
+		t.Error("expected checksum mismatch error")
+	}
+}
+
+// buildTarGz creates an in-memory .tar.gz with a single file.
+func buildTarGz(t *testing.T, name string, content []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Size:     int64(len(content)),
+		Mode:     0755,
+		Typeflag: tar.TypeReg,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	tw.Close()
+	gw.Close()
+	return buf.Bytes()
+}

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -127,7 +127,7 @@ func TestEnsureBinary_Cached(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := EnsureBinary(Spec{CachePath: cachePath})
+	got, err := EnsureBinary(Spec{CachePath: cachePath, CacheBase: dir})
 	if err != nil {
 		t.Fatalf("EnsureBinary: %v", err)
 	}
@@ -165,6 +165,7 @@ func TestEnsureBinary_DownloadZip(t *testing.T) {
 		ChecksumURL: srv.URL + "/checksum",
 		BinName:     "mybinary",
 		CachePath:   cachePath,
+		CacheBase:   dir,
 		Format:      FormatZip,
 		Extract:     MatchExact,
 	})
@@ -208,6 +209,7 @@ func TestEnsureBinary_DownloadTarGz(t *testing.T) {
 		ChecksumURL: srv.URL + "/checksum",
 		BinName:     "uv",
 		CachePath:   cachePath,
+		CacheBase:   dir,
 		Format:      FormatTarGz,
 		Extract:     MatchBaseName,
 	})
@@ -249,6 +251,7 @@ func TestEnsureBinary_ChecksumMismatch(t *testing.T) {
 		ChecksumURL: srv.URL + "/checksum",
 		BinName:     "mybinary",
 		CachePath:   filepath.Join(dir, "mybinary"),
+		CacheBase:   dir,
 		Format:      FormatZip,
 		Extract:     MatchExact,
 	})

--- a/pkg/deno/manager.go
+++ b/pkg/deno/manager.go
@@ -2,17 +2,12 @@
 package deno
 
 import (
-	"archive/zip"
-	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
+
+	"github.com/dicode/dicode/internal/installer"
 )
 
 // EnsureDeno returns the path to the cached Deno binary for the current
@@ -27,15 +22,7 @@ func EnsureDeno(version string) (string, error) {
 		return "", err
 	}
 
-	if _, err := os.Stat(cachePath); err == nil {
-		return cachePath, nil
-	}
-
-	if err := os.MkdirAll(filepath.Dir(cachePath), 0755); err != nil {
-		return "", fmt.Errorf("create cache dir: %w", err)
-	}
-
-	platform, err := platformName()
+	platform, err := installer.PlatformName()
 	if err != nil {
 		return "", err
 	}
@@ -44,60 +31,15 @@ func EnsureDeno(version string) (string, error) {
 		"https://github.com/denoland/deno/releases/download/v%s/deno-%s.zip",
 		version, platform,
 	)
-	checksumURL := zipURL + ".sha256sum"
 
-	zipData, err := downloadBytes(zipURL)
-	if err != nil {
-		return "", fmt.Errorf("download deno: %w", err)
-	}
-
-	checksumData, err := downloadBytes(checksumURL)
-	if err != nil {
-		return "", fmt.Errorf("download checksum: %w", err)
-	}
-
-	if err := verifyChecksum(zipData, string(checksumData)); err != nil {
-		return "", fmt.Errorf("checksum verification failed: %w", err)
-	}
-
-	binName := "deno"
-	if runtime.GOOS == "windows" {
-		binName = "deno.exe"
-	}
-
-	binData, err := extractFromZip(zipData, binName)
-	if err != nil {
-		return "", fmt.Errorf("extract deno binary: %w", err)
-	}
-
-	// Write to a temp file in the same directory, then rename atomically.
-	// This prevents concurrent downloaders from corrupting the binary: if two
-	// goroutines both find the binary missing and both download, the last rename
-	// wins and the final file is always a complete binary.
-	tmp, err := os.CreateTemp(filepath.Dir(cachePath), "deno-*.tmp")
-	if err != nil {
-		return "", fmt.Errorf("create temp file: %w", err)
-	}
-	tmpPath := tmp.Name()
-	if _, err := tmp.Write(binData); err != nil {
-		tmp.Close()
-		_ = os.Remove(tmpPath)
-		return "", fmt.Errorf("write deno binary: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-		return "", fmt.Errorf("close temp file: %w", err)
-	}
-	if err := os.Chmod(tmpPath, 0755); err != nil {
-		_ = os.Remove(tmpPath)
-		return "", fmt.Errorf("chmod deno binary: %w", err)
-	}
-	if err := os.Rename(tmpPath, cachePath); err != nil {
-		_ = os.Remove(tmpPath)
-		return "", fmt.Errorf("install deno binary: %w", err)
-	}
-
-	return cachePath, nil
+	return installer.EnsureBinary(installer.Spec{
+		ArchiveURL:  zipURL,
+		ChecksumURL: zipURL + ".sha256sum",
+		BinName:     binName(),
+		CachePath:   cachePath,
+		Format:      installer.FormatZip,
+		Extract:     installer.MatchExact,
+	})
 }
 
 // BinaryPath returns the expected filesystem path for the cached Deno binary
@@ -111,72 +53,12 @@ func cacheBinPath(version string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("home dir: %w", err)
 	}
-	binName := "deno"
+	return filepath.Join(home, ".cache", "dicode", "deno", version, binName()), nil
+}
+
+func binName() string {
 	if runtime.GOOS == "windows" {
-		binName = "deno.exe"
+		return "deno.exe"
 	}
-	return filepath.Join(home, ".cache", "dicode", "deno", version, binName), nil
-}
-
-func platformName() (string, error) {
-	type entry struct{ goos, goarch, name string }
-	platforms := []entry{
-		{"linux", "amd64", "x86_64-unknown-linux-gnu"},
-		{"linux", "arm64", "aarch64-unknown-linux-gnu"},
-		{"darwin", "amd64", "x86_64-apple-darwin"},
-		{"darwin", "arm64", "aarch64-apple-darwin"},
-		{"windows", "amd64", "x86_64-pc-windows-msvc"},
-	}
-	for _, p := range platforms {
-		if p.goos == runtime.GOOS && p.goarch == runtime.GOARCH {
-			return p.name, nil
-		}
-	}
-	return "", fmt.Errorf("unsupported platform %s/%s", runtime.GOOS, runtime.GOARCH)
-}
-
-func downloadBytes(url string) ([]byte, error) {
-	resp, err := http.Get(url) //nolint:gosec
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP %d fetching %s", resp.StatusCode, url)
-	}
-	return io.ReadAll(resp.Body)
-}
-
-// verifyChecksum checks the SHA-256 of data against a checksum file line
-// in the format "<hex>  <filename>" (standard sha256sum output).
-func verifyChecksum(data []byte, checksumLine string) error {
-	fields := strings.Fields(checksumLine)
-	if len(fields) == 0 {
-		return fmt.Errorf("empty checksum file")
-	}
-	expected := strings.ToLower(fields[0])
-	h := sha256.Sum256(data)
-	got := hex.EncodeToString(h[:])
-	if got != expected {
-		return fmt.Errorf("expected %s got %s", expected, got)
-	}
-	return nil
-}
-
-func extractFromZip(zipData []byte, name string) ([]byte, error) {
-	r, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
-	if err != nil {
-		return nil, err
-	}
-	for _, f := range r.File {
-		if f.Name == name {
-			rc, err := f.Open()
-			if err != nil {
-				return nil, err
-			}
-			defer rc.Close()
-			return io.ReadAll(rc)
-		}
-	}
-	return nil, fmt.Errorf("file %q not found in zip", name)
+	return "deno"
 }

--- a/pkg/uv/manager.go
+++ b/pkg/uv/manager.go
@@ -4,19 +4,12 @@
 package uv
 
 import (
-	"archive/tar"
-	"archive/zip"
-	"bytes"
-	"compress/gzip"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
+
+	"github.com/dicode/dicode/internal/installer"
 )
 
 // EnsureUv returns the path to the cached uv binary for the current
@@ -31,67 +24,38 @@ func EnsureUv(version string) (string, error) {
 		return "", err
 	}
 
-	if _, err := os.Stat(cachePath); err == nil {
-		return cachePath, nil
-	}
-
-	if err := os.MkdirAll(filepath.Dir(cachePath), 0755); err != nil {
-		return "", fmt.Errorf("create cache dir: %w", err)
-	}
-
-	platform, err := platformName()
+	platform, err := installer.PlatformName()
 	if err != nil {
 		return "", err
 	}
 
 	// uv uses .zip on Windows, .tar.gz everywhere else.
-	var archiveExt string
+	var (
+		archiveExt string
+		format     installer.ArchiveFormat
+	)
 	if runtime.GOOS == "windows" {
 		archiveExt = ".zip"
+		format = installer.FormatZip
 	} else {
 		archiveExt = ".tar.gz"
+		format = installer.FormatTarGz
 	}
+
 	archiveName := fmt.Sprintf("uv-%s%s", platform, archiveExt)
 	archiveURL := fmt.Sprintf(
 		"https://github.com/astral-sh/uv/releases/download/%s/%s",
 		version, archiveName,
 	)
-	checksumURL := archiveURL + ".sha256"
 
-	archiveData, err := downloadBytes(archiveURL)
-	if err != nil {
-		return "", fmt.Errorf("download uv: %w", err)
-	}
-
-	checksumData, err := downloadBytes(checksumURL)
-	if err != nil {
-		return "", fmt.Errorf("download checksum: %w", err)
-	}
-
-	if err := verifyChecksum(archiveData, string(checksumData)); err != nil {
-		return "", fmt.Errorf("checksum verification failed: %w", err)
-	}
-
-	binName := "uv"
-	if runtime.GOOS == "windows" {
-		binName = "uv.exe"
-	}
-
-	var binData []byte
-	if runtime.GOOS == "windows" {
-		binData, err = extractFromZip(archiveData, binName)
-	} else {
-		binData, err = extractFromTarGz(archiveData, binName)
-	}
-	if err != nil {
-		return "", fmt.Errorf("extract uv binary: %w", err)
-	}
-
-	if err := os.WriteFile(cachePath, binData, 0755); err != nil {
-		return "", fmt.Errorf("write uv binary: %w", err)
-	}
-
-	return cachePath, nil
+	return installer.EnsureBinary(installer.Spec{
+		ArchiveURL:  archiveURL,
+		ChecksumURL: archiveURL + ".sha256",
+		BinName:     binName(),
+		CachePath:   cachePath,
+		Format:      format,
+		Extract:     installer.MatchBaseName,
+	})
 }
 
 // BinaryPath returns the expected filesystem path for the cached uv binary at
@@ -101,100 +65,12 @@ func BinaryPath(version string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("home dir: %w", err)
 	}
-	binName := "uv"
+	return filepath.Join(home, ".cache", "dicode", "uv", version, binName()), nil
+}
+
+func binName() string {
 	if runtime.GOOS == "windows" {
-		binName = "uv.exe"
+		return "uv.exe"
 	}
-	return filepath.Join(home, ".cache", "dicode", "uv", version, binName), nil
-}
-
-func platformName() (string, error) {
-	type entry struct{ goos, goarch, name string }
-	platforms := []entry{
-		{"linux", "amd64", "x86_64-unknown-linux-gnu"},
-		{"linux", "arm64", "aarch64-unknown-linux-gnu"},
-		{"darwin", "amd64", "x86_64-apple-darwin"},
-		{"darwin", "arm64", "aarch64-apple-darwin"},
-		{"windows", "amd64", "x86_64-pc-windows-msvc"},
-	}
-	for _, p := range platforms {
-		if p.goos == runtime.GOOS && p.goarch == runtime.GOARCH {
-			return p.name, nil
-		}
-	}
-	return "", fmt.Errorf("unsupported platform %s/%s", runtime.GOOS, runtime.GOARCH)
-}
-
-func downloadBytes(url string) ([]byte, error) {
-	resp, err := http.Get(url) //nolint:gosec
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP %d fetching %s", resp.StatusCode, url)
-	}
-	return io.ReadAll(resp.Body)
-}
-
-// verifyChecksum checks the SHA-256 of data against a checksum file line
-// in the format "<hex>  <filename>" (standard sha256sum output).
-func verifyChecksum(data []byte, checksumLine string) error {
-	fields := strings.Fields(checksumLine)
-	if len(fields) == 0 {
-		return fmt.Errorf("empty checksum file")
-	}
-	expected := strings.ToLower(fields[0])
-	h := sha256.Sum256(data)
-	got := hex.EncodeToString(h[:])
-	if got != expected {
-		return fmt.Errorf("expected %s got %s", expected, got)
-	}
-	return nil
-}
-
-// extractFromTarGz finds the first entry whose base name matches binName
-// inside a .tar.gz archive and returns its content.
-// uv archives contain entries like "uv-x86_64-unknown-linux-gnu/uv".
-func extractFromTarGz(data []byte, binName string) ([]byte, error) {
-	gz, err := gzip.NewReader(bytes.NewReader(data))
-	if err != nil {
-		return nil, fmt.Errorf("open gzip: %w", err)
-	}
-	defer gz.Close()
-
-	tr := tar.NewReader(gz)
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-		if filepath.Base(hdr.Name) == binName && hdr.Typeflag == tar.TypeReg {
-			return io.ReadAll(tr)
-		}
-	}
-	return nil, fmt.Errorf("file %q not found in tar archive", binName)
-}
-
-// extractFromZip finds the entry whose base name matches binName in a .zip
-// archive (used on Windows).
-func extractFromZip(data []byte, binName string) ([]byte, error) {
-	r, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
-	if err != nil {
-		return nil, err
-	}
-	for _, f := range r.File {
-		if filepath.Base(f.Name) == binName {
-			rc, err := f.Open()
-			if err != nil {
-				return nil, err
-			}
-			defer rc.Close()
-			return io.ReadAll(rc)
-		}
-	}
-	return nil, fmt.Errorf("file %q not found in zip", binName)
+	return "uv"
 }

--- a/pkg/uv/manager_test.go
+++ b/pkg/uv/manager_test.go
@@ -1,4 +1,4 @@
-package deno
+package uv
 
 import (
 	"os"
@@ -6,10 +6,10 @@ import (
 	"testing"
 )
 
-func TestEnsureDeno_CachedPath(t *testing.T) {
-	// Write a fake binary to the cache path, then verify EnsureDeno returns it
+func TestEnsureUv_CachedPath(t *testing.T) {
+	// Write a fake binary to the cache path, then verify EnsureUv returns it
 	// without hitting the network.
-	cachePath, err := cacheBinPath("0.0.0-test")
+	cachePath, err := BinaryPath("0.0.0-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -21,9 +21,9 @@ func TestEnsureDeno_CachedPath(t *testing.T) {
 	}
 	t.Cleanup(func() { os.Remove(cachePath) })
 
-	got, err := EnsureDeno("0.0.0-test")
+	got, err := EnsureUv("0.0.0-test")
 	if err != nil {
-		t.Fatalf("EnsureDeno: %v", err)
+		t.Fatalf("EnsureUv: %v", err)
 	}
 	if got != cachePath {
 		t.Errorf("expected %s, got %s", cachePath, got)
@@ -41,7 +41,7 @@ func TestBinaryPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := filepath.Join(home, ".cache", "dicode", "deno", "1.2.3", binName())
+	want := filepath.Join(home, ".cache", "dicode", "uv", "1.2.3", binName())
 	if p != want {
 		t.Errorf("BinaryPath = %q, want %q", p, want)
 	}


### PR DESCRIPTION
## Summary
- Extracted shared download/verify/extract/cache logic from `pkg/deno` and `pkg/uv` into `internal/installer`, eliminating ~340 lines of copy-pasted code (platformName, downloadBytes, verifyChecksum, extractFromZip, extractFromTarGz, atomic-rename write)
- Added previously-missing `pkg/uv/manager_test.go` (cache hit + binary path tests)
- Added comprehensive `internal/installer/installer_test.go` covering all shared functions: PlatformName, VerifyChecksum (valid/invalid/empty), ExtractFromZip (exact/basename/missing), ExtractFromTarGz, EnsureBinary (cached/download-zip/download-targz/checksum-mismatch)
- Upgraded uv's write path from non-atomic `os.WriteFile` to atomic temp-file + rename (matching deno's safer approach)
- Public API of both packages (`EnsureDeno`, `EnsureUv`, `BinaryPath`) unchanged

Closes epic #195 item 7.

## Test plan
- [x] `go test ./internal/installer/... -v` -- 13 tests pass
- [x] `go test ./pkg/uv/... -v` -- 2 tests pass
- [x] `go test ./pkg/deno/... -v` -- 2 tests pass
- [x] `make build` -- compiles clean
- [x] `make lint` -- no issues
- [x] `make test` -- full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)