### PR TITLE
fix(auth-providers): restore connected-providers indication via secrets.has (#255)

### DIFF
--- a/pkg/runtime/python/sdk/dicode_sdk.py
+++ b/pkg/runtime/python/sdk/dicode_sdk.py
@@ -353,11 +353,15 @@ class _Secrets:
 
     def has(self, key):
         """Return True if key exists in the secrets store."""
-        return _call({"method": "dicode.secrets.has", "key": key})
+        if not isinstance(key, str) or not key:
+            raise TypeError("secrets.has: key must be a non-empty string")
+        return bool(_call({"method": "dicode.secrets.has", "key": key}))
 
     async def has_async(self, key):
         """Async variant of has."""
-        return await _call_async({"method": "dicode.secrets.has", "key": key})
+        if not isinstance(key, str) or not key:
+            raise TypeError("secrets.has: key must be a non-empty string")
+        return bool(await _call_async({"method": "dicode.secrets.has", "key": key}))
 
 
 class _Git:

--- a/pkg/runtime/python/sdk/dicode_sdk.py
+++ b/pkg/runtime/python/sdk/dicode_sdk.py
@@ -348,6 +348,18 @@ class _Sources:
                                   "base": base, "run_id": run_id})
 
 
+class _Secrets:
+    """Presence-only secret checks — never returns the value."""
+
+    def has(self, key):
+        """Return True if key exists in the secrets store."""
+        return _call({"method": "dicode.secrets.has", "key": key})
+
+    async def has_async(self, key):
+        """Async variant of has."""
+        return await _call_async({"method": "dicode.secrets.has", "key": key})
+
+
 class _Git:
     def commit_push(self, source_id, *, message, branch, author_name,
                     author_email, branch_prefix="", allow_main=False,
@@ -385,6 +397,7 @@ class _Dicode:
         self.tasks = _Tasks()
         self.sources = _Sources()
         self.git = _Git()
+        self.secrets = _Secrets()
 
     def run_task(self, task_id, params=None):
         return _call({"method": "dicode.run_task", "taskID": task_id,


### PR DESCRIPTION
## Summary
- Add `dicode.secrets.has(key)` to the Python SDK (`_Secrets` class with sync `has` and async `has_async` methods), matching the Deno SDK surface that was already in place
- The Go IPC handler (`dicode.secrets.has`), capability (`CapSecretsHas`), task spec field (`secrets_has`), Deno SDK, auth-providers task, and IPC tests were all already implemented on `main`; the Python SDK was the only missing piece

## Test plan
- [x] `make build` passes
- [x] `make lint` passes
- [x] `make test` passes (all packages, including existing `TestServer_Dicode_SecretsHas_*` IPC tests)
- [ ] Manual: verify auth-providers UI shows connected providers when tokens exist in secrets store

🤖 Generated with [Claude Code](https://claude.com/claude-code)