### PR TITLE
feat(cli): dicode task delete <id> (#285)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 node_modules/
 .playwright-mcp/
 .worktrees/
+.claude/worktrees/
 playwright-report/
 test-results/
 .playwright/

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -26,6 +26,7 @@
 package main
 
 import (
+	"bufio"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -486,8 +487,10 @@ func cmdTask(c *ipc.ControlClient, args []string) error {
 		return cmdTaskSave(c, args[1:])
 	case "cancel":
 		return cmdTaskCancel(c, args[1:])
+	case "delete":
+		return cmdTaskDelete(c, args[1:])
 	default:
-		return fmt.Errorf("unknown task subcommand %q — supported: test, create, edit, save, cancel", args[0])
+		return fmt.Errorf("unknown task subcommand %q — supported: test, create, edit, save, cancel, delete", args[0])
 	}
 }
 
@@ -526,6 +529,112 @@ func cmdTaskTest(c *ipc.ControlClient, taskID string) error {
 	fmt.Printf(" (runtime=%s, %dms)\n", r.Runtime, r.DurMs)
 	if r.Failed > 0 || r.ExitCode != 0 {
 		return fmt.Errorf("%d test(s) failed", r.Failed)
+	}
+	return nil
+}
+
+// cmdTaskDelete implements `dicode task delete <task-id> [--source NAME] [--force]`.
+//
+// Without --force it first fetches a non-destructive preview (chained
+// references, trigger schedule, owning source), prints the warnings, and
+// prompts for confirmation on stderr; the destructive request is sent only
+// after the operator confirms. stdout carries the piped value (the PR URL for
+// git sources, or "deleted" for local sources); stderr carries progress and
+// warnings so pipelines stay clean.
+func cmdTaskDelete(c *ipc.ControlClient, args []string) error {
+	var taskID, source string
+	force := false
+	parseFlags := true
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if parseFlags && a == "--" {
+			parseFlags = false
+			continue
+		}
+		if parseFlags {
+			switch {
+			case a == "--force", a == "-f":
+				force = true
+				continue
+			case a == "--source":
+				if i+1 >= len(args) {
+					return fmt.Errorf("--source requires a value")
+				}
+				source = args[i+1]
+				i++
+				continue
+			case strings.HasPrefix(a, "--source="):
+				source = strings.TrimPrefix(a, "--source=")
+				continue
+			case a == "--help", a == "-h":
+				fmt.Fprintln(os.Stderr, "Usage: dicode task delete <task-id> [--source NAME] [--force]")
+				return nil
+			case strings.HasPrefix(a, "-"):
+				return fmt.Errorf("unknown flag %q — usage: dicode task delete <task-id> [--source NAME] [--force]", a)
+			}
+		}
+		if taskID != "" {
+			return fmt.Errorf("unexpected argument %q — only one task id is allowed", a)
+		}
+		taskID = a
+	}
+	if taskID == "" {
+		return fmt.Errorf("usage: dicode task delete <task-id> [--source NAME] [--force]")
+	}
+
+	if !force {
+		preview, err := c.Send(ipc.Request{Method: "cli.task.delete", TaskID: taskID, Source: source, Force: false})
+		if err != nil {
+			return err
+		}
+		if preview.Error != "" {
+			return fmt.Errorf("%s", preview.Error)
+		}
+		var p ipc.TaskDeleteResult
+		if err := remarshal(preview.Result, &p); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "About to delete task %q from source %q.\n", p.TaskID, p.Source)
+		if p.Trigger != "" {
+			fmt.Fprintf(os.Stderr, "  trigger: %s\n", p.Trigger)
+		}
+		if len(p.Refs) > 0 {
+			fmt.Fprintf(os.Stderr, "  WARNING: %d task(s) chain off this one and will dangle: %s\n",
+				len(p.Refs), strings.Join(p.Refs, ", "))
+		}
+		fmt.Fprintln(os.Stderr, "  Pinned/historical runs of this task remain viewable but lose their friendly name.")
+		fmt.Fprint(os.Stderr, "Proceed? [y/N] ")
+		reader := bufio.NewReader(os.Stdin)
+		line, _ := reader.ReadString('\n')
+		switch strings.ToLower(strings.TrimSpace(line)) {
+		case "y", "yes":
+		default:
+			return fmt.Errorf("aborted")
+		}
+	}
+
+	resp, err := c.Send(ipc.Request{Method: "cli.task.delete", TaskID: taskID, Source: source, Force: true})
+	if err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	var r ipc.TaskDeleteResult
+	if err := remarshal(resp.Result, &r); err != nil {
+		return err
+	}
+	switch r.Mode {
+	case "git":
+		fmt.Fprintf(os.Stderr, "Pushed deletion to branch %q; opened PR (run %s).\n", r.Branch, r.PRRunID)
+		if r.PRValue != "" {
+			fmt.Println(r.PRValue) // PR URL → stdout
+		} else {
+			fmt.Println(r.Branch)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "Deleted task %q from source %q. Reconciler will deregister it within ~30s.\n", r.TaskID, r.Source)
+		fmt.Println("deleted")
 	}
 	return nil
 }
@@ -890,6 +999,8 @@ Commands:
   ai <prompt> [flags]             run the configured AI task with a prompt
                                   flags: --session-id ID, --task TASK_ID
   task test <task-id>             run the task's sibling task.test.* through its runtime
+  task delete <task-id> [flags]   remove a task from its source (local rm / git PR)
+                                  flags: --source NAME, --force
   secrets list                    list secret keys
   secrets set <key> <value>       store a secret
   secrets delete <key>            delete a secret

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -121,7 +121,7 @@ func dispatch(c *ipc.ControlClient, args []string) error {
 		return cmdAI(c, args[1:])
 	case "task":
 		if len(args) < 2 {
-			return fmt.Errorf("usage: dicode task <test|create|edit|save|cancel> [args...]")
+			return fmt.Errorf("usage: dicode task <test|create|edit|save|cancel|delete> [args...]")
 		}
 		return cmdTask(c, args[1:])
 	case "auth":

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -406,6 +406,10 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	// handlers use.
 	ctrlSrv.SetAuthoringService(srv)
 
+	// Wire task deletion so `dicode task delete` can remove a task from its
+	// source. The SourceManager owns source state, repo paths, and dev-clones.
+	ctrlSrv.SetTaskDeleter(sourceMgr)
+
 	// Wire the generic dicode.crypto.{encrypt, decrypt} IPC verb so buildin
 	// tasks (relay-client, auth-start, auth-relay) can encrypt/decrypt blobs
 	// via DeriveSubKey-derived sub-keys. Sub-keys never cross IPC; only the

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -40,6 +40,7 @@ type ControlServer struct {
 	database        db.DB            // for broker pubkey trust pinning; nil in tests
 	apiKeys         APIKeyMinter     // nil if webui not wired (tests)
 	authoring       AuthoringService // nil if webui not wired (tests)
+	taskDeleter     TaskDeleter      // nil if webui not wired (tests)
 	log             *zap.Logger
 
 	// defaultAITask is cfg.AI.Task — the task id that `dicode ai` fires when
@@ -243,6 +244,9 @@ func (cs *ControlServer) dispatch(ctx context.Context, req Request) (any, error)
 
 	case "cli.task.cancel":
 		return cs.handleTaskCancel(ctx, req)
+
+	case "cli.task.delete":
+		return cs.handleTaskDelete(ctx, req)
 
 	case "cli.auth.reset_passphrase":
 		return cs.handleAuthResetPassphrase(ctx)

--- a/pkg/ipc/control_task_delete.go
+++ b/pkg/ipc/control_task_delete.go
@@ -39,11 +39,18 @@ type TaskDeleter interface {
 	ResolveTaskSource(taskID, sourceOverride string) (name string, isGit bool, err error)
 
 	// DeleteTaskFromSource performs the removal. For a local source it removes
-	// the task directory in place. For a git source it clones the repo, removes
-	// the task directory, commits, and pushes to delete/<sanitized-task-id>;
-	// the returned outcome carries the branch + clone path so the caller can
-	// open a PR. spec.TaskDir locates the task on disk.
+	// the task directory in place. For a git source it clones the repo (leaving
+	// the source in clone-mode so the PR task can run in the clone), removes the
+	// task directory, commits, and pushes to delete/<sanitized-task-id>; the
+	// returned outcome carries the branch + clone path so the caller can open a
+	// PR. spec.TaskDir locates the task on disk. The caller MUST call
+	// DisableSourceDevMode once the PR step finishes.
 	DeleteTaskFromSource(ctx context.Context, taskID, sourceName string, spec *task.Spec) (TaskDeleteOutcome, error)
+
+	// DisableSourceDevMode reverts a git source out of the clone-mode that
+	// DeleteTaskFromSource leaves it in. It removes the local clone but not the
+	// pushed remote branch. Idempotent for sources not in clone-mode.
+	DisableSourceDevMode(ctx context.Context, sourceName string) error
 }
 
 // SetTaskDeleter wires the task-deletion backend for cli.task.delete dispatch.
@@ -123,10 +130,15 @@ func (cs *ControlServer) handleTaskDelete(ctx context.Context, req Request) (Tas
 		return res, nil
 	}
 
-	// Git source: open the PR via the same buildin task the authoring save
-	// flow uses. A push without a PR would still be picked up by the
-	// reconciler, but the operator needs the PR to actually merge the
-	// removal — so a PR-task failure fails the whole delete.
+	// The git path left the source in clone-mode so buildin/git-pr can run `gh`
+	// inside the clone. Revert it once the PR step finishes — on every exit. The
+	// disable removes the local clone but not the pushed remote branch, which the
+	// PR depends on.
+	defer func() { _ = cs.taskDeleter.DisableSourceDevMode(ctx, sourceName) }()
+
+	// Open the PR via the same buildin task the authoring save flow uses. The
+	// operator needs the PR to merge the removal, so a PR-task failure fails the
+	// whole delete.
 	prParams := map[string]string{
 		"source_id":  sourceName,
 		"branch":     outcome.Branch,
@@ -147,41 +159,85 @@ func (cs *ControlServer) handleTaskDelete(ctx context.Context, req Request) (Tas
 	if runRes.Status != "success" {
 		return res, fmt.Errorf("delete pushed to branch %q but the PR task finished %s (run %s)", outcome.Branch, runRes.Status, runID)
 	}
-	res.PRValue = prReturnString(runRes.ReturnValue)
+	url, err := prURLFromReturn(runRes.ReturnValue)
+	if err != nil {
+		return res, fmt.Errorf("delete pushed to branch %q but the PR was not opened: %w", outcome.Branch, err)
+	}
+	res.PRValue = url
 	return res, nil
 }
 
-// chainReferrers returns the ids of registered tasks that reference target via
-// a chain trigger (trigger.chain.from) or an on_failure_chain (on_failure_chain.task).
-// The result is sorted and excludes target itself.
+// chainReferrers returns the ids of registered tasks/pipelines that reference
+// target via a chain trigger (trigger.chain.from), an on_failure_chain
+// (on_failure_chain.task), or a pipeline stage (stages[].task). The result is
+// sorted, de-duplicated, and excludes target itself.
 func (cs *ControlServer) chainReferrers(target string) []string {
-	var refs []string
+	seen := map[string]struct{}{}
+	add := func(id string) {
+		if id != target {
+			seen[id] = struct{}{}
+		}
+	}
 	for _, s := range cs.reg.All() {
 		if s.ID == target {
 			continue
 		}
 		if s.Trigger.Chain != nil && s.Trigger.Chain.From == target {
-			refs = append(refs, s.ID)
-			continue
+			add(s.ID)
 		}
 		if s.OnFailureChain != nil && s.OnFailureChain.Task == target {
-			refs = append(refs, s.ID)
+			add(s.ID)
 		}
+	}
+	for _, k := range cs.reg.AllKinded() {
+		p, ok := k.(*task.PipelineTask)
+		if !ok || p.ID == target {
+			continue
+		}
+		if p.Trigger.Chain != nil && p.Trigger.Chain.From == target {
+			add(p.ID)
+		}
+		for _, st := range p.Stages {
+			if st.Task == target {
+				add(p.ID)
+				break
+			}
+		}
+	}
+	refs := make([]string, 0, len(seen))
+	for id := range seen {
+		refs = append(refs, id)
 	}
 	sort.Strings(refs)
 	return refs
 }
 
-// prReturnString renders the buildin/git-pr task's return value as a string —
-// the PR URL when the task returns one. A bare string passes through; other
-// shapes are stringified so the operator still sees something useful.
-func prReturnString(v any) string {
+// prURLFromReturn extracts the PR URL from the buildin/git-pr task's return
+// value. git-pr returns {ok, url?, error?}, which WaitRun unmarshals to
+// map[string]any. A non-true ok (or empty url) is an error — surfacing the
+// task's "error" field — so a failed `gh` can never masquerade as a PR URL.
+// A bare string is accepted as the URL for forward-compatibility; any other
+// shape is rejected rather than stringified.
+func prURLFromReturn(v any) (string, error) {
 	switch t := v.(type) {
-	case nil:
-		return ""
 	case string:
-		return t
+		if t == "" {
+			return "", fmt.Errorf("git-pr returned an empty result")
+		}
+		return t, nil
+	case map[string]any:
+		if ok, _ := t["ok"].(bool); !ok {
+			if msg, _ := t["error"].(string); msg != "" {
+				return "", fmt.Errorf("git-pr failed: %s", msg)
+			}
+			return "", fmt.Errorf("git-pr did not report success")
+		}
+		url, _ := t["url"].(string)
+		if url == "" {
+			return "", fmt.Errorf("git-pr reported success but returned no PR url")
+		}
+		return url, nil
 	default:
-		return fmt.Sprintf("%v", t)
+		return "", fmt.Errorf("git-pr returned an unexpected result shape %T", v)
 	}
 }

--- a/pkg/ipc/control_task_delete.go
+++ b/pkg/ipc/control_task_delete.go
@@ -89,7 +89,7 @@ func (cs *ControlServer) handleTaskDelete(ctx context.Context, req Request) (Tas
 		return TaskDeleteResult{}, errors.New("task deletion not configured (no source manager)")
 	}
 
-	spec, ok := cs.reg.Get(req.TaskID)
+	spec, ok := cs.deletableSpec(req.TaskID)
 	if !ok {
 		return TaskDeleteResult{}, fmt.Errorf("task %q not found", req.TaskID)
 	}
@@ -165,6 +165,37 @@ func (cs *ControlServer) handleTaskDelete(ctx context.Context, req Request) (Tas
 	}
 	res.PRValue = url
 	return res, nil
+}
+
+// deletableSpec resolves the registered task whose on-disk directory the delete
+// path will remove. A kind: Task resolves to its own *task.Spec. A registered
+// pipeline (kind: PipelineTask) has no *task.Spec but carries the same TaskDir
+// and source-resolvable id, so it is adapted into a minimal Spec — the delete
+// path consumes only TaskDir (removal) and Trigger (the preview label). The
+// buildin guard, containment check, and dangling-ref preview operate on the id
+// and TaskDir and so apply identically to a pipeline.
+func (cs *ControlServer) deletableSpec(id string) (*task.Spec, bool) {
+	if spec, ok := cs.reg.Get(id); ok {
+		return spec, true
+	}
+	k, ok := cs.reg.GetKinded(id)
+	if !ok {
+		return nil, false
+	}
+	p, ok := k.(*task.PipelineTask)
+	if !ok {
+		return nil, false
+	}
+	return &task.Spec{
+		ID:      p.ID,
+		TaskDir: p.TaskDir,
+		Trigger: task.TriggerConfig{
+			Cron:    p.Trigger.Cron,
+			Webhook: p.Trigger.Webhook,
+			Manual:  p.Trigger.Manual,
+			Chain:   p.Trigger.Chain,
+		},
+	}, true
 }
 
 // chainReferrers returns the ids of registered tasks/pipelines that reference

--- a/pkg/ipc/control_task_delete.go
+++ b/pkg/ipc/control_task_delete.go
@@ -1,0 +1,187 @@
+package ipc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// buildinSourcePrefix is the namespace prefix of the shipped buildin taskset.
+// Tasks under it are part of the binary's reference taskset and cannot be
+// removed via `dicode task delete` — operators override them through the
+// taskset entry mechanism instead.
+const buildinSourcePrefix = "buildin/"
+
+// TaskDeleteOutcome reports what a TaskDeleter did. For local sources only
+// Mode and Source are set. For git sources the task was committed onto Branch
+// in a fresh dev-clone at ClonePath and pushed; the caller then fires the
+// PR-opening task.
+type TaskDeleteOutcome struct {
+	Source    string
+	Mode      string // "local" | "git"
+	Branch    string
+	Base      string
+	ClonePath string
+}
+
+// TaskDeleter removes a task from its owning source. It is implemented by
+// webui.SourceManager (which owns source state, repo paths, and dev-clones).
+// Defined here so pkg/ipc need not import pkg/webui — the same decoupling
+// pattern as APIKeyMinter and SourceDevModeSetter.
+type TaskDeleter interface {
+	// ResolveTaskSource returns the owning source name for a task and whether
+	// that source is a git source. sourceOverride, when non-empty, forces the
+	// resolution to that source (and validates the task belongs to it).
+	ResolveTaskSource(taskID, sourceOverride string) (name string, isGit bool, err error)
+
+	// DeleteTaskFromSource performs the removal. For a local source it removes
+	// the task directory in place. For a git source it clones the repo, removes
+	// the task directory, commits, and pushes to delete/<sanitized-task-id>;
+	// the returned outcome carries the branch + clone path so the caller can
+	// open a PR. spec.TaskDir locates the task on disk.
+	DeleteTaskFromSource(ctx context.Context, taskID, sourceName string, spec *task.Spec) (TaskDeleteOutcome, error)
+}
+
+// SetTaskDeleter wires the task-deletion backend for cli.task.delete dispatch.
+// Nil leaves the method returning a clear error (tests without webui).
+func (cs *ControlServer) SetTaskDeleter(d TaskDeleter) { cs.taskDeleter = d }
+
+// gitPRTaskID is the buildin task that opens the pull request for a git-source
+// deletion — the same task the AI-authoring save flow and auto-fix loop use.
+const gitPRTaskID = "buildin/git-pr"
+
+// handleTaskDelete removes a task from its owning source — or, when Force is
+// false, returns a preview so the CLI can render its confirmation prompt.
+//
+// Resolution → guards → deletion:
+//  1. The task must exist in the registry (so we know its on-disk path).
+//  2. Buildin tasks are undeletable.
+//  3. Chained references (on_failure / chain triggers pointing at this task),
+//     the trigger schedule, and the owning source are surfaced in the result
+//     so the CLI can warn the operator. Stale run rows are unaffected —
+//     apiGetRun falls back to the task id when the spec is gone.
+//  4. The actual removal happens ONLY when Force is true. Local sources: the
+//     directory is removed in place. Git sources: the removal is pushed to a
+//     delete/<id> branch and buildin/git-pr opens a PR.
+//
+// The reconciler deregisters the task on its next sync (~30s).
+func (cs *ControlServer) handleTaskDelete(ctx context.Context, req Request) (TaskDeleteResult, error) {
+	if req.TaskID == "" {
+		return TaskDeleteResult{}, errors.New("taskID required")
+	}
+	if strings.HasPrefix(req.TaskID, buildinSourcePrefix) {
+		return TaskDeleteResult{}, fmt.Errorf(
+			"task %q is a buildin task and cannot be deleted — override it via a taskset entry (set `enabled: false` or point the entry at your own ref) instead",
+			req.TaskID)
+	}
+	if cs.taskDeleter == nil {
+		return TaskDeleteResult{}, errors.New("task deletion not configured (no source manager)")
+	}
+
+	spec, ok := cs.reg.Get(req.TaskID)
+	if !ok {
+		return TaskDeleteResult{}, fmt.Errorf("task %q not found", req.TaskID)
+	}
+
+	sourceName, _, err := cs.taskDeleter.ResolveTaskSource(req.TaskID, req.Source)
+	if err != nil {
+		return TaskDeleteResult{}, err
+	}
+
+	refs := cs.chainReferrers(req.TaskID)
+
+	// Preview: resolve + guards only, no destructive action. The CLI renders
+	// the confirmation prompt from this and re-sends with Force=true.
+	if !req.Force {
+		return TaskDeleteResult{
+			TaskID:  req.TaskID,
+			Source:  sourceName,
+			Mode:    "preview",
+			Trigger: triggerLabel(spec),
+			Refs:    refs,
+		}, nil
+	}
+
+	outcome, err := cs.taskDeleter.DeleteTaskFromSource(ctx, req.TaskID, sourceName, spec)
+	if err != nil {
+		return TaskDeleteResult{Refs: refs}, err
+	}
+
+	res := TaskDeleteResult{
+		TaskID: req.TaskID,
+		Source: sourceName,
+		Mode:   outcome.Mode,
+		Branch: outcome.Branch,
+		Refs:   refs,
+	}
+
+	if outcome.Mode != "git" {
+		return res, nil
+	}
+
+	// Git source: open the PR via the same buildin task the authoring save
+	// flow uses. A push without a PR would still be picked up by the
+	// reconciler, but the operator needs the PR to actually merge the
+	// removal — so a PR-task failure fails the whole delete.
+	prParams := map[string]string{
+		"source_id":  sourceName,
+		"branch":     outcome.Branch,
+		"base":       outcome.Base,
+		"title":      fmt.Sprintf("Delete task %s", req.TaskID),
+		"body":       fmt.Sprintf("Removes task `%s` from its source. Filed by `dicode task delete`.", req.TaskID),
+		"clone_path": outcome.ClonePath,
+	}
+	runID, err := cs.engine.FireManual(ctx, gitPRTaskID, prParams)
+	if err != nil {
+		return res, fmt.Errorf("delete pushed to branch %q but opening the PR failed: %w", outcome.Branch, err)
+	}
+	res.PRRunID = runID
+	runRes, err := cs.engine.WaitRun(ctx, runID)
+	if err != nil {
+		return res, fmt.Errorf("delete pushed to branch %q but the PR task did not complete: %w", outcome.Branch, err)
+	}
+	if runRes.Status != "success" {
+		return res, fmt.Errorf("delete pushed to branch %q but the PR task finished %s (run %s)", outcome.Branch, runRes.Status, runID)
+	}
+	res.PRValue = prReturnString(runRes.ReturnValue)
+	return res, nil
+}
+
+// chainReferrers returns the ids of registered tasks that reference target via
+// a chain trigger (trigger.chain.from) or an on_failure_chain (on_failure_chain.task).
+// The result is sorted and excludes target itself.
+func (cs *ControlServer) chainReferrers(target string) []string {
+	var refs []string
+	for _, s := range cs.reg.All() {
+		if s.ID == target {
+			continue
+		}
+		if s.Trigger.Chain != nil && s.Trigger.Chain.From == target {
+			refs = append(refs, s.ID)
+			continue
+		}
+		if s.OnFailureChain != nil && s.OnFailureChain.Task == target {
+			refs = append(refs, s.ID)
+		}
+	}
+	sort.Strings(refs)
+	return refs
+}
+
+// prReturnString renders the buildin/git-pr task's return value as a string —
+// the PR URL when the task returns one. A bare string passes through; other
+// shapes are stringified so the operator still sees something useful.
+func prReturnString(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	default:
+		return fmt.Sprintf("%v", t)
+	}
+}

--- a/pkg/ipc/control_task_delete_test.go
+++ b/pkg/ipc/control_task_delete_test.go
@@ -200,6 +200,49 @@ func TestTaskDelete_Local_DeletesAndReturns(t *testing.T) {
 	}
 }
 
+// A registered pipeline (kind: PipelineTask) has no *task.Spec but carries a
+// TaskDir, so it must resolve through the same delete path rather than erroring
+// with the misleading "task not found".
+func TestTaskDelete_Pipeline_DeletesViaSamePath(t *testing.T) {
+	reg := newTestRegistry(t)
+	pipe := &task.PipelineTask{
+		ID:      "tasks/pipe",
+		Kind:    task.KindPipelineTask,
+		TaskDir: "/tmp/pipe",
+		Stages:  []task.Stage{{Task: "tasks/a"}, {Task: "tasks/b"}},
+	}
+	if err := reg.Register(pipe); err != nil {
+		t.Fatalf("register pipeline: %v", err)
+	}
+	del := &fakeDeleter{resolveName: "tasks", outcome: TaskDeleteOutcome{Source: "tasks", Mode: "local"}}
+	eng := &recordingEngine{}
+	cs := newDeleteTestServer(t, reg, eng, del)
+
+	// Preview must succeed (not "task not found") and resolve the source.
+	prev, err := cs.handleTaskDelete(context.Background(), Request{TaskID: "tasks/pipe", Force: false})
+	if err != nil {
+		t.Fatalf("pipeline preview: %v", err)
+	}
+	if prev.Mode != "preview" || prev.Source != "tasks" {
+		t.Fatalf("preview = %+v, want mode=preview source=tasks", prev)
+	}
+
+	// Force must delete through DeleteTaskFromSource, not error.
+	res, err := cs.handleTaskDelete(context.Background(), Request{TaskID: "tasks/pipe", Force: true})
+	if err != nil {
+		t.Fatalf("pipeline delete: %v", err)
+	}
+	if !del.deleteCalled {
+		t.Fatal("DeleteTaskFromSource was not called for a pipeline")
+	}
+	if del.deletedTaskID != "tasks/pipe" {
+		t.Fatalf("deleted task id = %q, want tasks/pipe", del.deletedTaskID)
+	}
+	if res.Mode != "local" {
+		t.Fatalf("Mode = %q, want local", res.Mode)
+	}
+}
+
 func TestTaskDelete_Git_FiresGitPRTask(t *testing.T) {
 	reg := newTestRegistry(t)
 	if err := reg.Register(&task.Spec{ID: "tasks/git-task", Name: "git", TaskDir: "/tmp/x"}); err != nil {

--- a/pkg/ipc/control_task_delete_test.go
+++ b/pkg/ipc/control_task_delete_test.go
@@ -3,6 +3,7 @@ package ipc
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/dicode/dicode/pkg/db"
@@ -36,6 +37,8 @@ type fakeDeleter struct {
 	deleteErr     error
 	deleteCalled  bool
 	deletedTaskID string
+
+	devModeDisabled bool
 }
 
 func (f *fakeDeleter) ResolveTaskSource(taskID, sourceOverride string) (string, bool, error) {
@@ -56,6 +59,11 @@ func (f *fakeDeleter) DeleteTaskFromSource(_ context.Context, taskID, _ string, 
 		return TaskDeleteOutcome{}, f.deleteErr
 	}
 	return f.outcome, nil
+}
+
+func (f *fakeDeleter) DisableSourceDevMode(_ context.Context, _ string) error {
+	f.devModeDisabled = true
+	return nil
 }
 
 func newDeleteTestServer(t *testing.T, reg *registry.Registry, eng EngineRunner, del TaskDeleter) *ControlServer {
@@ -140,6 +148,34 @@ func TestTaskDelete_Preview_SurfacesChainedReferences(t *testing.T) {
 	}
 }
 
+// A pipeline whose stage references the deleted task must surface as a dangling
+// referrer alongside chain/on_failure referrers.
+func TestTaskDelete_Preview_SurfacesPipelineStageReference(t *testing.T) {
+	reg := newTestRegistry(t)
+	target := &task.Spec{ID: "tasks/source-task", Name: "source"}
+	if err := reg.Register(target); err != nil {
+		t.Fatalf("register target: %v", err)
+	}
+	pipe := &task.PipelineTask{
+		ID:     "tasks/pipe",
+		Kind:   task.KindPipelineTask,
+		Stages: []task.Stage{{Task: "tasks/other"}, {Task: "tasks/source-task"}},
+	}
+	if err := reg.Register(pipe); err != nil {
+		t.Fatalf("register pipeline: %v", err)
+	}
+	del := &fakeDeleter{resolveName: "tasks"}
+	cs := newDeleteTestServer(t, reg, &recordingEngine{}, del)
+
+	res, err := cs.handleTaskDelete(context.Background(), Request{TaskID: "tasks/source-task", Force: false})
+	if err != nil {
+		t.Fatalf("preview: %v", err)
+	}
+	if len(res.Refs) != 1 || res.Refs[0] != "tasks/pipe" {
+		t.Fatalf("Refs = %v, want [tasks/pipe]", res.Refs)
+	}
+}
+
 func TestTaskDelete_Local_DeletesAndReturns(t *testing.T) {
 	reg := newTestRegistry(t)
 	if err := reg.Register(&task.Spec{ID: "tasks/local-task", Name: "local", TaskDir: "/tmp/x"}); err != nil {
@@ -182,7 +218,12 @@ func TestTaskDelete_Git_FiresGitPRTask(t *testing.T) {
 	}
 	eng := &recordingEngine{}
 	eng.runID = "pr-run-1"
-	eng.result = RunResult{RunID: "pr-run-1", Status: "success", ReturnValue: "https://example/pr/1"}
+	// git-pr returns an object; WaitRun unmarshals it to map[string]any. The URL
+	// must be read from the "url" key, not the map's %v stringification.
+	eng.result = RunResult{RunID: "pr-run-1", Status: "success", ReturnValue: map[string]any{
+		"ok":  true,
+		"url": "https://example/pr/1",
+	}}
 	cs := newDeleteTestServer(t, reg, eng, del)
 
 	res, err := cs.handleTaskDelete(context.Background(), Request{TaskID: "tasks/git-task", Force: true})
@@ -199,10 +240,66 @@ func TestTaskDelete_Git_FiresGitPRTask(t *testing.T) {
 		t.Fatalf("clone_path param = %q", eng.firedParams["clone_path"])
 	}
 	if res.PRValue != "https://example/pr/1" {
-		t.Fatalf("PRValue = %q, want the PR url", res.PRValue)
+		t.Fatalf("PRValue = %q, want the PR url parsed from the map", res.PRValue)
 	}
 	if res.PRRunID != "pr-run-1" {
 		t.Fatalf("PRRunID = %q", res.PRRunID)
+	}
+	if !del.devModeDisabled {
+		t.Fatal("dev-mode must be disabled after a successful git delete")
+	}
+}
+
+// A git-pr {ok:false} return means `gh` failed even though the run Status is
+// "success"; the delete must FAIL and surface the error, not print a map.
+func TestTaskDelete_Git_GitPRNotOK_Fails(t *testing.T) {
+	reg := newTestRegistry(t)
+	if err := reg.Register(&task.Spec{ID: "tasks/git-task", Name: "git", TaskDir: "/tmp/x"}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	del := &fakeDeleter{
+		resolveName: "tasks",
+		isGit:       true,
+		outcome:     TaskDeleteOutcome{Source: "tasks", Mode: "git", Branch: "delete/tasks/git-task", Base: "main"},
+	}
+	eng := &recordingEngine{}
+	eng.runID = "pr-run-3"
+	eng.result = RunResult{RunID: "pr-run-3", Status: "success", ReturnValue: map[string]any{
+		"ok":    false,
+		"error": "gh: not authenticated",
+	}}
+	cs := newDeleteTestServer(t, reg, eng, del)
+
+	_, err := cs.handleTaskDelete(context.Background(), Request{TaskID: "tasks/git-task", Force: true})
+	if err == nil {
+		t.Fatal("expected error when git-pr returns ok:false")
+	}
+	if !strings.Contains(err.Error(), "gh: not authenticated") {
+		t.Fatalf("error must surface the git-pr error field, got: %v", err)
+	}
+	if !del.devModeDisabled {
+		t.Fatal("dev-mode must be disabled even when git-pr fails")
+	}
+}
+
+func TestPRURLFromReturn(t *testing.T) {
+	if got, err := prURLFromReturn(map[string]any{"ok": true, "url": "u"}); err != nil || got != "u" {
+		t.Fatalf("ok+url: got (%q, %v)", got, err)
+	}
+	if _, err := prURLFromReturn(map[string]any{"ok": true}); err == nil {
+		t.Fatal("ok without url must error")
+	}
+	if _, err := prURLFromReturn(map[string]any{"ok": false, "error": "boom"}); err == nil {
+		t.Fatal("ok:false must error")
+	}
+	if _, err := prURLFromReturn(map[string]any{"url": "u"}); err == nil {
+		t.Fatal("missing ok must error")
+	}
+	if got, err := prURLFromReturn("u"); err != nil || got != "u" {
+		t.Fatalf("bare string: got (%q, %v)", got, err)
+	}
+	if _, err := prURLFromReturn(42); err == nil {
+		t.Fatal("unexpected shape must error")
 	}
 }
 
@@ -224,6 +321,9 @@ func TestTaskDelete_Git_PRTaskFailure_IsReported(t *testing.T) {
 	_, err := cs.handleTaskDelete(context.Background(), Request{TaskID: "tasks/git-task", Force: true})
 	if err == nil {
 		t.Fatal("expected error when the PR task fails")
+	}
+	if !del.devModeDisabled {
+		t.Fatal("dev-mode must be disabled even when the PR task fails")
 	}
 }
 

--- a/pkg/ipc/control_task_delete_test.go
+++ b/pkg/ipc/control_task_delete_test.go
@@ -1,0 +1,245 @@
+package ipc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
+)
+
+// recordingEngine captures the task id + params of the last FireManual call so
+// the git-delete path can assert that buildin/git-pr was fired correctly.
+type recordingEngine struct {
+	mockEngine
+	firedTask   string
+	firedParams map[string]string
+}
+
+func (e *recordingEngine) FireManual(_ context.Context, taskID string, params map[string]string) (string, error) {
+	e.firedTask = taskID
+	e.firedParams = params
+	return e.runID, e.err
+}
+
+// fakeDeleter is a test double for TaskDeleter. resolveErr / deleteErr force
+// the respective failures; outcome is returned from DeleteTaskFromSource.
+type fakeDeleter struct {
+	resolveName string
+	isGit       bool
+	resolveErr  error
+
+	outcome       TaskDeleteOutcome
+	deleteErr     error
+	deleteCalled  bool
+	deletedTaskID string
+}
+
+func (f *fakeDeleter) ResolveTaskSource(taskID, sourceOverride string) (string, bool, error) {
+	if f.resolveErr != nil {
+		return "", false, f.resolveErr
+	}
+	name := f.resolveName
+	if sourceOverride != "" {
+		name = sourceOverride
+	}
+	return name, f.isGit, nil
+}
+
+func (f *fakeDeleter) DeleteTaskFromSource(_ context.Context, taskID, _ string, _ *task.Spec) (TaskDeleteOutcome, error) {
+	f.deleteCalled = true
+	f.deletedTaskID = taskID
+	if f.deleteErr != nil {
+		return TaskDeleteOutcome{}, f.deleteErr
+	}
+	return f.outcome, nil
+}
+
+func newDeleteTestServer(t *testing.T, reg *registry.Registry, eng EngineRunner, del TaskDeleter) *ControlServer {
+	t.Helper()
+	cs := &ControlServer{
+		reg:         reg,
+		engine:      eng,
+		taskDeleter: del,
+		log:         zap.NewNop(),
+	}
+	return cs
+}
+
+func newTestRegistry(t *testing.T) *registry.Registry {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return registry.New(d)
+}
+
+func TestTaskDelete_Buildin_Undeletable(t *testing.T) {
+	reg := newTestRegistry(t)
+	if err := reg.Register(&task.Spec{ID: "buildin/git-pr", Name: "git-pr"}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	del := &fakeDeleter{resolveName: "buildin"}
+	cs := newDeleteTestServer(t, reg, &recordingEngine{}, del)
+
+	_, err := cs.handleTaskDelete(context.Background(), Request{TaskID: "buildin/git-pr", Force: true})
+	if err == nil {
+		t.Fatal("expected error deleting a buildin task")
+	}
+	if del.deleteCalled {
+		t.Fatal("DeleteTaskFromSource must not be called for a buildin task")
+	}
+}
+
+func TestTaskDelete_NotFound(t *testing.T) {
+	reg := newTestRegistry(t)
+	cs := newDeleteTestServer(t, reg, &recordingEngine{}, &fakeDeleter{resolveName: "tasks"})
+
+	_, err := cs.handleTaskDelete(context.Background(), Request{TaskID: "tasks/ghost", Force: true})
+	if err == nil {
+		t.Fatal("expected not-found error")
+	}
+}
+
+func TestTaskDelete_Preview_SurfacesChainedReferences(t *testing.T) {
+	reg := newTestRegistry(t)
+	target := &task.Spec{ID: "tasks/source-task", Name: "source"}
+	chainer := &task.Spec{ID: "tasks/downstream", Name: "downstream"}
+	chainer.Trigger.Chain = &task.ChainTrigger{From: "tasks/source-task"}
+	failer := &task.Spec{ID: "tasks/notifier", Name: "notifier"}
+	failer.OnFailureChain = &task.OnFailureChainSpec{Task: "tasks/source-task"}
+	for _, s := range []*task.Spec{target, chainer, failer} {
+		if err := reg.Register(s); err != nil {
+			t.Fatalf("register %s: %v", s.ID, err)
+		}
+	}
+	del := &fakeDeleter{resolveName: "tasks"}
+	cs := newDeleteTestServer(t, reg, &recordingEngine{}, del)
+
+	// Preview (Force=false) must not delete and must report both referrers.
+	res, err := cs.handleTaskDelete(context.Background(), Request{TaskID: "tasks/source-task", Force: false})
+	if err != nil {
+		t.Fatalf("preview: %v", err)
+	}
+	if del.deleteCalled {
+		t.Fatal("preview must not call DeleteTaskFromSource")
+	}
+	if res.Mode != "preview" {
+		t.Fatalf("Mode = %q, want preview", res.Mode)
+	}
+	if len(res.Refs) != 2 {
+		t.Fatalf("Refs = %v, want 2 referrers", res.Refs)
+	}
+	if res.Refs[0] != "tasks/downstream" || res.Refs[1] != "tasks/notifier" {
+		t.Fatalf("Refs = %v, want sorted [tasks/downstream tasks/notifier]", res.Refs)
+	}
+}
+
+func TestTaskDelete_Local_DeletesAndReturns(t *testing.T) {
+	reg := newTestRegistry(t)
+	if err := reg.Register(&task.Spec{ID: "tasks/local-task", Name: "local", TaskDir: "/tmp/x"}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	del := &fakeDeleter{resolveName: "tasks", outcome: TaskDeleteOutcome{Source: "tasks", Mode: "local"}}
+	eng := &recordingEngine{}
+	cs := newDeleteTestServer(t, reg, eng, del)
+
+	res, err := cs.handleTaskDelete(context.Background(), Request{TaskID: "tasks/local-task", Force: true})
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if !del.deleteCalled {
+		t.Fatal("DeleteTaskFromSource was not called")
+	}
+	if res.Mode != "local" {
+		t.Fatalf("Mode = %q, want local", res.Mode)
+	}
+	if eng.firedTask != "" {
+		t.Fatalf("local delete must not fire any task, fired %q", eng.firedTask)
+	}
+}
+
+func TestTaskDelete_Git_FiresGitPRTask(t *testing.T) {
+	reg := newTestRegistry(t)
+	if err := reg.Register(&task.Spec{ID: "tasks/git-task", Name: "git", TaskDir: "/tmp/x"}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	del := &fakeDeleter{
+		resolveName: "tasks",
+		isGit:       true,
+		outcome: TaskDeleteOutcome{
+			Source:    "tasks",
+			Mode:      "git",
+			Branch:    "delete/tasks/git-task",
+			Base:      "main",
+			ClonePath: "/clones/tasks/run1",
+		},
+	}
+	eng := &recordingEngine{}
+	eng.runID = "pr-run-1"
+	eng.result = RunResult{RunID: "pr-run-1", Status: "success", ReturnValue: "https://example/pr/1"}
+	cs := newDeleteTestServer(t, reg, eng, del)
+
+	res, err := cs.handleTaskDelete(context.Background(), Request{TaskID: "tasks/git-task", Force: true})
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if eng.firedTask != gitPRTaskID {
+		t.Fatalf("fired task = %q, want %q", eng.firedTask, gitPRTaskID)
+	}
+	if eng.firedParams["source_id"] != "tasks" || eng.firedParams["branch"] != "delete/tasks/git-task" {
+		t.Fatalf("git-pr params wrong: %v", eng.firedParams)
+	}
+	if eng.firedParams["clone_path"] != "/clones/tasks/run1" {
+		t.Fatalf("clone_path param = %q", eng.firedParams["clone_path"])
+	}
+	if res.PRValue != "https://example/pr/1" {
+		t.Fatalf("PRValue = %q, want the PR url", res.PRValue)
+	}
+	if res.PRRunID != "pr-run-1" {
+		t.Fatalf("PRRunID = %q", res.PRRunID)
+	}
+}
+
+func TestTaskDelete_Git_PRTaskFailure_IsReported(t *testing.T) {
+	reg := newTestRegistry(t)
+	if err := reg.Register(&task.Spec{ID: "tasks/git-task", Name: "git", TaskDir: "/tmp/x"}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	del := &fakeDeleter{
+		resolveName: "tasks",
+		isGit:       true,
+		outcome:     TaskDeleteOutcome{Source: "tasks", Mode: "git", Branch: "delete/tasks/git-task", Base: "main"},
+	}
+	eng := &recordingEngine{}
+	eng.runID = "pr-run-2"
+	eng.result = RunResult{RunID: "pr-run-2", Status: "failure"}
+	cs := newDeleteTestServer(t, reg, eng, del)
+
+	_, err := cs.handleTaskDelete(context.Background(), Request{TaskID: "tasks/git-task", Force: true})
+	if err == nil {
+		t.Fatal("expected error when the PR task fails")
+	}
+}
+
+func TestTaskDelete_ResolveError_Propagates(t *testing.T) {
+	reg := newTestRegistry(t)
+	if err := reg.Register(&task.Spec{ID: "tasks/x", Name: "x", TaskDir: "/tmp/x"}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	del := &fakeDeleter{resolveErr: errors.New("source boom")}
+	cs := newDeleteTestServer(t, reg, &recordingEngine{}, del)
+
+	_, err := cs.handleTaskDelete(context.Background(), Request{TaskID: "tasks/x", Force: true})
+	if err == nil {
+		t.Fatal("expected resolve error to propagate")
+	}
+	if del.deleteCalled {
+		t.Fatal("delete must not run when resolution fails")
+	}
+}

--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -121,10 +121,15 @@ type Request struct {
 	SessionID string `json:"sessionID,omitempty"`
 
 	// cli.task.{create,edit,save,cancel} — AI-first task authoring.
-	// TaskName is the create verb's task name; Source is the create verb's
-	// target source. TaskID/SessionID/Prompt are reused from the fields above.
+	// TaskName is the create verb's task name. TaskID/SessionID/Prompt are
+	// reused from the fields above.
 	TaskName string `json:"taskName,omitempty"`
-	Source   string `json:"source,omitempty"`
+
+	// Source names the owning source: the create verb's target, or the
+	// delete verb's ID-prefix-resolution override. Force skips the delete
+	// verb's dangling-reference / confirmation guard.
+	Source string `json:"source,omitempty"`
+	Force  bool   `json:"force,omitempty"`
 
 	// dicode.crypto.{encrypt, decrypt} inputs
 	Context       string `json:"context,omitempty"`
@@ -270,6 +275,25 @@ type TaskSaveResult struct {
 type TaskCancelResult struct {
 	SessionID string `json:"sessionID"`
 	Cancelled bool   `json:"cancelled"`
+}
+
+// TaskDeleteResult is the cli.task.delete response.
+//
+// Mode is "local" when the task directory was removed in place, or "git"
+// when the deletion was pushed to a branch and a PR was filed. For "git",
+// PRRunID is the run id of the buildin/git-pr task that opened the PR and
+// PRValue is whatever that task returned (typically the PR URL). Refs lists
+// task ids that chain off the deleted task (on_failure / chain triggers) —
+// surfaced so the CLI can warn before the deletion takes effect.
+type TaskDeleteResult struct {
+	TaskID  string   `json:"taskID"`
+	Source  string   `json:"source"`
+	Mode    string   `json:"mode"` // "preview" | "local" | "git"
+	Trigger string   `json:"trigger,omitempty"`
+	Branch  string   `json:"branch,omitempty"`
+	PRRunID string   `json:"prRunID,omitempty"`
+	PRValue string   `json:"prValue,omitempty"`
+	Refs    []string `json:"refs,omitempty"`
 }
 
 // MetricsSnapshot is the cli.metrics response.

--- a/pkg/source/git/commit_push.go
+++ b/pkg/source/git/commit_push.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -101,7 +102,7 @@ func CommitPush(ctx context.Context, repoPath string, opts CommitPushOptions) (s
 		}
 	} else {
 		for _, p := range opts.Files {
-			if _, err := wt.Add(p); err != nil {
+			if err := addPath(repo, wt, p); err != nil {
 				return "", fmt.Errorf("add %q: %w", p, err)
 			}
 		}
@@ -129,4 +130,37 @@ func CommitPush(ctx context.Context, repoPath string, opts CommitPushOptions) (s
 		return "", fmt.Errorf("push: %w", err)
 	}
 	return commit.String(), nil
+}
+
+// addPath stages the change at p (relative to the repo root). go-git's Add
+// stages a removed FILE as a deletion, but a removed DIRECTORY can no longer be
+// Lstat-ed, so Add mis-handles it as a missing single file. When p is a removed
+// directory we enumerate its tracked index entries and stage each child's
+// removal individually. Existing files are staged directly.
+func addPath(repo *gogit.Repository, wt *gogit.Worktree, p string) error {
+	if _, err := wt.Add(p); err == nil {
+		return nil
+	} else if _, statErr := wt.Filesystem.Lstat(p); statErr == nil {
+		// p exists on disk; the Add error is real.
+		return err
+	}
+	idx, err := repo.Storer.Index()
+	if err != nil {
+		return fmt.Errorf("read index: %w", err)
+	}
+	prefix := strings.TrimSuffix(filepath.ToSlash(filepath.Clean(p)), "/") + "/"
+	staged := false
+	for _, e := range idx.Entries {
+		if !strings.HasPrefix(e.Name, prefix) {
+			continue
+		}
+		if _, err := wt.Add(e.Name); err != nil {
+			return fmt.Errorf("stage removal of %q: %w", e.Name, err)
+		}
+		staged = true
+	}
+	if !staged {
+		return fmt.Errorf("path %q matched no worktree file or tracked index entry", p)
+	}
+	return nil
 }

--- a/pkg/source/git/commit_push_test.go
+++ b/pkg/source/git/commit_push_test.go
@@ -8,6 +8,7 @@ import (
 
 	gogit "github.com/go-git/go-git/v5"
 	gogitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
 )
 
 func TestCommitPush_AddsAndCommits(t *testing.T) {
@@ -58,6 +59,90 @@ func TestCommitPush_AddsAndCommits(t *testing.T) {
 	}
 	if head.Hash().String() != hash {
 		t.Errorf("HEAD = %s, want %s", head.Hash().String(), hash)
+	}
+}
+
+// A directory removal passed via Files must stage every tracked file under the
+// directory as a deletion — and must NOT stage unrelated working-tree changes.
+func TestCommitPush_RemovesDirectoryOnly(t *testing.T) {
+	tmp := t.TempDir()
+	bare := filepath.Join(tmp, "remote.git")
+	if _, err := gogit.PlainInit(bare, true); err != nil {
+		t.Fatal(err)
+	}
+	local := filepath.Join(tmp, "local")
+	repo, err := gogit.PlainInit(local, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.CreateRemote(&gogitconfig.RemoteConfig{Name: "origin", URLs: []string{bare}}); err != nil {
+		t.Fatal(err)
+	}
+
+	mustWrite := func(rel, content string) {
+		full := filepath.Join(local, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite("victim/a.txt", "a")
+	mustWrite("victim/nested/b.txt", "b")
+	mustWrite("unrelated.txt", "original")
+
+	// Seed: commit everything so the dir + unrelated file are tracked.
+	if _, err := CommitPush(context.Background(), local, CommitPushOptions{
+		Message:   "seed",
+		Branch:    "main",
+		AllowMain: true,
+		Author:    Signature{Name: "T", Email: "t@x"},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Remove the directory AND dirty the unrelated file in the worktree.
+	if err := os.RemoveAll(filepath.Join(local, "victim")); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite("unrelated.txt", "MODIFIED — must not be committed")
+
+	hash, err := CommitPush(context.Background(), local, CommitPushOptions{
+		Message:   "delete victim/",
+		Branch:    "main",
+		Files:     []string{"victim"},
+		AllowMain: true,
+		Author:    Signature{Name: "T", Email: "t@x"},
+	})
+	if err != nil {
+		t.Fatalf("CommitPush: %v", err)
+	}
+
+	commit, err := repo.CommitObject(plumbing.NewHash(hash))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tree.File("victim/a.txt"); err == nil {
+		t.Error("victim/a.txt should be removed")
+	}
+	if _, err := tree.File("victim/nested/b.txt"); err == nil {
+		t.Error("victim/nested/b.txt should be removed")
+	}
+	f, err := tree.File("unrelated.txt")
+	if err != nil {
+		t.Fatalf("unrelated.txt should still be tracked: %v", err)
+	}
+	content, err := f.Contents()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content != "original" {
+		t.Errorf("unrelated.txt content = %q, want the unmodified original (dirty change must not be staged)", content)
 	}
 }
 

--- a/pkg/webui/task_delete.go
+++ b/pkg/webui/task_delete.go
@@ -1,0 +1,201 @@
+package webui
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dicode/dicode/pkg/ipc"
+	gitSource "github.com/dicode/dicode/pkg/source/git"
+	"github.com/dicode/dicode/pkg/task"
+	"github.com/dicode/dicode/pkg/taskset"
+	"go.uber.org/zap"
+)
+
+// deleteBranchPrefix is the branch namespace deletions are pushed to. The PR
+// the buildin/git-pr task opens targets the source's tracked branch.
+const deleteBranchPrefix = "delete/"
+
+// deleteCommitAuthor names the author on deletion commits. Operator-facing
+// attribution is fixed here because the control socket has no per-user
+// identity to thread through.
+var deleteCommitAuthor = gitSource.Signature{Name: "dicode", Email: "dicode@localhost"}
+
+// ResolveTaskSource maps a task id to its owning source. It implements
+// ipc.TaskDeleter. The source is the first path segment of the task id unless
+// sourceOverride forces a specific source (in which case the task id must be
+// namespaced under it). The returned isGit reports whether the source is a git
+// ref (vs a local-path ref).
+func (m *SourceManager) ResolveTaskSource(taskID, sourceOverride string) (string, bool, error) {
+	name := sourceOverride
+	if name == "" {
+		seg, _, ok := strings.Cut(taskID, "/")
+		if !ok || seg == "" {
+			return "", false, fmt.Errorf("cannot resolve source for task %q: not namespaced — pass --source", taskID)
+		}
+		name = seg
+	} else if !strings.HasPrefix(taskID, sourceOverride+"/") {
+		return "", false, fmt.Errorf("task %q is not under source %q", taskID, sourceOverride)
+	}
+
+	m.mu.RLock()
+	_, isTaskset := m.tasksets[name]
+	m.mu.RUnlock()
+	if !isTaskset {
+		return "", false, fmt.Errorf("source %q not found or not a taskset source", name)
+	}
+
+	m.rLockCfg()
+	entry := m.cfg.Spec.Entries[name]
+	m.rUnlockCfg()
+	if entry == nil || entry.Ref == nil {
+		return "", false, fmt.Errorf("source %q has no ref", name)
+	}
+	return name, entry.Ref.IsGit(), nil
+}
+
+// DeleteTaskFromSource removes a task from its source. It implements
+// ipc.TaskDeleter.
+//
+// Local sources: the task directory is removed in place; the reconciler
+// deregisters the task on its next sync.
+//
+// Git sources: the repo is cloned (dev-mode clone-mode), the task directory is
+// removed from the clone, and the removal is committed and pushed to
+// delete/<sanitized-id>. The returned outcome carries the branch + clone path
+// so the caller opens a PR via buildin/git-pr. The clone is intentionally left
+// in place for the PR task to operate in; the dev-clones-cleanup buildin task
+// sweeps it afterwards.
+func (m *SourceManager) DeleteTaskFromSource(ctx context.Context, taskID, sourceName string, spec *task.Spec) (ipc.TaskDeleteOutcome, error) {
+	if spec == nil || spec.TaskDir == "" {
+		return ipc.TaskDeleteOutcome{}, fmt.Errorf("task %q has no on-disk directory", taskID)
+	}
+
+	m.mu.RLock()
+	src, ok := m.tasksets[sourceName]
+	m.mu.RUnlock()
+	if !ok {
+		return ipc.TaskDeleteOutcome{}, fmt.Errorf("source %q not found", sourceName)
+	}
+
+	m.rLockCfg()
+	entry := m.cfg.Spec.Entries[sourceName]
+	m.rUnlockCfg()
+	if entry == nil || entry.Ref == nil {
+		return ipc.TaskDeleteOutcome{}, fmt.Errorf("source %q has no ref", sourceName)
+	}
+
+	if !entry.Ref.IsGit() {
+		return m.deleteLocal(taskID, sourceName, spec, src)
+	}
+	return m.deleteGit(ctx, taskID, sourceName, spec, src, entry.Ref)
+}
+
+// deleteLocal removes the task directory under a local source. It refuses to
+// remove a directory that does not sit under the source's resolved root — a
+// defense against a stale or attacker-supplied TaskDir escaping the source.
+func (m *SourceManager) deleteLocal(taskID, sourceName string, spec *task.Spec, src *taskset.Source) (ipc.TaskDeleteOutcome, error) {
+	root := src.RepoPath()
+	if root == "" {
+		return ipc.TaskDeleteOutcome{}, fmt.Errorf("source %q root path not resolved", sourceName)
+	}
+	taskDir := filepath.Clean(spec.TaskDir)
+	root = filepath.Clean(root)
+	if taskDir != root && !strings.HasPrefix(taskDir+string(filepath.Separator), root+string(filepath.Separator)) {
+		return ipc.TaskDeleteOutcome{}, fmt.Errorf("task directory %q is not under source %q root %q; refusing to remove", taskDir, sourceName, root)
+	}
+	if taskDir == root {
+		return ipc.TaskDeleteOutcome{}, fmt.Errorf("task directory equals source root %q; refusing to remove", root)
+	}
+	if err := os.RemoveAll(taskDir); err != nil {
+		return ipc.TaskDeleteOutcome{}, fmt.Errorf("remove task directory: %w", err)
+	}
+	m.log.Info("task deleted from local source",
+		zap.String("task", taskID), zap.String("source", sourceName), zap.String("dir", taskDir))
+	return ipc.TaskDeleteOutcome{Source: sourceName, Mode: "local"}, nil
+}
+
+// deleteGit clones the source repo, removes the task directory, and pushes the
+// removal to delete/<sanitized-id>.
+func (m *SourceManager) deleteGit(ctx context.Context, taskID, sourceName string, spec *task.Spec, src *taskset.Source, ref *taskset.Ref) (ipc.TaskDeleteOutcome, error) {
+	// Repo-relative path of the task, computed against the PRIMARY repo path
+	// before clone-mode swaps RepoPath() to the clone dir.
+	primaryRoot := filepath.Clean(src.RepoPath())
+	taskDir := filepath.Clean(spec.TaskDir)
+	rel, err := filepath.Rel(primaryRoot, taskDir)
+	if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+		return ipc.TaskDeleteOutcome{}, fmt.Errorf("cannot locate task %q within source repo (%q vs %q)", taskID, taskDir, primaryRoot)
+	}
+
+	runID := sanitizeRunID(taskID)
+	branch := deleteBranchPrefix + taskID
+	base := ref.Branch
+	if base == "" {
+		base = "main"
+	}
+
+	if err := src.SetDevMode(ctx, true, taskset.DevModeOpts{Branch: branch, Base: base, RunID: runID}); err != nil {
+		return ipc.TaskDeleteOutcome{}, fmt.Errorf("clone source for delete: %w", err)
+	}
+
+	clonePath := filepath.Clean(src.RepoPath())
+	cloneTaskDir := filepath.Join(clonePath, rel)
+	if !strings.HasPrefix(filepath.Clean(cloneTaskDir)+string(filepath.Separator), clonePath+string(filepath.Separator)) {
+		return ipc.TaskDeleteOutcome{}, fmt.Errorf("clone task path escapes clone root: %q", cloneTaskDir)
+	}
+	if err := os.RemoveAll(cloneTaskDir); err != nil {
+		return ipc.TaskDeleteOutcome{}, fmt.Errorf("remove task in clone: %w", err)
+	}
+
+	authToken := ""
+	if ref.Auth.TokenEnv != "" {
+		authToken = os.Getenv(ref.Auth.TokenEnv)
+	}
+
+	// All:true stages the deletion (go-git treats a removed worktree file as a
+	// staged removal), so no explicit `git rm` index call is needed.
+	if _, err := gitSource.CommitPush(ctx, clonePath, gitSource.CommitPushOptions{
+		Message:      fmt.Sprintf("Delete task %s", taskID),
+		Branch:       branch,
+		BranchPrefix: deleteBranchPrefix,
+		Author:       deleteCommitAuthor,
+		AuthToken:    authToken,
+	}); err != nil {
+		return ipc.TaskDeleteOutcome{}, fmt.Errorf("commit+push deletion: %w", err)
+	}
+
+	m.log.Info("task deletion pushed",
+		zap.String("task", taskID), zap.String("source", sourceName), zap.String("branch", branch))
+	return ipc.TaskDeleteOutcome{
+		Source:    sourceName,
+		Mode:      "git",
+		Branch:    branch,
+		Base:      base,
+		ClonePath: clonePath,
+	}, nil
+}
+
+// sanitizeRunID maps a task id to a valid dev-clone run id (taskset.ValidateRunID:
+// [A-Za-z0-9_-]{1,64}). Path separators and other disallowed characters become
+// underscores; the result is truncated to 64 characters.
+func sanitizeRunID(taskID string) string {
+	var b strings.Builder
+	for _, r := range taskID {
+		switch {
+		case 'a' <= r && r <= 'z', 'A' <= r && r <= 'Z', '0' <= r && r <= '9', r == '_' || r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	s := b.String()
+	if s == "" {
+		s = "delete"
+	}
+	if len(s) > 64 {
+		s = s[:64]
+	}
+	return s
+}

--- a/pkg/webui/task_delete.go
+++ b/pkg/webui/task_delete.go
@@ -65,9 +65,9 @@ func (m *SourceManager) ResolveTaskSource(taskID, sourceOverride string) (string
 // Git sources: the repo is cloned (dev-mode clone-mode), the task directory is
 // removed from the clone, and the removal is committed and pushed to
 // delete/<sanitized-id>. The returned outcome carries the branch + clone path
-// so the caller opens a PR via buildin/git-pr. The clone is intentionally left
-// in place for the PR task to operate in; the dev-clones-cleanup buildin task
-// sweeps it afterwards.
+// so the caller opens a PR via buildin/git-pr. The source is left in clone-mode
+// so the PR task can run `gh` inside the clone; the caller reverts it via
+// DisableSourceDevMode once the PR step finishes.
 func (m *SourceManager) DeleteTaskFromSource(ctx context.Context, taskID, sourceName string, spec *task.Spec) (ipc.TaskDeleteOutcome, error) {
 	if spec == nil || spec.TaskDir == "" {
 		return ipc.TaskDeleteOutcome{}, fmt.Errorf("task %q has no on-disk directory", taskID)
@@ -93,21 +93,67 @@ func (m *SourceManager) DeleteTaskFromSource(ctx context.Context, taskID, source
 	return m.deleteGit(ctx, taskID, sourceName, spec, src, entry.Ref)
 }
 
-// deleteLocal removes the task directory under a local source. It refuses to
-// remove a directory that does not sit under the source's resolved root — a
-// defense against a stale or attacker-supplied TaskDir escaping the source.
-func (m *SourceManager) deleteLocal(taskID, sourceName string, spec *task.Spec, src *taskset.Source) (ipc.TaskDeleteOutcome, error) {
-	root := src.RepoPath()
+// containedTaskDir canonicalises root and taskDir (resolving symlinks on every
+// existing path component) and verifies taskDir sits strictly under root. A
+// symlinked source root, intermediate component, or task dir cannot let the
+// lexical path pass while os.RemoveAll follows the link outside root. It returns
+// the canonical task-dir path to remove. The task dir need not exist (nothing
+// to remove); the root must.
+func containedTaskDir(root, taskDir, sourceName string) (string, error) {
 	if root == "" {
-		return ipc.TaskDeleteOutcome{}, fmt.Errorf("source %q root path not resolved", sourceName)
+		return "", fmt.Errorf("source %q root path not resolved", sourceName)
 	}
-	taskDir := filepath.Clean(spec.TaskDir)
-	root = filepath.Clean(root)
-	if taskDir != root && !strings.HasPrefix(taskDir+string(filepath.Separator), root+string(filepath.Separator)) {
-		return ipc.TaskDeleteOutcome{}, fmt.Errorf("task directory %q is not under source %q root %q; refusing to remove", taskDir, sourceName, root)
+	if taskDir == "" {
+		return "", fmt.Errorf("task %q has no on-disk directory", sourceName)
 	}
-	if taskDir == root {
-		return ipc.TaskDeleteOutcome{}, fmt.Errorf("task directory equals source root %q; refusing to remove", root)
+	canonRoot, err := filepath.EvalSymlinks(filepath.Clean(root))
+	if err != nil {
+		return "", fmt.Errorf("resolve source %q root: %w", sourceName, err)
+	}
+	canonTask, err := resolveExisting(filepath.Clean(taskDir))
+	if err != nil {
+		return "", fmt.Errorf("resolve task directory %q: %w", taskDir, err)
+	}
+	if canonTask == canonRoot {
+		return "", fmt.Errorf("task directory equals source root %q; refusing to remove", canonRoot)
+	}
+	if !strings.HasPrefix(canonTask+string(filepath.Separator), canonRoot+string(filepath.Separator)) {
+		return "", fmt.Errorf("task directory %q is not under source %q root %q; refusing to remove", canonTask, sourceName, canonRoot)
+	}
+	return canonTask, nil
+}
+
+// resolveExisting canonicalises p with EvalSymlinks, walking up to the nearest
+// existing ancestor when p itself does not exist and re-appending the missing
+// tail. This canonicalises every real (and therefore symlink-bearing) component
+// while tolerating an already-absent task dir.
+func resolveExisting(p string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(p)
+	if err == nil {
+		return resolved, nil
+	}
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+	parent := filepath.Dir(p)
+	if parent == p {
+		return "", err
+	}
+	resolvedParent, perr := resolveExisting(parent)
+	if perr != nil {
+		return "", perr
+	}
+	return filepath.Join(resolvedParent, filepath.Base(p)), nil
+}
+
+// deleteLocal removes the task directory under a local source. It refuses to
+// remove a directory that does not sit under the source's canonical root —
+// defends against a stale or attacker-supplied TaskDir (or a symlink) escaping
+// the source.
+func (m *SourceManager) deleteLocal(taskID, sourceName string, spec *task.Spec, src *taskset.Source) (ipc.TaskDeleteOutcome, error) {
+	taskDir, err := containedTaskDir(src.RepoPath(), spec.TaskDir, sourceName)
+	if err != nil {
+		return ipc.TaskDeleteOutcome{}, err
 	}
 	if err := os.RemoveAll(taskDir); err != nil {
 		return ipc.TaskDeleteOutcome{}, fmt.Errorf("remove task directory: %w", err)
@@ -119,7 +165,7 @@ func (m *SourceManager) deleteLocal(taskID, sourceName string, spec *task.Spec, 
 
 // deleteGit clones the source repo, removes the task directory, and pushes the
 // removal to delete/<sanitized-id>.
-func (m *SourceManager) deleteGit(ctx context.Context, taskID, sourceName string, spec *task.Spec, src *taskset.Source, ref *taskset.Ref) (ipc.TaskDeleteOutcome, error) {
+func (m *SourceManager) deleteGit(ctx context.Context, taskID, sourceName string, spec *task.Spec, src *taskset.Source, ref *taskset.Ref) (out ipc.TaskDeleteOutcome, err error) {
 	// Repo-relative path of the task, computed against the PRIMARY repo path
 	// before clone-mode swaps RepoPath() to the clone dir.
 	primaryRoot := filepath.Clean(src.RepoPath())
@@ -139,13 +185,22 @@ func (m *SourceManager) deleteGit(ctx context.Context, taskID, sourceName string
 	if err := src.SetDevMode(ctx, true, taskset.DevModeOpts{Branch: branch, Base: base, RunID: runID}); err != nil {
 		return ipc.TaskDeleteOutcome{}, fmt.Errorf("clone source for delete: %w", err)
 	}
+	// On a successful push the source stays in clone-mode: handleTaskDelete runs
+	// the PR task inside the clone, then disables it. On any error here we revert
+	// clone-mode ourselves so the source isn't wedged.
+	defer func() {
+		if err != nil {
+			_ = src.SetDevMode(ctx, false, taskset.DevModeOpts{})
+		}
+	}()
 
 	clonePath := filepath.Clean(src.RepoPath())
-	cloneTaskDir := filepath.Join(clonePath, rel)
-	if !strings.HasPrefix(filepath.Clean(cloneTaskDir)+string(filepath.Separator), clonePath+string(filepath.Separator)) {
-		return ipc.TaskDeleteOutcome{}, fmt.Errorf("clone task path escapes clone root: %q", cloneTaskDir)
+	var cloneTaskDir string
+	cloneTaskDir, err = containedTaskDir(clonePath, filepath.Join(clonePath, rel), sourceName)
+	if err != nil {
+		return ipc.TaskDeleteOutcome{}, err
 	}
-	if err := os.RemoveAll(cloneTaskDir); err != nil {
+	if err = os.RemoveAll(cloneTaskDir); err != nil {
 		return ipc.TaskDeleteOutcome{}, fmt.Errorf("remove task in clone: %w", err)
 	}
 
@@ -154,12 +209,14 @@ func (m *SourceManager) deleteGit(ctx context.Context, taskID, sourceName string
 		authToken = os.Getenv(ref.Auth.TokenEnv)
 	}
 
-	// All:true stages the deletion (go-git treats a removed worktree file as a
-	// staged removal), so no explicit `git rm` index call is needed.
-	if _, err := gitSource.CommitPush(ctx, clonePath, gitSource.CommitPushOptions{
+	// Stage only the removed task path: go-git records a deleted worktree file as
+	// a staged removal when its tracked path is Add-ed. An empty Files would stage
+	// every change in the clone, including unrelated artifacts.
+	if _, err = gitSource.CommitPush(ctx, clonePath, gitSource.CommitPushOptions{
 		Message:      fmt.Sprintf("Delete task %s", taskID),
 		Branch:       branch,
 		BranchPrefix: deleteBranchPrefix,
+		Files:        []string{rel},
 		Author:       deleteCommitAuthor,
 		AuthToken:    authToken,
 	}); err != nil {
@@ -175,6 +232,19 @@ func (m *SourceManager) deleteGit(ctx context.Context, taskID, sourceName string
 		Base:      base,
 		ClonePath: clonePath,
 	}, nil
+}
+
+// DisableSourceDevMode reverts a source out of clone-mode. It implements
+// ipc.TaskDeleter. Disabling removes the local clone but leaves the pushed
+// remote branch intact. Idempotent for sources not in clone-mode.
+func (m *SourceManager) DisableSourceDevMode(ctx context.Context, sourceName string) error {
+	m.mu.RLock()
+	src, ok := m.tasksets[sourceName]
+	m.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("source %q not found", sourceName)
+	}
+	return src.SetDevMode(ctx, false, taskset.DevModeOpts{})
 }
 
 // sanitizeRunID maps a task id to a valid dev-clone run id (taskset.ValidateRunID:

--- a/pkg/webui/task_delete.go
+++ b/pkg/webui/task_delete.go
@@ -103,9 +103,6 @@ func containedTaskDir(root, taskDir, sourceName string) (string, error) {
 	if root == "" {
 		return "", fmt.Errorf("source %q root path not resolved", sourceName)
 	}
-	if taskDir == "" {
-		return "", fmt.Errorf("task %q has no on-disk directory", sourceName)
-	}
 	canonRoot, err := filepath.EvalSymlinks(filepath.Clean(root))
 	if err != nil {
 		return "", fmt.Errorf("resolve source %q root: %w", sourceName, err)

--- a/pkg/webui/task_delete_test.go
+++ b/pkg/webui/task_delete_test.go
@@ -1,0 +1,286 @@
+package webui
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	gogitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+
+	"github.com/dicode/dicode/pkg/config"
+	"github.com/dicode/dicode/pkg/task"
+	"github.com/dicode/dicode/pkg/taskset"
+	"go.uber.org/zap"
+)
+
+func TestResolveTaskSource_FromIDPrefix(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{}
+	cfg.Spec.Entries = map[string]*taskset.Entry{
+		"tasks": {Ref: &taskset.Ref{Path: filepath.Join(dir, "taskset.yaml")}},
+	}
+	m := NewSourceManager(cfg, nil, dir, zap.NewNop())
+	m.Register("tasks", newStubTasksetSource(t, "tasks", dir))
+
+	name, isGit, err := m.ResolveTaskSource("tasks/my-task", "")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if name != "tasks" {
+		t.Fatalf("name = %q, want tasks", name)
+	}
+	if isGit {
+		t.Fatal("local source must report isGit=false")
+	}
+}
+
+func TestResolveTaskSource_GitDetected(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{}
+	cfg.Spec.Entries = map[string]*taskset.Entry{
+		"remote": {Ref: &taskset.Ref{URL: "https://example.com/repo.git", Branch: "main"}},
+	}
+	m := NewSourceManager(cfg, nil, dir, zap.NewNop())
+	m.Register("remote", newStubTasksetSource(t, "remote", dir))
+
+	name, isGit, err := m.ResolveTaskSource("remote/thing", "")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if name != "remote" || !isGit {
+		t.Fatalf("got (%q, %v), want (remote, true)", name, isGit)
+	}
+}
+
+func TestResolveTaskSource_SourceOverride_Mismatch(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{}
+	cfg.Spec.Entries = map[string]*taskset.Entry{
+		"tasks": {Ref: &taskset.Ref{Path: filepath.Join(dir, "taskset.yaml")}},
+	}
+	m := NewSourceManager(cfg, nil, dir, zap.NewNop())
+	m.Register("tasks", newStubTasksetSource(t, "tasks", dir))
+
+	if _, _, err := m.ResolveTaskSource("other/task", "tasks"); err == nil {
+		t.Fatal("expected error: task is not under the overridden source")
+	}
+}
+
+func TestResolveTaskSource_UnknownSource(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Spec.Entries = map[string]*taskset.Entry{}
+	m := NewSourceManager(cfg, nil, t.TempDir(), zap.NewNop())
+
+	if _, _, err := m.ResolveTaskSource("ghost/task", ""); err == nil {
+		t.Fatal("expected error for unknown source")
+	}
+}
+
+func TestDeleteTaskFromSource_Local_RemovesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	taskDir := filepath.Join(dir, "my-task")
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(taskDir, "task.yaml"), []byte("name: x\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg := &config.Config{}
+	cfg.Spec.Entries = map[string]*taskset.Entry{
+		"tasks": {Ref: &taskset.Ref{Path: filepath.Join(dir, "taskset.yaml")}},
+	}
+	m := NewSourceManager(cfg, nil, dir, zap.NewNop())
+	m.Register("tasks", newStubTasksetSource(t, "tasks", dir))
+
+	spec := &task.Spec{ID: "tasks/my-task", TaskDir: taskDir}
+	out, err := m.DeleteTaskFromSource(context.Background(), "tasks/my-task", "tasks", spec)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if out.Mode != "local" {
+		t.Fatalf("Mode = %q, want local", out.Mode)
+	}
+	if _, statErr := os.Stat(taskDir); !os.IsNotExist(statErr) {
+		t.Fatalf("task directory still exists: %v", statErr)
+	}
+}
+
+// A TaskDir that escapes the source root must be refused — defends against a
+// stale or crafted spec removing arbitrary directories.
+func TestDeleteTaskFromSource_Local_RefusesEscape(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	escapeDir := filepath.Join(outside, "victim")
+	if err := os.MkdirAll(escapeDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	cfg := &config.Config{}
+	cfg.Spec.Entries = map[string]*taskset.Entry{
+		"tasks": {Ref: &taskset.Ref{Path: filepath.Join(dir, "taskset.yaml")}},
+	}
+	m := NewSourceManager(cfg, nil, dir, zap.NewNop())
+	m.Register("tasks", newStubTasksetSource(t, "tasks", dir))
+
+	spec := &task.Spec{ID: "tasks/evil", TaskDir: escapeDir}
+	if _, err := m.DeleteTaskFromSource(context.Background(), "tasks/evil", "tasks", spec); err == nil {
+		t.Fatal("expected refusal when TaskDir escapes source root")
+	}
+	if _, statErr := os.Stat(escapeDir); statErr != nil {
+		t.Fatalf("escape dir must NOT have been removed: %v", statErr)
+	}
+}
+
+// gitFixtureRemote builds a bare git remote seeded with the given files on
+// `branch` and returns a file:// URL usable as a taskset git ref. Mirrors the
+// taskset package's own fixture helper.
+func gitFixtureRemote(t *testing.T, branch string, files map[string]string) string {
+	t.Helper()
+	bareDir := filepath.Join(t.TempDir(), "bare.git")
+	if _, err := gogit.PlainInitWithOptions(bareDir, &gogit.PlainInitOptions{
+		Bare:        true,
+		InitOptions: gogit.InitOptions{DefaultBranch: plumbing.NewBranchReferenceName(branch)},
+	}); err != nil {
+		t.Fatalf("init bare: %v", err)
+	}
+	wtPath := filepath.Join(t.TempDir(), "seed-wt")
+	wt, err := gogit.PlainInitWithOptions(wtPath, &gogit.PlainInitOptions{
+		InitOptions: gogit.InitOptions{DefaultBranch: plumbing.NewBranchReferenceName(branch)},
+	})
+	if err != nil {
+		t.Fatalf("init wt: %v", err)
+	}
+	if _, err := wt.CreateRemote(&gogitconfig.RemoteConfig{Name: "origin", URLs: []string{bareDir}}); err != nil {
+		t.Fatalf("create remote: %v", err)
+	}
+	tree, err := wt.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+	for name, content := range files {
+		full := filepath.Join(wtPath, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		if _, err := tree.Add(name); err != nil {
+			t.Fatalf("add %s: %v", name, err)
+		}
+	}
+	if _, err := tree.Commit("initial", &gogit.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@t", When: time.Now()},
+	}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if err := wt.Push(&gogit.PushOptions{RemoteName: "origin"}); err != nil && err != gogit.NoErrAlreadyUpToDate {
+		t.Fatalf("push: %v", err)
+	}
+	return "file://" + bareDir
+}
+
+// TestDeleteTaskFromSource_Git_ClonePushesDeleteBranch exercises the real
+// git-source path: clone the source, remove the task dir, commit, push to
+// delete/<id>. It asserts the bare remote ends up with the delete branch and
+// that the task file is gone from that branch's tree. The PR-opening step is
+// the control server's job (covered in pkg/ipc) and is out of scope here.
+func TestDeleteTaskFromSource_Git_ClonePushesDeleteBranch(t *testing.T) {
+	remoteURL := gitFixtureRemote(t, "main", map[string]string{
+		"taskset.yaml": "apiVersion: dicode/v1\nkind: TaskSet\nspec:\n  entries:\n" +
+			"    my-task:\n      ref:\n        path: ./my-task/task.yaml\n" +
+			"    keep-task:\n      ref:\n        path: ./keep-task/task.yaml\n",
+		"my-task/task.yaml":   "apiVersion: dicode/v1\nkind: Task\nname: my-task\nruntime: deno\ntrigger:\n  manual: true\n",
+		"my-task/task.ts":     "export default async function () {}\n",
+		"keep-task/task.yaml": "apiVersion: dicode/v1\nkind: Task\nname: keep\nruntime: deno\ntrigger:\n  manual: true\n",
+		"keep-task/task.ts":   "export default async function () {}\n",
+	})
+
+	dataDir := t.TempDir()
+	cfg := &config.Config{}
+	cfg.Spec.Entries = map[string]*taskset.Entry{
+		"remote": {Ref: &taskset.Ref{URL: remoteURL, Branch: "main"}},
+	}
+	m := NewSourceManager(cfg, nil, dataDir, zap.NewNop())
+
+	src := taskset.NewSource(remoteURL, "remote", &taskset.Ref{URL: remoteURL, Branch: "main"}, "", dataDir, false, 30*time.Second, zap.NewNop())
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	if _, err := src.Start(ctx); err != nil {
+		t.Fatalf("start git source: %v", err)
+	}
+	m.Register("remote", src)
+
+	primaryRoot := src.RepoPath()
+	spec := &task.Spec{ID: "remote/my-task", TaskDir: filepath.Join(primaryRoot, "my-task")}
+
+	out, err := m.DeleteTaskFromSource(ctx, "remote/my-task", "remote", spec)
+	if err != nil {
+		t.Fatalf("git delete: %v", err)
+	}
+	if out.Mode != "git" {
+		t.Fatalf("Mode = %q, want git", out.Mode)
+	}
+	if out.Branch != "delete/remote/my-task" {
+		t.Fatalf("Branch = %q, want delete/remote/my-task", out.Branch)
+	}
+	if out.ClonePath == "" {
+		t.Fatal("ClonePath should be set for the PR task")
+	}
+
+	// Verify the bare remote now has the delete branch with my-task removed.
+	verifyDir := filepath.Join(t.TempDir(), "verify")
+	vr, err := gogit.PlainCloneContext(ctx, verifyDir, false, &gogit.CloneOptions{
+		URL:           remoteURL,
+		ReferenceName: plumbing.NewBranchReferenceName("delete/remote/my-task"),
+	})
+	if err != nil {
+		t.Fatalf("clone delete branch: %v", err)
+	}
+	head, err := vr.Head()
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+	commit, err := vr.CommitObject(head.Hash())
+	if err != nil {
+		t.Fatalf("commit object: %v", err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		t.Fatalf("tree: %v", err)
+	}
+	if _, err := tree.File("my-task/task.yaml"); err == nil {
+		t.Fatal("my-task/task.yaml should be gone on the delete branch")
+	}
+	if _, err := tree.File("keep-task/task.yaml"); err != nil {
+		t.Fatalf("keep-task/task.yaml should still exist: %v", err)
+	}
+}
+
+func TestSanitizeRunID(t *testing.T) {
+	cases := map[string]string{
+		"tasks/my-task": "tasks_my-task",
+		"a/b/c":         "a_b_c",
+		"weird name!@#": "weird_name___",
+		"":              "delete",
+		"keep_-AZ09":    "keep_-AZ09",
+	}
+	for in, want := range cases {
+		if got := sanitizeRunID(in); got != want {
+			t.Errorf("sanitizeRunID(%q) = %q, want %q", in, got, want)
+		}
+	}
+	long := make([]byte, 100)
+	for i := range long {
+		long[i] = 'x'
+	}
+	if got := sanitizeRunID(string(long)); len(got) != 64 {
+		t.Errorf("sanitizeRunID truncation: len = %d, want 64", len(got))
+	}
+}

--- a/pkg/webui/task_delete_test.go
+++ b/pkg/webui/task_delete_test.go
@@ -137,6 +137,43 @@ func TestDeleteTaskFromSource_Local_RefusesEscape(t *testing.T) {
 	}
 }
 
+// A task dir that is a symlink pointing outside the source root must be refused:
+// the lexical path sits under root, but os.RemoveAll would follow the link out.
+func TestDeleteTaskFromSource_Local_RefusesSymlinkEscape(t *testing.T) {
+	if _, err := os.Lstat("/"); err != nil {
+		t.Skip("filesystem unavailable")
+	}
+	dir := t.TempDir()
+	outside := t.TempDir()
+	victim := filepath.Join(outside, "victim")
+	if err := os.MkdirAll(victim, 0o755); err != nil {
+		t.Fatalf("mkdir victim: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(victim, "keep.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// A symlink inside the source root pointing at the outside victim dir.
+	link := filepath.Join(dir, "evil")
+	if err := os.Symlink(victim, link); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+
+	cfg := &config.Config{}
+	cfg.Spec.Entries = map[string]*taskset.Entry{
+		"tasks": {Ref: &taskset.Ref{Path: filepath.Join(dir, "taskset.yaml")}},
+	}
+	m := NewSourceManager(cfg, nil, dir, zap.NewNop())
+	m.Register("tasks", newStubTasksetSource(t, "tasks", dir))
+
+	spec := &task.Spec{ID: "tasks/evil", TaskDir: link}
+	if _, err := m.DeleteTaskFromSource(context.Background(), "tasks/evil", "tasks", spec); err == nil {
+		t.Fatal("expected refusal when TaskDir is a symlink escaping the source root")
+	}
+	if _, statErr := os.Stat(filepath.Join(victim, "keep.txt")); statErr != nil {
+		t.Fatalf("symlink target must NOT have been removed: %v", statErr)
+	}
+}
+
 // gitFixtureRemote builds a bare git remote seeded with the given files on
 // `branch` and returns a file:// URL usable as a taskset git ref. Mirrors the
 // taskset package's own fixture helper.


### PR DESCRIPTION
## Summary

Closes #285. There was no first-class way to remove a task — operators `rm -rf`'d local source dirs or pushed empty commits to git sources. This adds `dicode task delete <task-id> [--source NAME] [--force]`.

The verb resolves the task to its owning source via the registry, then deletes it per source type:

- **Local sources** — the task directory is removed in place (with a guard that refuses any `TaskDir` escaping the resolved source root).
- **Git sources** — the repo is cloned through the existing dev-mode clone path, the task directory is git-removed, and the change is committed + pushed to a `delete/<id>` branch. The PR is then filed via the **buildin/git-pr** task — the *same* push+PR plumbing the AI-authoring save flow and auto-fix loop use (`set_dev_mode` clone → `gitSource.CommitPush` → fire `buildin/git-pr`). All git ops are go-git; no git binary.

The reconciler deregisters the task on its next sync (~30s). The CLI returns once the deletion is committed (local) or the PR is filed (git): stdout carries the piped value (PR URL, or `deleted`), stderr carries progress/warnings.

## Edge cases

- **Buildin tasks** (`buildin/…`) are undeletable; the error points the operator at the taskset override mechanism instead.
- **Chained references** — chain (`trigger.chain.from`) and on-failure (`on_failure_chain.task`) referrers are detected by scanning the registry and surfaced in a non-destructive **preview**. Without `--force` the CLI renders the preview (trigger, dangling referrers, pinned-runs note), prompts for confirmation, and only then sends the destructive request. The server performs the removal **only** when `Force` is true.
- **Pinned runs** — verified the runs-history view degrades gracefully: `apiGetRun` reads the run row from SQLite and falls back to `run.TaskID` when `registry.Get` misses, so stale run rows for a deleted task render (task id instead of the friendly name) with no 404 or panic. No new machinery added.

## Design / coordination

The control server stays decoupled from `pkg/webui` via a new `TaskDeleter` interface (same pattern as `APIKeyMinter` / `SourceDevModeSetter`), implemented by `SourceManager`. The deletion git/fs logic lives in its own files (`pkg/webui/task_delete.go`, `pkg/ipc/control_task_delete.go`).

Shares the `dicode task` dispatcher and the `pkg/ipc` control switch with **#288** (slice 3, in parallel). To minimize merge conflicts the delete verb is self-contained: one new `case "delete"` in the task subcommand switch, one new `cli.task.delete` IPC case, appended (not reordered) IPC struct fields, and dedicated handler files.

## Deliberately left behind

The `dc-task-detail` webui delete button is **out of scope** here and deferred to a follow-up, per the issue.

## Tests

Added unit tests for source resolution (id-prefix, git detection, `--source` override mismatch, unknown source), buildin-undeletable, chained-reference detection + preview, local-dir removal (+ escape refusal), and the git delete→PR path (a real go-git fixture remote for the source-side clone/rm/push; a mock-engine assertion that `buildin/git-pr` is fired with the right params on the control-server side). `make test` and `make lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)