### PR TITLE
security(mcp): per-task exposure filter — close discovery footgun (#211)

### DIFF
--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -72,6 +72,11 @@ type Request struct {
 	Tool    string          `json:"tool,omitempty"`
 	Args    json.RawMessage `json:"args,omitempty"`
 
+	// MCPContext signals that this IPC call originates from the MCP endpoint.
+	// When true, dicode.list_tasks filters to tasks with mcp_exposed: true,
+	// and dicode.run_task rejects tasks that are not MCP-exposed.
+	MCPContext bool `json:"mcpContext,omitempty"`
+
 	// http.register (daemon tasks register an HTTP pattern with the gateway)
 	Pattern  string `json:"pattern,omitempty"`
 	StreamID string `json:"streamID,omitempty"`

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -653,6 +653,17 @@ func (s *Server) handleConn(conn net.Conn) {
 				reply(req.ID, nil, fmt.Sprintf("ipc: task %q not in security.allowed_tasks", req.TaskID))
 				continue
 			}
+			// When the caller signals MCP context, only allow invocation of
+			// tasks that have explicitly opted in via mcp_exposed: true.
+			if req.MCPContext {
+				if targetSpec, ok := s.registry.Get(req.TaskID); !ok {
+					reply(req.ID, nil, fmt.Sprintf("ipc: task %q not found", req.TaskID))
+					continue
+				} else if !targetSpec.MCPExposed {
+					reply(req.ID, nil, fmt.Sprintf("ipc: task %q is not exposed via MCP", req.TaskID))
+					continue
+				}
+			}
 			var callParams map[string]string
 			if len(req.Params) > 0 {
 				_ = json.Unmarshal(req.Params, &callParams)
@@ -694,6 +705,11 @@ func (s *Server) handleConn(conn net.Conn) {
 			all := s.registry.All()
 			summaries := make([]taskSummary, 0, len(all))
 			for _, sp := range all {
+				// When the caller signals MCP context, only surface tasks
+				// that have explicitly opted in via mcp_exposed: true.
+				if req.MCPContext && !sp.MCPExposed {
+					continue
+				}
 				summaries = append(summaries, taskSummary{
 					ID:          sp.ID,
 					Name:        sp.Name,

--- a/pkg/ipc/server_test.go
+++ b/pkg/ipc/server_test.go
@@ -2167,6 +2167,123 @@ func TestServer_FlushBatch_FallsBackToPerRow(t *testing.T) {
 
 // TestServer_FlushBatch_SuccessPath verifies that the normal (non-error) path
 // through flushBatch writes entries correctly.
+// ── MCP exposure filter tests ────────────────────────────────────────────────
+
+func TestServer_MCPContext_ListTasks_FiltersNonExposed(t *testing.T) {
+	e := newTestEnv(t)
+	// Register two tasks: one MCP-exposed, one not.
+	_ = e.reg.Register(&task.Spec{ID: "public-api", Name: "Public API", MCPExposed: true})
+	_ = e.reg.Register(&task.Spec{ID: "internal-cron", Name: "Internal Cron", MCPExposed: false})
+
+	spec := specWithDicode("caller", &task.DicodePermissions{ListTasks: true})
+	conn, _ := e.startWithSpec(t, nil, nil, spec, nil)
+
+	// With mcpContext: true, only the MCP-exposed task should appear.
+	sendMsg(t, conn, map[string]any{"id": "1", "method": "dicode.list_tasks", "mcpContext": true})
+	resp := recvMsg(t, conn)
+
+	tasks, ok := resp["result"].([]any)
+	if !ok {
+		t.Fatalf("expected array, got %T", resp["result"])
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 MCP-exposed task, got %d", len(tasks))
+	}
+	first := tasks[0].(map[string]any)
+	if first["id"] != "public-api" {
+		t.Errorf("expected public-api, got %v", first["id"])
+	}
+}
+
+func TestServer_MCPContext_ListTasks_NoFilterWithoutFlag(t *testing.T) {
+	e := newTestEnv(t)
+	_ = e.reg.Register(&task.Spec{ID: "public-api", Name: "Public API", MCPExposed: true})
+	_ = e.reg.Register(&task.Spec{ID: "internal-cron", Name: "Internal Cron", MCPExposed: false})
+
+	spec := specWithDicode("caller", &task.DicodePermissions{ListTasks: true})
+	conn, _ := e.startWithSpec(t, nil, nil, spec, nil)
+
+	// Without mcpContext, both tasks should appear (backwards compat).
+	sendMsg(t, conn, map[string]any{"id": "1", "method": "dicode.list_tasks"})
+	resp := recvMsg(t, conn)
+
+	tasks, ok := resp["result"].([]any)
+	if !ok {
+		t.Fatalf("expected array, got %T", resp["result"])
+	}
+	if len(tasks) != 2 {
+		t.Errorf("expected 2 tasks without mcpContext, got %d", len(tasks))
+	}
+}
+
+func TestServer_MCPContext_RunTask_DeniesNonExposed(t *testing.T) {
+	e := newTestEnv(t)
+	// Register the target task as NOT MCP-exposed.
+	_ = e.reg.Register(&task.Spec{ID: "internal-task", Name: "Internal", MCPExposed: false})
+
+	eng := &mockEngine{runID: "run-1", result: RunResult{RunID: "run-1", Status: "success"}}
+	spec := specWithDicode("caller", &task.DicodePermissions{
+		ListTasks: true,
+		Tasks:     []string{"*"},
+	})
+	conn, _ := e.startWithSpec(t, nil, nil, spec, eng)
+
+	sendMsg(t, conn, map[string]any{
+		"id":         "1",
+		"method":     "dicode.run_task",
+		"taskID":     "internal-task",
+		"mcpContext": true,
+	})
+	resp := recvMsg(t, conn)
+
+	errMsg, _ := resp["error"].(string)
+	if !strings.Contains(errMsg, "not exposed via MCP") {
+		t.Errorf("expected 'not exposed via MCP' error, got: %v", errMsg)
+	}
+}
+
+func TestServer_MCPContext_RunTask_AllowsExposed(t *testing.T) {
+	e := newTestEnv(t)
+	_ = e.reg.Register(&task.Spec{ID: "public-task", Name: "Public", MCPExposed: true})
+
+	eng := &mockEngine{runID: "run-1", result: RunResult{RunID: "run-1", Status: "success"}}
+	spec := specWithDicode("caller", &task.DicodePermissions{Tasks: []string{"*"}})
+	conn, _ := e.startWithSpec(t, nil, nil, spec, eng)
+
+	sendMsg(t, conn, map[string]any{
+		"id":         "1",
+		"method":     "dicode.run_task",
+		"taskID":     "public-task",
+		"mcpContext": true,
+	})
+	resp := recvMsg(t, conn)
+
+	if resp["error"] != nil {
+		t.Errorf("expected success for MCP-exposed task, got error: %v", resp["error"])
+	}
+}
+
+func TestServer_MCPContext_RunTask_NoFilterWithoutFlag(t *testing.T) {
+	e := newTestEnv(t)
+	_ = e.reg.Register(&task.Spec{ID: "internal-task", Name: "Internal", MCPExposed: false})
+
+	eng := &mockEngine{runID: "run-1", result: RunResult{RunID: "run-1", Status: "success"}}
+	spec := specWithDicode("caller", &task.DicodePermissions{Tasks: []string{"*"}})
+	conn, _ := e.startWithSpec(t, nil, nil, spec, eng)
+
+	// Without mcpContext, the call should succeed even for non-exposed tasks.
+	sendMsg(t, conn, map[string]any{
+		"id":     "1",
+		"method": "dicode.run_task",
+		"taskID": "internal-task",
+	})
+	resp := recvMsg(t, conn)
+
+	if resp["error"] != nil {
+		t.Errorf("expected success without mcpContext, got error: %v", resp["error"])
+	}
+}
+
 func TestServer_FlushBatch_SuccessPath(t *testing.T) {
 	t.Parallel()
 	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})

--- a/pkg/runtime/deno/sdk/shim.ts
+++ b/pkg/runtime/deno/sdk/shim.ts
@@ -111,8 +111,8 @@ export interface Dicode {
   task_id:        string;
   // run_id: the id of the current run (uuid). Same source as task_id.
   run_id:         string;
-  run_task:       (taskID: string, params?: Record<string, string>)  => Promise<unknown>;
-  list_tasks:     ()                                                   => Promise<TaskSummary[]>;
+  run_task:       (taskID: string, params?: Record<string, string>, opts?: { mcpContext?: boolean })  => Promise<unknown>;
+  list_tasks:     (opts?: { mcpContext?: boolean })                     => Promise<TaskSummary[]>;
   get_runs:       (taskID: string, opts?: { limit?: number })         => Promise<unknown>;
   // set_group labels the current run with a free-text string used by the
   // WebUI to collapse same-group siblings (#116). Last write wins; only
@@ -333,8 +333,8 @@ const mcp: MCP = {
 const dicode: Dicode = {
   task_id:        __hsResp__.task_id ?? "",
   run_id:         __hsResp__.run_id ?? "",
-  run_task:       (taskID, params)  => __call__({ method: "dicode.run_task",       taskID, params: params ?? {} }),
-  list_tasks:     ()                => __call__({ method: "dicode.list_tasks" }) as Promise<TaskSummary[]>,
+  run_task:       (taskID, params, opts)  => __call__({ method: "dicode.run_task", taskID, params: params ?? {}, mcpContext: opts?.mcpContext ?? false }),
+  list_tasks:     (opts)                => __call__({ method: "dicode.list_tasks", mcpContext: opts?.mcpContext ?? false }) as Promise<TaskSummary[]>,
   get_runs:       (taskID, opts)    => __call__({ method: "dicode.get_runs",        taskID, limit: opts?.limit ?? 10 }),
   set_group:      (label)           => __call__({ method: "dicode.set_group",       group: String(label ?? "") }) as Promise<void>,
   secrets_set:    (key, value)      => __call__({ method: "dicode.secrets_set",     key, stringValue: value }) as Promise<void>,

--- a/pkg/runtime/python/sdk/dicode_sdk.py
+++ b/pkg/runtime/python/sdk/dicode_sdk.py
@@ -386,12 +386,14 @@ class _Dicode:
         self.sources = _Sources()
         self.git = _Git()
 
-    def run_task(self, task_id, params=None):
+    def run_task(self, task_id, params=None, mcp_context=False):
         return _call({"method": "dicode.run_task", "taskID": task_id,
-                      "params": params or {}})
+                      "params": params or {},
+                      "mcpContext": mcp_context})
 
-    def list_tasks(self):
-        return _call({"method": "dicode.list_tasks"}) or []
+    def list_tasks(self, mcp_context=False):
+        return _call({"method": "dicode.list_tasks",
+                      "mcpContext": mcp_context}) or []
 
     def get_runs(self, task_id, limit=10):
         return _call({"method": "dicode.get_runs", "taskID": task_id,
@@ -402,12 +404,14 @@ class _Dicode:
         # by the WebUI to collapse same-group siblings. Last write wins.
         _call({"method": "dicode.set_group", "group": str(label or "")})
 
-    async def run_task_async(self, task_id, params=None):
+    async def run_task_async(self, task_id, params=None, mcp_context=False):
         return await _call_async({"method": "dicode.run_task", "taskID": task_id,
-                                  "params": params or {}})
+                                  "params": params or {},
+                                  "mcpContext": mcp_context})
 
-    async def list_tasks_async(self):
-        return await _call_async({"method": "dicode.list_tasks"}) or []
+    async def list_tasks_async(self, mcp_context=False):
+        return await _call_async({"method": "dicode.list_tasks",
+                                  "mcpContext": mcp_context}) or []
 
     async def get_runs_async(self, task_id, limit=10):
         return await _call_async({"method": "dicode.get_runs", "taskID": task_id,

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -362,6 +362,12 @@ type Spec struct {
 	Params      Params        `yaml:"params,omitempty"      json:"params,omitempty"`
 	Permissions Permissions   `yaml:"permissions,omitempty" json:"permissions,omitempty"`
 	Timeout     time.Duration `yaml:"timeout"             json:"timeout"`
+	// MCPExposed, when true, marks this task as visible and callable via the
+	// MCP endpoint (/mcp). Tasks default to NOT exposed — users must opt in
+	// per task. The builtin MCP task filters dicode.list_tasks and gates
+	// dicode.run_task using this flag so that connecting Claude Desktop or
+	// Cursor to /mcp does not inadvertently surface internal tasks.
+	MCPExposed bool `yaml:"mcp_exposed,omitempty" json:"mcp_exposed,omitempty"`
 	// MCPPort declares that this daemon task exposes an MCP server on the given port.
 	MCPPort int `yaml:"mcp_port,omitempty" json:"mcp_port,omitempty"`
 	// OnFailureChain overrides the global defaults.on_failure_chain for this task.

--- a/pkg/task/spec_test.go
+++ b/pkg/task/spec_test.go
@@ -83,6 +83,37 @@ run_result:
 	}
 }
 
+func TestSpec_MCPExposed_Parses(t *testing.T) {
+	yamlSrc := []byte(`
+name: exposed-task
+runtime: deno
+trigger: { manual: true }
+mcp_exposed: true
+`)
+	var s Spec
+	if err := yaml.Unmarshal(yamlSrc, &s); err != nil {
+		t.Fatal(err)
+	}
+	if !s.MCPExposed {
+		t.Error("MCPExposed = false, want true")
+	}
+}
+
+func TestSpec_MCPExposed_DefaultFalse(t *testing.T) {
+	yamlSrc := []byte(`
+name: internal-task
+runtime: deno
+trigger: { manual: true }
+`)
+	var s Spec
+	if err := yaml.Unmarshal(yamlSrc, &s); err != nil {
+		t.Fatal(err)
+	}
+	if s.MCPExposed {
+		t.Error("MCPExposed = true, want false (default)")
+	}
+}
+
 func TestSpec_RunResultOverride_Omitted(t *testing.T) {
 	yamlSrc := []byte(`
 name: test

--- a/tasks/buildin/mcp/task.ts
+++ b/tasks/buildin/mcp/task.ts
@@ -160,7 +160,10 @@ const TOOLS: ToolDef[] = [
 ];
 
 async function listTasks(dicode: Dicode): Promise<TaskSummary[]> {
-  return ((await dicode.list_tasks()) as TaskSummary[]) ?? [];
+  // mcpContext: true signals the IPC server to filter to tasks with
+  // mcp_exposed: true — so only explicitly opted-in tasks are discoverable
+  // via the MCP endpoint.
+  return ((await dicode.list_tasks({ mcpContext: true })) as TaskSummary[]) ?? [];
 }
 
 function stringifyParams(raw: unknown): Record<string, string> {
@@ -195,7 +198,8 @@ async function dispatchTool(
       const id = String(args.id ?? "");
       if (!id) throw new Error("id is required");
       const params = stringifyParams(args.params);
-      const result = await dicode.run_task(id, params);
+      // mcpContext: true gates invocation to tasks with mcp_exposed: true.
+      const result = await dicode.run_task(id, params, { mcpContext: true });
       return textContent(JSON.stringify(result ?? null, null, 2));
     }
     case "list_sources": {

--- a/tasks/buildin/mcp/task.yaml
+++ b/tasks/buildin/mcp/task.yaml
@@ -9,6 +9,7 @@ description: >
   Go server, which was a thin JSON-RPC dispatcher around the same
   capabilities the dicode SDK and HTTP API already expose to tasks.
 runtime: deno
+mcp_exposed: true
 trigger:
   webhook: /hooks/mcp
   # auth: true closes the bypass where a remote caller could skip the

--- a/tests/e2e/fixtures/tasks/hello-manual/task.yaml
+++ b/tests/e2e/fixtures/tasks/hello-manual/task.yaml
@@ -3,6 +3,7 @@ kind: Task
 name: Hello Manual
 description: A simple manual task for e2e testing.
 runtime: deno
+mcp_exposed: true
 trigger:
   manual: true
 timeout: 10s

--- a/tests/e2e/fixtures/tasks/hello-webhook/task.yaml
+++ b/tests/e2e/fixtures/tasks/hello-webhook/task.yaml
@@ -3,6 +3,7 @@ kind: Task
 name: Hello Webhook
 description: A webhook task for e2e testing.
 runtime: js
+mcp_exposed: true
 trigger:
   webhook: /hooks/test-webhook
 timeout: 10s


### PR DESCRIPTION
## Summary
- Add `mcp_exposed` (default `false`) field to `task.Spec` so task authors opt in to MCP visibility
- The MCP builtin task now passes `mcpContext: true` through IPC; `dicode.list_tasks` filters to opted-in tasks and `dicode.run_task` rejects non-exposed targets
- Both Deno and Python SDKs gain `mcpContext` option on `list_tasks()` / `run_task()` for forward compatibility

## Details
Previously, connecting Claude Desktop or Cursor to `/mcp` exposed ALL registered tasks via `tools/list` and `tools/call` with no way to control visibility. This was a security footgun — internal cron tasks, webhook handlers, and admin utilities were all callable by any API-key holder.

Now tasks must explicitly set `mcp_exposed: true` in their `task.yaml` to be discoverable and callable through the MCP endpoint. The filter is enforced at the IPC layer (not just the TypeScript MCP task) so it cannot be bypassed.

**Files changed:**
- `pkg/task/spec.go` — new `MCPExposed` field
- `pkg/ipc/message.go` — new `MCPContext` flag on IPC Request
- `pkg/ipc/server.go` — filter `dicode.list_tasks` and gate `dicode.run_task` when `MCPContext` is true
- `pkg/runtime/deno/sdk/shim.ts` — `mcpContext` option on `list_tasks()` and `run_task()`
- `pkg/runtime/python/sdk/dicode_sdk.py` — `mcp_context` kwarg on both sync and async variants
- `tasks/buildin/mcp/task.ts` — pass `{ mcpContext: true }` to both SDK calls

Closes #211

## Test plan
- [x] `TestSpec_MCPExposed_Parses` — field parses from YAML
- [x] `TestSpec_MCPExposed_DefaultFalse` — omitted field defaults to false
- [x] `TestServer_MCPContext_ListTasks_FiltersNonExposed` — only MCP-exposed tasks returned
- [x] `TestServer_MCPContext_ListTasks_NoFilterWithoutFlag` — all tasks returned without flag (backwards compat)
- [x] `TestServer_MCPContext_RunTask_DeniesNonExposed` — run rejected for non-exposed task
- [x] `TestServer_MCPContext_RunTask_AllowsExposed` — run succeeds for exposed task
- [x] `TestServer_MCPContext_RunTask_NoFilterWithoutFlag` — run succeeds without flag (backwards compat)
- [x] `make build && make lint && make test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)