### PR TITLE
feat(authoring): sessions table + REST handlers for AI task create/edit (#288)

### DIFF
--- a/pkg/db/sqlite.go
+++ b/pkg/db/sqlite.go
@@ -202,7 +202,7 @@ func (s *SQLiteDB) migrate() error {
 	_, err = s.db.Exec(`
 		CREATE TABLE IF NOT EXISTS author_sessions (
 			id           TEXT PRIMARY KEY,
-			kind         TEXT NOT NULL,
+			kind         TEXT NOT NULL CHECK(kind IN ('create','edit')),
 			source       TEXT NOT NULL,
 			task_id      TEXT NOT NULL DEFAULT '',
 			sandbox_path TEXT NOT NULL DEFAULT '',
@@ -214,6 +214,17 @@ func (s *SQLiteDB) migrate() error {
 	`)
 	if err != nil {
 		return fmt.Errorf("migrate author_sessions: %w", err)
+	}
+	// Enforce single-session-per-source at the DB level. Two concurrent
+	// edit requests can race past the application-level GetOpenForSource
+	// check (TOCTOU); this partial unique index makes the second INSERT
+	// fail with a constraint violation.
+	_, err = s.db.Exec(`
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_author_sessions_open_source
+		ON author_sessions(source) WHERE closed_at IS NULL;
+	`)
+	if err != nil {
+		return fmt.Errorf("migrate author_sessions index: %w", err)
 	}
 
 	return nil

--- a/pkg/db/sqlite.go
+++ b/pkg/db/sqlite.go
@@ -197,6 +197,25 @@ func (s *SQLiteDB) migrate() error {
 	if err != nil {
 		return fmt.Errorf("migrate run-grouping indexes: %w", err)
 	}
+
+	// author_sessions — AI-first task authoring sessions (#288).
+	_, err = s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS author_sessions (
+			id           TEXT PRIMARY KEY,
+			kind         TEXT NOT NULL,
+			source       TEXT NOT NULL,
+			task_id      TEXT NOT NULL DEFAULT '',
+			sandbox_path TEXT NOT NULL DEFAULT '',
+			created_at   INTEGER NOT NULL,
+			last_turn_at INTEGER NOT NULL,
+			closed_at    INTEGER,
+			applied      INTEGER NOT NULL DEFAULT 0
+		);
+	`)
+	if err != nil {
+		return fmt.Errorf("migrate author_sessions: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/webui/authoring.go
+++ b/pkg/webui/authoring.go
@@ -1,0 +1,353 @@
+package webui
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// --- request / response types -----------------------------------------------
+
+type taskCreateReq struct {
+	Name   string `json:"name"`
+	Source string `json:"source"`
+}
+
+type taskCreateResp struct {
+	TaskID string   `json:"task_id"`
+	Source string   `json:"source"`
+	Files  []string `json:"files"`
+}
+
+type taskEditReq struct {
+	SessionID string `json:"session_id"`
+	TaskID    string `json:"task_id"`
+	Prompt    string `json:"prompt"`
+}
+
+type taskEditResp struct {
+	SessionID   string `json:"session_id"`
+	SandboxPath string `json:"sandbox_path"`
+	Source      string `json:"source"`
+	SourceKind  string `json:"source_kind"`
+}
+
+type taskSaveReq struct {
+	SessionID string `json:"session_id"`
+}
+
+type taskCancelReq struct {
+	SessionID string `json:"session_id"`
+}
+
+// --- POST /api/task/create --------------------------------------------------
+
+func (s *Server) apiTaskCreate(w http.ResponseWriter, r *http.Request) {
+	var req taskCreateReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonErr(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	// Default source to "ai-scratch".
+	source := req.Source
+	if source == "" {
+		source = "ai-scratch"
+	}
+
+	// Ensure source exists.
+	if s.sourceMgr == nil {
+		jsonErr(w, "source manager not available", http.StatusServiceUnavailable)
+		return
+	}
+	src, ok := s.sourceMgr.Get(source)
+	if !ok {
+		jsonErr(w, fmt.Sprintf("source %q not found", source), http.StatusNotFound)
+		return
+	}
+
+	// Generate task name if not provided.
+	name := req.Name
+	if name == "" {
+		name = "new-task-" + uuid.New().String()[:8]
+	}
+
+	// Sanitize: lowercase, replace spaces with hyphens, strip non-alnum/hyphen.
+	name = sanitizeTaskName(name)
+	if name == "" {
+		jsonErr(w, "invalid task name", http.StatusBadRequest)
+		return
+	}
+
+	// Determine the directory to write the boilerplate.
+	repoPath := src.RepoPath()
+	if repoPath == "" {
+		jsonErr(w, "source has no repo path; is it started?", http.StatusServiceUnavailable)
+		return
+	}
+	taskDir := filepath.Join(repoPath, name)
+	if err := os.MkdirAll(taskDir, 0755); err != nil {
+		jsonErr(w, fmt.Sprintf("create task dir: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Write boilerplate task.yaml.
+	taskYAML := fmt.Sprintf(`apiVersion: dicode/v1
+kind: Task
+name: %s
+description: ""
+runtime: deno
+trigger:
+  manual: true
+timeout: 30s
+`, name)
+	yamlPath := filepath.Join(taskDir, "task.yaml")
+	if err := os.WriteFile(yamlPath, []byte(taskYAML), 0644); err != nil {
+		jsonErr(w, fmt.Sprintf("write task.yaml: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Write boilerplate task.js.
+	taskJS := `export default async function main() {
+  dicode.log.info("Hello from " + dicode.params.task_id);
+}
+`
+	jsPath := filepath.Join(taskDir, "task.js")
+	if err := os.WriteFile(jsPath, []byte(taskJS), 0644); err != nil {
+		jsonErr(w, fmt.Sprintf("write task.js: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	taskID := source + "/" + name
+	w.WriteHeader(http.StatusCreated)
+	jsonOK(w, taskCreateResp{
+		TaskID: taskID,
+		Source: source,
+		Files:  []string{"task.yaml", "task.js"},
+	})
+}
+
+// --- POST /api/task/edit ----------------------------------------------------
+
+func (s *Server) apiTaskEdit(w http.ResponseWriter, r *http.Request) {
+	var req taskEditReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonErr(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	if s.authoringSessions == nil {
+		jsonErr(w, "authoring sessions not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	ctx := r.Context()
+
+	// Resume existing session.
+	if req.SessionID != "" {
+		sess, err := s.authoringSessions.Get(ctx, req.SessionID)
+		if err != nil {
+			jsonErr(w, fmt.Sprintf("lookup session: %v", err), http.StatusInternalServerError)
+			return
+		}
+		if sess == nil {
+			jsonErr(w, "session not found", http.StatusNotFound)
+			return
+		}
+		if sess.ClosedAt != nil {
+			jsonErr(w, "session is closed", http.StatusConflict)
+			return
+		}
+		// Bump last_turn_at.
+		_ = s.authoringSessions.UpdateLastTurn(ctx, sess.ID)
+
+		sourceKind := s.resolveSourceKind(sess.Source)
+		w.WriteHeader(http.StatusAccepted)
+		jsonOK(w, taskEditResp{
+			SessionID:   sess.ID,
+			SandboxPath: sess.SandboxPath,
+			Source:      sess.Source,
+			SourceKind:  sourceKind,
+		})
+		return
+	}
+
+	// Need task_id to create/resume.
+	if req.TaskID == "" {
+		jsonErr(w, "task_id or session_id required", http.StatusBadRequest)
+		return
+	}
+
+	// Derive source name from task_id (first path segment).
+	source := req.TaskID
+	if idx := strings.Index(source, "/"); idx > 0 {
+		source = source[:idx]
+	}
+
+	// Single-session-per-source: check if one is already open.
+	existing, err := s.authoringSessions.GetOpenForSource(ctx, source)
+	if err != nil {
+		jsonErr(w, fmt.Sprintf("check open sessions: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if existing != nil {
+		jsonErr(w, fmt.Sprintf("source %q already has an open session %s", source, existing.ID), http.StatusConflict)
+		return
+	}
+
+	// Create a new session.
+	sessID := uuid.New().String()
+	now := time.Now()
+	sess := AuthoringSession{
+		ID:          sessID,
+		Kind:        "edit",
+		Source:      source,
+		TaskID:      req.TaskID,
+		SandboxPath: "", // TODO: set when AI agent dispatch is wired
+		CreatedAt:   now,
+		LastTurnAt:  now,
+	}
+
+	if err := s.authoringSessions.Create(ctx, sess); err != nil {
+		jsonErr(w, fmt.Sprintf("create session: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// TODO(#288): call set_dev_mode on the source and dispatch to cfg.AI.CreateTask.
+	// For this slice the session is created but the AI agent invocation is stubbed.
+
+	sourceKind := s.resolveSourceKind(source)
+	w.WriteHeader(http.StatusAccepted)
+	jsonOK(w, taskEditResp{
+		SessionID:   sessID,
+		SandboxPath: sess.SandboxPath,
+		Source:      source,
+		SourceKind:  sourceKind,
+	})
+}
+
+// --- POST /api/task/save ----------------------------------------------------
+
+func (s *Server) apiTaskSave(w http.ResponseWriter, r *http.Request) {
+	var req taskSaveReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonErr(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	if req.SessionID == "" {
+		jsonErr(w, "session_id required", http.StatusBadRequest)
+		return
+	}
+
+	if s.authoringSessions == nil {
+		jsonErr(w, "authoring sessions not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	ctx := r.Context()
+	sess, err := s.authoringSessions.Get(ctx, req.SessionID)
+	if err != nil {
+		jsonErr(w, fmt.Sprintf("lookup session: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if sess == nil {
+		jsonErr(w, "session not found", http.StatusNotFound)
+		return
+	}
+	if sess.ClosedAt != nil {
+		jsonErr(w, "session is already closed", http.StatusConflict)
+		return
+	}
+
+	// TODO(#288): for git sources, chain into buildin/git-pr.
+	// For local sources: rsync sandbox → source root, disable dev mode.
+
+	// Close the session as applied.
+	if err := s.authoringSessions.Close(ctx, sess.ID, true); err != nil {
+		jsonErr(w, fmt.Sprintf("close session: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	jsonOK(w, map[string]any{"applied": true})
+}
+
+// --- POST /api/task/cancel --------------------------------------------------
+
+func (s *Server) apiTaskCancel(w http.ResponseWriter, r *http.Request) {
+	var req taskCancelReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonErr(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	if req.SessionID == "" {
+		jsonErr(w, "session_id required", http.StatusBadRequest)
+		return
+	}
+
+	if s.authoringSessions == nil {
+		jsonErr(w, "authoring sessions not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	ctx := r.Context()
+	sess, err := s.authoringSessions.Get(ctx, req.SessionID)
+	if err != nil {
+		jsonErr(w, fmt.Sprintf("lookup session: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if sess == nil {
+		jsonErr(w, "session not found", http.StatusNotFound)
+		return
+	}
+	if sess.ClosedAt != nil {
+		// Already closed — idempotent.
+		jsonOK(w, map[string]bool{"cancelled": true})
+		return
+	}
+
+	// TODO(#288): disable dev mode on the source, clean up sandbox directory.
+
+	if err := s.authoringSessions.Close(ctx, sess.ID, false); err != nil {
+		jsonErr(w, fmt.Sprintf("close session: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	jsonOK(w, map[string]bool{"cancelled": true})
+}
+
+// --- helpers ----------------------------------------------------------------
+
+// sanitizeTaskName lowercases, replaces spaces with hyphens, and strips
+// characters that are not alphanumeric or hyphen.
+func sanitizeTaskName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	name = strings.ReplaceAll(name, " ", "-")
+	var b strings.Builder
+	for _, c := range name {
+		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' {
+			b.WriteRune(c)
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// resolveSourceKind returns "git", "local", or "taskset" for the named source.
+func (s *Server) resolveSourceKind(name string) string {
+	if s.sourceMgr == nil {
+		return ""
+	}
+	for _, info := range s.sourceMgr.List() {
+		if info.Name == name {
+			return info.Type
+		}
+	}
+	return ""
+}

--- a/pkg/webui/authoring.go
+++ b/pkg/webui/authoring.go
@@ -125,8 +125,9 @@ timeout: 30s
 	}
 
 	taskID := source + "/" + name
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	jsonOK(w, taskCreateResp{
+	_ = json.NewEncoder(w).Encode(taskCreateResp{
 		TaskID: taskID,
 		Source: source,
 		Files:  []string{"task.yaml", "task.js"},
@@ -168,8 +169,9 @@ func (s *Server) apiTaskEdit(w http.ResponseWriter, r *http.Request) {
 		_ = s.authoringSessions.UpdateLastTurn(ctx, sess.ID)
 
 		sourceKind := s.resolveSourceKind(sess.Source)
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
-		jsonOK(w, taskEditResp{
+		_ = json.NewEncoder(w).Encode(taskEditResp{
 			SessionID:   sess.ID,
 			SandboxPath: sess.SandboxPath,
 			Source:      sess.Source,
@@ -223,8 +225,9 @@ func (s *Server) apiTaskEdit(w http.ResponseWriter, r *http.Request) {
 	// For this slice the session is created but the AI agent invocation is stubbed.
 
 	sourceKind := s.resolveSourceKind(source)
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
-	jsonOK(w, taskEditResp{
+	_ = json.NewEncoder(w).Encode(taskEditResp{
 		SessionID:   sessID,
 		SandboxPath: sess.SandboxPath,
 		Source:      source,

--- a/pkg/webui/authoring_db.go
+++ b/pkg/webui/authoring_db.go
@@ -1,0 +1,194 @@
+package webui
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+)
+
+// AuthoringSession represents an AI-first task authoring session (#288).
+type AuthoringSession struct {
+	ID          string    `json:"id"`
+	Kind        string    `json:"kind"`         // "create" or "edit"
+	Source      string    `json:"source"`        // source name (e.g. "ai-scratch")
+	TaskID      string    `json:"task_id"`       // empty for new-task sessions until scaffold
+	SandboxPath string    `json:"sandbox_path"`  // working directory for the session
+	CreatedAt   time.Time `json:"created_at"`
+	LastTurnAt  time.Time `json:"last_turn_at"`
+	ClosedAt    *int64    `json:"closed_at"`     // nil = open
+	Applied     bool      `json:"applied"`
+}
+
+// authoringSessionStore wraps db.DB to manage author_sessions rows.
+type authoringSessionStore struct {
+	db db.DB
+}
+
+func newAuthoringSessionStore(d db.DB) *authoringSessionStore {
+	return &authoringSessionStore{db: d}
+}
+
+// Create inserts a new authoring session.
+func (s *authoringSessionStore) Create(ctx context.Context, sess AuthoringSession) error {
+	applied := 0
+	if sess.Applied {
+		applied = 1
+	}
+	return s.db.Exec(ctx,
+		`INSERT INTO author_sessions (id, kind, source, task_id, sandbox_path, created_at, last_turn_at, closed_at, applied)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		sess.ID, sess.Kind, sess.Source, sess.TaskID, sess.SandboxPath,
+		sess.CreatedAt.Unix(), sess.LastTurnAt.Unix(), sess.ClosedAt, applied,
+	)
+}
+
+// Get returns an authoring session by ID.
+func (s *authoringSessionStore) Get(ctx context.Context, id string) (*AuthoringSession, error) {
+	var sess AuthoringSession
+	var found bool
+	err := s.db.Query(ctx,
+		`SELECT id, kind, source, task_id, sandbox_path, created_at, last_turn_at, closed_at, applied
+		 FROM author_sessions WHERE id = ?`,
+		[]any{id},
+		func(rows db.Scanner) error {
+			if rows.Next() {
+				found = true
+				return scanAuthoringSession(rows, &sess)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+	return &sess, nil
+}
+
+// GetOpenForSource returns the single open session for a given source, or nil.
+func (s *authoringSessionStore) GetOpenForSource(ctx context.Context, source string) (*AuthoringSession, error) {
+	var sess AuthoringSession
+	var found bool
+	err := s.db.Query(ctx,
+		`SELECT id, kind, source, task_id, sandbox_path, created_at, last_turn_at, closed_at, applied
+		 FROM author_sessions WHERE source = ? AND closed_at IS NULL
+		 LIMIT 1`,
+		[]any{source},
+		func(rows db.Scanner) error {
+			if rows.Next() {
+				found = true
+				return scanAuthoringSession(rows, &sess)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+	return &sess, nil
+}
+
+// UpdateLastTurn bumps the last_turn_at timestamp for the given session.
+func (s *authoringSessionStore) UpdateLastTurn(ctx context.Context, id string) error {
+	return s.db.Exec(ctx,
+		`UPDATE author_sessions SET last_turn_at = ? WHERE id = ?`,
+		time.Now().Unix(), id,
+	)
+}
+
+// Close marks a session as closed, setting closed_at and the applied flag.
+func (s *authoringSessionStore) Close(ctx context.Context, id string, applied bool) error {
+	appliedInt := 0
+	if applied {
+		appliedInt = 1
+	}
+	return s.db.Exec(ctx,
+		`UPDATE author_sessions SET closed_at = ?, applied = ? WHERE id = ?`,
+		time.Now().Unix(), appliedInt, id,
+	)
+}
+
+// ListOpen returns all sessions that have not been closed.
+func (s *authoringSessionStore) ListOpen(ctx context.Context) ([]AuthoringSession, error) {
+	var sessions []AuthoringSession
+	err := s.db.Query(ctx,
+		`SELECT id, kind, source, task_id, sandbox_path, created_at, last_turn_at, closed_at, applied
+		 FROM author_sessions WHERE closed_at IS NULL
+		 ORDER BY created_at DESC`,
+		nil,
+		func(rows db.Scanner) error {
+			for rows.Next() {
+				var sess AuthoringSession
+				if err := scanAuthoringSession(rows, &sess); err != nil {
+					return err
+				}
+				sessions = append(sessions, sess)
+			}
+			return nil
+		},
+	)
+	return sessions, err
+}
+
+// PurgeExpired closes sessions whose last_turn_at is older than ttl ago.
+// Returns the number of sessions closed.
+func (s *authoringSessionStore) PurgeExpired(ctx context.Context, ttl time.Duration) (int, error) {
+	cutoff := time.Now().Add(-ttl).Unix()
+	now := time.Now().Unix()
+
+	// Count how many will be purged.
+	var count int
+	err := s.db.Query(ctx,
+		`SELECT COUNT(*) FROM author_sessions WHERE closed_at IS NULL AND last_turn_at < ?`,
+		[]any{cutoff},
+		func(rows db.Scanner) error {
+			if rows.Next() {
+				return rows.Scan(&count)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return 0, err
+	}
+	if count == 0 {
+		return 0, nil
+	}
+
+	err = s.db.Exec(ctx,
+		`UPDATE author_sessions SET closed_at = ?, applied = 0 WHERE closed_at IS NULL AND last_turn_at < ?`,
+		now, cutoff,
+	)
+	return count, err
+}
+
+// scanAuthoringSession scans a row into an AuthoringSession.
+func scanAuthoringSession(rows db.Scanner, sess *AuthoringSession) error {
+	var createdAt, lastTurnAt int64
+	var closedAt sql.NullInt64
+	var applied int
+	if err := rows.Scan(
+		&sess.ID, &sess.Kind, &sess.Source, &sess.TaskID, &sess.SandboxPath,
+		&createdAt, &lastTurnAt, &closedAt, &applied,
+	); err != nil {
+		return err
+	}
+	sess.CreatedAt = time.Unix(createdAt, 0)
+	sess.LastTurnAt = time.Unix(lastTurnAt, 0)
+	if closedAt.Valid {
+		sess.ClosedAt = &closedAt.Int64
+	}
+	sess.Applied = applied != 0
+	return nil
+}
+
+// errSessionNotFound is a sentinel for session lookup misses in handlers.
+var errSessionNotFound = errors.New("authoring session not found")

--- a/pkg/webui/authoring_db.go
+++ b/pkg/webui/authoring_db.go
@@ -13,12 +13,12 @@ import (
 type AuthoringSession struct {
 	ID          string    `json:"id"`
 	Kind        string    `json:"kind"`         // "create" or "edit"
-	Source      string    `json:"source"`        // source name (e.g. "ai-scratch")
-	TaskID      string    `json:"task_id"`       // empty for new-task sessions until scaffold
-	SandboxPath string    `json:"sandbox_path"`  // working directory for the session
+	Source      string    `json:"source"`       // source name (e.g. "ai-scratch")
+	TaskID      string    `json:"task_id"`      // empty for new-task sessions until scaffold
+	SandboxPath string    `json:"sandbox_path"` // working directory for the session
 	CreatedAt   time.Time `json:"created_at"`
 	LastTurnAt  time.Time `json:"last_turn_at"`
-	ClosedAt    *int64    `json:"closed_at"`     // nil = open
+	ClosedAt    *int64    `json:"closed_at"` // nil = open
 	Applied     bool      `json:"applied"`
 }
 

--- a/pkg/webui/authoring_db_test.go
+++ b/pkg/webui/authoring_db_test.go
@@ -1,0 +1,277 @@
+package webui
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+)
+
+func openTestDB(t *testing.T) db.DB {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+func TestAuthoringSessionStore_CreateAndGet(t *testing.T) {
+	d := openTestDB(t)
+	store := newAuthoringSessionStore(d)
+	ctx := context.Background()
+
+	now := time.Now()
+	sess := AuthoringSession{
+		ID:         "sess-1",
+		Kind:       "create",
+		Source:     "ai-scratch",
+		TaskID:     "ai-scratch/my-task",
+		CreatedAt:  now,
+		LastTurnAt: now,
+	}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := store.Get(ctx, "sess-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Get returned nil")
+	}
+	if got.Kind != "create" {
+		t.Errorf("Kind = %q, want %q", got.Kind, "create")
+	}
+	if got.Source != "ai-scratch" {
+		t.Errorf("Source = %q, want %q", got.Source, "ai-scratch")
+	}
+	if got.TaskID != "ai-scratch/my-task" {
+		t.Errorf("TaskID = %q, want %q", got.TaskID, "ai-scratch/my-task")
+	}
+	if got.ClosedAt != nil {
+		t.Errorf("ClosedAt = %v, want nil", got.ClosedAt)
+	}
+	if got.Applied {
+		t.Error("Applied = true, want false")
+	}
+}
+
+func TestAuthoringSessionStore_GetNotFound(t *testing.T) {
+	d := openTestDB(t)
+	store := newAuthoringSessionStore(d)
+	ctx := context.Background()
+
+	got, err := store.Get(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
+func TestAuthoringSessionStore_GetOpenForSource(t *testing.T) {
+	d := openTestDB(t)
+	store := newAuthoringSessionStore(d)
+	ctx := context.Background()
+
+	now := time.Now()
+
+	// Create an open session.
+	sess := AuthoringSession{
+		ID:         "sess-open",
+		Kind:       "edit",
+		Source:     "examples",
+		TaskID:     "examples/hello",
+		CreatedAt:  now,
+		LastTurnAt: now,
+	}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Should find it.
+	got, err := store.GetOpenForSource(ctx, "examples")
+	if err != nil {
+		t.Fatalf("GetOpenForSource: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected open session, got nil")
+	}
+	if got.ID != "sess-open" {
+		t.Errorf("ID = %q, want %q", got.ID, "sess-open")
+	}
+
+	// No open session for another source.
+	got, err = store.GetOpenForSource(ctx, "ai-scratch")
+	if err != nil {
+		t.Fatalf("GetOpenForSource(other): %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for other source, got %+v", got)
+	}
+}
+
+func TestAuthoringSessionStore_Close(t *testing.T) {
+	d := openTestDB(t)
+	store := newAuthoringSessionStore(d)
+	ctx := context.Background()
+
+	now := time.Now()
+	sess := AuthoringSession{
+		ID:         "sess-close",
+		Kind:       "create",
+		Source:     "ai-scratch",
+		CreatedAt:  now,
+		LastTurnAt: now,
+	}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Close with applied=true.
+	if err := store.Close(ctx, "sess-close", true); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	got, err := store.Get(ctx, "sess-close")
+	if err != nil {
+		t.Fatalf("Get after close: %v", err)
+	}
+	if got.ClosedAt == nil {
+		t.Fatal("ClosedAt should be set after close")
+	}
+	if !got.Applied {
+		t.Error("Applied should be true")
+	}
+
+	// GetOpenForSource should no longer find it.
+	open, err := store.GetOpenForSource(ctx, "ai-scratch")
+	if err != nil {
+		t.Fatalf("GetOpenForSource: %v", err)
+	}
+	if open != nil {
+		t.Errorf("expected nil after close, got %+v", open)
+	}
+}
+
+func TestAuthoringSessionStore_ListOpen(t *testing.T) {
+	d := openTestDB(t)
+	store := newAuthoringSessionStore(d)
+	ctx := context.Background()
+
+	now := time.Now()
+	for _, id := range []string{"a", "b", "c"} {
+		sess := AuthoringSession{
+			ID:         id,
+			Kind:       "edit",
+			Source:     "src-" + id,
+			CreatedAt:  now,
+			LastTurnAt: now,
+		}
+		if err := store.Create(ctx, sess); err != nil {
+			t.Fatalf("Create %s: %v", id, err)
+		}
+	}
+	// Close one.
+	if err := store.Close(ctx, "b", false); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	open, err := store.ListOpen(ctx)
+	if err != nil {
+		t.Fatalf("ListOpen: %v", err)
+	}
+	if len(open) != 2 {
+		t.Fatalf("ListOpen returned %d, want 2", len(open))
+	}
+}
+
+func TestAuthoringSessionStore_PurgeExpired(t *testing.T) {
+	d := openTestDB(t)
+	store := newAuthoringSessionStore(d)
+	ctx := context.Background()
+
+	old := time.Now().Add(-2 * time.Hour)
+	recent := time.Now()
+
+	// One old session, one recent.
+	for _, tc := range []struct {
+		id string
+		ts time.Time
+	}{
+		{"old", old},
+		{"new", recent},
+	} {
+		sess := AuthoringSession{
+			ID:         tc.id,
+			Kind:       "edit",
+			Source:     "src-" + tc.id,
+			CreatedAt:  tc.ts,
+			LastTurnAt: tc.ts,
+		}
+		if err := store.Create(ctx, sess); err != nil {
+			t.Fatalf("Create %s: %v", tc.id, err)
+		}
+	}
+
+	n, err := store.PurgeExpired(ctx, time.Hour)
+	if err != nil {
+		t.Fatalf("PurgeExpired: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("PurgeExpired returned %d, want 1", n)
+	}
+
+	// "old" should be closed now.
+	got, err := store.Get(ctx, "old")
+	if err != nil {
+		t.Fatalf("Get old: %v", err)
+	}
+	if got.ClosedAt == nil {
+		t.Error("old session should be closed after purge")
+	}
+
+	// "new" should still be open.
+	got, err = store.Get(ctx, "new")
+	if err != nil {
+		t.Fatalf("Get new: %v", err)
+	}
+	if got.ClosedAt != nil {
+		t.Error("new session should still be open")
+	}
+}
+
+func TestAuthoringSessionStore_UpdateLastTurn(t *testing.T) {
+	d := openTestDB(t)
+	store := newAuthoringSessionStore(d)
+	ctx := context.Background()
+
+	past := time.Now().Add(-time.Hour)
+	sess := AuthoringSession{
+		ID:         "sess-turn",
+		Kind:       "edit",
+		Source:     "ai-scratch",
+		CreatedAt:  past,
+		LastTurnAt: past,
+	}
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := store.UpdateLastTurn(ctx, "sess-turn"); err != nil {
+		t.Fatalf("UpdateLastTurn: %v", err)
+	}
+
+	got, err := store.Get(ctx, "sess-turn")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.LastTurnAt.Before(past.Add(30 * time.Minute)) {
+		t.Errorf("LastTurnAt was not bumped: %v", got.LastTurnAt)
+	}
+}

--- a/pkg/webui/authoring_test.go
+++ b/pkg/webui/authoring_test.go
@@ -1,0 +1,399 @@
+package webui
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/config"
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/ipc"
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/taskset"
+	"github.com/dicode/dicode/pkg/trigger"
+	"go.uber.org/zap"
+)
+
+// newAuthoringTestServer builds a Server with auth disabled, a real SQLite DB,
+// and a SourceManager wired up with a local taskset source rooted at dir.
+func newAuthoringTestServer(t *testing.T, sourceName, sourceDir string) *Server {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+
+	reg := registry.New(d)
+	eng := trigger.New(reg, nil, zap.NewNop())
+	cfg := &config.Config{}
+
+	var sm *SourceManager
+	if sourceName != "" && sourceDir != "" {
+		sm = NewSourceManager(cfg, nil, "", zap.NewNop())
+		// Create a minimal taskset source. We only need RepoPath() to return
+		// the dir so the create handler can write files.
+		src := newStubTasksetSource(t, sourceName, sourceDir)
+		sm.Register(sourceName, src)
+	}
+
+	srv, err := New(0, reg, eng, cfg, "", nil, nil, sm, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
+	if err != nil {
+		t.Fatalf("webui.New: %v", err)
+	}
+	return srv
+}
+
+// newStubTasksetSource creates a *taskset.Source backed by a local directory.
+// The source is not started (no fsnotify), but RepoPath() returns the dir.
+func newStubTasksetSource(t *testing.T, name, dir string) *taskset.Source {
+	t.Helper()
+	// Write a minimal taskset.yaml so taskset.NewSource doesn't fail.
+	tsYAML := filepath.Join(dir, "taskset.yaml")
+	if err := os.WriteFile(tsYAML, []byte("apiVersion: dicode/v1\nkind: TaskSet\n"), 0644); err != nil {
+		t.Fatalf("write taskset.yaml: %v", err)
+	}
+	ref := &taskset.Ref{Path: tsYAML}
+	src := taskset.NewSource(name, name, ref, "", "", false, 0, zap.NewNop())
+
+	// Start the source so RepoPath() returns the directory. For a local ref
+	// this just sets watchRoot = dir and runs an initial resolve.
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	if _, err := src.Start(ctx); err != nil {
+		t.Fatalf("start source: %v", err)
+	}
+
+	return src
+}
+
+func postJSON(handler http.Handler, path string, body any) *httptest.ResponseRecorder {
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+func decodeJSON(t *testing.T, w *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&m); err != nil {
+		t.Fatalf("decode JSON: %v (body: %s)", err, w.Body.String())
+	}
+	return m
+}
+
+// --- POST /api/task/create --------------------------------------------------
+
+func TestAPITaskCreate_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	w := postJSON(h, "/api/task/create", map[string]string{"name": "My Cool Task"})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body: %s", w.Code, w.Body.String())
+	}
+
+	body := decodeJSON(t, w)
+	taskID, _ := body["task_id"].(string)
+	if taskID != "ai-scratch/my-cool-task" {
+		t.Errorf("task_id = %q, want %q", taskID, "ai-scratch/my-cool-task")
+	}
+	files, _ := body["files"].([]any)
+	if len(files) != 2 {
+		t.Errorf("files = %v, want 2 entries", files)
+	}
+
+	// Verify files on disk.
+	if _, err := os.Stat(filepath.Join(dir, "my-cool-task", "task.yaml")); err != nil {
+		t.Errorf("task.yaml not found on disk: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "my-cool-task", "task.js")); err != nil {
+		t.Errorf("task.js not found on disk: %v", err)
+	}
+}
+
+func TestAPITaskCreate_AutoName(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	w := postJSON(h, "/api/task/create", map[string]string{})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body: %s", w.Code, w.Body.String())
+	}
+
+	body := decodeJSON(t, w)
+	taskID, _ := body["task_id"].(string)
+	if taskID == "" {
+		t.Error("task_id should not be empty")
+	}
+}
+
+func TestAPITaskCreate_SourceNotFound(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	w := postJSON(h, "/api/task/create", map[string]string{"source": "nonexistent"})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPITaskCreate_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/task/create", bytes.NewReader([]byte("not json")))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+// --- POST /api/task/edit ----------------------------------------------------
+
+func TestAPITaskEdit_CreateSession(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	w := postJSON(h, "/api/task/edit", map[string]string{"task_id": "ai-scratch/hello"})
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body: %s", w.Code, w.Body.String())
+	}
+
+	body := decodeJSON(t, w)
+	sessID, _ := body["session_id"].(string)
+	if sessID == "" {
+		t.Error("session_id should not be empty")
+	}
+	src, _ := body["source"].(string)
+	if src != "ai-scratch" {
+		t.Errorf("source = %q, want %q", src, "ai-scratch")
+	}
+}
+
+func TestAPITaskEdit_ResumeSession(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	// Create a session first.
+	w := postJSON(h, "/api/task/edit", map[string]string{"task_id": "ai-scratch/hello"})
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", w.Code)
+	}
+	body := decodeJSON(t, w)
+	sessID := body["session_id"].(string)
+
+	// Resume it.
+	w = postJSON(h, "/api/task/edit", map[string]string{"session_id": sessID})
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("resume status = %d, want 202; body: %s", w.Code, w.Body.String())
+	}
+	body2 := decodeJSON(t, w)
+	if body2["session_id"] != sessID {
+		t.Errorf("resumed session_id = %q, want %q", body2["session_id"], sessID)
+	}
+}
+
+func TestAPITaskEdit_ConflictSameSource(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	// Create first session.
+	w := postJSON(h, "/api/task/edit", map[string]string{"task_id": "ai-scratch/hello"})
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("first status = %d, want 202", w.Code)
+	}
+
+	// Try second session on same source.
+	w = postJSON(h, "/api/task/edit", map[string]string{"task_id": "ai-scratch/other"})
+	if w.Code != http.StatusConflict {
+		t.Fatalf("second status = %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPITaskEdit_MissingTaskAndSession(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	w := postJSON(h, "/api/task/edit", map[string]string{})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPITaskEdit_SessionNotFound(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	w := postJSON(h, "/api/task/edit", map[string]string{"session_id": "nonexistent"})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body: %s", w.Code, w.Body.String())
+	}
+}
+
+// --- POST /api/task/save ----------------------------------------------------
+
+func TestAPITaskSave_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	// Create a session.
+	w := postJSON(h, "/api/task/edit", map[string]string{"task_id": "ai-scratch/hello"})
+	body := decodeJSON(t, w)
+	sessID := body["session_id"].(string)
+
+	// Save it.
+	w = postJSON(h, "/api/task/save", map[string]string{"session_id": sessID})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	body = decodeJSON(t, w)
+	if body["applied"] != true {
+		t.Errorf("applied = %v, want true", body["applied"])
+	}
+}
+
+func TestAPITaskSave_SessionNotFound(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	w := postJSON(h, "/api/task/save", map[string]string{"session_id": "nonexistent"})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPITaskSave_MissingSessionID(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	w := postJSON(h, "/api/task/save", map[string]string{})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPITaskSave_AlreadyClosed(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	// Create and save.
+	w := postJSON(h, "/api/task/edit", map[string]string{"task_id": "ai-scratch/hello"})
+	body := decodeJSON(t, w)
+	sessID := body["session_id"].(string)
+	postJSON(h, "/api/task/save", map[string]string{"session_id": sessID})
+
+	// Save again.
+	w = postJSON(h, "/api/task/save", map[string]string{"session_id": sessID})
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+}
+
+// --- POST /api/task/cancel --------------------------------------------------
+
+func TestAPITaskCancel_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	// Create a session.
+	w := postJSON(h, "/api/task/edit", map[string]string{"task_id": "ai-scratch/hello"})
+	body := decodeJSON(t, w)
+	sessID := body["session_id"].(string)
+
+	// Cancel it.
+	w = postJSON(h, "/api/task/cancel", map[string]string{"session_id": sessID})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	body = decodeJSON(t, w)
+	if body["cancelled"] != true {
+		t.Errorf("cancelled = %v, want true", body["cancelled"])
+	}
+}
+
+func TestAPITaskCancel_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	// Create and cancel.
+	w := postJSON(h, "/api/task/edit", map[string]string{"task_id": "ai-scratch/hello"})
+	body := decodeJSON(t, w)
+	sessID := body["session_id"].(string)
+	postJSON(h, "/api/task/cancel", map[string]string{"session_id": sessID})
+
+	// Cancel again — should be idempotent.
+	w = postJSON(h, "/api/task/cancel", map[string]string{"session_id": sessID})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPITaskCancel_SessionNotFound(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	w := postJSON(h, "/api/task/cancel", map[string]string{"session_id": "nonexistent"})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPITaskCancel_MissingSessionID(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	w := postJSON(h, "/api/task/cancel", map[string]string{})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+}
+
+// --- sanitizeTaskName -------------------------------------------------------
+
+func TestSanitizeTaskName(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"My Cool Task", "my-cool-task"},
+		{"hello_world", "helloworld"},
+		{"--abc--", "abc"},
+		{"123", "123"},
+		{"", ""},
+		{"  spaces  ", "spaces"},
+	}
+	for _, tc := range tests {
+		got := sanitizeTaskName(tc.in)
+		if got != tc.want {
+			t.Errorf("sanitizeTaskName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -124,15 +124,15 @@ type Server struct {
 	gateway            *ipc.Gateway
 	db                 db.DB
 	managedRuntimes    []pkgruntime.ManagedRuntime
-	sm                 *scs.SessionManager // short-lived browser sessions (scs/v2)
-	scsStore           *scsStore           // underlying SQLite store for sm; nil in DB-less tests
-	dbSessions         *dbSessionStore     // persistent trusted-device tokens
-	apiKeys            *apiKeyStore        // MCP / programmatic API keys
+	sm                 *scs.SessionManager    // short-lived browser sessions (scs/v2)
+	scsStore           *scsStore              // underlying SQLite store for sm; nil in DB-less tests
+	dbSessions         *dbSessionStore        // persistent trusted-device tokens
+	apiKeys            *apiKeyStore           // MCP / programmatic API keys
 	authoringSessions  *authoringSessionStore // AI-first authoring sessions (#288)
-	passphraseStore    *passphraseStore    // auth passphrase persisted in DB
-	cachedPassphrase   string              // in-memory cache of stored DB value (bcrypt hash, or legacy plaintext during migration); invalidated on change
-	cachedPassphraseMu sync.RWMutex        // guards cachedPassphrase
-	migrateGroup       passphraseMigrator  // collapses concurrent legacy-passphrase migrations to one bcrypt+write
+	passphraseStore    *passphraseStore       // auth passphrase persisted in DB
+	cachedPassphrase   string                 // in-memory cache of stored DB value (bcrypt hash, or legacy plaintext during migration); invalidated on change
+	cachedPassphraseMu sync.RWMutex           // guards cachedPassphrase
+	migrateGroup       passphraseMigrator     // collapses concurrent legacy-passphrase migrations to one bcrypt+write
 	logs               *LogBroadcaster
 	ws                 *WSHub
 	log                *zap.Logger
@@ -216,27 +216,27 @@ func New(port int, r *registry.Registry, eng *trigger.Engine, cfg *config.Config
 	}
 
 	s := &Server{
-		registry:        r,
-		engine:          eng,
-		cfg:             cfg,
-		cfgPath:         cfgPath,
-		secretsMgr:      secretsMgr,
-		reconciler:      rec,
-		sourceMgr:       sourceMgr,
-		dataDir:         dataDir,
-		sm:              sm,
-		scsStore:        store,
+		registry:          r,
+		engine:            eng,
+		cfg:               cfg,
+		cfgPath:           cfgPath,
+		secretsMgr:        secretsMgr,
+		reconciler:        rec,
+		sourceMgr:         sourceMgr,
+		dataDir:           dataDir,
+		sm:                sm,
+		scsStore:          store,
 		dbSessions:        dbs,
 		apiKeys:           aks,
 		authoringSessions: as,
 		passphraseStore:   ps,
-		logs:            logs,
-		ws:              wsHub,
-		log:             log,
-		port:            port,
-		gateway:         gateway,
-		csrfKey:         csrfKey,
-		db:              database,
+		logs:              logs,
+		ws:                wsHub,
+		log:               log,
+		port:              port,
+		gateway:           gateway,
+		csrfKey:           csrfKey,
+		db:                database,
 	}
 
 	// Wire run started hook → broadcast run:started

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -128,6 +128,7 @@ type Server struct {
 	scsStore           *scsStore           // underlying SQLite store for sm; nil in DB-less tests
 	dbSessions         *dbSessionStore     // persistent trusted-device tokens
 	apiKeys            *apiKeyStore        // MCP / programmatic API keys
+	authoringSessions  *authoringSessionStore // AI-first authoring sessions (#288)
 	passphraseStore    *passphraseStore    // auth passphrase persisted in DB
 	cachedPassphrase   string              // in-memory cache of stored DB value (bcrypt hash, or legacy plaintext during migration); invalidated on change
 	cachedPassphraseMu sync.RWMutex        // guards cachedPassphrase
@@ -205,11 +206,13 @@ func New(port int, r *registry.Registry, eng *trigger.Engine, cfg *config.Config
 	var aks *apiKeyStore
 	var ps *passphraseStore
 	var store *scsStore
+	var as *authoringSessionStore
 	if database != nil {
 		dbs = newDBSessionStore(database)
 		aks = newAPIKeyStore(database)
 		ps = newPassphraseStore(database)
 		store = sm.Store.(*scsStore)
+		as = newAuthoringSessionStore(database)
 	}
 
 	s := &Server{
@@ -223,9 +226,10 @@ func New(port int, r *registry.Registry, eng *trigger.Engine, cfg *config.Config
 		dataDir:         dataDir,
 		sm:              sm,
 		scsStore:        store,
-		dbSessions:      dbs,
-		apiKeys:         aks,
-		passphraseStore: ps,
+		dbSessions:        dbs,
+		apiKeys:           aks,
+		authoringSessions: as,
+		passphraseStore:   ps,
 		logs:            logs,
 		ws:              wsHub,
 		log:             log,
@@ -534,6 +538,12 @@ func (s *Server) Handler() http.Handler {
 
 			// AI chat — forwards to the task named by cfg.AI.Task.
 			r.Post("/ai/chat", s.apiAIChat)
+
+			// AI-first task authoring (#288)
+			r.Post("/task/create", s.apiTaskCreate)
+			r.Post("/task/edit", s.apiTaskEdit)
+			r.Post("/task/save", s.apiTaskSave)
+			r.Post("/task/cancel", s.apiTaskCancel)
 
 			// Managed runtime lifecycle
 			r.Get("/runtimes", s.apiListRuntimes)


### PR DESCRIPTION
## Summary
- Add `author_sessions` SQLite table migration for tracking AI-first task authoring sessions
- Implement `authoringSessionStore` DB layer with Create, Get, GetOpenForSource, UpdateLastTurn, Close, ListOpen, and PurgeExpired methods
- Add four REST endpoints under `/api/task/`: `create` (201, scaffolds boilerplate), `edit` (202, creates/resumes session with single-session-per-source enforcement), `save` (200, closes as applied), `cancel` (200, idempotent close)
- Wire `authoringSessions` field into Server struct and chi router

## Test plan
- [x] 7 unit tests for `authoringSessionStore` (create, get, get-not-found, get-open-for-source, close, list-open, purge-expired, update-last-turn)
- [x] 4 happy-path HTTP handler tests (create, edit, save, cancel)
- [x] Error-case HTTP handler tests (400 invalid JSON, 400 missing fields, 404 not found, 409 conflict/already-closed, idempotent cancel)
- [x] `sanitizeTaskName` unit tests
- [x] `make build && make lint && make test` all pass

Closes slice 2 of #288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)