### PR TITLE
fix: post-alpha correctness — scanner limits, FD leak, WS origin (#194)

### DIFF
--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -415,15 +415,23 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		go func() {
 			defer wg.Done()
 			scanner := bufio.NewScanner(stdout)
+			scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 			for scanner.Scan() {
 				_ = rt.registry.AppendLog(context.Background(), runID, "info", redactor.RedactString(scanner.Text()))
+			}
+			if err := scanner.Err(); err != nil {
+				rt.log.Warn("stdout scanner error", zap.String("run", runID), zap.Error(err))
 			}
 		}()
 		go func() {
 			defer wg.Done()
 			scanner := bufio.NewScanner(stderr)
+			scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 			for scanner.Scan() {
 				_ = rt.registry.AppendLog(context.Background(), runID, "error", redactor.RedactString(scanner.Text()))
+			}
+			if err := scanner.Err(); err != nil {
+				rt.log.Warn("stderr scanner error", zap.String("run", runID), zap.Error(err))
 			}
 		}()
 	}

--- a/pkg/runtime/docker/docker.go
+++ b/pkg/runtime/docker/docker.go
@@ -282,6 +282,7 @@ func (rt *Runtime) buildImage(ctx context.Context, dc *dockerclient.Client, spec
 		Error  string `json:"error"`
 	}
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if err := json.Unmarshal([]byte(line), &msg); err != nil {
@@ -293,6 +294,9 @@ func (rt *Runtime) buildImage(ctx context.Context, dc *dockerclient.Client, spec
 		if out := strings.TrimSpace(msg.Stream); out != "" {
 			_ = rt.registry.AppendLog(ctx, runID, "info", out)
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		rt.log.Warn("build output scanner error", zap.String("run", runID), zap.Error(err))
 	}
 
 	return tag, nil
@@ -322,13 +326,17 @@ func buildContextTar(dir string) (io.Reader, error) {
 			return err
 		}
 		if !info.IsDir() {
-			f, err := os.Open(path) //nolint:gosec
-			if err != nil {
+			if err := func() error {
+				f, err := os.Open(path) //nolint:gosec
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+				_, err = io.Copy(tw, f)
+				return err
+			}(); err != nil {
 				return err
 			}
-			defer f.Close()
-			_, err = io.Copy(tw, f)
-			return err
 		}
 		return nil
 	})
@@ -360,11 +368,15 @@ func (rt *Runtime) maybePull(ctx context.Context, dc *dockerclient.Client, img, 
 		Status string `json:"status"`
 	}
 	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if err := json.Unmarshal([]byte(line), &pullMsg); err == nil && pullMsg.Status != "" {
 			_ = rt.registry.AppendLog(ctx, runID, "info", pullMsg.Status)
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		rt.log.Warn("image pull scanner error", zap.String("run", runID), zap.Error(err))
 	}
 	return nil
 }
@@ -372,8 +384,12 @@ func (rt *Runtime) maybePull(ctx context.Context, dc *dockerclient.Client, img, 
 // streamLines reads lines from r and appends them to the run log.
 func (rt *Runtime) streamLines(runID string, r io.Reader, level string) {
 	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		_ = rt.registry.AppendLog(context.Background(), runID, level, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		rt.log.Warn("stream scanner error", zap.String("run", runID), zap.Error(err))
 	}
 }
 

--- a/pkg/runtime/podman/runtime.go
+++ b/pkg/runtime/podman/runtime.go
@@ -141,14 +141,22 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	go func() {
 		defer close(logDone)
 		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 		for scanner.Scan() {
 			_ = e.reg.AppendLog(context.Background(), runID, "info", scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
+			e.log.Warn("stdout scanner error", zap.String("run", runID), zap.Error(err))
 		}
 	}()
 	go func() {
 		scanner := bufio.NewScanner(stderr)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 		for scanner.Scan() {
 			_ = e.reg.AppendLog(context.Background(), runID, "warn", scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
+			e.log.Warn("stderr scanner error", zap.String("run", runID), zap.Error(err))
 		}
 	}()
 
@@ -212,14 +220,22 @@ func (e *executor) buildImage(ctx context.Context, spec *task.Spec, runID string
 	go func() {
 		defer close(buildDone)
 		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 		for scanner.Scan() {
 			_ = e.reg.AppendLog(ctx, runID, "info", scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
+			e.log.Warn("build stdout scanner error", zap.String("run", runID), zap.Error(err))
 		}
 	}()
 	go func() {
 		scanner := bufio.NewScanner(stderr)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 		for scanner.Scan() {
 			_ = e.reg.AppendLog(ctx, runID, "warn", scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
+			e.log.Warn("build stderr scanner error", zap.String("run", runID), zap.Error(err))
 		}
 	}()
 

--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -313,8 +313,12 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	go func() {
 		defer wg.Done()
 		scanner := bufio.NewScanner(stderr)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 		for scanner.Scan() {
 			_ = e.reg.AppendLog(context.Background(), runID, "warn", redactor.RedactString(scanner.Text()))
+		}
+		if err := scanner.Err(); err != nil {
+			e.log.Warn("stderr scanner error", zap.String("run", runID), zap.Error(err))
 		}
 	}()
 

--- a/pkg/webui/passphrase_test.go
+++ b/pkg/webui/passphrase_test.go
@@ -39,7 +39,7 @@ func newAuthServerNoDB(t *testing.T, passphrase string) *Server {
 		cfg:      cfg,
 		sm:       newSessionManager(nil),
 		logs:     NewLogBroadcaster(),
-		ws:       NewWSHub(zap.NewNop()),
+		ws:       NewWSHub(zap.NewNop(), nil),
 		log:      zap.NewNop(),
 		port:     8080,
 	}

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -194,7 +194,7 @@ func (s *Server) SetManagedRuntimes(runtimes []pkgruntime.ManagedRuntime) {
 func New(port int, r *registry.Registry, eng *trigger.Engine, cfg *config.Config, cfgPath string, secretsMgr SecretsManager, rec *registry.Reconciler, sourceMgr *SourceManager, dataDir string, logs *LogBroadcaster, log *zap.Logger, database db.DB, gateway *ipc.Gateway) (*Server, error) {
 	sm := newSessionManager(database)
 
-	wsHub := NewWSHub(log)
+	wsHub := NewWSHub(log, cfg.Server.AllowedOrigins)
 
 	csrfKey := make([]byte, 32)
 	if _, err := rand.Read(csrfKey); err != nil {

--- a/pkg/webui/ws.go
+++ b/pkg/webui/ws.go
@@ -46,10 +46,11 @@ type RunFinishedData struct {
 
 // WSHub manages all WebSocket clients.
 type WSHub struct {
-	mu         sync.Mutex
-	clients    map[*wsClient]struct{}
-	log        *zap.Logger
-	recentLogs func() []string // returns buffered log lines for replay on subscribe
+	mu             sync.Mutex
+	clients        map[*wsClient]struct{}
+	log            *zap.Logger
+	recentLogs     func() []string // returns buffered log lines for replay on subscribe
+	allowedOrigins []string        // origin patterns for websocket.AcceptOptions; empty = same-origin only
 }
 
 type wsClient struct {
@@ -60,8 +61,8 @@ type wsClient struct {
 	mu     sync.Mutex
 }
 
-func NewWSHub(log *zap.Logger) *WSHub {
-	return &WSHub{clients: make(map[*wsClient]struct{}), log: log}
+func NewWSHub(log *zap.Logger, allowedOrigins []string) *WSHub {
+	return &WSHub{clients: make(map[*wsClient]struct{}), log: log, allowedOrigins: allowedOrigins}
 }
 
 func (h *WSHub) add(c *wsClient) {
@@ -113,7 +114,7 @@ func (h *WSHub) BroadcastLog(line string) {
 // ServeHTTP upgrades the connection to WebSocket and manages the client.
 func (h *WSHub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		InsecureSkipVerify: true, // local dev — allow any origin
+		OriginPatterns: h.allowedOrigins,
 	})
 	if err != nil {
 		h.log.Debug("ws accept failed", zap.Error(err))


### PR DESCRIPTION
## Summary

- **Scanner buffer limits**: Raise `bufio.Scanner` buffer from default 64 KiB to 1 MiB across all runtime scanners (deno, python, docker, podman) to prevent silent truncation of long JSON output lines. Added `scanner.Err()` checks after every scan loop to log errors instead of silently dropping data.
- **FD leak in Docker build context**: Wrap file open/write/close in `filepath.Walk` callback inside an immediately-invoked function so `defer f.Close()` runs per-file instead of accumulating until Walk returns, preventing file descriptor exhaustion on large build contexts.
- **WebSocket origin validation**: Replace `InsecureSkipVerify: true` with `OriginPatterns` sourced from `cfg.Server.AllowedOrigins`. When empty, only same-origin requests are accepted (coder/websocket library default).

**Note on Fix 3 (notification goroutines)**: Skipped — there is no `ntfy.go` or notification dispatch subsystem in the current codebase. The issue description references code that does not exist.

Closes #194

## Test plan
- [x] `make build` passes
- [x] `make lint` passes
- [x] `make test` — all tests pass
- [x] Targeted tests: `go test ./pkg/runtime/deno/... ./pkg/runtime/python/... ./pkg/runtime/docker/... ./pkg/runtime/podman/... ./pkg/trigger/... ./pkg/webui/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)