### PR TITLE
security(auth): bind trusted-device cookie to IP subnet + UA family (#132)

### DIFF
--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -231,7 +231,7 @@ Managed by `dbSessionStore` in [sessions_db.go](../../pkg/webui/sessions_db.go).
 2. Open a **database transaction**
 3. Query for a matching, non-expired `device` row
 4. If not found → return `("", false)`
-5. Evaluate device binding (`mode` = `server.device_binding`) — see below. In `strict` mode a drift takes the reject path (`("", false)`); in `warn` mode the drift reason is recorded on the row and a structured event is logged.
+5. Evaluate device binding (`mode` = `server.device_binding`) — see below. In `strict` mode a drift hard-revokes the device row (`DELETE` in the same transaction) and returns the reject path; every caller then destroys the session and clears the `dicode_device` cookie, so a cookie judged stolen cannot be replayed until its 30-day expiry. In `warn` mode the drift reason is recorded on the row and a structured event is logged.
 6. If found and `age < deviceRotateAfter` (24h) → update `last_seen` + `ip` + `ua_family`, commit
 7. If found and `age ≥ deviceRotateAfter` → **rotate**:
    - Generate a new raw token
@@ -251,13 +251,15 @@ A trusted-device cookie is a 30-day bearer credential. To limit the blast radius
 | Mode     | Behaviour |
 | -------- | --------- |
 | `off`    | Default. IP/UA are recorded but never verified — backward-compatible. |
-| `warn`   | Renewal is allowed even on drift, but the drift is flagged (`drift: true` + reason) on the `/security` device row and a structured `device.binding_drift` log event is emitted. |
-| `strict` | Renewal is **rejected** on drift; the session is destroyed and the device cookie cleared, forcing a fresh login. |
+| `warn`   | Renewal is allowed even on drift, but the drift is flagged (`drift: true` + reason) on the `/security` device row and a structured `device.binding_drift` log event is emitted. The flag is **sticky**: it is compared against the issue-time baseline (the stored IP/UA family is not re-anchored to the drifted client), so a persistent drift keeps showing until the client genuinely returns to its issuing subnet/family. |
+| `strict` | Renewal is **rejected** on drift, the offending device row is **hard-revoked** in the same transaction, and the session is destroyed and the device cookie cleared on every code path (`requireAuth`, `hasValidSession`, `/api/auth/refresh`), forcing a fresh login. |
 
 "Drift" means either:
 
 - **IP subnet change** — compared at **/24 for IPv4** and **/48 for IPv6**, deliberately coarse so mobile NAT and carrier IP churn within a network do not trip the binding. Full-IP comparison is intentionally *not* used.
 - **UA-family mismatch** — the User-Agent is reduced to a coarse `browser/os` family (e.g. `chrome/macos`), dropping version numbers so routine browser auto-updates don't force a re-login. A cookie replayed from a different browser or OS is caught.
+
+> **Caveat:** UA-family binding only catches *accidental* cross-browser cookie copy (e.g. a token pasted into a different browser). A deliberate attacker can trivially set the victim's User-Agent header, so this is a defence-in-depth signal, not a primary control — the IP-subnet check and the short session TTL carry the real weight.
 
 **UA family** is stored in the `ua_family` column. Rows issued before this feature have `ua_family = NULL`; a NULL family is **never** treated as a mismatch — the current family is backfilled on the next renewal. This keeps existing trusted devices working when an operator first enables binding.
 

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -32,6 +32,7 @@ server:
   secret: ""                          # optional YAML override — see passphrase source priority below
   allowed_origins: []                 # empty = same-origin only
   trust_proxy: false                  # set true when behind nginx/Caddy
+  device_binding: off                 # off | warn | strict — bind trusted-device cookie to IP subnet + UA family
 ```
 
 ### Passphrase source priority
@@ -224,23 +225,43 @@ Managed by `dbSessionStore` in [sessions_db.go](../../pkg/webui/sessions_db.go).
 2. Compute `sha256(raw)` → store only the hash in the `sessions` table
 3. Return raw token to be placed in the `dicode_device` cookie
 
-**Renewal** (`renewFromDevice(ctx, rawDeviceToken, ip string)`):
+**Renewal** (`renewFromDevice(ctx, rawDeviceToken, ip, userAgent, mode string)`):
 
 1. Hash the incoming cookie value
 2. Open a **database transaction**
 3. Query for a matching, non-expired `device` row
 4. If not found → return `("", false)`
-5. If found and `age < deviceRotateAfter` (24h) → update `last_seen` + `ip`, commit
-6. If found and `age ≥ deviceRotateAfter` → **rotate**:
+5. Evaluate device binding (`mode` = `server.device_binding`) — see below. In `strict` mode a drift takes the reject path (`("", false)`); in `warn` mode the drift reason is recorded on the row and a structured event is logged.
+6. If found and `age < deviceRotateAfter` (24h) → update `last_seen` + `ip` + `ua_family`, commit
+7. If found and `age ≥ deviceRotateAfter` → **rotate**:
    - Generate a new raw token
    - INSERT new row (new hash, new expiry, same label)
    - DELETE old row
    - Commit transaction
    - Return `(newRawToken, true)`
-7. Caller always generates a new in-memory session via `sessions.issue()` and sets it as the session cookie
-8. If `newRawToken != ""` (rotation occurred), caller also calls `setDeviceCookie(w, newRawToken)`
+8. Caller always generates a new in-memory session via `sessions.issue()` and sets it as the session cookie
+9. If `newRawToken != ""` (rotation occurred), caller also calls `setDeviceCookie(w, newRawToken)`
 
 The transaction ensures that even under concurrent logins, you never end up with both the old and new token simultaneously valid, and you never lose the device record mid-rotation.
+
+### Device binding (`server.device_binding`)
+
+A trusted-device cookie is a 30-day bearer credential. To limit the blast radius of a stolen cookie, the issuing **IP subnet** and **User-Agent family** are recorded and can be verified on each renewal:
+
+| Mode     | Behaviour |
+| -------- | --------- |
+| `off`    | Default. IP/UA are recorded but never verified — backward-compatible. |
+| `warn`   | Renewal is allowed even on drift, but the drift is flagged (`drift: true` + reason) on the `/security` device row and a structured `device.binding_drift` log event is emitted. |
+| `strict` | Renewal is **rejected** on drift; the session is destroyed and the device cookie cleared, forcing a fresh login. |
+
+"Drift" means either:
+
+- **IP subnet change** — compared at **/24 for IPv4** and **/48 for IPv6**, deliberately coarse so mobile NAT and carrier IP churn within a network do not trip the binding. Full-IP comparison is intentionally *not* used.
+- **UA-family mismatch** — the User-Agent is reduced to a coarse `browser/os` family (e.g. `chrome/macos`), dropping version numbers so routine browser auto-updates don't force a re-login. A cookie replayed from a different browser or OS is caught.
+
+**UA family** is stored in the `ua_family` column. Rows issued before this feature have `ua_family = NULL`; a NULL family is **never** treated as a mismatch — the current family is backfilled on the next renewal. This keeps existing trusted devices working when an operator first enables binding.
+
+The passphrase-rotation kill-switch (`pkg/webui/passphrase.go`) still revokes **all** device tokens, independent of binding mode.
 
 **Storage schema** (`sessions` table):
 
@@ -249,8 +270,10 @@ CREATE TABLE IF NOT EXISTS sessions (
     id         TEXT PRIMARY KEY,
     token_hash TEXT NOT NULL,          -- sha256(raw_token), never raw
     kind       TEXT NOT NULL,          -- 'device' (reserved: 'session' for future RBAC)
-    label      TEXT,                   -- truncated User-Agent (≤200 chars)
-    ip         TEXT,
+    label       TEXT,                  -- truncated User-Agent (≤200 chars)
+    ip          TEXT,
+    ua_family    TEXT,                  -- coarse browser/os family; NULL on legacy rows
+    drift_reason TEXT NOT NULL DEFAULT '', -- last warn-mode binding drift: '', 'ip', 'ua', 'ip+ua'
     created_at INTEGER NOT NULL,
     last_seen  INTEGER NOT NULL,
     expires_at INTEGER NOT NULL
@@ -541,6 +564,7 @@ All security-relevant fields in `ServerConfig`:
 | `trust_proxy` | bool | `false` | Trust `X-Forwarded-For` (set when behind a reverse proxy) |
 | `mcp` | bool | `true` | Expose MCP endpoint at `/mcp` |
 | `bcrypt_cost` | int | `12` | bcrypt work factor for the stored passphrase hash; valid range 4–14 |
+| `device_binding` | string | `off` | Bind trusted-device cookie to issuing IP subnet (/24, /48) + UA family. `off` \| `warn` \| `strict` |
 
 ---
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -241,6 +241,13 @@ type ServerConfig struct {
 	// (e.g. Raspberry Pi Zero) where the default ~300ms login is too slow.
 	// Values outside 4–14 are rejected by validate.
 	BcryptCost int `yaml:"bcrypt_cost,omitempty"`
+	// DeviceBinding controls how strictly a trusted-device cookie is bound to
+	// the IP subnet and User-Agent family it was issued for. One of:
+	//   "off"    — record IP/UA but never verify them (default, backward compatible)
+	//   "warn"   — allow renewal on drift, but flag it on /security
+	//   "strict" — reject renewal when the IP subnet or UA family drifts
+	// Empty resolves to "off" in applyDefaults; validate rejects other values.
+	DeviceBinding string `yaml:"device_binding,omitempty"`
 }
 
 // Load reads and parses the config file at path, then applies defaults.
@@ -388,6 +395,11 @@ func applyDefaults(cfg *Config, configDir string) {
 	if cfg.Server.BcryptCost == 0 {
 		cfg.Server.BcryptCost = 12
 	}
+	// Device binding defaults to off so existing deployments keep their
+	// current trusted-device behaviour until an operator opts in.
+	if cfg.Server.DeviceBinding == "" {
+		cfg.Server.DeviceBinding = "off"
+	}
 	// Default secret providers if none configured
 	if len(cfg.Secrets.Providers) == 0 {
 		cfg.Secrets.Providers = []SecretProviderConfig{
@@ -483,6 +495,11 @@ func (cfg *Config) validate() error {
 	// mid-attempt timeout) by setting 20 "to be safe".
 	if cfg.Server.BcryptCost != 0 && (cfg.Server.BcryptCost < 4 || cfg.Server.BcryptCost > 14) {
 		return fmt.Errorf("server.bcrypt_cost: must be between 4 and 14, got %d", cfg.Server.BcryptCost)
+	}
+	switch cfg.Server.DeviceBinding {
+	case "", "off", "warn", "strict":
+	default:
+		return fmt.Errorf("server.device_binding: must be one of off, warn, strict, got %q", cfg.Server.DeviceBinding)
 	}
 	if err := cfg.Defaults.OnFailureChain.ValidateAtDefaults(); err != nil {
 		return fmt.Errorf("defaults.on_failure_chain: %w", err)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -217,6 +217,83 @@ spec:
 	}
 }
 
+// TestLoad_DeviceBindingDefault ensures server.device_binding defaults to "off"
+// when omitted, preserving the pre-#132 trusted-device behaviour.
+func TestLoad_DeviceBindingDefault(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+
+	content := `
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Server.DeviceBinding != "off" {
+		t.Errorf("DeviceBinding default = %q, want %q", cfg.Server.DeviceBinding, "off")
+	}
+}
+
+// TestLoad_DeviceBindingOverride checks that warn/strict survive the round-trip.
+func TestLoad_DeviceBindingOverride(t *testing.T) {
+	for _, mode := range []string{"warn", "strict", "off"} {
+		t.Run(mode, func(t *testing.T) {
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "dicode.yaml")
+			content := fmt.Sprintf(`
+server:
+  device_binding: %s
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
+`, mode)
+			if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := Load(cfgPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.Server.DeviceBinding != mode {
+				t.Errorf("DeviceBinding = %q, want %q", cfg.Server.DeviceBinding, mode)
+			}
+		})
+	}
+}
+
+// TestLoad_DeviceBindingInvalid rejects unknown modes at Load() time.
+func TestLoad_DeviceBindingInvalid(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+	content := `
+server:
+  device_binding: paranoid
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(cfgPath); err == nil {
+		t.Fatal("expected error for invalid device_binding, got nil")
+	} else if !strings.Contains(err.Error(), "device_binding") {
+		t.Errorf("error = %v, want mention of device_binding", err)
+	}
+}
+
 // TestResolvedBrokerURL_Override exercises the explicit RelayConfig.BrokerURL
 // path: when set it wins over any derivation from ServerURL.
 func TestResolvedBrokerURL_Override(t *testing.T) {

--- a/pkg/db/sqlite.go
+++ b/pkg/db/sqlite.go
@@ -176,7 +176,7 @@ func (s *SQLiteDB) migrate() error {
 		}
 	}
 
-	// ua_family on trusted-device rows (#132). Nullable on purpose: rows issued
+	// ua_family on trusted-device rows. Nullable on purpose: rows issued
 	// before this migration have no recorded UA family and must not be treated
 	// as a mismatch — see renewFromDevice for the NULL-is-not-drift handling.
 	if err := addColumnIfMissing(ctx, s.db, "sessions", "ua_family", "TEXT"); err != nil {

--- a/pkg/db/sqlite.go
+++ b/pkg/db/sqlite.go
@@ -126,6 +126,8 @@ func (s *SQLiteDB) migrate() error {
 			kind        TEXT NOT NULL CHECK(kind IN ('session','device')),
 			label       TEXT NOT NULL DEFAULT '',
 			ip          TEXT NOT NULL DEFAULT '',
+			ua_family   TEXT,
+			drift_reason TEXT NOT NULL DEFAULT '',
 			created_at  INTEGER NOT NULL,
 			last_seen   INTEGER NOT NULL,
 			expires_at  INTEGER NOT NULL
@@ -172,6 +174,19 @@ func (s *SQLiteDB) migrate() error {
 		if err := addColumnIfMissing(ctx, s.db, "runs", m.name, m.ddl); err != nil {
 			return fmt.Errorf("migrate runs.%s: %w", m.name, err)
 		}
+	}
+
+	// ua_family on trusted-device rows (#132). Nullable on purpose: rows issued
+	// before this migration have no recorded UA family and must not be treated
+	// as a mismatch — see renewFromDevice for the NULL-is-not-drift handling.
+	if err := addColumnIfMissing(ctx, s.db, "sessions", "ua_family", "TEXT"); err != nil {
+		return fmt.Errorf("migrate sessions.ua_family: %w", err)
+	}
+	// drift_reason records the last observed device-binding drift ("ip", "ua",
+	// "ip+ua") for warn mode so /security can surface it. Empty string means no
+	// drift seen on this row.
+	if err := addColumnIfMissing(ctx, s.db, "sessions", "drift_reason", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		return fmt.Errorf("migrate sessions.drift_reason: %w", err)
 	}
 
 	// scs_sessions — SQLite-backed store for alexedwards/scs/v2 session

--- a/pkg/webui/auth.go
+++ b/pkg/webui/auth.go
@@ -110,7 +110,7 @@ func (s *Server) hasValidSession(r *http.Request) bool {
 	}
 	if s.dbSessions != nil {
 		if dc, err := r.Cookie(deviceCookie); err == nil {
-			_, ok := s.dbSessions.renewFromDevice(r.Context(), dc.Value, clientIP(r, s.cfg.Server.TrustProxy))
+			_, ok := s.dbSessions.renewFromDevice(r.Context(), dc.Value, clientIP(r, s.cfg.Server.TrustProxy), r.Header.Get("User-Agent"), s.cfg.Server.DeviceBinding)
 			return ok
 		}
 	}
@@ -165,7 +165,7 @@ func (s *Server) requireAuth(next http.Handler) http.Handler {
 
 		// Session missing or expired — try device token for auto-renewal.
 		if dc, err := r.Cookie(deviceCookie); err == nil {
-			if newDevToken, ok := s.dbSessions.renewFromDevice(r.Context(), dc.Value, clientIP(r, s.cfg.Server.TrustProxy)); ok {
+			if newDevToken, ok := s.dbSessions.renewFromDevice(r.Context(), dc.Value, clientIP(r, s.cfg.Server.TrustProxy), r.Header.Get("User-Agent"), s.cfg.Server.DeviceBinding); ok {
 				s.sm.Put(r.Context(), "authenticated", true)
 				if newDevToken != "" {
 					setDeviceCookie(w, newDevToken)

--- a/pkg/webui/auth.go
+++ b/pkg/webui/auth.go
@@ -293,7 +293,12 @@ func clientIP(r *http.Request, trustProxy bool) string {
 			if idx := strings.Index(fwd, ","); idx != -1 {
 				first = fwd[:idx]
 			}
-			return normalizeIP(strings.TrimSpace(first))
+			// A leftmost token that normalizes to "" (e.g. a client-supplied
+			// "[]") must not erase the client IP — fall back to RemoteAddr so
+			// callers (rate-limiter, device binding) always get a bound value.
+			if ip := normalizeIP(strings.TrimSpace(first)); ip != "" {
+				return ip
+			}
 		}
 	}
 	return normalizeIP(r.RemoteAddr)

--- a/pkg/webui/auth.go
+++ b/pkg/webui/auth.go
@@ -1,6 +1,7 @@
 package webui
 
 import (
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -56,7 +57,7 @@ func (s *Server) webhookAuthGuard(w http.ResponseWriter, r *http.Request, next h
 	}
 
 	// Task requires a valid dicode session.
-	if s.hasValidSession(r) {
+	if s.hasValidSession(w, r) {
 		next.ServeHTTP(w, r)
 		return
 	}
@@ -103,14 +104,19 @@ func isSafeNextPath(next string) bool {
 }
 
 // hasValidSession returns true if the request carries a valid scs session
-// or a device token that can be auto-renewed.
-func (s *Server) hasValidSession(r *http.Request) bool {
+// or a device token that can be auto-renewed. On a strict-drift reject the
+// offending device row is hard-revoked inside renewFromDevice; w lets this path
+// clear the now-dead device cookie so the browser stops replaying it.
+func (s *Server) hasValidSession(w http.ResponseWriter, r *http.Request) bool {
 	if s.sm.GetBool(r.Context(), "authenticated") {
 		return true
 	}
 	if s.dbSessions != nil {
 		if dc, err := r.Cookie(deviceCookie); err == nil {
-			_, ok := s.dbSessions.renewFromDevice(r.Context(), dc.Value, clientIP(r, s.cfg.Server.TrustProxy), r.Header.Get("User-Agent"), s.cfg.Server.DeviceBinding)
+			_, ok, driftReject := s.dbSessions.renewFromDevice(r.Context(), dc.Value, clientIP(r, s.cfg.Server.TrustProxy), r.Header.Get("User-Agent"), s.cfg.Server.DeviceBinding)
+			if !ok && driftReject {
+				clearDeviceCookie(w)
+			}
 			return ok
 		}
 	}
@@ -130,7 +136,7 @@ func (s *Server) requireSessionOrAPIKey(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
-		if s.hasValidSession(r) {
+		if s.hasValidSession(w, r) {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -165,13 +171,19 @@ func (s *Server) requireAuth(next http.Handler) http.Handler {
 
 		// Session missing or expired — try device token for auto-renewal.
 		if dc, err := r.Cookie(deviceCookie); err == nil {
-			if newDevToken, ok := s.dbSessions.renewFromDevice(r.Context(), dc.Value, clientIP(r, s.cfg.Server.TrustProxy), r.Header.Get("User-Agent"), s.cfg.Server.DeviceBinding); ok {
+			newDevToken, ok, driftReject := s.dbSessions.renewFromDevice(r.Context(), dc.Value, clientIP(r, s.cfg.Server.TrustProxy), r.Header.Get("User-Agent"), s.cfg.Server.DeviceBinding)
+			if ok {
 				s.sm.Put(r.Context(), "authenticated", true)
 				if newDevToken != "" {
 					setDeviceCookie(w, newDevToken)
 				}
 				next.ServeHTTP(w, r)
 				return
+			}
+			// A strict-drift reject already hard-revoked the row; clear the now-
+			// dead cookie so the browser stops replaying it.
+			if driftReject {
+				clearDeviceCookie(w)
 			}
 		}
 
@@ -271,25 +283,34 @@ func isAPIRequest(r *http.Request) bool {
 
 // clientIP extracts the real client IP. X-Forwarded-For is only trusted when
 // trustProxy is true (i.e. server.trust_proxy: true in config), so that direct
-// clients cannot spoof their IP and bypass rate limiting.
+// clients cannot spoof their IP and bypass rate limiting. The returned value is
+// a bare address (no port, no IPv6 brackets) so it parses with netip.ParseAddr
+// for subnet binding.
 func clientIP(r *http.Request, trustProxy bool) string {
 	if trustProxy {
 		if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
+			first := fwd
 			if idx := strings.Index(fwd, ","); idx != -1 {
-				return strings.TrimSpace(fwd[:idx])
+				first = fwd[:idx]
 			}
-			return strings.TrimSpace(fwd)
+			return normalizeIP(strings.TrimSpace(first))
 		}
 	}
-	ip, _, _ := splitHostPort(r.RemoteAddr)
-	return ip
+	return normalizeIP(r.RemoteAddr)
 }
 
-// splitHostPort is a nil-safe wrapper around net.SplitHostPort.
-func splitHostPort(hostport string) (host, port string, err error) {
-	// Fast path: avoid importing net just for this.
-	if i := strings.LastIndex(hostport, ":"); i >= 0 {
-		return hostport[:i], hostport[i+1:], nil
+// normalizeIP strips any port and IPv6 brackets so the result is a bare address
+// that netip.ParseAddr accepts. Inputs may be "host:port", "[v6]:port", "[v6]",
+// or a bare address; anything unparseable is returned trimmed of brackets.
+func normalizeIP(s string) string {
+	if s == "" {
+		return ""
 	}
-	return hostport, "", nil
+	if host, _, err := net.SplitHostPort(s); err == nil {
+		return host // SplitHostPort already strips IPv6 brackets
+	}
+	// No port present: drop surrounding brackets on a bare IPv6 literal.
+	s = strings.TrimPrefix(s, "[")
+	s = strings.TrimSuffix(s, "]")
+	return s
 }

--- a/pkg/webui/auth_test.go
+++ b/pkg/webui/auth_test.go
@@ -489,7 +489,7 @@ func TestAuth_DeviceToken_Rotation(t *testing.T) {
 		t.Fatalf("insert: %v", err)
 	}
 
-	newDevToken, ok := store.renewFromDevice(ctx, raw, "127.0.0.1", "", "off")
+	newDevToken, ok, _ := store.renewFromDevice(ctx, raw, "127.0.0.1", "", "off")
 	if !ok {
 		t.Fatal("renewFromDevice returned not-ok for valid token")
 	}
@@ -501,13 +501,13 @@ func TestAuth_DeviceToken_Rotation(t *testing.T) {
 	}
 
 	// Old token must now be rejected.
-	_, ok2 := store.renewFromDevice(ctx, raw, "127.0.0.1", "", "off")
+	_, ok2, _ := store.renewFromDevice(ctx, raw, "127.0.0.1", "", "off")
 	if ok2 {
 		t.Error("old device token should be rejected after rotation")
 	}
 
 	// New token must be accepted.
-	_, ok3 := store.renewFromDevice(ctx, newDevToken, "127.0.0.1", "", "off")
+	_, ok3, _ := store.renewFromDevice(ctx, newDevToken, "127.0.0.1", "", "off")
 	if !ok3 {
 		t.Error("new rotated device token should be accepted")
 	}

--- a/pkg/webui/auth_test.go
+++ b/pkg/webui/auth_test.go
@@ -470,7 +470,7 @@ func TestAuth_DeviceToken_Rotation(t *testing.T) {
 	}
 	defer d.Close()
 
-	store := newDBSessionStore(d)
+	store := newDBSessionStore(d, nil)
 	ctx := t.Context()
 
 	// Issue a device token with a created_at far enough in the past to trigger rotation.
@@ -489,7 +489,7 @@ func TestAuth_DeviceToken_Rotation(t *testing.T) {
 		t.Fatalf("insert: %v", err)
 	}
 
-	newDevToken, ok := store.renewFromDevice(ctx, raw, "127.0.0.1")
+	newDevToken, ok := store.renewFromDevice(ctx, raw, "127.0.0.1", "", "off")
 	if !ok {
 		t.Fatal("renewFromDevice returned not-ok for valid token")
 	}
@@ -501,13 +501,13 @@ func TestAuth_DeviceToken_Rotation(t *testing.T) {
 	}
 
 	// Old token must now be rejected.
-	_, ok2 := store.renewFromDevice(ctx, raw, "127.0.0.1")
+	_, ok2 := store.renewFromDevice(ctx, raw, "127.0.0.1", "", "off")
 	if ok2 {
 		t.Error("old device token should be rejected after rotation")
 	}
 
 	// New token must be accepted.
-	_, ok3 := store.renewFromDevice(ctx, newDevToken, "127.0.0.1")
+	_, ok3 := store.renewFromDevice(ctx, newDevToken, "127.0.0.1", "", "off")
 	if !ok3 {
 		t.Error("new rotated device token should be accepted")
 	}

--- a/pkg/webui/device_binding_test.go
+++ b/pkg/webui/device_binding_test.go
@@ -71,7 +71,7 @@ func TestDeviceBinding_StrictCrossSubnetRejected(t *testing.T) {
 	if !driftReject {
 		t.Fatal("strict cross-subnet reject should set driftReject=true")
 	}
-	// H1: the offending row must be hard-revoked, not left replayable.
+	// The offending row must be hard-revoked, not left replayable.
 	devices, _ := store.listDevices(ctx)
 	if len(devices) != 0 {
 		t.Fatalf("strict drift must delete the device row, got %d rows", len(devices))
@@ -133,7 +133,7 @@ func TestDeviceBinding_WarnUAFamilyDriftFlagged(t *testing.T) {
 	}
 }
 
-// M3: warn-mode drift is sticky against the issue-time anchor. A renewal that is
+// Warn-mode drift is sticky against the issue-time anchor. A renewal that is
 // still off the issuing subnet keeps the flag; only a genuine return to the
 // issuing subnet clears it.
 func TestDeviceBinding_WarnDriftStickyUntilReturnToBaseline(t *testing.T) {
@@ -212,7 +212,7 @@ func TestDeviceBinding_StrictIPv6Subnet(t *testing.T) {
 	}
 }
 
-// H2: drive the IP through the real clientIP path. A bracketed IPv6 RemoteAddr
+// Drive the IP through the real clientIP path. A bracketed IPv6 RemoteAddr
 // (host:port form, "[2001:db8::1]:443") must be normalized to a bare address so
 // sameSubnet's /48 mask applies — otherwise IPv6 silently degrades to exact
 // string compare and RFC 4941 privacy-address clients re-login constantly.
@@ -240,7 +240,7 @@ func TestDeviceBinding_StrictIPv6ThroughClientIP(t *testing.T) {
 	}
 }
 
-// M1: an IPv4-mapped IPv6 address (::ffff:a.b.c.d) and the native IPv4 form of
+// An IPv4-mapped IPv6 address (::ffff:a.b.c.d) and the native IPv4 form of
 // the same /24 must compare equal, not be rejected as a family mismatch.
 func TestSameSubnet_IPv4MappedIPv6(t *testing.T) {
 	if !sameSubnet("::ffff:203.0.113.10", "203.0.113.99") {
@@ -248,6 +248,93 @@ func TestSameSubnet_IPv4MappedIPv6(t *testing.T) {
 	}
 	if sameSubnet("::ffff:203.0.113.10", "203.0.114.10") {
 		t.Error("IPv4-mapped IPv6 across /24 boundary should not match")
+	}
+}
+
+// Strict mode must fail closed when the row has a recorded IP but the incoming
+// IP normalizes to empty (e.g. a crafted X-Forwarded-For token that yields "").
+// An empty current IP is treated as drift, not "no IP signal", so it cannot
+// silently disable the subnet binding.
+func TestDeviceBinding_StrictEmptyCurrentIPRejected(t *testing.T) {
+	store, d := newTestStore(t)
+	ctx := context.Background()
+
+	raw := issueRow(t, d, "203.0.113.10", strptr(uaFamily(chromeMac)), fresh)
+	if _, ok, driftReject := store.renewFromDevice(ctx, raw, "", chromeMac, bindingStrict); ok || !driftReject {
+		t.Fatalf("strict mode must reject an empty current IP against a recorded IP, got ok=%v driftReject=%v", ok, driftReject)
+	}
+
+	// Warn mode must not flag an empty current IP (transient missing signal),
+	// and the renewal proceeds without setting a drift reason.
+	raw2 := issueRow(t, d, "203.0.113.10", strptr(uaFamily(chromeMac)), fresh)
+	if _, ok, _ := store.renewFromDevice(ctx, raw2, "", chromeMac, bindingWarn); !ok {
+		t.Fatal("warn mode rejected an empty-IP renewal; should allow")
+	}
+	devices, _ := store.listDevices(ctx)
+	for _, dv := range devices {
+		if dv.Drift {
+			t.Errorf("warn mode should not flag an empty current IP, got %+v", dv)
+		}
+	}
+}
+
+// Strict mode must fail closed when the row has a recorded ua_family but the
+// incoming request carries no User-Agent (curFam == ""). A row with NO recorded
+// family (legacy NULL) must still not drift on the UA axis.
+func TestDeviceBinding_StrictEmptyUAWithRecordedFamilyRejected(t *testing.T) {
+	store, d := newTestStore(t)
+	ctx := context.Background()
+
+	raw := issueRow(t, d, "203.0.113.10", strptr(uaFamily(chromeMac)), fresh)
+	if _, ok, driftReject := store.renewFromDevice(ctx, raw, "203.0.113.10", "", bindingStrict); ok || !driftReject {
+		t.Fatalf("strict mode must reject an empty UA against a recorded ua_family, got ok=%v driftReject=%v", ok, driftReject)
+	}
+
+	// Legacy NULL ua_family row: an empty UA is not drift even in strict mode.
+	rawLegacy := issueRow(t, d, "203.0.113.10", nil, fresh)
+	if _, ok, _ := store.renewFromDevice(ctx, rawLegacy, "203.0.113.10", "", bindingStrict); !ok {
+		t.Fatal("strict mode rejected an empty UA on a legacy NULL-ua_family row")
+	}
+}
+
+// Sticky warn-mode drift must survive a rotation: when the device row is old
+// enough to rotate (createdAgo >= deviceRotateAfter) and renews from a drifted
+// subnet under warn, the freshly INSERTed row keeps Drift=true with the baseline
+// IP pinned (not re-baselined to the drifted client).
+func TestDeviceBinding_WarnDriftStickyThroughRotation(t *testing.T) {
+	store, d := newTestStore(t)
+	ctx := context.Background()
+
+	// Old enough to trigger the rotate branch.
+	raw := issueRow(t, d, "203.0.113.10", strptr(uaFamily(chromeMac)), deviceRotateAfter+time.Hour)
+	newToken, ok, _ := store.renewFromDevice(ctx, raw, "198.51.100.10", chromeMac, bindingWarn)
+	if !ok {
+		t.Fatal("warn drift renewal through rotation rejected")
+	}
+	if newToken == "" {
+		t.Fatal("expected a rotated device token (old row should rotate)")
+	}
+
+	devices, _ := store.listDevices(ctx)
+	if len(devices) != 1 {
+		t.Fatalf("expected 1 device after rotation, got %d", len(devices))
+	}
+	if !devices[0].Drift || devices[0].DriftReason != "ip" {
+		t.Errorf("rotated row should keep ip drift flag, got %+v", devices[0])
+	}
+	// Baseline IP must stay pinned to the issuing /24, not the drifted client.
+	if !sameSubnet(devices[0].IP, "203.0.113.10") {
+		t.Errorf("rotated row baseline IP re-anchored to drifted client: %q", devices[0].IP)
+	}
+
+	// The rotated token still drifting from another off-baseline subnet stays
+	// flagged (the anchor did not move to 198.51.100.x).
+	if _, ok, _ := store.renewFromDevice(ctx, newToken, "198.51.100.20", chromeMac, bindingWarn); !ok {
+		t.Fatal("post-rotation warn renewal rejected")
+	}
+	devices, _ = store.listDevices(ctx)
+	if len(devices) != 1 || !devices[0].Drift {
+		t.Errorf("drift flag should stay set while still off the issuing subnet after rotation, got %+v", devices)
 	}
 }
 

--- a/pkg/webui/device_binding_test.go
+++ b/pkg/webui/device_binding_test.go
@@ -1,0 +1,226 @@
+package webui
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+)
+
+// issueRow inserts a device token directly so tests control created_at, ip and
+// ua_family. Returns the raw token to present on renewal.
+func issueRow(t *testing.T, d db.DB, ip string, fam *string, createdAgo time.Duration) string {
+	t.Helper()
+	raw, err := randomToken()
+	if err != nil {
+		t.Fatalf("randomToken: %v", err)
+	}
+	created := time.Now().Add(-createdAgo).Unix()
+	exp := time.Now().Add(deviceTTL).Unix()
+	if err := d.Exec(context.Background(),
+		`INSERT INTO sessions (id, token_hash, kind, label, ip, ua_family, created_at, last_seen, expires_at)
+		 VALUES (?, ?, 'device', 'test', ?, ?, ?, ?, ?)`,
+		"id-"+raw[:8], hashToken(raw), ip, fam, created, created, exp,
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	return raw
+}
+
+func strptr(s string) *string { return &s }
+
+func newTestStore(t *testing.T) (*dbSessionStore, db.DB) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return newDBSessionStore(d, nil), d
+}
+
+const chromeMac = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+const firefoxMac = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:126.0) Gecko/20100101 Firefox/126.0"
+
+// Within-rotation-window: no new token, just last_seen refresh.
+const fresh = time.Minute
+
+func TestDeviceBinding_StrictSameSubnetPasses(t *testing.T) {
+	store, d := newTestStore(t)
+	ctx := context.Background()
+
+	raw := issueRow(t, d, "203.0.113.10", strptr(uaFamily(chromeMac)), fresh)
+	// Same /24, different host octet.
+	_, ok := store.renewFromDevice(ctx, raw, "203.0.113.99", chromeMac, bindingStrict)
+	if !ok {
+		t.Fatal("strict mode rejected a same-/24 renewal")
+	}
+}
+
+func TestDeviceBinding_StrictCrossSubnetRejected(t *testing.T) {
+	store, d := newTestStore(t)
+	ctx := context.Background()
+
+	raw := issueRow(t, d, "203.0.113.10", strptr(uaFamily(chromeMac)), fresh)
+	_, ok := store.renewFromDevice(ctx, raw, "198.51.100.10", chromeMac, bindingStrict)
+	if ok {
+		t.Fatal("strict mode allowed a cross-/24 renewal")
+	}
+}
+
+func TestDeviceBinding_StrictUAFamilyMismatchRejected(t *testing.T) {
+	store, d := newTestStore(t)
+	ctx := context.Background()
+
+	raw := issueRow(t, d, "203.0.113.10", strptr(uaFamily(chromeMac)), fresh)
+	_, ok := store.renewFromDevice(ctx, raw, "203.0.113.10", firefoxMac, bindingStrict)
+	if ok {
+		t.Fatal("strict mode allowed a UA-family mismatch")
+	}
+}
+
+func TestDeviceBinding_WarnCrossSubnetAllowedAndFlagged(t *testing.T) {
+	store, d := newTestStore(t)
+	ctx := context.Background()
+
+	raw := issueRow(t, d, "203.0.113.10", strptr(uaFamily(chromeMac)), fresh)
+	_, ok := store.renewFromDevice(ctx, raw, "198.51.100.10", chromeMac, bindingWarn)
+	if !ok {
+		t.Fatal("warn mode rejected a renewal; should allow")
+	}
+	devices, err := store.listDevices(ctx)
+	if err != nil {
+		t.Fatalf("listDevices: %v", err)
+	}
+	if len(devices) != 1 {
+		t.Fatalf("expected 1 device, got %d", len(devices))
+	}
+	if !devices[0].Drift || devices[0].DriftReason != "ip" {
+		t.Errorf("expected ip drift flag, got drift=%v reason=%q", devices[0].Drift, devices[0].DriftReason)
+	}
+}
+
+func TestDeviceBinding_WarnUAFamilyDriftFlagged(t *testing.T) {
+	store, d := newTestStore(t)
+	ctx := context.Background()
+
+	raw := issueRow(t, d, "203.0.113.10", strptr(uaFamily(chromeMac)), fresh)
+	_, ok := store.renewFromDevice(ctx, raw, "203.0.113.10", firefoxMac, bindingWarn)
+	if !ok {
+		t.Fatal("warn mode rejected a UA-drift renewal; should allow")
+	}
+	devices, _ := store.listDevices(ctx)
+	if len(devices) != 1 || devices[0].DriftReason != "ua" {
+		t.Fatalf("expected ua drift, got %+v", devices)
+	}
+}
+
+func TestDeviceBinding_WarnCleanRenewalClearsFlag(t *testing.T) {
+	store, d := newTestStore(t)
+	ctx := context.Background()
+
+	raw := issueRow(t, d, "203.0.113.10", strptr(uaFamily(chromeMac)), fresh)
+	// Drift once.
+	store.renewFromDevice(ctx, raw, "198.51.100.10", chromeMac, bindingWarn)
+	// Clean renewal from a same-subnet-as-last IP. last_seen ip is now 198.51.100.10.
+	if _, ok := store.renewFromDevice(ctx, raw, "198.51.100.20", chromeMac, bindingWarn); !ok {
+		t.Fatal("clean renewal rejected")
+	}
+	devices, _ := store.listDevices(ctx)
+	if len(devices) != 1 || devices[0].Drift {
+		t.Errorf("drift flag should be cleared after clean renewal, got %+v", devices)
+	}
+}
+
+// Off mode never rejects and never flags, even on a hard IP+UA change.
+func TestDeviceBinding_OffNeverEnforces(t *testing.T) {
+	store, d := newTestStore(t)
+	ctx := context.Background()
+
+	raw := issueRow(t, d, "203.0.113.10", strptr(uaFamily(chromeMac)), fresh)
+	_, ok := store.renewFromDevice(ctx, raw, "198.51.100.10", firefoxMac, bindingOff)
+	if !ok {
+		t.Fatal("off mode rejected a renewal")
+	}
+	devices, _ := store.listDevices(ctx)
+	if len(devices) != 1 || devices[0].Drift {
+		t.Errorf("off mode should not flag drift, got %+v", devices)
+	}
+}
+
+// A legacy row with NULL ua_family must not be treated as a UA mismatch; the
+// current family is backfilled on renewal.
+func TestDeviceBinding_NullUAFamilyNotDrift(t *testing.T) {
+	store, d := newTestStore(t)
+	ctx := context.Background()
+
+	raw := issueRow(t, d, "203.0.113.10", nil, fresh)
+	if _, ok := store.renewFromDevice(ctx, raw, "203.0.113.10", firefoxMac, bindingStrict); !ok {
+		t.Fatal("strict mode rejected a NULL-ua_family (legacy) row")
+	}
+	// Family is now backfilled — a subsequent mismatch must be caught.
+	if _, ok := store.renewFromDevice(ctx, raw, "203.0.113.10", chromeMac, bindingStrict); ok {
+		t.Fatal("strict mode allowed a mismatch after ua_family backfill")
+	}
+}
+
+// IPv6 binding granularity is /48: same /48 passes, different /48 rejected.
+func TestDeviceBinding_StrictIPv6Subnet(t *testing.T) {
+	store, d := newTestStore(t)
+	ctx := context.Background()
+
+	raw := issueRow(t, d, "2001:db8:abcd:1::1", strptr(uaFamily(chromeMac)), fresh)
+	if _, ok := store.renewFromDevice(ctx, raw, "2001:db8:abcd:9::42", chromeMac, bindingStrict); !ok {
+		t.Fatal("strict mode rejected a same-/48 IPv6 renewal")
+	}
+	raw2 := issueRow(t, d, "2001:db8:abcd:1::1", strptr(uaFamily(chromeMac)), fresh)
+	if _, ok := store.renewFromDevice(ctx, raw2, "2001:db8:ffff:1::1", chromeMac, bindingStrict); ok {
+		t.Fatal("strict mode allowed a cross-/48 IPv6 renewal")
+	}
+}
+
+func TestUAFamily(t *testing.T) {
+	cases := []struct {
+		ua   string
+		want string
+	}{
+		{chromeMac, "chrome/macos"},
+		{firefoxMac, "firefox/macos"},
+		{"Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0", "chrome/windows"},
+		{"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Safari/604.1", "safari/ios"},
+		{"Mozilla/5.0 (Linux; Android 14) Chrome/120.0 Mobile", "chrome/android"},
+		{"Mozilla/5.0 (Windows NT 10.0) Edg/120.0", "edge/windows"},
+		{"", ""},
+		{"curl/8.0", "other/other"},
+	}
+	for _, c := range cases {
+		if got := uaFamily(c.ua); got != c.want {
+			t.Errorf("uaFamily(%q) = %q, want %q", c.ua, got, c.want)
+		}
+	}
+	// Chrome version churn must not change the family.
+	if uaFamily(chromeMac) != uaFamily("Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0) Chrome/200.0 Safari/537.36") {
+		t.Error("uaFamily must be stable across Chrome version bumps")
+	}
+}
+
+func TestSameSubnet(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"203.0.113.1", "203.0.113.254", true},
+		{"203.0.113.1", "203.0.114.1", false},
+		{"2001:db8:abcd:1::1", "2001:db8:abcd:ffff::9", true},
+		{"2001:db8:abcd:1::1", "2001:db8:abce:1::1", false},
+		{"203.0.113.1", "2001:db8::1", false}, // mixed family
+		{"garbage", "garbage", true},          // unparseable falls back to equality
+		{"garbage", "other", false},
+	}
+	for _, c := range cases {
+		if got := sameSubnet(c.a, c.b); got != c.want {
+			t.Errorf("sameSubnet(%q,%q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}

--- a/pkg/webui/device_binding_test.go
+++ b/pkg/webui/device_binding_test.go
@@ -2,6 +2,7 @@ package webui
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 
@@ -52,7 +53,7 @@ func TestDeviceBinding_StrictSameSubnetPasses(t *testing.T) {
 
 	raw := issueRow(t, d, "203.0.113.10", strptr(uaFamily(chromeMac)), fresh)
 	// Same /24, different host octet.
-	_, ok := store.renewFromDevice(ctx, raw, "203.0.113.99", chromeMac, bindingStrict)
+	_, ok, _ := store.renewFromDevice(ctx, raw, "203.0.113.99", chromeMac, bindingStrict)
 	if !ok {
 		t.Fatal("strict mode rejected a same-/24 renewal")
 	}
@@ -63,9 +64,22 @@ func TestDeviceBinding_StrictCrossSubnetRejected(t *testing.T) {
 	ctx := context.Background()
 
 	raw := issueRow(t, d, "203.0.113.10", strptr(uaFamily(chromeMac)), fresh)
-	_, ok := store.renewFromDevice(ctx, raw, "198.51.100.10", chromeMac, bindingStrict)
+	_, ok, driftReject := store.renewFromDevice(ctx, raw, "198.51.100.10", chromeMac, bindingStrict)
 	if ok {
 		t.Fatal("strict mode allowed a cross-/24 renewal")
+	}
+	if !driftReject {
+		t.Fatal("strict cross-subnet reject should set driftReject=true")
+	}
+	// H1: the offending row must be hard-revoked, not left replayable.
+	devices, _ := store.listDevices(ctx)
+	if len(devices) != 0 {
+		t.Fatalf("strict drift must delete the device row, got %d rows", len(devices))
+	}
+	// Re-presenting the same cookie from the legit subnet must now also fail —
+	// the row is gone.
+	if _, ok2, _ := store.renewFromDevice(ctx, raw, "203.0.113.10", chromeMac, bindingStrict); ok2 {
+		t.Fatal("revoked device token still accepted after strict-drift reject")
 	}
 }
 
@@ -74,9 +88,12 @@ func TestDeviceBinding_StrictUAFamilyMismatchRejected(t *testing.T) {
 	ctx := context.Background()
 
 	raw := issueRow(t, d, "203.0.113.10", strptr(uaFamily(chromeMac)), fresh)
-	_, ok := store.renewFromDevice(ctx, raw, "203.0.113.10", firefoxMac, bindingStrict)
+	_, ok, driftReject := store.renewFromDevice(ctx, raw, "203.0.113.10", firefoxMac, bindingStrict)
 	if ok {
 		t.Fatal("strict mode allowed a UA-family mismatch")
+	}
+	if !driftReject {
+		t.Fatal("strict UA-mismatch reject should set driftReject=true")
 	}
 }
 
@@ -85,7 +102,7 @@ func TestDeviceBinding_WarnCrossSubnetAllowedAndFlagged(t *testing.T) {
 	ctx := context.Background()
 
 	raw := issueRow(t, d, "203.0.113.10", strptr(uaFamily(chromeMac)), fresh)
-	_, ok := store.renewFromDevice(ctx, raw, "198.51.100.10", chromeMac, bindingWarn)
+	_, ok, _ := store.renewFromDevice(ctx, raw, "198.51.100.10", chromeMac, bindingWarn)
 	if !ok {
 		t.Fatal("warn mode rejected a renewal; should allow")
 	}
@@ -106,7 +123,7 @@ func TestDeviceBinding_WarnUAFamilyDriftFlagged(t *testing.T) {
 	ctx := context.Background()
 
 	raw := issueRow(t, d, "203.0.113.10", strptr(uaFamily(chromeMac)), fresh)
-	_, ok := store.renewFromDevice(ctx, raw, "203.0.113.10", firefoxMac, bindingWarn)
+	_, ok, _ := store.renewFromDevice(ctx, raw, "203.0.113.10", firefoxMac, bindingWarn)
 	if !ok {
 		t.Fatal("warn mode rejected a UA-drift renewal; should allow")
 	}
@@ -116,20 +133,35 @@ func TestDeviceBinding_WarnUAFamilyDriftFlagged(t *testing.T) {
 	}
 }
 
-func TestDeviceBinding_WarnCleanRenewalClearsFlag(t *testing.T) {
+// M3: warn-mode drift is sticky against the issue-time anchor. A renewal that is
+// still off the issuing subnet keeps the flag; only a genuine return to the
+// issuing subnet clears it.
+func TestDeviceBinding_WarnDriftStickyUntilReturnToBaseline(t *testing.T) {
 	store, d := newTestStore(t)
 	ctx := context.Background()
 
 	raw := issueRow(t, d, "203.0.113.10", strptr(uaFamily(chromeMac)), fresh)
-	// Drift once.
-	store.renewFromDevice(ctx, raw, "198.51.100.10", chromeMac, bindingWarn)
-	// Clean renewal from a same-subnet-as-last IP. last_seen ip is now 198.51.100.10.
-	if _, ok := store.renewFromDevice(ctx, raw, "198.51.100.20", chromeMac, bindingWarn); !ok {
-		t.Fatal("clean renewal rejected")
+	// Drift away from the issuing /24.
+	if _, ok, _ := store.renewFromDevice(ctx, raw, "198.51.100.10", chromeMac, bindingWarn); !ok {
+		t.Fatal("warn drift renewal rejected")
+	}
+	// Still off the issuing subnet (different from issue IP). The baseline must
+	// not have re-anchored to 198.51.100.x, so this stays flagged.
+	if _, ok, _ := store.renewFromDevice(ctx, raw, "198.51.100.20", chromeMac, bindingWarn); !ok {
+		t.Fatal("warn renewal rejected")
 	}
 	devices, _ := store.listDevices(ctx)
+	if len(devices) != 1 || !devices[0].Drift {
+		t.Errorf("drift flag should stay set while still off the issuing subnet, got %+v", devices)
+	}
+
+	// Genuine return to the issuing /24 clears the flag.
+	if _, ok, _ := store.renewFromDevice(ctx, raw, "203.0.113.55", chromeMac, bindingWarn); !ok {
+		t.Fatal("return-to-baseline renewal rejected")
+	}
+	devices, _ = store.listDevices(ctx)
 	if len(devices) != 1 || devices[0].Drift {
-		t.Errorf("drift flag should be cleared after clean renewal, got %+v", devices)
+		t.Errorf("drift flag should clear on return to issuing subnet, got %+v", devices)
 	}
 }
 
@@ -139,7 +171,7 @@ func TestDeviceBinding_OffNeverEnforces(t *testing.T) {
 	ctx := context.Background()
 
 	raw := issueRow(t, d, "203.0.113.10", strptr(uaFamily(chromeMac)), fresh)
-	_, ok := store.renewFromDevice(ctx, raw, "198.51.100.10", firefoxMac, bindingOff)
+	_, ok, _ := store.renewFromDevice(ctx, raw, "198.51.100.10", firefoxMac, bindingOff)
 	if !ok {
 		t.Fatal("off mode rejected a renewal")
 	}
@@ -156,11 +188,11 @@ func TestDeviceBinding_NullUAFamilyNotDrift(t *testing.T) {
 	ctx := context.Background()
 
 	raw := issueRow(t, d, "203.0.113.10", nil, fresh)
-	if _, ok := store.renewFromDevice(ctx, raw, "203.0.113.10", firefoxMac, bindingStrict); !ok {
+	if _, ok, _ := store.renewFromDevice(ctx, raw, "203.0.113.10", firefoxMac, bindingStrict); !ok {
 		t.Fatal("strict mode rejected a NULL-ua_family (legacy) row")
 	}
 	// Family is now backfilled — a subsequent mismatch must be caught.
-	if _, ok := store.renewFromDevice(ctx, raw, "203.0.113.10", chromeMac, bindingStrict); ok {
+	if _, ok, _ := store.renewFromDevice(ctx, raw, "203.0.113.10", chromeMac, bindingStrict); ok {
 		t.Fatal("strict mode allowed a mismatch after ua_family backfill")
 	}
 }
@@ -171,12 +203,51 @@ func TestDeviceBinding_StrictIPv6Subnet(t *testing.T) {
 	ctx := context.Background()
 
 	raw := issueRow(t, d, "2001:db8:abcd:1::1", strptr(uaFamily(chromeMac)), fresh)
-	if _, ok := store.renewFromDevice(ctx, raw, "2001:db8:abcd:9::42", chromeMac, bindingStrict); !ok {
+	if _, ok, _ := store.renewFromDevice(ctx, raw, "2001:db8:abcd:9::42", chromeMac, bindingStrict); !ok {
 		t.Fatal("strict mode rejected a same-/48 IPv6 renewal")
 	}
 	raw2 := issueRow(t, d, "2001:db8:abcd:1::1", strptr(uaFamily(chromeMac)), fresh)
-	if _, ok := store.renewFromDevice(ctx, raw2, "2001:db8:ffff:1::1", chromeMac, bindingStrict); ok {
+	if _, ok, _ := store.renewFromDevice(ctx, raw2, "2001:db8:ffff:1::1", chromeMac, bindingStrict); ok {
 		t.Fatal("strict mode allowed a cross-/48 IPv6 renewal")
+	}
+}
+
+// H2: drive the IP through the real clientIP path. A bracketed IPv6 RemoteAddr
+// (host:port form, "[2001:db8::1]:443") must be normalized to a bare address so
+// sameSubnet's /48 mask applies — otherwise IPv6 silently degrades to exact
+// string compare and RFC 4941 privacy-address clients re-login constantly.
+func TestDeviceBinding_StrictIPv6ThroughClientIP(t *testing.T) {
+	store, d := newTestStore(t)
+	ctx := context.Background()
+
+	issueIP := clientIP(&http.Request{RemoteAddr: "[2001:db8:abcd:1::1]:51000"}, false)
+	if issueIP != "2001:db8:abcd:1::1" {
+		t.Fatalf("clientIP did not strip IPv6 brackets/port: got %q", issueIP)
+	}
+	raw := issueRow(t, d, issueIP, strptr(uaFamily(chromeMac)), fresh)
+
+	// Same /48, different lower bits and a fresh ephemeral port (RFC 4941 churn).
+	renewIP := clientIP(&http.Request{RemoteAddr: "[2001:db8:abcd:ffff::dead]:62000"}, false)
+	if _, ok, _ := store.renewFromDevice(ctx, raw, renewIP, chromeMac, bindingStrict); !ok {
+		t.Fatal("strict mode rejected a same-/48 IPv6 renewal via clientIP (bracket bug)")
+	}
+
+	// Trust-proxy XFF path with a bracketed IPv6 must normalize too.
+	r := &http.Request{RemoteAddr: "10.0.0.1:80", Header: http.Header{}}
+	r.Header.Set("X-Forwarded-For", "[2001:db8:abcd:2::9]:40000, 10.0.0.1")
+	if got := clientIP(r, true); got != "2001:db8:abcd:2::9" {
+		t.Fatalf("clientIP XFF did not normalize bracketed IPv6: got %q", got)
+	}
+}
+
+// M1: an IPv4-mapped IPv6 address (::ffff:a.b.c.d) and the native IPv4 form of
+// the same /24 must compare equal, not be rejected as a family mismatch.
+func TestSameSubnet_IPv4MappedIPv6(t *testing.T) {
+	if !sameSubnet("::ffff:203.0.113.10", "203.0.113.99") {
+		t.Error("IPv4-mapped IPv6 and native IPv4 in the same /24 should match")
+	}
+	if sameSubnet("::ffff:203.0.113.10", "203.0.114.10") {
+		t.Error("IPv4-mapped IPv6 across /24 boundary should not match")
 	}
 }
 

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -208,7 +208,7 @@ func New(port int, r *registry.Registry, eng *trigger.Engine, cfg *config.Config
 	var store *scsStore
 	var as *authoringSessionStore
 	if database != nil {
-		dbs = newDBSessionStore(database)
+		dbs = newDBSessionStore(database, log)
 		aks = newAPIKeyStore(database)
 		ps = newPassphraseStore(database)
 		store = sm.Store.(*scsStore)

--- a/pkg/webui/sessions_db.go
+++ b/pkg/webui/sessions_db.go
@@ -6,11 +6,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"net/http"
+	"net/netip"
 	"time"
 
 	"github.com/dicode/dicode/pkg/db"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"go.uber.org/zap"
 )
 
 const (
@@ -24,10 +26,16 @@ const (
 // survive server restarts. Short-lived browser sessions are managed by the
 // scs.SessionManager; this store handles only device tokens.
 type dbSessionStore struct {
-	db db.DB
+	db  db.DB
+	log *zap.Logger
 }
 
-func newDBSessionStore(d db.DB) *dbSessionStore { return &dbSessionStore{db: d} }
+func newDBSessionStore(d db.DB, log *zap.Logger) *dbSessionStore {
+	if log == nil {
+		log = zap.NewNop()
+	}
+	return &dbSessionStore{db: d, log: log}
+}
 
 // IssueDeviceToken generates a long-lived device token, stores its hash in the
 // DB, and returns the raw token to be placed in a cookie.
@@ -45,11 +53,12 @@ func (s *dbSessionStore) issueDeviceToken(ctx context.Context, ip, userAgent str
 	if len(label) > 200 {
 		label = label[:200]
 	}
+	fam := uaFamily(userAgent)
 
 	err = s.db.Exec(ctx,
-		`INSERT INTO sessions (id, token_hash, kind, label, ip, created_at, last_seen, expires_at)
-		 VALUES (?, ?, 'device', ?, ?, ?, ?, ?)`,
-		id, hash, label, ip, now, now, exp,
+		`INSERT INTO sessions (id, token_hash, kind, label, ip, ua_family, created_at, last_seen, expires_at)
+		 VALUES (?, ?, 'device', ?, ?, ?, ?, ?, ?)`,
+		id, hash, label, ip, fam, now, now, exp,
 	)
 	if err != nil {
 		return "", err
@@ -57,36 +66,54 @@ func (s *dbSessionStore) issueDeviceToken(ctx context.Context, ip, userAgent str
 	return raw, nil
 }
 
+// Device-binding modes for renewFromDevice. Mirror the validated
+// server.device_binding config values.
+const (
+	bindingOff    = "off"
+	bindingWarn   = "warn"
+	bindingStrict = "strict"
+)
+
 // renewFromDevice validates a device token cookie value. If valid it updates
 // last_seen inside a transaction and returns ok=true. When the token is older
 // than deviceRotateAfter a new device token is issued and the old one deleted
 // atomically; the new raw token is returned in newDeviceToken so the caller
 // can set a fresh device cookie. The caller is responsible for establishing
 // a new scs session.
-func (s *dbSessionStore) renewFromDevice(ctx context.Context, rawDeviceToken, ip string) (newDeviceToken string, ok bool) {
+//
+// mode controls IP-subnet / UA-family binding enforcement (see the package's
+// device_binding config). In strict mode a /24 (IPv4) or /48 (IPv6) subnet
+// change or a UA-family mismatch rejects the renewal (ok=false). In warn mode
+// the renewal proceeds but the drift is recorded on the row so /security can
+// surface it. A stored ua_family of NULL (rows issued before this feature) is
+// never treated as a mismatch; the current family is recorded on renewal.
+func (s *dbSessionStore) renewFromDevice(ctx context.Context, rawDeviceToken, ip, userAgent, mode string) (newDeviceToken string, ok bool) {
 	if rawDeviceToken == "" {
 		return "", false
 	}
 	hash := hashToken(rawDeviceToken)
 	now := time.Now()
 	nowUnix := now.Unix()
+	curFam := uaFamily(userAgent)
 
 	var notFound bool
 	var rotated string
+	var driftReason, driftDevice, driftStoredIP string
 
 	err := s.db.Tx(ctx, func(tx db.DB) error {
-		var id, label string
+		var id, label, storedIP string
+		var storedFam *string
 		var createdAt int64
 		found := false
 
 		if err := tx.Query(ctx,
-			`SELECT id, label, created_at FROM sessions
+			`SELECT id, label, ip, ua_family, created_at FROM sessions
 			 WHERE token_hash = ? AND kind = 'device' AND expires_at > ?`,
 			[]any{hash, nowUnix},
 			func(rows db.Scanner) error {
 				if rows.Next() {
 					found = true
-					return rows.Scan(&id, &label, &createdAt)
+					return rows.Scan(&id, &label, &storedIP, &storedFam, &createdAt)
 				}
 				return nil
 			},
@@ -98,9 +125,25 @@ func (s *dbSessionStore) renewFromDevice(ctx context.Context, rawDeviceToken, ip
 			return nil
 		}
 
+		drift, reason := deviceDrift(storedIP, ip, storedFam, curFam)
+		if drift && mode == bindingStrict {
+			notFound = true // reuse the reject path; caller clears the cookie
+			return nil
+		}
+		// warn mode records the drift on the row and logs the event after commit.
+		// Only persist a reason when actually drifting so a later clean renewal
+		// clears the flag.
+		persistReason := ""
+		if drift && mode == bindingWarn {
+			driftReason, driftDevice, driftStoredIP = reason, id, storedIP
+			persistReason = reason
+		}
+
 		age := now.Sub(time.Unix(createdAt, 0))
 		if age >= deviceRotateAfter {
-			// Rotate: insert a fresh token, delete the old one.
+			// Rotate: insert a fresh token, delete the old one. The fresh row
+			// re-records the current UA family so the binding tracks the live
+			// client rather than a stale value.
 			raw, err := randomToken()
 			if err != nil {
 				return err
@@ -108,9 +151,9 @@ func (s *dbSessionStore) renewFromDevice(ctx context.Context, rawDeviceToken, ip
 			newHash := hashToken(raw)
 			newExp := now.Add(deviceTTL).Unix()
 			if err := tx.Exec(ctx,
-				`INSERT INTO sessions (id, token_hash, kind, label, ip, created_at, last_seen, expires_at)
-				 VALUES (?, ?, 'device', ?, ?, ?, ?, ?)`,
-				uuid.New().String(), newHash, label, ip, nowUnix, nowUnix, newExp,
+				`INSERT INTO sessions (id, token_hash, kind, label, ip, ua_family, drift_reason, created_at, last_seen, expires_at)
+				 VALUES (?, ?, 'device', ?, ?, ?, ?, ?, ?, ?)`,
+				uuid.New().String(), newHash, label, ip, curFam, persistReason, nowUnix, nowUnix, newExp,
 			); err != nil {
 				return err
 			}
@@ -119,9 +162,12 @@ func (s *dbSessionStore) renewFromDevice(ctx context.Context, rawDeviceToken, ip
 			}
 			rotated = raw
 		} else {
+			// Below the rotation window the token is unchanged; refresh ip and
+			// backfill ua_family (NULL on legacy rows) so the next comparison
+			// has a baseline.
 			if err := tx.Exec(ctx,
-				`UPDATE sessions SET last_seen = ?, ip = ? WHERE id = ?`,
-				nowUnix, ip, id,
+				`UPDATE sessions SET last_seen = ?, ip = ?, ua_family = ?, drift_reason = ? WHERE id = ?`,
+				nowUnix, ip, curFam, persistReason, id,
 			); err != nil {
 				return err
 			}
@@ -132,14 +178,70 @@ func (s *dbSessionStore) renewFromDevice(ctx context.Context, rawDeviceToken, ip
 	if err != nil || notFound {
 		return "", false
 	}
+	if driftReason != "" {
+		// Structured device.binding_drift event. Issue #45's audit subsystem is
+		// not yet implemented, so the drift is also recorded on the row
+		// (drift_reason) and surfaced inline on /security.
+		s.log.Warn("device.binding_drift",
+			zap.String("event", "device.binding_drift"),
+			zap.String("device_id", driftDevice),
+			zap.String("reason", driftReason),
+			zap.String("stored_ip", driftStoredIP),
+			zap.String("current_ip", ip),
+		)
+	}
 	return rotated, true // rotated is "" when no rotation occurred
+}
+
+// deviceDrift reports whether the presenting IP subnet or UA family differs
+// from what was recorded for a device token. A stored UA family of NULL (legacy
+// rows) is not a mismatch. The reason string ("ip", "ua", "ip+ua", or "") is
+// suitable for surfacing on /security.
+func deviceDrift(storedIP, curIP string, storedFam *string, curFam string) (bool, string) {
+	ipDrift := storedIP != "" && curIP != "" && !sameSubnet(storedIP, curIP)
+	uaDrift := storedFam != nil && *storedFam != "" && curFam != "" && *storedFam != curFam
+
+	switch {
+	case ipDrift && uaDrift:
+		return true, "ip+ua"
+	case ipDrift:
+		return true, "ip"
+	case uaDrift:
+		return true, "ua"
+	default:
+		return false, ""
+	}
+}
+
+// sameSubnet reports whether two IPs share a subnet at the binding granularity:
+// /24 for IPv4, /48 for IPv6. Coarse on purpose so mobile NAT and carrier IP
+// churn within a network do not trip the binding. Unparseable inputs fall back
+// to exact-string equality.
+func sameSubnet(a, b string) bool {
+	ipa, erra := netip.ParseAddr(a)
+	ipb, errb := netip.ParseAddr(b)
+	if erra != nil || errb != nil {
+		return a == b
+	}
+	if ipa.Is4() != ipb.Is4() {
+		return false
+	}
+	bits := 24
+	if ipa.Is6() {
+		bits = 48
+	}
+	pa, err := ipa.Prefix(bits)
+	if err != nil {
+		return false
+	}
+	return pa.Contains(ipb)
 }
 
 // ListDevices returns all active trusted devices.
 func (s *dbSessionStore) listDevices(ctx context.Context) ([]DeviceInfo, error) {
 	var devices []DeviceInfo
 	err := s.db.Query(ctx,
-		`SELECT id, label, ip, created_at, last_seen, expires_at
+		`SELECT id, label, ip, drift_reason, created_at, last_seen, expires_at
 		 FROM sessions WHERE kind = 'device' AND expires_at > ?
 		 ORDER BY last_seen DESC`,
 		[]any{time.Now().Unix()},
@@ -147,9 +249,10 @@ func (s *dbSessionStore) listDevices(ctx context.Context) ([]DeviceInfo, error) 
 			for rows.Next() {
 				var d DeviceInfo
 				var createdAt, lastSeen, expiresAt int64
-				if err := rows.Scan(&d.ID, &d.Label, &d.IP, &createdAt, &lastSeen, &expiresAt); err != nil {
+				if err := rows.Scan(&d.ID, &d.Label, &d.IP, &d.DriftReason, &createdAt, &lastSeen, &expiresAt); err != nil {
 					return err
 				}
+				d.Drift = d.DriftReason != ""
 				d.CreatedAt = time.Unix(createdAt, 0)
 				d.LastSeen = time.Unix(lastSeen, 0)
 				d.ExpiresAt = time.Unix(expiresAt, 0)
@@ -184,6 +287,10 @@ type DeviceInfo struct {
 	CreatedAt time.Time `json:"created_at"`
 	LastSeen  time.Time `json:"last_seen"`
 	ExpiresAt time.Time `json:"expires_at"`
+	// Drift is true when the last renewal under warn-mode binding came from a
+	// different IP subnet or UA family than the device was issued for.
+	Drift       bool   `json:"drift"`
+	DriftReason string `json:"drift_reason,omitempty"` // "ip", "ua", or "ip+ua"
 }
 
 // --- helpers -----------------------------------------------------------------
@@ -234,7 +341,7 @@ func (s *Server) apiAuthRefresh(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, "no device token", http.StatusUnauthorized)
 		return
 	}
-	newDevToken, ok := s.dbSessions.renewFromDevice(r.Context(), dc.Value, clientIP(r, s.cfg.Server.TrustProxy))
+	newDevToken, ok := s.dbSessions.renewFromDevice(r.Context(), dc.Value, clientIP(r, s.cfg.Server.TrustProxy), r.Header.Get("User-Agent"), s.cfg.Server.DeviceBinding)
 	if !ok {
 		_ = s.sm.Destroy(r.Context())
 		clearDeviceCookie(w)

--- a/pkg/webui/sessions_db.go
+++ b/pkg/webui/sessions_db.go
@@ -131,7 +131,7 @@ func (s *dbSessionStore) renewFromDevice(ctx context.Context, rawDeviceToken, ip
 			return nil
 		}
 
-		drift, reason := deviceDrift(storedIP, ip, storedFam, curFam)
+		drift, reason := deviceDrift(storedIP, ip, storedFam, curFam, mode == bindingStrict)
 		if drift && mode == bindingStrict {
 			// Hard-revoke: a strict-mode drift means the cookie is presenting
 			// from an unexpected subnet/UA, so delete the row in this same
@@ -227,9 +227,29 @@ func (s *dbSessionStore) renewFromDevice(ctx context.Context, rawDeviceToken, ip
 // from what was recorded for a device token. A stored UA family of NULL (legacy
 // rows) is not a mismatch. The reason string ("ip", "ua", "ip+ua", or "") is
 // suitable for surfacing on /security.
-func deviceDrift(storedIP, curIP string, storedFam *string, curFam string) (bool, string) {
+//
+// strict makes the binding fail closed when the device had a recorded signal but
+// the request carries none: an empty curIP against a recorded storedIP, or an
+// empty curFam against a recorded storedFam, both count as drift. This blocks a
+// crafted request that strips the IP/UA signal (e.g. an X-Forwarded-For token
+// that normalizes to "" or a missing User-Agent header) from silently disabling
+// a binding axis. In warn/off the empty-signal case is not flagged so a transient
+// missing signal does not raise a benign warning. Legacy rows with no recorded
+// ua_family (storedFam == nil) never drift on the UA axis regardless of mode.
+func deviceDrift(storedIP, curIP string, storedFam *string, curFam string, strict bool) (bool, string) {
 	ipDrift := storedIP != "" && curIP != "" && !sameSubnet(storedIP, curIP)
 	uaDrift := storedFam != nil && *storedFam != "" && curFam != "" && *storedFam != curFam
+	if strict {
+		// Fail closed: a recorded signal with no incoming counterpart is drift,
+		// not "no signal". curFam is only enforced when the row has a recorded
+		// family, so legacy NULL rows still do not drift here.
+		if storedIP != "" && curIP == "" {
+			ipDrift = true
+		}
+		if storedFam != nil && *storedFam != "" && curFam == "" {
+			uaDrift = true
+		}
+	}
 
 	switch {
 	case ipDrift && uaDrift:

--- a/pkg/webui/sessions_db.go
+++ b/pkg/webui/sessions_db.go
@@ -83,37 +83,43 @@ const (
 //
 // mode controls IP-subnet / UA-family binding enforcement (see the package's
 // device_binding config). In strict mode a /24 (IPv4) or /48 (IPv6) subnet
-// change or a UA-family mismatch rejects the renewal (ok=false). In warn mode
-// the renewal proceeds but the drift is recorded on the row so /security can
-// surface it. A stored ua_family of NULL (rows issued before this feature) is
-// never treated as a mismatch; the current family is recorded on renewal.
-func (s *dbSessionStore) renewFromDevice(ctx context.Context, rawDeviceToken, ip, userAgent, mode string) (newDeviceToken string, ok bool) {
+// change or a UA-family mismatch rejects the renewal (ok=false) AND hard-revokes
+// the device row in the same transaction, so a cookie judged stolen cannot be
+// replayed until its 30-day expiry; driftReject is set so the caller clears the
+// device cookie. In warn mode the renewal proceeds but the drift is recorded on
+// the row so /security can surface it; warn-mode drift is sticky — the stored
+// baseline IP/ua_family is not re-anchored to the drifted values while a drift
+// is flagged, so a persistent drift keeps showing until the client genuinely
+// returns to its issuing subnet/family. A stored ua_family of NULL (rows issued
+// before this feature) is never treated as a mismatch; the current family is
+// recorded on renewal.
+func (s *dbSessionStore) renewFromDevice(ctx context.Context, rawDeviceToken, ip, userAgent, mode string) (newDeviceToken string, ok bool, driftReject bool) {
 	if rawDeviceToken == "" {
-		return "", false
+		return "", false, false
 	}
 	hash := hashToken(rawDeviceToken)
 	now := time.Now()
 	nowUnix := now.Unix()
 	curFam := uaFamily(userAgent)
 
-	var notFound bool
+	var notFound, rejected bool
 	var rotated string
 	var driftReason, driftDevice, driftStoredIP string
 
 	err := s.db.Tx(ctx, func(tx db.DB) error {
-		var id, label, storedIP string
+		var id, label, storedIP, storedReason string
 		var storedFam *string
 		var createdAt int64
 		found := false
 
 		if err := tx.Query(ctx,
-			`SELECT id, label, ip, ua_family, created_at FROM sessions
+			`SELECT id, label, ip, ua_family, drift_reason, created_at FROM sessions
 			 WHERE token_hash = ? AND kind = 'device' AND expires_at > ?`,
 			[]any{hash, nowUnix},
 			func(rows db.Scanner) error {
 				if rows.Next() {
 					found = true
-					return rows.Scan(&id, &label, &storedIP, &storedFam, &createdAt)
+					return rows.Scan(&id, &label, &storedIP, &storedFam, &storedReason, &createdAt)
 				}
 				return nil
 			},
@@ -127,23 +133,45 @@ func (s *dbSessionStore) renewFromDevice(ctx context.Context, rawDeviceToken, ip
 
 		drift, reason := deviceDrift(storedIP, ip, storedFam, curFam)
 		if drift && mode == bindingStrict {
-			notFound = true // reuse the reject path; caller clears the cookie
+			// Hard-revoke: a strict-mode drift means the cookie is presenting
+			// from an unexpected subnet/UA, so delete the row in this same
+			// transaction rather than leaving it replayable until expiry.
+			if err := tx.Exec(ctx, `DELETE FROM sessions WHERE id = ?`, id); err != nil {
+				return err
+			}
+			rejected = true
 			return nil
 		}
 		// warn mode records the drift on the row and logs the event after commit.
-		// Only persist a reason when actually drifting so a later clean renewal
-		// clears the flag.
+		// Only persist a reason when actually drifting (vs the issue-time anchor)
+		// so a genuine return to baseline clears the flag.
 		persistReason := ""
 		if drift && mode == bindingWarn {
 			driftReason, driftDevice, driftStoredIP = reason, id, storedIP
 			persistReason = reason
 		}
 
+		// Anchor the stored baseline IP/ua_family. In warn mode, while the device
+		// has ever drifted (or is drifting now) keep the baseline pinned to the
+		// issuing values instead of re-baselining to the drifted client; the
+		// drift comparison above is against storedIP/storedFam, so re-baselining
+		// would let a persistent drift self-heal after a single renewal. Off mode
+		// and never-drifted devices track the live client as before.
+		anchorIP, anchorFam := ip, curFam
+		if mode == bindingWarn && (drift || storedReason != "") {
+			anchorIP = storedIP
+			if storedFam != nil {
+				anchorFam = *storedFam
+			}
+			// storedFam == nil (legacy NULL): backfill with curFam (anchorFam
+			// already holds it) so the baseline gains a UA family exactly once.
+		}
+
 		age := now.Sub(time.Unix(createdAt, 0))
 		if age >= deviceRotateAfter {
 			// Rotate: insert a fresh token, delete the old one. The fresh row
-			// re-records the current UA family so the binding tracks the live
-			// client rather than a stale value.
+			// carries the anchored IP/UA family so warn-mode drift stays sticky
+			// across a rotation rather than re-baselining to the drifted client.
 			raw, err := randomToken()
 			if err != nil {
 				return err
@@ -153,7 +181,7 @@ func (s *dbSessionStore) renewFromDevice(ctx context.Context, rawDeviceToken, ip
 			if err := tx.Exec(ctx,
 				`INSERT INTO sessions (id, token_hash, kind, label, ip, ua_family, drift_reason, created_at, last_seen, expires_at)
 				 VALUES (?, ?, 'device', ?, ?, ?, ?, ?, ?, ?)`,
-				uuid.New().String(), newHash, label, ip, curFam, persistReason, nowUnix, nowUnix, newExp,
+				uuid.New().String(), newHash, label, anchorIP, anchorFam, persistReason, nowUnix, nowUnix, newExp,
 			); err != nil {
 				return err
 			}
@@ -167,7 +195,7 @@ func (s *dbSessionStore) renewFromDevice(ctx context.Context, rawDeviceToken, ip
 			// has a baseline.
 			if err := tx.Exec(ctx,
 				`UPDATE sessions SET last_seen = ?, ip = ?, ua_family = ?, drift_reason = ? WHERE id = ?`,
-				nowUnix, ip, curFam, persistReason, id,
+				nowUnix, anchorIP, anchorFam, persistReason, id,
 			); err != nil {
 				return err
 			}
@@ -176,12 +204,14 @@ func (s *dbSessionStore) renewFromDevice(ctx context.Context, rawDeviceToken, ip
 	})
 
 	if err != nil || notFound {
-		return "", false
+		return "", false, false
+	}
+	if rejected {
+		return "", false, true
 	}
 	if driftReason != "" {
-		// Structured device.binding_drift event. Issue #45's audit subsystem is
-		// not yet implemented, so the drift is also recorded on the row
-		// (drift_reason) and surfaced inline on /security.
+		// Structured device.binding_drift event. Drift is also recorded on the
+		// row (drift_reason) and surfaced inline on /security.
 		s.log.Warn("device.binding_drift",
 			zap.String("event", "device.binding_drift"),
 			zap.String("device_id", driftDevice),
@@ -190,7 +220,7 @@ func (s *dbSessionStore) renewFromDevice(ctx context.Context, rawDeviceToken, ip
 			zap.String("current_ip", ip),
 		)
 	}
-	return rotated, true // rotated is "" when no rotation occurred
+	return rotated, true, false // rotated is "" when no rotation occurred
 }
 
 // deviceDrift reports whether the presenting IP subnet or UA family differs
@@ -223,6 +253,10 @@ func sameSubnet(a, b string) bool {
 	if erra != nil || errb != nil {
 		return a == b
 	}
+	// Unmap IPv4-in-IPv6 (::ffff:a.b.c.d) so a mapped and a native form of the
+	// same IPv4 address compare in the same family at /24.
+	ipa = ipa.Unmap()
+	ipb = ipb.Unmap()
 	if ipa.Is4() != ipb.Is4() {
 		return false
 	}
@@ -341,8 +375,11 @@ func (s *Server) apiAuthRefresh(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, "no device token", http.StatusUnauthorized)
 		return
 	}
-	newDevToken, ok := s.dbSessions.renewFromDevice(r.Context(), dc.Value, clientIP(r, s.cfg.Server.TrustProxy), r.Header.Get("User-Agent"), s.cfg.Server.DeviceBinding)
+	newDevToken, ok, _ := s.dbSessions.renewFromDevice(r.Context(), dc.Value, clientIP(r, s.cfg.Server.TrustProxy), r.Header.Get("User-Agent"), s.cfg.Server.DeviceBinding)
 	if !ok {
+		// On strict-drift the row is already hard-revoked inside renewFromDevice;
+		// clearing the cookie + destroying the session here covers both the
+		// drift-reject and the benign expiry case.
 		_ = s.sm.Destroy(r.Context())
 		clearDeviceCookie(w)
 		jsonErr(w, "device token invalid or expired", http.StatusUnauthorized)

--- a/pkg/webui/uafamily.go
+++ b/pkg/webui/uafamily.go
@@ -1,0 +1,58 @@
+package webui
+
+import "strings"
+
+// uaFamily reduces a User-Agent string to a coarse "browser+OS family"
+// fingerprint, deliberately dropping version numbers. Versions churn on every
+// auto-update, so binding to an exact UA would force a re-login after each
+// browser patch; the family is stable across updates while still catching a
+// cookie replayed from a different browser or OS.
+//
+// The parser is intentionally compact rather than a full UA database: it covers
+// the mainstream desktop/mobile combinations and falls back to "other" for the
+// long tail. "other" compares equal to itself, so an unrecognised-but-consistent
+// client is not flagged as drift.
+func uaFamily(ua string) string {
+	ua = strings.ToLower(ua)
+	if ua == "" {
+		return ""
+	}
+
+	var browser string
+	switch {
+	// Order matters: Edge/Opera/Brave UAs also contain "chrome"; Chrome UAs
+	// contain "safari". Check the more specific tokens first.
+	case strings.Contains(ua, "edg/") || strings.Contains(ua, "edge"):
+		browser = "edge"
+	case strings.Contains(ua, "opr/") || strings.Contains(ua, "opera"):
+		browser = "opera"
+	case strings.Contains(ua, "firefox") || strings.Contains(ua, "fxios"):
+		browser = "firefox"
+	case strings.Contains(ua, "chrome") || strings.Contains(ua, "crios") || strings.Contains(ua, "chromium"):
+		browser = "chrome"
+	case strings.Contains(ua, "safari"):
+		browser = "safari"
+	default:
+		browser = "other"
+	}
+
+	var os string
+	switch {
+	case strings.Contains(ua, "android"):
+		os = "android"
+	case strings.Contains(ua, "iphone") || strings.Contains(ua, "ipad") || strings.Contains(ua, "ipod"):
+		os = "ios"
+	case strings.Contains(ua, "windows"):
+		os = "windows"
+	case strings.Contains(ua, "mac os") || strings.Contains(ua, "macos") || strings.Contains(ua, "macintosh"):
+		os = "macos"
+	case strings.Contains(ua, "cros"):
+		os = "chromeos"
+	case strings.Contains(ua, "linux"):
+		os = "linux"
+	default:
+		os = "other"
+	}
+
+	return browser + "/" + os
+}

--- a/tasks/buildin/webui/app/components/dc-security.js
+++ b/tasks/buildin/webui/app/components/dc-security.js
@@ -135,7 +135,11 @@ class DcSecurity extends LitElement {
                 <td style="font-size:0.8rem;max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title=${d.label}>
                   ${d.label || '—'}
                 </td>
-                <td><code style="font-size:0.8rem">${d.ip || '—'}</code></td>
+                <td>
+                  <code style="font-size:0.8rem">${d.ip || '—'}</code>
+                  ${d.drift ? html`<span style="margin-left:0.4rem;font-size:0.7rem;color:var(--red);border:1px solid var(--red);border-radius:3px;padding:0 0.3rem"
+                    title=${`Device-binding drift: ${d.drift_reason}. The cookie was presented from a different IP subnet or browser family than it was issued for.`}>drift: ${d.drift_reason}</span>` : ''}
+                </td>
                 <td style="font-size:0.8rem">${this._fmtDate(d.last_seen)}</td>
                 <td style="font-size:0.8rem">${this._fmtDate(d.expires_at)}</td>
                 <td style="text-align:right">


### PR DESCRIPTION
## Summary

The "Trust this browser" checkbox issues a 30-day device cookie. The issuing IP and User-Agent were *recorded* on issuance and every renewal but never *verified* — a replayed cookie authenticated any client until the 24h rotation window closed. This adds an opt-in binding that verifies the cookie against the IP subnet and User-Agent family it was issued for.

## Approach

New `server.device_binding` config with three modes (default `off`, backward compatible):

- `off` — record IP/UA, never verify (current behaviour)
- `warn` — allow renewal on drift, but flag it on `/security` (`drift: true` + reason) and emit a structured `device.binding_drift` log event
- `strict` — reject renewal on drift (session destroyed, cookie cleared → forced re-login)

"Drift" = IP-subnet change **or** UA-family mismatch:

- **IP** compared at **/24 (IPv4) / /48 (IPv6)** via `net/netip`, deliberately coarse so mobile-NAT / carrier IP churn within a network doesn't trip it. Full-IP comparison is intentionally avoided.
- **UA family** is a compact internal `browser/os` parser (`pkg/webui/uafamily.go`) — no new dependency. Version numbers are dropped so routine browser auto-updates don't force re-logins, while a different browser/OS is caught.

`renewFromDevice` now takes `(ip, userAgent, mode)` and honours the mode inside its existing rotation transaction. A new nullable `ua_family` column plus a `drift_reason` column are added to the `sessions` table via the existing `addColumnIfMissing` migration pattern.

## NULL-`ua_family` backward-compat decision

Device tokens issued before this change have `ua_family = NULL`. A NULL stored family is **never** treated as a UA mismatch; the current family is **backfilled** on the next renewal so a baseline exists for subsequent comparisons. This means enabling `strict`/`warn` does **not** log out existing trusted devices — they get bound on their next renewal. The passphrase-rotation kill-switch (revoke-all-devices) is unchanged.

## Acceptance checklist

- [x] `server.device_binding` config field (off/warn/strict), default `off`, validated in `Load()`; tests for default/override/invalid.
- [x] `ua_family` column on the device-tokens table via migration; compact internal UA-family parser (browser+OS, no version).
- [x] `renewFromDevice` honours the mode; subnet comparison /24 (IPv4) and /48 (IPv6) via `net/netip`.
- [x] `warn` emits structured `device.binding_drift` event; drift surfaced inline on `/security` device rows (issue #45's audit subsystem is unimplemented, so drift is recorded on the row rather than inventing one).
- [x] Tests: same-network renewal passes in strict; cross-subnet rejected in strict / allowed+flagged in warn; UA-family drift same treatment; NULL-ua_family and IPv6 cases. `make test` + `go vet` pass; race detector clean on `pkg/webui`, `pkg/db`, `pkg/config`.

## Cross-repo doc note

The `dicode-site` `configuration.md` needs a `server.device_binding` entry added (off/warn/strict, default off) — that lives in a separate repo and is not editable here. The in-repo `docs/concepts/security.md` has been updated (config example, renewal lifecycle, schema, a "Device binding" section, and the config table).

## Deliberately out of scope

- No general audit-log subsystem (issue #45) — drift is recorded on the device row + a structured log line.
- Binding is not retroactive: legacy tokens bind on their next renewal, by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)