### PR TITLE
fix(envresolve): share resolver across launches for cross-fire cache TTL (#242)

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -483,6 +483,10 @@ func buildRuntimes(
 	// per-run secretOutputCh for each provider invocation.
 	eng.SetDenoRuntime(denoRT)
 	denoRT.SetProviderRunner(eng)
+	// Issue #242: share a single env resolver across all task launches so
+	// that provider.cache_ttl survives across fires. The resolver's cache is
+	// in-memory and reset on daemon restart.
+	denoRT.SetEnvResolver(eng.Resolver())
 	if !cfg.Defaults.OnFailureChain.IsZero() {
 		if err := eng.SetDefaultsOnFailureChain(cfg.Defaults.OnFailureChain); err != nil {
 			return nil, nil, nil, nil, fmt.Errorf("set on_failure_chain defaults: %w", err)
@@ -518,6 +522,7 @@ func buildRuntimes(
 	pythonMgr.SetSecretsManager(secretsMgr)
 	eng.SetPythonRuntime(pythonMgr)
 	pythonMgr.SetProviderRunner(eng)
+	pythonMgr.SetEnvResolver(eng.Resolver())
 	managed = append(managed, pythonMgr)
 
 	if rc, ok := cfg.Runtimes["python"]; ok && !rc.Disabled {

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -101,6 +101,10 @@ type Runtime struct {
 	// the env resolver can spawn provider tasks for from: task:<id>
 	// entries. Nil disables provider lookups; legacy paths still work.
 	providerRunner envresolve.ProviderRunner
+	// sharedResolver is the daemon-scoped env resolver whose TTL cache
+	// survives across task launches (issue #242). When non-nil, envresolver()
+	// returns it instead of constructing a fresh instance per Run.
+	sharedResolver *envresolve.Resolver
 	// replayer, sourceMgr, repoResolver are wired after buildRuntimes returns
 	// (same late-wiring pattern as inputStore). effectiveReplayer /
 	// effectiveSourceMgr / effectiveRepoResolver read through parent when
@@ -222,6 +226,13 @@ func (rt *Runtime) SetSecretOutputChannel(ch chan map[string]string) {
 // daemon startup. Nil disables provider task: lookups.
 func (rt *Runtime) SetProviderRunner(p envresolve.ProviderRunner) {
 	rt.providerRunner = p
+}
+
+// SetEnvResolver wires the daemon-scoped env resolver whose TTL cache
+// survives across task launches (issue #242). When set, envresolver()
+// returns it instead of constructing a fresh instance per Run.
+func (rt *Runtime) SetEnvResolver(r *envresolve.Resolver) {
+	rt.sharedResolver = r
 }
 
 // Run executes a task script and returns the result.
@@ -568,11 +579,18 @@ func buildEnv(resolved map[string]string, socketPath, token string) []string {
 	return env
 }
 
-// envresolver lazily constructs the env resolver. Wired with the daemon's
-// secret chain + a provider runner that calls back into the trigger
-// engine. Nil engine (test harness with no providers) yields a resolver
-// that errors on any from: task:<id> entry.
+// envresolver returns the env resolver to use for a Run. When a
+// daemon-scoped shared resolver is wired (issue #242), it is returned so
+// the TTL cache survives across launches. Otherwise a fresh instance is
+// constructed (legacy / test path).
 func (rt *Runtime) envresolver() *envresolve.Resolver {
+	// Read through parent for per-version executors.
+	if rt.parent != nil && rt.parent.sharedResolver != nil {
+		return rt.parent.sharedResolver
+	}
+	if rt.sharedResolver != nil {
+		return rt.sharedResolver
+	}
 	return envresolve.New(rt.registry, rt.secrets, rt.providerRunner)
 }
 

--- a/pkg/runtime/envresolve/resolver.go
+++ b/pkg/runtime/envresolve/resolver.go
@@ -162,6 +162,9 @@ func (r *Resolver) resolveProvider(
 		}
 	}
 
+	// Hash error → empty string → cache always misses (content-hash
+	// mismatch path in cache.get). Safe but wasteful; the empty hash
+	// is defence-in-depth against stale data from a corrupted task dir.
 	providerHash, _ := contentHashOf(spec)
 	now := r.Now()
 

--- a/pkg/runtime/envresolve/resolver.go
+++ b/pkg/runtime/envresolve/resolver.go
@@ -52,8 +52,8 @@ type Resolver struct {
 	Now func() time.Time
 }
 
-// New constructs a Resolver. Each runtime constructs its own Resolver;
-// the cache lives inside the Resolver instance.
+// New constructs a Resolver. The daemon constructs a single shared instance
+// whose cache survives across task launches (issue #242).
 func New(reg Registry, sc secrets.Chain, runner ProviderRunner) *Resolver {
 	return &Resolver{
 		Runner:   runner,

--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -75,6 +75,10 @@ type Runtime struct {
 	// the env resolver can spawn provider tasks for from: task:<id>
 	// entries. Nil disables provider lookups; legacy paths still work.
 	providerRunner envresolve.ProviderRunner
+	// sharedResolver is the daemon-scoped env resolver whose TTL cache
+	// survives across task launches (issue #242). When non-nil, the executor
+	// uses it instead of constructing a fresh instance per Execute.
+	sharedResolver *envresolve.Resolver
 	// replayer, sourceMgr, repoResolver are wired after buildRuntimes returns
 	// (same late-wiring pattern as inputStore). Executors read these fields
 	// from parent at IPC server creation time.
@@ -122,6 +126,13 @@ func (rt *Runtime) SetSecretOutputChannel(ch chan map[string]string) {
 // daemon startup. Nil disables provider task: lookups.
 func (rt *Runtime) SetProviderRunner(p envresolve.ProviderRunner) {
 	rt.providerRunner = p
+}
+
+// SetEnvResolver wires the daemon-scoped env resolver whose TTL cache
+// survives across task launches (issue #242). When set, the executor
+// uses it instead of constructing a fresh instance per Execute.
+func (rt *Runtime) SetEnvResolver(r *envresolve.Resolver) {
+	rt.sharedResolver = r
 }
 
 // New creates a Python Runtime manager.
@@ -202,6 +213,17 @@ type executor struct {
 	providerRunner envresolve.ProviderRunner
 }
 
+// envresolver returns the env resolver to use for an Execute call. When a
+// daemon-scoped shared resolver is wired (issue #242), it is returned so
+// the TTL cache survives across launches. Otherwise a fresh instance is
+// constructed (legacy / test path).
+func (e *executor) envresolver() *envresolve.Resolver {
+	if e.parent != nil && e.parent.sharedResolver != nil {
+		return e.parent.sharedResolver
+	}
+	return envresolve.New(e.reg, e.secrets, e.providerRunner)
+}
+
 // Execute implements runtime.Executor.
 func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
 	runID := opts.RunID
@@ -219,7 +241,7 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	if opts.PreResolvedEnv != nil {
 		resolvedRes = opts.PreResolvedEnv
 	} else {
-		resolvedRes, err = envresolve.New(e.reg, e.secrets, e.providerRunner).Resolve(ctx, spec)
+		resolvedRes, err = e.envresolver().Resolve(ctx, spec)
 		if err != nil {
 			result.Error = err
 			return result, nil

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -163,6 +163,11 @@ type Engine struct {
 	denoRuntime   DenoRuntimeAPI
 	pythonRuntime PythonRuntimeAPI
 
+	// envResolver is the daemon-scoped env resolver shared across all task
+	// launches. The cache lives inside this instance, so cross-launch TTL
+	// hits work as intended (issue #242). Constructed lazily by Resolver().
+	envResolver *envresolve.Resolver
+
 	// providerRunMu serializes Engine.Run invocations so concurrent provider
 	// resolutions don't clobber each other's secretOutputCh on the runtime.
 	// MVP-quality: a per-run channel registry would allow parallelism but
@@ -240,6 +245,18 @@ func (e *Engine) SetPythonRuntime(r PythonRuntimeAPI) { e.pythonRuntime = r }
 // run-start. Called by the daemon after secrets are available (so the derived
 // sub-key exists). When nil (the default), input persistence is a no-op.
 func (e *Engine) SetInputStore(s *registry.InputStore) { e.inputStore = s }
+
+// Resolver returns the daemon-scoped env resolver, constructing it lazily on
+// first call. The resolver's TTL cache survives across task launches so that
+// provider.cache_ttl actually provides cross-fire benefit (issue #242).
+func (e *Engine) Resolver() *envresolve.Resolver {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.envResolver == nil {
+		e.envResolver = envresolve.New(e.registry, e.secrets, e)
+	}
+	return e.envResolver
+}
 
 // SetMaxConcurrentTasks configures a semaphore that limits how many task
 // goroutines run concurrently. n == 0 (the default) means unlimited.
@@ -988,8 +1005,7 @@ func (e *Engine) preflightEnv(ctx context.Context, spec *task.Spec) (*envresolve
 	if e.secrets == nil || len(spec.Permissions.Env) == 0 {
 		return nil, "", ""
 	}
-	r := envresolve.New(e.registry, e.secrets, e)
-	resolved, err := r.Resolve(ctx, spec)
+	resolved, err := e.Resolver().Resolve(ctx, spec)
 	if err != nil {
 		var pu *envresolve.ErrProviderUnavailable
 		var rsm *envresolve.ErrRequiredSecretMissing

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -253,6 +253,9 @@ func (e *Engine) Resolver() *envresolve.Resolver {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.envResolver == nil {
+		if e.secrets == nil {
+			e.log.Warn("Resolver() called before SetSecrets() — resolver will have no secrets chain")
+		}
 		e.envResolver = envresolve.New(e.registry, e.secrets, e)
 	}
 	return e.envResolver
@@ -1018,7 +1021,10 @@ func (e *Engine) preflightEnv(ctx context.Context, spec *task.Spec) (*envresolve
 		case errors.As(err, &mis):
 			return nil, registry.StatusFailure, "provider_misconfigured: " + mis.ProviderID
 		}
-		// Non-typed error: let dispatch surface it normally.
+		// Non-typed error: log for operator visibility, then let dispatch
+		// surface it through the runtime's inline resolver path.
+		e.log.Warn("preflight env-resolve returned non-typed error — falling through to inline resolution",
+			zap.String("task", spec.ID), zap.Error(err))
 		return nil, "", ""
 	}
 	return resolved, "", ""

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -1021,10 +1021,11 @@ func (e *Engine) preflightEnv(ctx context.Context, spec *task.Spec) (*envresolve
 		case errors.As(err, &mis):
 			return nil, registry.StatusFailure, "provider_misconfigured: " + mis.ProviderID
 		}
-		// Non-typed error: log for operator visibility, then let dispatch
+		// Non-typed error: log for operator visibility (without the error
+		// detail, which may contain secret key names), then let dispatch
 		// surface it through the runtime's inline resolver path.
 		e.log.Warn("preflight env-resolve returned non-typed error — falling through to inline resolution",
-			zap.String("task", spec.ID), zap.Error(err))
+			zap.String("task", spec.ID))
 		return nil, "", ""
 	}
 	return resolved, "", ""


### PR DESCRIPTION
## Summary
- Construct a single daemon-scoped `*envresolve.Resolver` on the trigger `Engine` (lazy via `Engine.Resolver()`), replacing per-launch `envresolve.New()` calls in `preflightEnv`, `deno.Runtime.envresolver()`, and `python.executor.envresolver()`
- Wire the shared resolver into both deno and python runtimes at daemon boot via `SetEnvResolver()`
- The TTL cache now survives across task fires, so two consecutive consumer launches within `provider.cache_ttl` hit the upstream provider exactly once
- Provider content-hash changes still bust the cache; daemon restart resets it (in-memory only)

Closes #242

## Test plan
- [x] `make build && make lint` pass
- [x] `go test ./pkg/runtime/envresolve/... -v` — all cache + resolver tests pass
- [x] `make test` — full suite passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)