### PR TITLE
feat(authoring): IPC + CLI verbs for AI task create/edit/save/cancel (#288)

### DIFF
--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -15,6 +15,10 @@
 //	status [task-id]                daemon health or latest run for a task
 //	ai <prompt> [flags]             run the configured AI task with a prompt
 //	task test <task-id>             run the task's sibling task.test.* through its runtime
+//	task create <name> [flags]      scaffold a task; with --ai, open an edit session
+//	task edit <task-id> <prompt>    open or resume an AI edit session
+//	task save <session-id>          apply a session's changes
+//	task cancel <session-id>        discard a session
 //	secrets list                    list secret keys
 //	secrets set <key> <value>       store a secret
 //	secrets delete <key>            delete a secret
@@ -116,7 +120,7 @@ func dispatch(c *ipc.ControlClient, args []string) error {
 		return cmdAI(c, args[1:])
 	case "task":
 		if len(args) < 2 {
-			return fmt.Errorf("usage: dicode task <test> <task-id>")
+			return fmt.Errorf("usage: dicode task <test|create|edit|save|cancel> [args...]")
 		}
 		return cmdTask(c, args[1:])
 	case "auth":
@@ -474,8 +478,16 @@ func cmdTask(c *ipc.ControlClient, args []string) error {
 			return fmt.Errorf("usage: dicode task test <task-id>")
 		}
 		return cmdTaskTest(c, args[1])
+	case "create":
+		return cmdTaskCreate(c, args[1:])
+	case "edit":
+		return cmdTaskEdit(c, args[1:])
+	case "save":
+		return cmdTaskSave(c, args[1:])
+	case "cancel":
+		return cmdTaskCancel(c, args[1:])
 	default:
-		return fmt.Errorf("unknown task subcommand %q — supported: test", args[0])
+		return fmt.Errorf("unknown task subcommand %q — supported: test, create, edit, save, cancel", args[0])
 	}
 }
 

--- a/cmd/dicode/task.go
+++ b/cmd/dicode/task.go
@@ -8,8 +8,6 @@ import (
 	"github.com/dicode/dicode/pkg/ipc"
 )
 
-// AI-first task authoring verbs (#288): create | edit | save | cancel.
-//
 // Output convention mirrors `dicode ai`: stdout carries the single piped
 // value (task id or PR url), stderr carries metadata (session id, webui URL,
 // progress). Pipelines can consume stdout cleanly while the operator still

--- a/cmd/dicode/task.go
+++ b/cmd/dicode/task.go
@@ -155,7 +155,11 @@ func cmdTaskEdit(c *ipc.ControlClient, args []string) error {
 	if res.WebUIURL != "" {
 		fmt.Fprintf(os.Stderr, "open: %s\n", res.WebUIURL)
 	}
-	fmt.Println(res.Reply)
+	// Reply is the piped (stdout) value; the AI turn that fills it is not wired
+	// yet, so only print when present to keep stdout empty rather than a blank line.
+	if res.Reply != "" {
+		fmt.Println(res.Reply)
+	}
 	return nil
 }
 

--- a/cmd/dicode/task.go
+++ b/cmd/dicode/task.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/dicode/dicode/pkg/ipc"
+)
+
+// AI-first task authoring verbs (#288): create | edit | save | cancel.
+//
+// Output convention mirrors `dicode ai`: stdout carries the single piped
+// value (task id or PR url), stderr carries metadata (session id, webui URL,
+// progress). Pipelines can consume stdout cleanly while the operator still
+// sees the session details on the terminal.
+
+// cmdTaskCreate scaffolds a new task. With --ai it chains straight into an
+// edit session in one round-trip.
+//
+//	dicode task create <name> [--source <name>] [--ai "<prompt>"]
+func cmdTaskCreate(c *ipc.ControlClient, args []string) error {
+	var source, prompt string
+	var positional []string
+	parseFlags := true
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if parseFlags && a == "--" {
+			parseFlags = false
+			continue
+		}
+		if !parseFlags {
+			positional = append(positional, a)
+			continue
+		}
+		switch {
+		case a == "--source":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--source requires a value")
+			}
+			source = args[i+1]
+			i++
+		case a == "--ai":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--ai requires a value")
+			}
+			prompt = args[i+1]
+			i++
+		case a == "--help" || a == "-h":
+			fmt.Fprintln(os.Stderr, `Usage: dicode task create <name> [--source NAME] [--ai "PROMPT"]`)
+			return nil
+		case strings.HasPrefix(a, "--source="):
+			source = strings.TrimPrefix(a, "--source=")
+		case strings.HasPrefix(a, "--ai="):
+			prompt = strings.TrimPrefix(a, "--ai=")
+		default:
+			positional = append(positional, a)
+		}
+	}
+	if len(positional) == 0 {
+		return fmt.Errorf(`usage: dicode task create <name> [--source NAME] [--ai "PROMPT"]`)
+	}
+	name := positional[0]
+
+	resp, err := c.Send(ipc.Request{
+		Method:   "cli.task.create",
+		TaskName: name,
+		Source:   source,
+		Prompt:   prompt,
+	})
+	if err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	var res ipc.TaskCreateResult
+	if err := remarshal(resp.Result, &res); err != nil {
+		return err
+	}
+
+	// On the --ai path, the session id + webui url are metadata (stderr) and
+	// the reply is the conversational output (stderr too, so stdout stays the
+	// piped task id). Plain create just prints the task id.
+	if res.SessionID != "" {
+		fmt.Fprintf(os.Stderr, "session: %s\n", res.SessionID)
+	}
+	if res.WebUIURL != "" {
+		fmt.Fprintf(os.Stderr, "open: %s\n", res.WebUIURL)
+	}
+	if res.Reply != "" {
+		fmt.Fprintln(os.Stderr, res.Reply)
+	}
+	fmt.Println(res.TaskID)
+	return nil
+}
+
+// cmdTaskEdit opens or resumes an AI edit session.
+//
+//	dicode task edit <task-id> "<prompt>" [--session <id>]
+func cmdTaskEdit(c *ipc.ControlClient, args []string) error {
+	var sessionID string
+	var positional []string
+	parseFlags := true
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if parseFlags && a == "--" {
+			parseFlags = false
+			continue
+		}
+		if !parseFlags {
+			positional = append(positional, a)
+			continue
+		}
+		switch {
+		case a == "--session":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--session requires a value")
+			}
+			sessionID = args[i+1]
+			i++
+		case a == "--help" || a == "-h":
+			fmt.Fprintln(os.Stderr, `Usage: dicode task edit <task-id> "<prompt>" [--session ID]`)
+			return nil
+		case strings.HasPrefix(a, "--session="):
+			sessionID = strings.TrimPrefix(a, "--session=")
+		default:
+			positional = append(positional, a)
+		}
+	}
+	if len(positional) == 0 {
+		return fmt.Errorf(`usage: dicode task edit <task-id> "<prompt>" [--session ID]`)
+	}
+	taskID := positional[0]
+	prompt := strings.Join(positional[1:], " ")
+
+	resp, err := c.Send(ipc.Request{
+		Method:    "cli.task.edit",
+		TaskID:    taskID,
+		Prompt:    prompt,
+		SessionID: sessionID,
+	})
+	if err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	var res ipc.TaskEditResult
+	if err := remarshal(resp.Result, &res); err != nil {
+		return err
+	}
+
+	if res.SessionID != "" {
+		fmt.Fprintf(os.Stderr, "session: %s\n", res.SessionID)
+	}
+	if res.WebUIURL != "" {
+		fmt.Fprintf(os.Stderr, "open: %s\n", res.WebUIURL)
+	}
+	fmt.Println(res.Reply)
+	return nil
+}
+
+// cmdTaskSave applies a session and closes it.
+//
+//	dicode task save <session-id>
+func cmdTaskSave(c *ipc.ControlClient, args []string) error {
+	sessionID, err := singleSessionArg(args, "save")
+	if err != nil || sessionID == "" {
+		return err
+	}
+
+	resp, err := c.Send(ipc.Request{Method: "cli.task.save", SessionID: sessionID})
+	if err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	var res ipc.TaskSaveResult
+	if err := remarshal(resp.Result, &res); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "session: %s\n", sessionID)
+	// stdout = the piped value: PR url for git sources, task id otherwise.
+	switch {
+	case res.PRURL != "":
+		fmt.Println(res.PRURL)
+	case res.TaskID != "":
+		fmt.Println(res.TaskID)
+	default:
+		fmt.Println(sessionID)
+	}
+	return nil
+}
+
+// cmdTaskCancel discards a session.
+//
+//	dicode task cancel <session-id>
+func cmdTaskCancel(c *ipc.ControlClient, args []string) error {
+	sessionID, err := singleSessionArg(args, "cancel")
+	if err != nil || sessionID == "" {
+		return err
+	}
+
+	resp, err := c.Send(ipc.Request{Method: "cli.task.cancel", SessionID: sessionID})
+	if err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+
+	fmt.Fprintf(os.Stderr, "session: %s\n", sessionID)
+	fmt.Printf("cancelled %s\n", sessionID)
+	return nil
+}
+
+// singleSessionArg parses a single positional <session-id> with `--` sentinel
+// support, shared by save and cancel.
+func singleSessionArg(args []string, verb string) (string, error) {
+	var positional []string
+	parseFlags := true
+	for _, a := range args {
+		if parseFlags && a == "--" {
+			parseFlags = false
+			continue
+		}
+		if parseFlags && (a == "--help" || a == "-h") {
+			fmt.Fprintf(os.Stderr, "Usage: dicode task %s <session-id>\n", verb)
+			return "", nil
+		}
+		positional = append(positional, a)
+	}
+	if len(positional) == 0 {
+		return "", fmt.Errorf("usage: dicode task %s <session-id>", verb)
+	}
+	return positional[0], nil
+}

--- a/cmd/dicode/task_test.go
+++ b/cmd/dicode/task_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -207,6 +208,34 @@ func TestCmdTaskCreate_AIPathChainsEditWithEqualsFlags(t *testing.T) {
 	// --ai presence makes the daemon chain create → edit against the new task.
 	if fa.editTask != "ai-scratch/x" {
 		t.Errorf("edit chained against %q, want ai-scratch/x", fa.editTask)
+	}
+}
+
+func TestCmdTaskCreate_AIEditFailureSurfacesTaskID(t *testing.T) {
+	// Drives the real control socket: create succeeds, the chained edit fails.
+	// The dispatch loop sends Error XOR Result, so the created task id must ride
+	// inside the error string to reach the CLI user (a retry command).
+	c, done := dialTestClient(t, &fakeAuthoring{
+		create:  ipc.AuthoringCreateResult{TaskID: "ai-scratch/hello", Source: "ai-scratch"},
+		editErr: errors.New("agent unavailable"),
+	})
+	defer done()
+	out, _, err := captureOutput(t, func() error {
+		return cmdTaskCreate(c, []string{"hello", "--ai", "make it greet"})
+	})
+	if err == nil {
+		t.Fatal("expected an error when the chained edit fails")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "ai-scratch/hello") {
+		t.Errorf("error must contain the created task id, got %q", msg)
+	}
+	if !strings.Contains(msg, "dicode task edit ai-scratch/hello") {
+		t.Errorf("error must contain a ready-to-run retry command, got %q", msg)
+	}
+	// stdout stays empty on failure — the task id reaches the user via stderr/error.
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("stdout should be empty on failure, got %q", out)
 	}
 }
 

--- a/cmd/dicode/task_test.go
+++ b/cmd/dicode/task_test.go
@@ -1,0 +1,344 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/ipc"
+	"go.uber.org/zap"
+)
+
+// fakeAuthoring is an in-process ipc.AuthoringService used to drive the CLI
+// verbs end-to-end over a real control socket, so the tests exercise the full
+// flag-parse → IPC → handler → stdout/stderr-split chain.
+type fakeAuthoring struct {
+	create    ipc.AuthoringCreateResult
+	createErr error
+	edit      ipc.AuthoringEditResult
+	editErr   error
+	saveErr   error
+	cancelErr error
+}
+
+func (f *fakeAuthoring) CreateTask(_ context.Context, name, source string) (ipc.AuthoringCreateResult, error) {
+	if f.createErr != nil {
+		return ipc.AuthoringCreateResult{}, f.createErr
+	}
+	res := f.create
+	if res.TaskID == "" {
+		res.TaskID = source + "/" + name
+	}
+	return res, nil
+}
+
+func (f *fakeAuthoring) EditTask(_ context.Context, sessionID, taskID string) (ipc.AuthoringEditResult, error) {
+	if f.editErr != nil {
+		return ipc.AuthoringEditResult{}, f.editErr
+	}
+	return f.edit, nil
+}
+
+func (f *fakeAuthoring) SaveTask(_ context.Context, sessionID string) error   { return f.saveErr }
+func (f *fakeAuthoring) CancelTask(_ context.Context, sessionID string) error { return f.cancelErr }
+func (f *fakeAuthoring) WebUIBaseURL() string                                 { return "http://localhost:8080" }
+
+// dialTestClient boots a ControlServer wired to auth and returns a connected
+// ControlClient plus a cleanup func.
+func dialTestClient(t *testing.T, auth ipc.AuthoringService) (*ipc.ControlClient, func()) {
+	t.Helper()
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "ctrl.sock")
+	tokenPath := filepath.Join(dir, "ctrl.token")
+
+	cs, err := ipc.NewControlServer(socketPath, tokenPath, nil, &noopEngine{}, nil, ipc.MetricsProvider{}, "test", zap.NewNop(), nil, "")
+	if err != nil {
+		t.Fatalf("NewControlServer: %v", err)
+	}
+	cs.SetAuthoringService(auth)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = cs.Start(ctx) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(socketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatal("control socket never appeared")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	c, err := ipc.Dial(socketPath, tokenPath)
+	if err != nil {
+		cancel()
+		t.Fatalf("dial: %v", err)
+	}
+	return c, func() { c.Close(); cancel() }
+}
+
+// noopEngine satisfies ipc.EngineRunner for tests that don't fire tasks.
+type noopEngine struct{}
+
+func (noopEngine) FireManual(context.Context, string, map[string]string) (string, error) {
+	return "", nil
+}
+func (noopEngine) FireFromTask(context.Context, string, string, map[string]string) (string, error) {
+	return "", nil
+}
+func (noopEngine) WaitRun(context.Context, string) (ipc.RunResult, error) {
+	return ipc.RunResult{}, nil
+}
+func (noopEngine) ActiveRunCount() int     { return 0 }
+func (noopEngine) ActiveTaskSlots() int    { return 0 }
+func (noopEngine) MaxConcurrentTasks() int { return 0 }
+func (noopEngine) WaitingTasks() int       { return 0 }
+
+// captureOutput redirects os.Stdout and os.Stderr around fn and returns what
+// each captured. The CLI verbs write directly to the process streams, so this
+// is how the stdout/stderr split is asserted.
+func captureOutput(t *testing.T, fn func() error) (stdout, stderr string, err error) {
+	t.Helper()
+	origOut, origErr := os.Stdout, os.Stderr
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout, os.Stderr = wOut, wErr
+
+	err = fn()
+
+	wOut.Close()
+	wErr.Close()
+	os.Stdout, os.Stderr = origOut, origErr
+
+	var bo, be bytes.Buffer
+	_, _ = io.Copy(&bo, rOut)
+	_, _ = io.Copy(&be, rErr)
+	return bo.String(), be.String(), err
+}
+
+// --- flag-parsing tests (no socket needed: they fail before Send) ----------
+
+func TestCmdTaskCreate_MissingName(t *testing.T) {
+	c, done := dialTestClient(t, &fakeAuthoring{})
+	defer done()
+	_, _, err := captureOutput(t, func() error { return cmdTaskCreate(c, nil) })
+	if err == nil || !strings.Contains(err.Error(), "usage") {
+		t.Fatalf("err = %v, want usage", err)
+	}
+}
+
+func TestCmdTaskCreate_DanglingFlag(t *testing.T) {
+	c, done := dialTestClient(t, &fakeAuthoring{})
+	defer done()
+	_, _, err := captureOutput(t, func() error { return cmdTaskCreate(c, []string{"name", "--source"}) })
+	if err == nil || !strings.Contains(err.Error(), "--source requires a value") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestCmdTaskCreate_Plain(t *testing.T) {
+	c, done := dialTestClient(t, &fakeAuthoring{
+		create: ipc.AuthoringCreateResult{TaskID: "ai-scratch/hello", Source: "ai-scratch"},
+	})
+	defer done()
+	out, errOut, err := captureOutput(t, func() error {
+		return cmdTaskCreate(c, []string{"hello", "--source", "ai-scratch"})
+	})
+	if err != nil {
+		t.Fatalf("cmdTaskCreate: %v", err)
+	}
+	if strings.TrimSpace(out) != "ai-scratch/hello" {
+		t.Errorf("stdout = %q, want task id", out)
+	}
+	if errOut != "" {
+		t.Errorf("plain create should have empty stderr, got %q", errOut)
+	}
+}
+
+func TestCmdTaskCreate_WithAI_SplitsStreams(t *testing.T) {
+	// The --ai metadata (session, url, reply) is produced by the daemon
+	// chaining create → edit; the edit result drives it.
+	c, done := dialTestClient(t, &fakeAuthoring{
+		create: ipc.AuthoringCreateResult{TaskID: "ai-scratch/hello", Source: "ai-scratch"},
+		edit:   ipc.AuthoringEditResult{SessionID: "sess-1", Source: "ai-scratch", SourceKind: "local"},
+	})
+	defer done()
+	out, errOut, err := captureOutput(t, func() error {
+		return cmdTaskCreate(c, []string{"hello", "--ai", "make it greet"})
+	})
+	if err != nil {
+		t.Fatalf("cmdTaskCreate: %v", err)
+	}
+	if strings.TrimSpace(out) != "ai-scratch/hello" {
+		t.Errorf("stdout = %q, want only task id", out)
+	}
+	if !strings.Contains(errOut, "session: sess-1") {
+		t.Errorf("stderr missing session line: %q", errOut)
+	}
+	if !strings.Contains(errOut, "open: http://localhost:8080/?session=sess-1") {
+		t.Errorf("stderr missing open line: %q", errOut)
+	}
+}
+
+func TestCmdTaskCreate_AIPathChainsEditWithEqualsFlags(t *testing.T) {
+	fa := &recordingAuthoring{fakeAuthoring: fakeAuthoring{
+		create: ipc.AuthoringCreateResult{TaskID: "ai-scratch/x"},
+		edit:   ipc.AuthoringEditResult{SessionID: "s"},
+	}}
+	c, done := dialTestClient(t, fa)
+	defer done()
+	_, _, err := captureOutput(t, func() error {
+		return cmdTaskCreate(c, []string{"x", "--ai=do it", "--source=ai-scratch"})
+	})
+	if err != nil {
+		t.Fatalf("cmdTaskCreate: %v", err)
+	}
+	if fa.source != "ai-scratch" {
+		t.Errorf("source forwarded = %q, want ai-scratch", fa.source)
+	}
+	// --ai presence makes the daemon chain create → edit against the new task.
+	if fa.editTask != "ai-scratch/x" {
+		t.Errorf("edit chained against %q, want ai-scratch/x", fa.editTask)
+	}
+}
+
+func TestCmdTaskEdit_MissingTaskID(t *testing.T) {
+	c, done := dialTestClient(t, &fakeAuthoring{})
+	defer done()
+	_, _, err := captureOutput(t, func() error { return cmdTaskEdit(c, nil) })
+	if err == nil || !strings.Contains(err.Error(), "usage") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestCmdTaskEdit_SplitsStreams(t *testing.T) {
+	c, done := dialTestClient(t, &fakeAuthoring{
+		edit: ipc.AuthoringEditResult{SessionID: "e1", Source: "ai-scratch", SourceKind: "local"},
+	})
+	defer done()
+	out, errOut, err := captureOutput(t, func() error {
+		return cmdTaskEdit(c, []string{"ai-scratch/t", "please", "fix", "it"})
+	})
+	if err != nil {
+		t.Fatalf("cmdTaskEdit: %v", err)
+	}
+	// Reply (empty here) goes to stdout; session + open go to stderr.
+	if !strings.Contains(errOut, "session: e1") {
+		t.Errorf("stderr missing session: %q", errOut)
+	}
+	if !strings.Contains(errOut, "open: http://localhost:8080/?session=e1") {
+		t.Errorf("stderr missing open url: %q", errOut)
+	}
+	_ = out
+}
+
+func TestCmdTaskEdit_DashSentinel(t *testing.T) {
+	fa := &recordingAuthoring{fakeAuthoring: fakeAuthoring{
+		edit: ipc.AuthoringEditResult{SessionID: "e1"},
+	}}
+	c, done := dialTestClient(t, fa)
+	defer done()
+	// After `--`, "--session" is a literal prompt word, not a flag.
+	_, _, err := captureOutput(t, func() error {
+		return cmdTaskEdit(c, []string{"ai-scratch/t", "--", "--session", "is", "a", "word"})
+	})
+	if err != nil {
+		t.Fatalf("cmdTaskEdit: %v", err)
+	}
+	if fa.editSession != "" {
+		t.Errorf("--session after -- must not set sessionID, got %q", fa.editSession)
+	}
+}
+
+func TestCmdTaskEdit_SessionFlag(t *testing.T) {
+	fa := &recordingAuthoring{fakeAuthoring: fakeAuthoring{
+		edit: ipc.AuthoringEditResult{SessionID: "resumed"},
+	}}
+	c, done := dialTestClient(t, fa)
+	defer done()
+	_, _, err := captureOutput(t, func() error {
+		return cmdTaskEdit(c, []string{"ai-scratch/t", "more", "--session", "resumed"})
+	})
+	if err != nil {
+		t.Fatalf("cmdTaskEdit: %v", err)
+	}
+	if fa.editSession != "resumed" {
+		t.Errorf("sessionID forwarded = %q, want resumed", fa.editSession)
+	}
+}
+
+func TestCmdTaskSave_MissingArg(t *testing.T) {
+	c, done := dialTestClient(t, &fakeAuthoring{})
+	defer done()
+	_, _, err := captureOutput(t, func() error { return cmdTaskSave(c, nil) })
+	if err == nil || !strings.Contains(err.Error(), "usage") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestCmdTaskSave_PrintsSessionToStderr(t *testing.T) {
+	c, done := dialTestClient(t, &fakeAuthoring{})
+	defer done()
+	out, errOut, err := captureOutput(t, func() error { return cmdTaskSave(c, []string{"s1"}) })
+	if err != nil {
+		t.Fatalf("cmdTaskSave: %v", err)
+	}
+	if !strings.Contains(errOut, "session: s1") {
+		t.Errorf("stderr = %q", errOut)
+	}
+	// No PR url / task id from the fake → stdout falls back to the session id.
+	if strings.TrimSpace(out) != "s1" {
+		t.Errorf("stdout = %q", out)
+	}
+}
+
+func TestCmdTaskCancel_PrintsConfirmation(t *testing.T) {
+	c, done := dialTestClient(t, &fakeAuthoring{})
+	defer done()
+	out, errOut, err := captureOutput(t, func() error { return cmdTaskCancel(c, []string{"s2"}) })
+	if err != nil {
+		t.Fatalf("cmdTaskCancel: %v", err)
+	}
+	if !strings.Contains(out, "cancelled s2") {
+		t.Errorf("stdout = %q", out)
+	}
+	if !strings.Contains(errOut, "session: s2") {
+		t.Errorf("stderr = %q", errOut)
+	}
+}
+
+func TestCmdTaskCancel_MissingArg(t *testing.T) {
+	c, done := dialTestClient(t, &fakeAuthoring{})
+	defer done()
+	_, _, err := captureOutput(t, func() error { return cmdTaskCancel(c, nil) })
+	if err == nil || !strings.Contains(err.Error(), "usage") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// recordingAuthoring captures the arguments forwarded to the service so the
+// CLI tests can assert flag wiring (prompt, source, sessionID).
+type recordingAuthoring struct {
+	fakeAuthoring
+	source, editSession, editTask string
+}
+
+func (r *recordingAuthoring) CreateTask(ctx context.Context, name, source string) (ipc.AuthoringCreateResult, error) {
+	r.source = source
+	return r.fakeAuthoring.CreateTask(ctx, name, source)
+}
+
+func (r *recordingAuthoring) EditTask(ctx context.Context, sessionID, taskID string) (ipc.AuthoringEditResult, error) {
+	// CreateTask's --ai chain forwards the prompt via EditTask on the daemon
+	// side, so record both the prompt-carrying edit and direct edits here.
+	r.editSession, r.editTask = sessionID, taskID
+	return r.fakeAuthoring.EditTask(ctx, sessionID, taskID)
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -401,6 +401,11 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	// the apiKeyStore; control just dispatches.
 	ctrlSrv.SetAPIKeyMinter(srv)
 
+	// Wire AI-first task authoring (#288) so `dicode task create|edit|save|
+	// cancel` reuses the same source manager and author_sessions store the
+	// REST handlers use.
+	ctrlSrv.SetAuthoringService(srv)
+
 	// Wire the generic dicode.crypto.{encrypt, decrypt} IPC verb so buildin
 	// tasks (relay-client, auth-start, auth-relay) can encrypt/decrypt blobs
 	// via DeriveSubKey-derived sub-keys. Sub-keys never cross IPC; only the

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -401,9 +401,9 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	// the apiKeyStore; control just dispatches.
 	ctrlSrv.SetAPIKeyMinter(srv)
 
-	// Wire AI-first task authoring (#288) so `dicode task create|edit|save|
-	// cancel` reuses the same source manager and author_sessions store the
-	// REST handlers use.
+	// Wire AI-first task authoring so `dicode task create|edit|save|cancel`
+	// reuses the same source manager and author_sessions store the REST
+	// handlers use.
 	ctrlSrv.SetAuthoringService(srv)
 
 	// Wire the generic dicode.crypto.{encrypt, decrypt} IPC verb so buildin

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -275,8 +275,8 @@ type APIKeyMinter interface {
 func (cs *ControlServer) SetAPIKeyMinter(m APIKeyMinter) { cs.apiKeys = m }
 
 // AuthoringService is the surface the control server uses to drive AI-first
-// task authoring (#288) on behalf of CLI clients. Implemented by webui.Server,
-// which owns the source manager and the author_sessions store. Defined here so
+// task authoring on behalf of CLI clients. Implemented by webui.Server, which
+// owns the source manager and the author_sessions store. Defined here so
 // pkg/ipc keeps no import on pkg/webui — same pattern as APIKeyMinter.
 //
 // These methods carry the same business logic the REST handlers
@@ -301,9 +301,12 @@ type AuthoringCreateResult struct {
 	Files  []string
 }
 
-// AuthoringEditResult mirrors webui.EditTaskResult on the IPC side.
+// AuthoringEditResult mirrors webui.EditTaskResult on the IPC side. TaskID is
+// the session's own task id (sess.TaskID), not the caller's claim, so the CLI
+// echoes back the identity the session actually belongs to.
 type AuthoringEditResult struct {
 	SessionID   string
+	TaskID      string
 	SandboxPath string
 	Source      string
 	SourceKind  string
@@ -331,9 +334,11 @@ func (cs *ControlServer) handleTaskCreate(ctx context.Context, req Request) (Tas
 	}
 	edit, err := cs.handleTaskEdit(ctx, Request{TaskID: res.TaskID, Prompt: req.Prompt})
 	if err != nil {
-		// The scaffold already landed; surface the edit failure but keep the
-		// task id so the user can retry the edit against the created task.
-		return out, fmt.Errorf("task %s created but opening edit session failed: %w", res.TaskID, err)
+		// The scaffold already landed. The dispatch loop sends Error XOR
+		// Result, so `out` (with the new task id) is dropped on the wire when
+		// err is non-nil — embed the task id and a ready-to-run retry command
+		// in the error string so the CLI user can recover the created task.
+		return out, fmt.Errorf("task %s created but opening edit session failed: %w; retry with: dicode task edit %s \"<prompt>\"", res.TaskID, err, res.TaskID)
 	}
 	// Fold the edit metadata into the create result's wire shape via the
 	// dedicated fields the CLI reads.
@@ -353,7 +358,7 @@ func (cs *ControlServer) handleTaskEdit(ctx context.Context, req Request) (TaskE
 	}
 	out := TaskEditResult{
 		SessionID:   res.SessionID,
-		TaskID:      req.TaskID,
+		TaskID:      res.TaskID,
 		Source:      res.Source,
 		SourceKind:  res.SourceKind,
 		SandboxPath: res.SandboxPath,

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -281,7 +281,7 @@ func (cs *ControlServer) SetAPIKeyMinter(m APIKeyMinter) { cs.apiKeys = m }
 //
 // These methods carry the same business logic the REST handlers
 // (POST /api/task/{create,edit,save,cancel}) call, so the CLI and the browser
-// share one code path. The 409 single-open-session-per-source rule (#283) is
+// share one code path. The 409 single-open-session-per-source rule is
 // enforced inside EditTask and surfaces as an error string.
 type AuthoringService interface {
 	CreateTask(ctx context.Context, name, source string) (AuthoringCreateResult, error)

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -37,8 +37,9 @@ type ControlServer struct {
 	engine          EngineRunner
 	secrets         secrets.Manager // nil if no local provider configured
 	metricsProvider MetricsProvider
-	database        db.DB        // for broker pubkey trust pinning; nil in tests
-	apiKeys         APIKeyMinter // nil if webui not wired (tests)
+	database        db.DB            // for broker pubkey trust pinning; nil in tests
+	apiKeys         APIKeyMinter     // nil if webui not wired (tests)
+	authoring       AuthoringService // nil if webui not wired (tests)
 	log             *zap.Logger
 
 	// defaultAITask is cfg.AI.Task — the task id that `dicode ai` fires when
@@ -231,6 +232,18 @@ func (cs *ControlServer) dispatch(ctx context.Context, req Request) (any, error)
 	case "cli.task.test":
 		return cs.handleTaskTest(ctx, req)
 
+	case "cli.task.create":
+		return cs.handleTaskCreate(ctx, req)
+
+	case "cli.task.edit":
+		return cs.handleTaskEdit(ctx, req)
+
+	case "cli.task.save":
+		return cs.handleTaskSave(ctx, req)
+
+	case "cli.task.cancel":
+		return cs.handleTaskCancel(ctx, req)
+
 	case "cli.auth.reset_passphrase":
 		return cs.handleAuthResetPassphrase(ctx)
 
@@ -260,6 +273,114 @@ type APIKeyMinter interface {
 // Nil leaves the methods returning a clear error (tests / configurations
 // without webui).
 func (cs *ControlServer) SetAPIKeyMinter(m APIKeyMinter) { cs.apiKeys = m }
+
+// AuthoringService is the surface the control server uses to drive AI-first
+// task authoring (#288) on behalf of CLI clients. Implemented by webui.Server,
+// which owns the source manager and the author_sessions store. Defined here so
+// pkg/ipc keeps no import on pkg/webui — same pattern as APIKeyMinter.
+//
+// These methods carry the same business logic the REST handlers
+// (POST /api/task/{create,edit,save,cancel}) call, so the CLI and the browser
+// share one code path. The 409 single-open-session-per-source rule (#283) is
+// enforced inside EditTask and surfaces as an error string.
+type AuthoringService interface {
+	CreateTask(ctx context.Context, name, source string) (AuthoringCreateResult, error)
+	EditTask(ctx context.Context, sessionID, taskID string) (AuthoringEditResult, error)
+	SaveTask(ctx context.Context, sessionID string) error
+	CancelTask(ctx context.Context, sessionID string) error
+	// WebUIBaseURL returns scheme://host:port for the daemon's web UI so the
+	// CLI can print an "open: <url>" hint pointing at the session.
+	WebUIBaseURL() string
+}
+
+// AuthoringCreateResult mirrors webui.CreateTaskResult on the IPC side so
+// pkg/ipc has no dependency on pkg/webui's concrete types.
+type AuthoringCreateResult struct {
+	TaskID string
+	Source string
+	Files  []string
+}
+
+// AuthoringEditResult mirrors webui.EditTaskResult on the IPC side.
+type AuthoringEditResult struct {
+	SessionID   string
+	SandboxPath string
+	Source      string
+	SourceKind  string
+}
+
+// SetAuthoringService wires the authoring service for cli.task.* dispatch.
+// Called from the daemon at startup once the webui Server is built. Nil leaves
+// the methods returning a clear error (tests / configurations without webui).
+func (cs *ControlServer) SetAuthoringService(a AuthoringService) { cs.authoring = a }
+
+func (cs *ControlServer) handleTaskCreate(ctx context.Context, req Request) (TaskCreateResult, error) {
+	if cs.authoring == nil {
+		return TaskCreateResult{}, errors.New("authoring service not configured")
+	}
+	res, err := cs.authoring.CreateTask(ctx, req.TaskName, req.Source)
+	if err != nil {
+		return TaskCreateResult{}, err
+	}
+	out := TaskCreateResult{TaskID: res.TaskID, Source: res.Source, Files: res.Files}
+
+	// With --ai, scaffolding chains straight into an edit session so the CLI
+	// gets the task id, session id, and webui URL in a single round-trip.
+	if req.Prompt == "" {
+		return out, nil
+	}
+	edit, err := cs.handleTaskEdit(ctx, Request{TaskID: res.TaskID, Prompt: req.Prompt})
+	if err != nil {
+		// The scaffold already landed; surface the edit failure but keep the
+		// task id so the user can retry the edit against the created task.
+		return out, fmt.Errorf("task %s created but opening edit session failed: %w", res.TaskID, err)
+	}
+	// Fold the edit metadata into the create result's wire shape via the
+	// dedicated fields the CLI reads.
+	out.SessionID = edit.SessionID
+	out.WebUIURL = edit.WebUIURL
+	out.Reply = edit.Reply
+	return out, nil
+}
+
+func (cs *ControlServer) handleTaskEdit(ctx context.Context, req Request) (TaskEditResult, error) {
+	if cs.authoring == nil {
+		return TaskEditResult{}, errors.New("authoring service not configured")
+	}
+	res, err := cs.authoring.EditTask(ctx, req.SessionID, req.TaskID)
+	if err != nil {
+		return TaskEditResult{}, err
+	}
+	out := TaskEditResult{
+		SessionID:   res.SessionID,
+		TaskID:      req.TaskID,
+		Source:      res.Source,
+		SourceKind:  res.SourceKind,
+		SandboxPath: res.SandboxPath,
+		WebUIURL:    cs.authoring.WebUIBaseURL() + "/?session=" + res.SessionID,
+	}
+	return out, nil
+}
+
+func (cs *ControlServer) handleTaskSave(ctx context.Context, req Request) (TaskSaveResult, error) {
+	if cs.authoring == nil {
+		return TaskSaveResult{}, errors.New("authoring service not configured")
+	}
+	if err := cs.authoring.SaveTask(ctx, req.SessionID); err != nil {
+		return TaskSaveResult{}, err
+	}
+	return TaskSaveResult{SessionID: req.SessionID, Applied: true}, nil
+}
+
+func (cs *ControlServer) handleTaskCancel(ctx context.Context, req Request) (TaskCancelResult, error) {
+	if cs.authoring == nil {
+		return TaskCancelResult{}, errors.New("authoring service not configured")
+	}
+	if err := cs.authoring.CancelTask(ctx, req.SessionID); err != nil {
+		return TaskCancelResult{}, err
+	}
+	return TaskCancelResult{SessionID: req.SessionID, Cancelled: true}, nil
+}
 
 func (cs *ControlServer) handleAPIKeyCreate(ctx context.Context, req Request) (any, error) {
 	if cs.apiKeys == nil {

--- a/pkg/ipc/control_task_authoring_test.go
+++ b/pkg/ipc/control_task_authoring_test.go
@@ -1,0 +1,189 @@
+package ipc
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// mockAuthoring is a controllable AuthoringService for the cli.task.*
+// handler tests. Each method either returns the canned result or the
+// canned error so a test can drive both the happy and failure paths.
+type mockAuthoring struct {
+	createResult AuthoringCreateResult
+	createErr    error
+	editResult   AuthoringEditResult
+	editErr      error
+	saveErr      error
+	cancelErr    error
+	baseURL      string
+
+	lastCreateName, lastCreateSource string
+	lastEditSession, lastEditTask    string
+	lastSaveSession, lastCancelSess  string
+}
+
+func (m *mockAuthoring) CreateTask(_ context.Context, name, source string) (AuthoringCreateResult, error) {
+	m.lastCreateName, m.lastCreateSource = name, source
+	return m.createResult, m.createErr
+}
+
+func (m *mockAuthoring) EditTask(_ context.Context, sessionID, taskID string) (AuthoringEditResult, error) {
+	m.lastEditSession, m.lastEditTask = sessionID, taskID
+	return m.editResult, m.editErr
+}
+
+func (m *mockAuthoring) SaveTask(_ context.Context, sessionID string) error {
+	m.lastSaveSession = sessionID
+	return m.saveErr
+}
+
+func (m *mockAuthoring) CancelTask(_ context.Context, sessionID string) error {
+	m.lastCancelSess = sessionID
+	return m.cancelErr
+}
+
+func (m *mockAuthoring) WebUIBaseURL() string {
+	if m.baseURL == "" {
+		return "http://localhost:8080"
+	}
+	return m.baseURL
+}
+
+func newAuthoringControl(a AuthoringService) *ControlServer {
+	return &ControlServer{authoring: a, log: zap.NewNop()}
+}
+
+func TestControl_TaskCreate_NoService(t *testing.T) {
+	cs := &ControlServer{log: zap.NewNop()}
+	_, err := cs.handleTaskCreate(context.Background(), Request{TaskName: "x"})
+	if err == nil || !strings.Contains(err.Error(), "not configured") {
+		t.Fatalf("err = %v, want 'not configured'", err)
+	}
+}
+
+func TestControl_TaskCreate_Plain(t *testing.T) {
+	m := &mockAuthoring{createResult: AuthoringCreateResult{
+		TaskID: "ai-scratch/hello", Source: "ai-scratch", Files: []string{"task.yaml", "task.js"},
+	}}
+	cs := newAuthoringControl(m)
+	res, err := cs.handleTaskCreate(context.Background(), Request{TaskName: "hello", Source: "ai-scratch"})
+	if err != nil {
+		t.Fatalf("handleTaskCreate: %v", err)
+	}
+	if res.TaskID != "ai-scratch/hello" || res.Source != "ai-scratch" {
+		t.Errorf("res = %+v", res)
+	}
+	if res.SessionID != "" || res.WebUIURL != "" {
+		t.Errorf("plain create must not carry edit metadata: %+v", res)
+	}
+	if m.lastCreateName != "hello" || m.lastCreateSource != "ai-scratch" {
+		t.Errorf("service args: name=%q source=%q", m.lastCreateName, m.lastCreateSource)
+	}
+}
+
+func TestControl_TaskCreate_WithAIChainsEdit(t *testing.T) {
+	m := &mockAuthoring{
+		createResult: AuthoringCreateResult{TaskID: "ai-scratch/hello", Source: "ai-scratch"},
+		editResult:   AuthoringEditResult{SessionID: "sess-1", Source: "ai-scratch", SourceKind: "local"},
+		baseURL:      "http://localhost:9999",
+	}
+	cs := newAuthoringControl(m)
+	res, err := cs.handleTaskCreate(context.Background(), Request{TaskName: "hello", Prompt: "do a thing"})
+	if err != nil {
+		t.Fatalf("handleTaskCreate: %v", err)
+	}
+	if res.SessionID != "sess-1" {
+		t.Errorf("session id = %q, want sess-1", res.SessionID)
+	}
+	if !strings.Contains(res.WebUIURL, "sess-1") || !strings.HasPrefix(res.WebUIURL, "http://localhost:9999") {
+		t.Errorf("webui url = %q", res.WebUIURL)
+	}
+	if m.lastEditTask != "ai-scratch/hello" {
+		t.Errorf("edit chained with task %q, want ai-scratch/hello", m.lastEditTask)
+	}
+}
+
+func TestControl_TaskCreate_AIEditFailureKeepsTaskID(t *testing.T) {
+	m := &mockAuthoring{
+		createResult: AuthoringCreateResult{TaskID: "ai-scratch/hello"},
+		editErr:      errors.New("boom"),
+	}
+	cs := newAuthoringControl(m)
+	res, err := cs.handleTaskCreate(context.Background(), Request{TaskName: "hello", Prompt: "p"})
+	if err == nil || !strings.Contains(err.Error(), "edit session failed") {
+		t.Fatalf("err = %v, want edit-failure", err)
+	}
+	if res.TaskID != "ai-scratch/hello" {
+		t.Errorf("task id should survive edit failure, got %q", res.TaskID)
+	}
+}
+
+func TestControl_TaskEdit_BuildsWebUIURL(t *testing.T) {
+	m := &mockAuthoring{
+		editResult: AuthoringEditResult{SessionID: "abc", Source: "ai-scratch", SourceKind: "local"},
+		baseURL:    "https://host:1234",
+	}
+	cs := newAuthoringControl(m)
+	res, err := cs.handleTaskEdit(context.Background(), Request{TaskID: "ai-scratch/t", Prompt: "p"})
+	if err != nil {
+		t.Fatalf("handleTaskEdit: %v", err)
+	}
+	if res.SessionID != "abc" || res.TaskID != "ai-scratch/t" {
+		t.Errorf("res = %+v", res)
+	}
+	if res.WebUIURL != "https://host:1234/?session=abc" {
+		t.Errorf("webui url = %q", res.WebUIURL)
+	}
+}
+
+func TestControl_TaskEdit_ConflictSurfaces(t *testing.T) {
+	m := &mockAuthoring{editErr: errors.New(`source "ai-scratch" already has an open session s2 for task "ai-scratch/other" (#283)`)}
+	cs := newAuthoringControl(m)
+	_, err := cs.handleTaskEdit(context.Background(), Request{TaskID: "ai-scratch/t", Prompt: "p"})
+	if err == nil || !strings.Contains(err.Error(), "#283") {
+		t.Fatalf("conflict err = %v, want #283 mention", err)
+	}
+}
+
+func TestControl_TaskSave(t *testing.T) {
+	m := &mockAuthoring{}
+	cs := newAuthoringControl(m)
+	res, err := cs.handleTaskSave(context.Background(), Request{SessionID: "s1"})
+	if err != nil {
+		t.Fatalf("handleTaskSave: %v", err)
+	}
+	if !res.Applied || res.SessionID != "s1" {
+		t.Errorf("res = %+v", res)
+	}
+	if m.lastSaveSession != "s1" {
+		t.Errorf("save session = %q", m.lastSaveSession)
+	}
+}
+
+func TestControl_TaskSave_Error(t *testing.T) {
+	m := &mockAuthoring{saveErr: errors.New("session not found")}
+	cs := newAuthoringControl(m)
+	_, err := cs.handleTaskSave(context.Background(), Request{SessionID: "missing"})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestControl_TaskCancel(t *testing.T) {
+	m := &mockAuthoring{}
+	cs := newAuthoringControl(m)
+	res, err := cs.handleTaskCancel(context.Background(), Request{SessionID: "s9"})
+	if err != nil {
+		t.Fatalf("handleTaskCancel: %v", err)
+	}
+	if !res.Cancelled || res.SessionID != "s9" {
+		t.Errorf("res = %+v", res)
+	}
+	if m.lastCancelSess != "s9" {
+		t.Errorf("cancel session = %q", m.lastCancelSess)
+	}
+}

--- a/pkg/ipc/control_task_authoring_test.go
+++ b/pkg/ipc/control_task_authoring_test.go
@@ -124,7 +124,7 @@ func TestControl_TaskCreate_AIEditFailureKeepsTaskID(t *testing.T) {
 
 func TestControl_TaskEdit_BuildsWebUIURL(t *testing.T) {
 	m := &mockAuthoring{
-		editResult: AuthoringEditResult{SessionID: "abc", Source: "ai-scratch", SourceKind: "local"},
+		editResult: AuthoringEditResult{SessionID: "abc", TaskID: "ai-scratch/t", Source: "ai-scratch", SourceKind: "local"},
 		baseURL:    "https://host:1234",
 	}
 	cs := newAuthoringControl(m)
@@ -132,6 +132,7 @@ func TestControl_TaskEdit_BuildsWebUIURL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("handleTaskEdit: %v", err)
 	}
+	// TaskID echoes the service result (sess.TaskID), not the request's claim.
 	if res.SessionID != "abc" || res.TaskID != "ai-scratch/t" {
 		t.Errorf("res = %+v", res)
 	}

--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -120,6 +120,12 @@ type Request struct {
 	Prompt    string `json:"prompt,omitempty"`
 	SessionID string `json:"sessionID,omitempty"`
 
+	// cli.task.{create,edit,save,cancel} — AI-first task authoring (#288).
+	// TaskName is the create verb's task name; Source is the create verb's
+	// target source. TaskID/SessionID/Prompt are reused from the fields above.
+	TaskName string `json:"taskName,omitempty"`
+	Source   string `json:"source,omitempty"`
+
 	// dicode.crypto.{encrypt, decrypt} inputs
 	Context       string `json:"context,omitempty"`
 	PlaintextB64  string `json:"plaintext_b64,omitempty"`
@@ -223,6 +229,47 @@ type AIResult struct {
 	RunID     string `json:"runID"`
 	SessionID string `json:"sessionID"`
 	Reply     string `json:"reply"`
+}
+
+// TaskCreateResult is the cli.task.create response (#288). TaskID is the
+// piped value the CLI prints to stdout; the rest is metadata. The SessionID /
+// WebUIURL / Reply fields are populated only on the --ai path, where create
+// chains straight into an edit session in one round-trip.
+type TaskCreateResult struct {
+	TaskID    string   `json:"taskID"`
+	Source    string   `json:"source"`
+	Files     []string `json:"files"`
+	SessionID string   `json:"sessionID,omitempty"`
+	WebUIURL  string   `json:"webuiURL,omitempty"`
+	Reply     string   `json:"reply,omitempty"`
+}
+
+// TaskEditResult is the cli.task.edit response (#288). Reply is the AI turn's
+// text (stdout); SessionID and the source metadata go to stderr. WebUIURL is
+// the page the user can open to continue the session in the browser.
+type TaskEditResult struct {
+	SessionID   string `json:"sessionID"`
+	TaskID      string `json:"taskID"`
+	Source      string `json:"source"`
+	SourceKind  string `json:"sourceKind"`
+	SandboxPath string `json:"sandboxPath"`
+	WebUIURL    string `json:"webuiURL"`
+	Reply       string `json:"reply"`
+}
+
+// TaskSaveResult is the cli.task.save response (#288). TaskID or PRURL is the
+// piped value (stdout); the rest is metadata.
+type TaskSaveResult struct {
+	SessionID string `json:"sessionID"`
+	TaskID    string `json:"taskID"`
+	PRURL     string `json:"prURL,omitempty"`
+	Applied   bool   `json:"applied"`
+}
+
+// TaskCancelResult is the cli.task.cancel response (#288).
+type TaskCancelResult struct {
+	SessionID string `json:"sessionID"`
+	Cancelled bool   `json:"cancelled"`
 }
 
 // MetricsSnapshot is the cli.metrics response.

--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -120,7 +120,7 @@ type Request struct {
 	Prompt    string `json:"prompt,omitempty"`
 	SessionID string `json:"sessionID,omitempty"`
 
-	// cli.task.{create,edit,save,cancel} — AI-first task authoring (#288).
+	// cli.task.{create,edit,save,cancel} — AI-first task authoring.
 	// TaskName is the create verb's task name; Source is the create verb's
 	// target source. TaskID/SessionID/Prompt are reused from the fields above.
 	TaskName string `json:"taskName,omitempty"`
@@ -231,7 +231,7 @@ type AIResult struct {
 	Reply     string `json:"reply"`
 }
 
-// TaskCreateResult is the cli.task.create response (#288). TaskID is the
+// TaskCreateResult is the cli.task.create response. TaskID is the
 // piped value the CLI prints to stdout; the rest is metadata. The SessionID /
 // WebUIURL / Reply fields are populated only on the --ai path, where create
 // chains straight into an edit session in one round-trip.
@@ -244,7 +244,7 @@ type TaskCreateResult struct {
 	Reply     string   `json:"reply,omitempty"`
 }
 
-// TaskEditResult is the cli.task.edit response (#288). Reply is the AI turn's
+// TaskEditResult is the cli.task.edit response. Reply is the AI turn's
 // text (stdout); SessionID and the source metadata go to stderr. WebUIURL is
 // the page the user can open to continue the session in the browser.
 type TaskEditResult struct {
@@ -257,7 +257,7 @@ type TaskEditResult struct {
 	Reply       string `json:"reply"`
 }
 
-// TaskSaveResult is the cli.task.save response (#288). TaskID or PRURL is the
+// TaskSaveResult is the cli.task.save response. TaskID or PRURL is the
 // piped value (stdout); the rest is metadata.
 type TaskSaveResult struct {
 	SessionID string `json:"sessionID"`
@@ -266,7 +266,7 @@ type TaskSaveResult struct {
 	Applied   bool   `json:"applied"`
 }
 
-// TaskCancelResult is the cli.task.cancel response (#288).
+// TaskCancelResult is the cli.task.cancel response.
 type TaskCancelResult struct {
 	SessionID string `json:"sessionID"`
 	Cancelled bool   `json:"cancelled"`

--- a/pkg/webui/authoring.go
+++ b/pkg/webui/authoring.go
@@ -2,14 +2,7 @@ package webui
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"os"
-	"path/filepath"
-	"strings"
-	"time"
-
-	"github.com/google/uuid"
 )
 
 // --- request / response types -----------------------------------------------
@@ -55,82 +48,18 @@ func (s *Server) apiTaskCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Default source to "ai-scratch".
-	source := req.Source
-	if source == "" {
-		source = "ai-scratch"
-	}
-
-	// Ensure source exists.
-	if s.sourceMgr == nil {
-		jsonErr(w, "source manager not available", http.StatusServiceUnavailable)
-		return
-	}
-	src, ok := s.sourceMgr.Get(source)
-	if !ok {
-		jsonErr(w, fmt.Sprintf("source %q not found", source), http.StatusNotFound)
+	res, err := s.CreateTask(r.Context(), req.Name, req.Source)
+	if err != nil {
+		jsonErr(w, err.Error(), statusFromAuthoringError(err))
 		return
 	}
 
-	// Generate task name if not provided.
-	name := req.Name
-	if name == "" {
-		name = "new-task-" + uuid.New().String()[:8]
-	}
-
-	// Sanitize: lowercase, replace spaces with hyphens, strip non-alnum/hyphen.
-	name = sanitizeTaskName(name)
-	if name == "" {
-		jsonErr(w, "invalid task name", http.StatusBadRequest)
-		return
-	}
-
-	// Determine the directory to write the boilerplate.
-	repoPath := src.RepoPath()
-	if repoPath == "" {
-		jsonErr(w, "source has no repo path; is it started?", http.StatusServiceUnavailable)
-		return
-	}
-	taskDir := filepath.Join(repoPath, name)
-	if err := os.MkdirAll(taskDir, 0755); err != nil {
-		jsonErr(w, fmt.Sprintf("create task dir: %v", err), http.StatusInternalServerError)
-		return
-	}
-
-	// Write boilerplate task.yaml.
-	taskYAML := fmt.Sprintf(`apiVersion: dicode/v1
-kind: Task
-name: %s
-description: ""
-runtime: deno
-trigger:
-  manual: true
-timeout: 30s
-`, name)
-	yamlPath := filepath.Join(taskDir, "task.yaml")
-	if err := os.WriteFile(yamlPath, []byte(taskYAML), 0644); err != nil {
-		jsonErr(w, fmt.Sprintf("write task.yaml: %v", err), http.StatusInternalServerError)
-		return
-	}
-
-	// Write boilerplate task.js.
-	taskJS := `export default async function main() {
-  dicode.log.info("Hello from " + dicode.params.task_id);
-}
-`
-	jsPath := filepath.Join(taskDir, "task.js")
-	if err := os.WriteFile(jsPath, []byte(taskJS), 0644); err != nil {
-		jsonErr(w, fmt.Sprintf("write task.js: %v", err), http.StatusInternalServerError)
-		return
-	}
-
-	taskID := source + "/" + name
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(taskCreateResp{
-		TaskID: taskID,
-		Source: source,
-		Files:  []string{"task.yaml", "task.js"},
+		TaskID: res.TaskID,
+		Source: res.Source,
+		Files:  res.Files,
 	})
 }
 
@@ -143,95 +72,19 @@ func (s *Server) apiTaskEdit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if s.authoringSessions == nil {
-		jsonErr(w, "authoring sessions not available", http.StatusServiceUnavailable)
-		return
-	}
-
-	ctx := r.Context()
-
-	// Resume existing session.
-	if req.SessionID != "" {
-		sess, err := s.authoringSessions.Get(ctx, req.SessionID)
-		if err != nil {
-			jsonErr(w, fmt.Sprintf("lookup session: %v", err), http.StatusInternalServerError)
-			return
-		}
-		if sess == nil {
-			jsonErr(w, "session not found", http.StatusNotFound)
-			return
-		}
-		if sess.ClosedAt != nil {
-			jsonErr(w, "session is closed", http.StatusConflict)
-			return
-		}
-		// Bump last_turn_at.
-		_ = s.authoringSessions.UpdateLastTurn(ctx, sess.ID)
-
-		sourceKind := s.resolveSourceKind(sess.Source)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusAccepted)
-		_ = json.NewEncoder(w).Encode(taskEditResp{
-			SessionID:   sess.ID,
-			SandboxPath: sess.SandboxPath,
-			Source:      sess.Source,
-			SourceKind:  sourceKind,
-		})
-		return
-	}
-
-	// Need task_id to create/resume.
-	if req.TaskID == "" {
-		jsonErr(w, "task_id or session_id required", http.StatusBadRequest)
-		return
-	}
-
-	// Derive source name from task_id (first path segment).
-	source := req.TaskID
-	if idx := strings.Index(source, "/"); idx > 0 {
-		source = source[:idx]
-	}
-
-	// Single-session-per-source: check if one is already open.
-	existing, err := s.authoringSessions.GetOpenForSource(ctx, source)
+	res, err := s.EditTask(r.Context(), req.SessionID, req.TaskID)
 	if err != nil {
-		jsonErr(w, fmt.Sprintf("check open sessions: %v", err), http.StatusInternalServerError)
-		return
-	}
-	if existing != nil {
-		jsonErr(w, fmt.Sprintf("source %q already has an open session %s", source, existing.ID), http.StatusConflict)
+		jsonErr(w, err.Error(), statusFromAuthoringError(err))
 		return
 	}
 
-	// Create a new session.
-	sessID := uuid.New().String()
-	now := time.Now()
-	sess := AuthoringSession{
-		ID:          sessID,
-		Kind:        "edit",
-		Source:      source,
-		TaskID:      req.TaskID,
-		SandboxPath: "", // TODO: set when AI agent dispatch is wired
-		CreatedAt:   now,
-		LastTurnAt:  now,
-	}
-
-	if err := s.authoringSessions.Create(ctx, sess); err != nil {
-		jsonErr(w, fmt.Sprintf("create session: %v", err), http.StatusInternalServerError)
-		return
-	}
-
-	// TODO(#288): call set_dev_mode on the source and dispatch to cfg.AI.CreateTask.
-	// For this slice the session is created but the AI agent invocation is stubbed.
-
-	sourceKind := s.resolveSourceKind(source)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(taskEditResp{
-		SessionID:   sessID,
-		SandboxPath: sess.SandboxPath,
-		Source:      source,
-		SourceKind:  sourceKind,
+		SessionID:   res.SessionID,
+		SandboxPath: res.SandboxPath,
+		Source:      res.Source,
+		SourceKind:  res.SourceKind,
 	})
 }
 
@@ -244,37 +97,8 @@ func (s *Server) apiTaskSave(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.SessionID == "" {
-		jsonErr(w, "session_id required", http.StatusBadRequest)
-		return
-	}
-
-	if s.authoringSessions == nil {
-		jsonErr(w, "authoring sessions not available", http.StatusServiceUnavailable)
-		return
-	}
-
-	ctx := r.Context()
-	sess, err := s.authoringSessions.Get(ctx, req.SessionID)
-	if err != nil {
-		jsonErr(w, fmt.Sprintf("lookup session: %v", err), http.StatusInternalServerError)
-		return
-	}
-	if sess == nil {
-		jsonErr(w, "session not found", http.StatusNotFound)
-		return
-	}
-	if sess.ClosedAt != nil {
-		jsonErr(w, "session is already closed", http.StatusConflict)
-		return
-	}
-
-	// TODO(#288): for git sources, chain into buildin/git-pr.
-	// For local sources: rsync sandbox → source root, disable dev mode.
-
-	// Close the session as applied.
-	if err := s.authoringSessions.Close(ctx, sess.ID, true); err != nil {
-		jsonErr(w, fmt.Sprintf("close session: %v", err), http.StatusInternalServerError)
+	if err := s.SaveTask(r.Context(), req.SessionID); err != nil {
+		jsonErr(w, err.Error(), statusFromAuthoringError(err))
 		return
 	}
 
@@ -290,67 +114,10 @@ func (s *Server) apiTaskCancel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.SessionID == "" {
-		jsonErr(w, "session_id required", http.StatusBadRequest)
-		return
-	}
-
-	if s.authoringSessions == nil {
-		jsonErr(w, "authoring sessions not available", http.StatusServiceUnavailable)
-		return
-	}
-
-	ctx := r.Context()
-	sess, err := s.authoringSessions.Get(ctx, req.SessionID)
-	if err != nil {
-		jsonErr(w, fmt.Sprintf("lookup session: %v", err), http.StatusInternalServerError)
-		return
-	}
-	if sess == nil {
-		jsonErr(w, "session not found", http.StatusNotFound)
-		return
-	}
-	if sess.ClosedAt != nil {
-		// Already closed — idempotent.
-		jsonOK(w, map[string]bool{"cancelled": true})
-		return
-	}
-
-	// TODO(#288): disable dev mode on the source, clean up sandbox directory.
-
-	if err := s.authoringSessions.Close(ctx, sess.ID, false); err != nil {
-		jsonErr(w, fmt.Sprintf("close session: %v", err), http.StatusInternalServerError)
+	if err := s.CancelTask(r.Context(), req.SessionID); err != nil {
+		jsonErr(w, err.Error(), statusFromAuthoringError(err))
 		return
 	}
 
 	jsonOK(w, map[string]bool{"cancelled": true})
-}
-
-// --- helpers ----------------------------------------------------------------
-
-// sanitizeTaskName lowercases, replaces spaces with hyphens, and strips
-// characters that are not alphanumeric or hyphen.
-func sanitizeTaskName(name string) string {
-	name = strings.ToLower(strings.TrimSpace(name))
-	name = strings.ReplaceAll(name, " ", "-")
-	var b strings.Builder
-	for _, c := range name {
-		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' {
-			b.WriteRune(c)
-		}
-	}
-	return strings.Trim(b.String(), "-")
-}
-
-// resolveSourceKind returns "git", "local", or "taskset" for the named source.
-func (s *Server) resolveSourceKind(name string) string {
-	if s.sourceMgr == nil {
-		return ""
-	}
-	for _, info := range s.sourceMgr.List() {
-		if info.Name == name {
-			return info.Type
-		}
-	}
-	return ""
 }

--- a/pkg/webui/authoring_db.go
+++ b/pkg/webui/authoring_db.go
@@ -9,7 +9,7 @@ import (
 	"github.com/dicode/dicode/pkg/db"
 )
 
-// AuthoringSession represents an AI-first task authoring session (#288).
+// AuthoringSession represents an AI-first task authoring session.
 type AuthoringSession struct {
 	ID          string    `json:"id"`
 	Kind        string    `json:"kind"`         // "create" or "edit"

--- a/pkg/webui/authoring_service.go
+++ b/pkg/webui/authoring_service.go
@@ -1,0 +1,274 @@
+package webui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/dicode/dicode/pkg/ipc"
+	"github.com/google/uuid"
+)
+
+// Authoring service layer (#288). The REST handlers in authoring.go and the
+// control-socket IPC handlers in pkg/ipc both call these methods, so the
+// create/edit/save/cancel business logic lives in exactly one place.
+
+// authoringError carries an HTTP-style status alongside the message so the
+// REST layer can map it back to a response code while the IPC layer surfaces
+// the same wording. The 409 conflict path (single open session per source)
+// references #283 and must reach CLI users intact.
+type authoringError struct {
+	status int
+	msg    string
+}
+
+func (e *authoringError) Error() string { return e.msg }
+
+func authErr(status int, format string, a ...any) *authoringError {
+	return &authoringError{status: status, msg: fmt.Sprintf(format, a...)}
+}
+
+// CreateTask scaffolds boilerplate task files into the named source and
+// returns the new task id. An empty source defaults to "ai-scratch"; an
+// empty name is generated.
+func (s *Server) CreateTask(ctx context.Context, name, source string) (ipc.AuthoringCreateResult, error) {
+	if source == "" {
+		source = "ai-scratch"
+	}
+	if s.sourceMgr == nil {
+		return ipc.AuthoringCreateResult{}, authErr(503, "source manager not available")
+	}
+	src, ok := s.sourceMgr.Get(source)
+	if !ok {
+		return ipc.AuthoringCreateResult{}, authErr(404, "source %q not found", source)
+	}
+
+	if name == "" {
+		name = "new-task-" + uuid.New().String()[:8]
+	}
+	name = sanitizeTaskName(name)
+	if name == "" {
+		return ipc.AuthoringCreateResult{}, authErr(400, "invalid task name")
+	}
+
+	repoPath := src.RepoPath()
+	if repoPath == "" {
+		return ipc.AuthoringCreateResult{}, authErr(503, "source has no repo path; is it started?")
+	}
+	taskDir := filepath.Join(repoPath, name)
+	if err := os.MkdirAll(taskDir, 0755); err != nil {
+		return ipc.AuthoringCreateResult{}, authErr(500, "create task dir: %v", err)
+	}
+
+	taskYAML := fmt.Sprintf(`apiVersion: dicode/v1
+kind: Task
+name: %s
+description: ""
+runtime: deno
+trigger:
+  manual: true
+timeout: 30s
+`, name)
+	if err := os.WriteFile(filepath.Join(taskDir, "task.yaml"), []byte(taskYAML), 0644); err != nil {
+		return ipc.AuthoringCreateResult{}, authErr(500, "write task.yaml: %v", err)
+	}
+
+	taskJS := `export default async function main() {
+  dicode.log.info("Hello from " + dicode.params.task_id);
+}
+`
+	if err := os.WriteFile(filepath.Join(taskDir, "task.js"), []byte(taskJS), 0644); err != nil {
+		return ipc.AuthoringCreateResult{}, authErr(500, "write task.js: %v", err)
+	}
+
+	return ipc.AuthoringCreateResult{
+		TaskID: source + "/" + name,
+		Source: source,
+		Files:  []string{"task.yaml", "task.js"},
+	}, nil
+}
+
+// EditTask opens a new AI edit session for taskID, or resumes the session
+// identified by sessionID. Exactly one of the two must be supplied. The
+// single-open-session-per-source rule (#283) is enforced here: a fresh edit
+// for a source that already has an open session returns a 409 conflict.
+func (s *Server) EditTask(ctx context.Context, sessionID, taskID string) (ipc.AuthoringEditResult, error) {
+	if s.authoringSessions == nil {
+		return ipc.AuthoringEditResult{}, authErr(503, "authoring sessions not available")
+	}
+
+	if sessionID != "" {
+		sess, err := s.authoringSessions.Get(ctx, sessionID)
+		if err != nil {
+			return ipc.AuthoringEditResult{}, authErr(500, "lookup session: %v", err)
+		}
+		if sess == nil {
+			return ipc.AuthoringEditResult{}, authErr(404, "session not found")
+		}
+		if sess.ClosedAt != nil {
+			return ipc.AuthoringEditResult{}, authErr(409, "session is closed")
+		}
+		_ = s.authoringSessions.UpdateLastTurn(ctx, sess.ID)
+		return ipc.AuthoringEditResult{
+			SessionID:   sess.ID,
+			SandboxPath: sess.SandboxPath,
+			Source:      sess.Source,
+			SourceKind:  s.resolveSourceKind(sess.Source),
+		}, nil
+	}
+
+	if taskID == "" {
+		return ipc.AuthoringEditResult{}, authErr(400, "task_id or session_id required")
+	}
+
+	source := taskID
+	if idx := strings.Index(source, "/"); idx > 0 {
+		source = source[:idx]
+	}
+
+	// Single-session-per-source (#283): auto-resume an open session for this
+	// source rather than rejecting, so the CLI's task-id-keyed edit verb
+	// transparently continues the in-flight conversation. A session opened
+	// against a different task in the same source surfaces as a conflict.
+	existing, err := s.authoringSessions.GetOpenForSource(ctx, source)
+	if err != nil {
+		return ipc.AuthoringEditResult{}, authErr(500, "check open sessions: %v", err)
+	}
+	if existing != nil {
+		if existing.TaskID != "" && existing.TaskID != taskID {
+			return ipc.AuthoringEditResult{}, authErr(409, "source %q already has an open session %s for task %q (#283)", source, existing.ID, existing.TaskID)
+		}
+		_ = s.authoringSessions.UpdateLastTurn(ctx, existing.ID)
+		return ipc.AuthoringEditResult{
+			SessionID:   existing.ID,
+			SandboxPath: existing.SandboxPath,
+			Source:      existing.Source,
+			SourceKind:  s.resolveSourceKind(existing.Source),
+		}, nil
+	}
+
+	sessID := uuid.New().String()
+	now := time.Now()
+	sess := AuthoringSession{
+		ID:         sessID,
+		Kind:       "edit",
+		Source:     source,
+		TaskID:     taskID,
+		CreatedAt:  now,
+		LastTurnAt: now,
+	}
+	if err := s.authoringSessions.Create(ctx, sess); err != nil {
+		return ipc.AuthoringEditResult{}, authErr(500, "create session: %v", err)
+	}
+
+	return ipc.AuthoringEditResult{
+		SessionID:   sessID,
+		SandboxPath: sess.SandboxPath,
+		Source:      source,
+		SourceKind:  s.resolveSourceKind(source),
+	}, nil
+}
+
+// SaveTask applies the session's pending changes and closes it as applied.
+func (s *Server) SaveTask(ctx context.Context, sessionID string) error {
+	if sessionID == "" {
+		return authErr(400, "session_id required")
+	}
+	if s.authoringSessions == nil {
+		return authErr(503, "authoring sessions not available")
+	}
+	sess, err := s.authoringSessions.Get(ctx, sessionID)
+	if err != nil {
+		return authErr(500, "lookup session: %v", err)
+	}
+	if sess == nil {
+		return authErr(404, "session not found")
+	}
+	if sess.ClosedAt != nil {
+		return authErr(409, "session is already closed")
+	}
+	if err := s.authoringSessions.Close(ctx, sess.ID, true); err != nil {
+		return authErr(500, "close session: %v", err)
+	}
+	return nil
+}
+
+// CancelTask discards the session. It is idempotent: cancelling an
+// already-closed session is a no-op success.
+func (s *Server) CancelTask(ctx context.Context, sessionID string) error {
+	if sessionID == "" {
+		return authErr(400, "session_id required")
+	}
+	if s.authoringSessions == nil {
+		return authErr(503, "authoring sessions not available")
+	}
+	sess, err := s.authoringSessions.Get(ctx, sessionID)
+	if err != nil {
+		return authErr(500, "lookup session: %v", err)
+	}
+	if sess == nil {
+		return authErr(404, "session not found")
+	}
+	if sess.ClosedAt != nil {
+		return nil
+	}
+	if err := s.authoringSessions.Close(ctx, sess.ID, false); err != nil {
+		return authErr(500, "close session: %v", err)
+	}
+	return nil
+}
+
+// WebUIBaseURL returns the scheme://host:port the browser would use to reach
+// this daemon's web UI. TLS config flips the scheme; the host defaults to
+// localhost since the daemon binds all interfaces and the CLI runs on the
+// same machine.
+func (s *Server) WebUIBaseURL() string {
+	scheme := "http"
+	s.cfgMu.RLock()
+	if s.cfg != nil && s.cfg.Server.TLSCertFile != "" && s.cfg.Server.TLSKeyFile != "" {
+		scheme = "https"
+	}
+	s.cfgMu.RUnlock()
+	return fmt.Sprintf("%s://localhost:%d", scheme, s.port)
+}
+
+// statusFromAuthoringError extracts the HTTP status from an authoringError,
+// defaulting to 500 for any other error type.
+func statusFromAuthoringError(err error) int {
+	var ae *authoringError
+	if errors.As(err, &ae) {
+		return ae.status
+	}
+	return 500
+}
+
+// sanitizeTaskName lowercases, replaces spaces with hyphens, and strips
+// characters that are not alphanumeric or hyphen.
+func sanitizeTaskName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	name = strings.ReplaceAll(name, " ", "-")
+	var b strings.Builder
+	for _, c := range name {
+		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' {
+			b.WriteRune(c)
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// resolveSourceKind returns "git", "local", or "taskset" for the named source.
+func (s *Server) resolveSourceKind(name string) string {
+	if s.sourceMgr == nil {
+		return ""
+	}
+	for _, info := range s.sourceMgr.List() {
+		if info.Name == name {
+			return info.Type
+		}
+	}
+	return ""
+}

--- a/pkg/webui/authoring_service.go
+++ b/pkg/webui/authoring_service.go
@@ -21,7 +21,8 @@ import (
 // authoringError carries an HTTP-style status alongside the message so the
 // REST layer can map it back to a response code while the IPC layer surfaces
 // the same wording. The 409 conflict path (single open session per source)
-// references #283 and must reach CLI users intact.
+// carries its #283 reference in the message itself and must reach CLI users
+// intact.
 type authoringError struct {
 	status int
 	msg    string
@@ -95,7 +96,7 @@ timeout: 30s
 
 // EditTask opens a new AI edit session for taskID, or resumes the session
 // identified by sessionID. Exactly one of the two must be supplied. The
-// single-open-session-per-source rule (#283) is enforced here: an edit for a
+// single-open-session-per-source rule is enforced here: an edit for a
 // source whose open session is the SAME task auto-resumes that session; an edit
 // for a DIFFERENT task in that source returns a 409 conflict.
 func (s *Server) EditTask(ctx context.Context, sessionID, taskID string) (ipc.AuthoringEditResult, error) {
@@ -136,7 +137,7 @@ func (s *Server) EditTask(ctx context.Context, sessionID, taskID string) (ipc.Au
 		source = source[:idx]
 	}
 
-	// Single-session-per-source (#283): auto-resume an open session for this
+	// Single-session-per-source: auto-resume an open session for this
 	// source rather than rejecting, so the CLI's task-id-keyed edit verb
 	// transparently continues the in-flight conversation. A session opened
 	// against a different task in the same source surfaces as a conflict.
@@ -181,8 +182,8 @@ func (s *Server) EditTask(ctx context.Context, sessionID, taskID string) (ipc.Au
 }
 
 // resumeOrConflict resumes an existing open session for a source when it is the
-// same task, or returns the 409 single-session conflict (#283) when the open
-// session belongs to a different task.
+// same task, or returns the 409 single-session conflict when the open session
+// belongs to a different task.
 func (s *Server) resumeOrConflict(ctx context.Context, existing *AuthoringSession, source, taskID string) (ipc.AuthoringEditResult, error) {
 	if existing.TaskID != "" && existing.TaskID != taskID {
 		return ipc.AuthoringEditResult{}, authErr(409, "source %q already has an open session %s for task %q (#283)", source, existing.ID, existing.TaskID)

--- a/pkg/webui/authoring_service.go
+++ b/pkg/webui/authoring_service.go
@@ -11,11 +11,12 @@ import (
 
 	"github.com/dicode/dicode/pkg/ipc"
 	"github.com/google/uuid"
+	"go.uber.org/zap"
 )
 
-// Authoring service layer (#288). The REST handlers in authoring.go and the
-// control-socket IPC handlers in pkg/ipc both call these methods, so the
-// create/edit/save/cancel business logic lives in exactly one place.
+// The REST handlers in authoring.go and the control-socket IPC handlers in
+// pkg/ipc both call these methods, so the create/edit/save/cancel business
+// logic lives in exactly one place.
 
 // authoringError carries an HTTP-style status alongside the message so the
 // REST layer can map it back to a response code while the IPC layer surfaces
@@ -94,8 +95,9 @@ timeout: 30s
 
 // EditTask opens a new AI edit session for taskID, or resumes the session
 // identified by sessionID. Exactly one of the two must be supplied. The
-// single-open-session-per-source rule (#283) is enforced here: a fresh edit
-// for a source that already has an open session returns a 409 conflict.
+// single-open-session-per-source rule (#283) is enforced here: an edit for a
+// source whose open session is the SAME task auto-resumes that session; an edit
+// for a DIFFERENT task in that source returns a 409 conflict.
 func (s *Server) EditTask(ctx context.Context, sessionID, taskID string) (ipc.AuthoringEditResult, error) {
 	if s.authoringSessions == nil {
 		return ipc.AuthoringEditResult{}, authErr(503, "authoring sessions not available")
@@ -112,9 +114,13 @@ func (s *Server) EditTask(ctx context.Context, sessionID, taskID string) (ipc.Au
 		if sess.ClosedAt != nil {
 			return ipc.AuthoringEditResult{}, authErr(409, "session is closed")
 		}
+		if taskID != "" && sess.TaskID != taskID {
+			return ipc.AuthoringEditResult{}, authErr(409, "session %s belongs to task %q, not %q", sess.ID, sess.TaskID, taskID)
+		}
 		_ = s.authoringSessions.UpdateLastTurn(ctx, sess.ID)
 		return ipc.AuthoringEditResult{
 			SessionID:   sess.ID,
+			TaskID:      sess.TaskID,
 			SandboxPath: sess.SandboxPath,
 			Source:      sess.Source,
 			SourceKind:  s.resolveSourceKind(sess.Source),
@@ -139,16 +145,7 @@ func (s *Server) EditTask(ctx context.Context, sessionID, taskID string) (ipc.Au
 		return ipc.AuthoringEditResult{}, authErr(500, "check open sessions: %v", err)
 	}
 	if existing != nil {
-		if existing.TaskID != "" && existing.TaskID != taskID {
-			return ipc.AuthoringEditResult{}, authErr(409, "source %q already has an open session %s for task %q (#283)", source, existing.ID, existing.TaskID)
-		}
-		_ = s.authoringSessions.UpdateLastTurn(ctx, existing.ID)
-		return ipc.AuthoringEditResult{
-			SessionID:   existing.ID,
-			SandboxPath: existing.SandboxPath,
-			Source:      existing.Source,
-			SourceKind:  s.resolveSourceKind(existing.Source),
-		}, nil
+		return s.resumeOrConflict(ctx, existing, source, taskID)
 	}
 
 	sessID := uuid.New().String()
@@ -162,15 +159,49 @@ func (s *Server) EditTask(ctx context.Context, sessionID, taskID string) (ipc.Au
 		LastTurnAt: now,
 	}
 	if err := s.authoringSessions.Create(ctx, sess); err != nil {
+		// The partial unique index idx_author_sessions_open_source rejects a
+		// second open session for this source. A concurrent insert that lost
+		// the race lands here: re-read the winner and return the same 409 the
+		// non-racing path returns, not a 500.
+		if isUniqueConstraint(err) {
+			if winner, gerr := s.authoringSessions.GetOpenForSource(ctx, source); gerr == nil && winner != nil {
+				return s.resumeOrConflict(ctx, winner, source, taskID)
+			}
+		}
 		return ipc.AuthoringEditResult{}, authErr(500, "create session: %v", err)
 	}
 
 	return ipc.AuthoringEditResult{
 		SessionID:   sessID,
+		TaskID:      taskID,
 		SandboxPath: sess.SandboxPath,
 		Source:      source,
 		SourceKind:  s.resolveSourceKind(source),
 	}, nil
+}
+
+// resumeOrConflict resumes an existing open session for a source when it is the
+// same task, or returns the 409 single-session conflict (#283) when the open
+// session belongs to a different task.
+func (s *Server) resumeOrConflict(ctx context.Context, existing *AuthoringSession, source, taskID string) (ipc.AuthoringEditResult, error) {
+	if existing.TaskID != "" && existing.TaskID != taskID {
+		return ipc.AuthoringEditResult{}, authErr(409, "source %q already has an open session %s for task %q (#283)", source, existing.ID, existing.TaskID)
+	}
+	_ = s.authoringSessions.UpdateLastTurn(ctx, existing.ID)
+	return ipc.AuthoringEditResult{
+		SessionID:   existing.ID,
+		TaskID:      existing.TaskID,
+		SandboxPath: existing.SandboxPath,
+		Source:      existing.Source,
+		SourceKind:  s.resolveSourceKind(existing.Source),
+	}, nil
+}
+
+// isUniqueConstraint reports whether err is a SQLite UNIQUE-constraint
+// violation. The db layer surfaces the driver error verbatim; modernc.org/sqlite
+// renders these as "...UNIQUE constraint failed: ...".
+func isUniqueConstraint(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed")
 }
 
 // SaveTask applies the session's pending changes and closes it as applied.
@@ -220,6 +251,53 @@ func (s *Server) CancelTask(ctx context.Context, sessionID string) error {
 		return authErr(500, "close session: %v", err)
 	}
 	return nil
+}
+
+// startAuthoringPurgeLoop sweeps idle open authoring sessions on the configured
+// ai.create_session_ttl cadence so a stale never-saved session stops blocking
+// its source (the single-session-per-source rule would otherwise wedge it
+// forever). A non-positive TTL disables the sweep. The loop exits when ctx is
+// cancelled at daemon shutdown.
+func (s *Server) startAuthoringPurgeLoop(ctx context.Context) {
+	if s.authoringSessions == nil {
+		return
+	}
+	s.cfgMu.RLock()
+	ttl := time.Duration(0)
+	if s.cfg != nil {
+		ttl = s.cfg.AI.CreateSessionTTL
+	}
+	s.cfgMu.RUnlock()
+	if ttl <= 0 {
+		return
+	}
+
+	// Sweep at a fraction of the TTL so a session is cancelled within a
+	// bounded window past its deadline rather than up to a full TTL late.
+	interval := ttl / 4
+	if interval < time.Minute {
+		interval = time.Minute
+	}
+
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				n, err := s.authoringSessions.PurgeExpired(ctx, ttl)
+				if err != nil {
+					s.log.Warn("authoring session purge failed", zap.Error(err))
+					continue
+				}
+				if n > 0 {
+					s.log.Info("purged idle authoring sessions", zap.Int("count", n))
+				}
+			}
+		}
+	}()
 }
 
 // WebUIBaseURL returns the scheme://host:port the browser would use to reach

--- a/pkg/webui/authoring_service_test.go
+++ b/pkg/webui/authoring_service_test.go
@@ -1,0 +1,78 @@
+package webui
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestIsUniqueConstraint_RealDriverError pins isUniqueConstraint against the
+// actual error the SQLite driver returns when the single-open-session-per-source
+// partial unique index rejects a second insert. If the driver's wording drifts,
+// the EditTask race-loser path would silently fall back to a 500 — this guards it.
+func TestIsUniqueConstraint_RealDriverError(t *testing.T) {
+	d := openTestDB(t)
+	store := newAuthoringSessionStore(d)
+	ctx := context.Background()
+
+	now := time.Now()
+	first := AuthoringSession{
+		ID: "s1", Kind: "edit", Source: "ai-scratch", TaskID: "ai-scratch/a",
+		CreatedAt: now, LastTurnAt: now,
+	}
+	if err := store.Create(ctx, first); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+	// Second open session for the same source must violate the partial index.
+	second := AuthoringSession{
+		ID: "s2", Kind: "edit", Source: "ai-scratch", TaskID: "ai-scratch/b",
+		CreatedAt: now, LastTurnAt: now,
+	}
+	err := store.Create(ctx, second)
+	if err == nil {
+		t.Fatal("second Create succeeded, want UNIQUE constraint violation")
+	}
+	if !isUniqueConstraint(err) {
+		t.Fatalf("isUniqueConstraint(%v) = false; driver wording drifted", err)
+	}
+}
+
+// TestEditTask_ConcurrentSameTaskNoServerError fires many concurrent edits for
+// the same task+source and asserts none get a 500. The single-session index
+// prevents double-creation; the race loser must re-resolve to the open session
+// (202), and at most one different-task collision would surface 409 — never 500.
+func TestEditTask_ConcurrentSameTaskNoServerError(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	sessions := make([]string, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			res, err := srv.EditTask(context.Background(), "", "ai-scratch/hello")
+			errs[i] = err
+			sessions[i] = res.SessionID
+		}(i)
+	}
+	wg.Wait()
+
+	var sessID string
+	for i, err := range errs {
+		if err != nil {
+			if status := statusFromAuthoringError(err); status >= 500 {
+				t.Fatalf("goroutine %d got server error %d: %v", i, status, err)
+			}
+			t.Fatalf("goroutine %d got unexpected error: %v", i, err)
+		}
+		if sessID == "" {
+			sessID = sessions[i]
+		} else if sessions[i] != sessID {
+			t.Fatalf("goroutine %d resolved to session %q, want shared %q", i, sessions[i], sessID)
+		}
+	}
+}

--- a/pkg/webui/authoring_test.go
+++ b/pkg/webui/authoring_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dicode/dicode/pkg/config"
@@ -211,6 +212,53 @@ func TestAPITaskEdit_ResumeSession(t *testing.T) {
 	}
 }
 
+func TestAPITaskEdit_SameTaskAutoResumes(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	// First edit opens a session for the task.
+	w := postJSON(h, "/api/task/edit", map[string]string{"task_id": "ai-scratch/hello"})
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("first status = %d, want 202; body: %s", w.Code, w.Body.String())
+	}
+	first := decodeJSON(t, w)
+	sessID, _ := first["session_id"].(string)
+	if sessID == "" {
+		t.Fatal("first edit returned empty session_id")
+	}
+
+	// A second edit for the SAME task id auto-resumes the open session rather
+	// than rejecting with 409 — pins the #288 same-task contract.
+	w = postJSON(h, "/api/task/edit", map[string]string{"task_id": "ai-scratch/hello"})
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("same-task status = %d, want 202 auto-resume; body: %s", w.Code, w.Body.String())
+	}
+	second := decodeJSON(t, w)
+	if second["session_id"] != sessID {
+		t.Errorf("auto-resume session_id = %v, want same %q", second["session_id"], sessID)
+	}
+}
+
+func TestAPITaskEdit_DifferentTaskSameSourceConflicts(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	w := postJSON(h, "/api/task/edit", map[string]string{"task_id": "ai-scratch/hello"})
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("first status = %d, want 202", w.Code)
+	}
+
+	w = postJSON(h, "/api/task/edit", map[string]string{"task_id": "ai-scratch/other"})
+	if w.Code != http.StatusConflict {
+		t.Fatalf("different-task status = %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); !strings.Contains(body, "#283") {
+		t.Errorf("409 body = %q, want #283 reference", body)
+	}
+}
+
 func TestAPITaskEdit_ConflictSameSource(t *testing.T) {
 	dir := t.TempDir()
 	srv := newAuthoringTestServer(t, "ai-scratch", dir)
@@ -226,6 +274,38 @@ func TestAPITaskEdit_ConflictSameSource(t *testing.T) {
 	w = postJSON(h, "/api/task/edit", map[string]string{"task_id": "ai-scratch/other"})
 	if w.Code != http.StatusConflict {
 		t.Fatalf("second status = %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPITaskEdit_ResumeRejectsTaskMismatch(t *testing.T) {
+	dir := t.TempDir()
+	srv := newAuthoringTestServer(t, "ai-scratch", dir)
+	h := srv.Handler()
+
+	// Open a session for ai-scratch/hello.
+	w := postJSON(h, "/api/task/edit", map[string]string{"task_id": "ai-scratch/hello"})
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("open status = %d, want 202", w.Code)
+	}
+	sessID := decodeJSON(t, w)["session_id"].(string)
+
+	// Resuming with a task id that does not match the session's must be
+	// rejected rather than silently editing the wrong task.
+	w = postJSON(h, "/api/task/edit", map[string]string{
+		"session_id": sessID,
+		"task_id":    "ai-scratch/wrong",
+	})
+	if w.Code != http.StatusConflict {
+		t.Fatalf("mismatch status = %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+
+	// The same session id resumes cleanly when the task id matches.
+	w = postJSON(h, "/api/task/edit", map[string]string{
+		"session_id": sessID,
+		"task_id":    "ai-scratch/hello",
+	})
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("matching-task resume status = %d, want 202; body: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -539,7 +539,7 @@ func (s *Server) Handler() http.Handler {
 			// AI chat — forwards to the task named by cfg.AI.Task.
 			r.Post("/ai/chat", s.apiAIChat)
 
-			// AI-first task authoring (#288)
+			// AI-first task authoring
 			r.Post("/task/create", s.apiTaskCreate)
 			r.Post("/task/edit", s.apiTaskEdit)
 			r.Post("/task/save", s.apiTaskSave)

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -128,7 +128,7 @@ type Server struct {
 	scsStore           *scsStore              // underlying SQLite store for sm; nil in DB-less tests
 	dbSessions         *dbSessionStore        // persistent trusted-device tokens
 	apiKeys            *apiKeyStore           // MCP / programmatic API keys
-	authoringSessions  *authoringSessionStore // AI-first authoring sessions (#288)
+	authoringSessions  *authoringSessionStore // AI-first authoring sessions
 	passphraseStore    *passphraseStore       // auth passphrase persisted in DB
 	cachedPassphrase   string                 // in-memory cache of stored DB value (bcrypt hash, or legacy plaintext during migration); invalidated on change
 	cachedPassphraseMu sync.RWMutex           // guards cachedPassphrase
@@ -598,6 +598,8 @@ func (s *Server) Start(ctx context.Context) error {
 	if err := s.ensurePassphrase(ctx); err != nil {
 		return fmt.Errorf("ensure auth passphrase: %w", err)
 	}
+
+	s.startAuthoringPurgeLoop(ctx)
 
 	s.srv = &http.Server{
 		Addr:              fmt.Sprintf(":%d", s.port),


### PR DESCRIPTION
## Summary

Slice 3 of the AI-first task authoring epic (#288): add the control-socket IPC methods and the CLI verbs that let an operator scaffold, AI-edit, save, and cancel tasks from the terminal. Slices 1 (#293) and 2 (#369) landed the config fields, the virtual `ai-scratch` source, the `author_sessions` table, and the four `/api/task/*` REST handlers; this slice exposes that same capability over the daemon control socket.

## Approach

The four authoring REST handlers from slice 2 carried their create/edit/save/cancel logic inline. Rather than duplicate it for the CLI, that logic is lifted into reusable `Server.{CreateTask,EditTask,SaveTask,CancelTask}` service methods (`pkg/webui/authoring_service.go`). The slice-2 HTTP handlers now decode the request, call the service, and map an `authoringError`'s carried HTTP status back to the response — so the browser and the CLI run the exact same code with one source of truth.

The control server reaches that layer through a new `ipc.AuthoringService` interface implemented by `webui.Server`, wired at daemon startup via `SetAuthoringService(srv)`. This mirrors the existing `APIKeyMinter` pattern and keeps `pkg/ipc` free of any import on `pkg/webui`. The service result types (`AuthoringCreateResult`, `AuthoringEditResult`) live in `pkg/ipc` so both packages share them without a circular dependency.

## CLI surface

```
dicode task create <name> [--source <name>] [--ai "<prompt>"]
      → boilerplate scaffold; prints task_id to stdout.
        With --ai: scaffold then open an edit session in one round-trip;
        session_id + webui URL to stderr, task_id to stdout.
dicode task edit <task-id> "<prompt>" [--session <id>]
      → opens/resumes an AI edit session. stdout = reply;
        stderr = "session: <id>" and "open: <webui-url>".
dicode task save <session-id>
      → applies the session. stdout = PR url or task id; stderr = session id.
dicode task cancel <session-id>
      → discards. stdout = confirmation; stderr = session id.
```

Stdout carries the single piped value; stderr carries metadata. This matches the existing `dicode ai` convention (`session: <id>` to stderr, reply to stdout). Flag parsing supports `--flag value`, `--flag=value`, and the `--` sentinel so prompts that literally start with `--` pass through. The `dicode task` subcommand scaffold is a clean per-verb switch with each body in `cmd/dicode/task.go`.

## Single-session / #283

The single-open-session-per-source rule is enforced in `EditTask`. A CLI `edit` is keyed by `task_id`; when an open session already exists for that source **and the same task**, the daemon auto-resumes it (so a multi-turn CLI conversation just continues). A session open against a *different* task in the same source returns a 409 that names the conflicting session and references #283, surfaced verbatim to the CLI user.

## Remaining epic work (out of scope here)

- `dc-task-create` web component
- `/api/author/events` websocket room
- `tasks/buildin/task-create/` agent + skill (the actual AI dispatch; `EditTask` currently opens the session but the agent invocation is still stubbed from slice 2)
- `dev-clones-cleanup` extension
- boilerplate templates beyond the minimal create scaffold
- concept docs

## Coordination with #285

`dicode task delete` (#285) is being implemented in parallel and touches the same `cmdTask` dispatcher, the `control.go` dispatch switch, and `message.go`. To minimize conflicts, the new verbs are appended (never reordered) and each verb body lives in `cmd/dicode/task.go`, so #285 only needs to append a `delete` case to the `cmdTask` switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)