### PR TITLE
feat(python-runtime): enforce permissions.{fs,net,run} via PEP 578 audit hook

### DIFF
--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -75,11 +75,11 @@ permissions:
 | `trigger.restart` | string | | daemon only: `always` (default), `on-failure`, `never` |
 | `permissions` | object | | Explicit access grants — nothing is implicit |
 | `permissions.env` | list | | Env vars the script may read (see below) |
-| `permissions.fs` | list | | Filesystem access declarations (Deno only) |
+| `permissions.fs` | list | | Filesystem access declarations (Deno: read+write; Python: write only) |
 | `permissions.fs[].path` | string | | Absolute or `~`-prefixed path |
 | `permissions.fs[].permission` | string | | `r`, `w`, or `rw` |
-| `permissions.run` | list of strings | | Executables the script may spawn (Deno only); use `["*"]` for all |
-| `permissions.net` | list of strings | | Outbound network hosts (Deno only); omit = unrestricted, `[]` = deny all |
+| `permissions.run` | list of strings | | Executables the script may spawn (Deno and Python); use `["*"]` for all |
+| `permissions.net` | list of strings | | Outbound network hosts (Deno and Python); omit = unrestricted, `[]` = deny all |
 | `permissions.sys` | list of strings | | Deno sys APIs (Deno only); omit = deny all, `["*"]` = all |
 | `permissions.dicode` | object | | Which dicode runtime APIs the task may call (all denied by default) |
 | `permissions.dicode.tasks` | list of strings | | Task IDs the script may invoke via `dicode.run_task()`; use `["*"]` for all |
@@ -915,10 +915,10 @@ permissions:
     - path: ~/reports
       permission: rw            # read + write + delete
   run:
-    - curl                      # allow spawning curl (Deno only)
+    - curl                      # allow spawning curl
     # - "*"                     # allow all executables
   sys:
-    - hostname                  # Deno system-info APIs (omit = deny all)
+    - hostname                  # Deno system-info APIs (omit = deny all; Deno only)
 ```
 
 ### `permissions.env` — environment variables
@@ -1045,7 +1045,7 @@ If the prereq itself fails — for example an OAuth task throwing *"Open this UR
 
 Only `secret:`-backed entries honor `if_missing:`. On a `from:`, `value:`, or bare entry the directive is silently ignored — there's no secret to check for presence in the first place.
 
-### `permissions.fs` — filesystem access (Deno only)
+### `permissions.fs` — filesystem access
 
 | Permission | Read | Write | Delete | mkdir |
 | --- | --- | --- | --- | --- |
@@ -1053,23 +1053,27 @@ Only `secret:`-backed entries honor `if_missing:`. On a `from:`, `value:`, or ba
 | `w` | ❌ | ✅ | ✅ | ✅ |
 | `rw` | ✅ | ✅ | ✅ | ✅ |
 
-`~` is expanded to the user's home directory at runtime.
+`~` is expanded to the user's home directory at runtime; relative paths resolve against the task directory.
 
-### `permissions.run` — subprocess execution (Deno only)
+Deno enforces both reads and writes via `--allow-read`/`--allow-write`. Python enforces **writes only** (via a PEP 578 audit hook): read allowlists are impractical in-interpreter — the interpreter and installed packages read files constantly — so reads stay unrestricted and `r` entries are ignored there.
 
-Lists executables the script may spawn via `Deno.Command`. Use `["*"]` to allow all. Omitting this field blocks all subprocess execution.
+### `permissions.run` — subprocess execution
 
-### `permissions.net` — outbound network (Deno only)
+Lists executables the script may spawn (`Deno.Command`, Python `subprocess`/`os.system`/`os.exec*`). Use `["*"]` to allow all. Omitting this field blocks all subprocess execution.
 
-Controls which hostnames the task may connect to.
+### `permissions.net` — outbound network
+
+Controls which hostnames the task may connect to (Deno `--allow-net`; Python audit hook on `socket.connect`/`socket.getaddrinfo`).
 
 | Value | Effect |
 | --- | --- |
-| Omit field (default) | Unrestricted outbound (`--allow-net`) |
+| Omit field (default) | Unrestricted outbound |
 | `["api.github.com", "hooks.slack.com"]` | Restrict to listed hosts only |
 | `[]` (empty list) | Deny all outbound network |
 
-### `permissions.sys` — system-info APIs (Deno only)
+The Python enforcement is a guardrail, not a security boundary: hostnames are vetted at DNS resolution, so IP-literal connections pass the allowlist (deny-all still blocks them), and pooled or exotic async connections may not re-emit audit events.
+
+### `permissions.sys` — system-info APIs (Deno only; Python ignores this field)
 
 Controls access to Deno's [`Deno.systemMemoryInfo()`](https://deno.land/api?s=Deno.systemMemoryInfo), `Deno.hostname()`, etc.
 

--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -1057,6 +1057,8 @@ Only `secret:`-backed entries honor `if_missing:`. On a `from:`, `value:`, or ba
 
 Deno enforces both reads and writes via `--allow-read`/`--allow-write`. Python enforces **writes only** (via a PEP 578 audit hook): read allowlists are impractical in-interpreter — the interpreter and installed packages read files constantly — so reads stay unrestricted and `r` entries are ignored there.
 
+Writes are denied by default: a Python task that writes a file, creates a directory or symlink, or uses the `tempfile` module must declare the target path with `w`/`rw`. Libraries that write under the temp directory therefore need an explicit grant, e.g. `- path: /tmp` with `permission: rw`.
+
 ### `permissions.run` — subprocess execution
 
 Lists executables the script may spawn (`Deno.Command`, Python `subprocess`/`os.system`/`os.exec*`). Use `["*"]` to allow all. Omitting this field blocks all subprocess execution.

--- a/pkg/runtime/python/guard.go
+++ b/pkg/runtime/python/guard.go
@@ -1,0 +1,124 @@
+package python
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+//go:embed sdk/guard.py
+var guardContent string
+
+// guardPolicy is the JSON document embedded into the generated wrapper and
+// consumed by the PEP 578 audit hook in sdk/guard.py.
+//
+// Enforcement scope (a guardrail on declared intent, not a security
+// boundary — the task author is trusted):
+//   - net, run, and fs writes are enforced.
+//   - fs reads are NOT enforced: the interpreter, stdlib, and site-packages
+//     read files constantly, so an in-interpreter read allowlist would break
+//     normal execution. Known divergence from the Deno runtime.
+//   - sys is NOT enforced: Deno's sys permission names (hostname, osRelease,
+//     ...) have no usable Python equivalent.
+type guardPolicy struct {
+	Net     guardNet `json:"net"`
+	Run     guardRun `json:"run"`
+	FSWrite []string `json:"fs_write"`
+}
+
+type guardNet struct {
+	Mode  string   `json:"mode"` // "unrestricted" | "allowlist" | "deny"
+	Hosts []string `json:"hosts,omitempty"`
+}
+
+type guardRun struct {
+	Mode     string   `json:"mode"` // "allow" | "allowlist" | "deny"
+	Commands []string `json:"commands,omitempty"`
+}
+
+// buildGuardPolicy maps spec.Permissions onto the audit-hook policy with the
+// same semantics as the Deno runtime's buildDenoArgs:
+//
+//	net: omit → unrestricted; ["*"] → unrestricted; [h, ...] → allowlist;
+//	     [] (explicit empty) → deny all. Omit=unrestricted is intentional
+//	     parity with Deno; #379 tracks changing the default to deny.
+//	run: ["*"] → allow all; [c, ...] → allowlist; empty/omit → deny all.
+//	fs:  "w"/"rw" entries form the write allowlist. "~" expands to the user
+//	     home; relative paths resolve against the task dir. "r" entries are
+//	     ignored (reads are unenforced, see guardPolicy).
+//
+// The IPC socket path is always writable so SDK traffic is never governed.
+func buildGuardPolicy(spec *task.Spec, socketPath string) guardPolicy {
+	var pol guardPolicy
+
+	net := spec.Permissions.Net
+	switch {
+	case net == nil, len(net) == 1 && net[0] == "*":
+		pol.Net.Mode = "unrestricted"
+	case len(net) > 0:
+		pol.Net.Mode = "allowlist"
+		pol.Net.Hosts = net
+	default:
+		pol.Net.Mode = "deny"
+	}
+
+	run := spec.Permissions.Run
+	switch {
+	case len(run) == 1 && run[0] == "*":
+		pol.Run.Mode = "allow"
+	case len(run) > 0:
+		pol.Run.Mode = "allowlist"
+		pol.Run.Commands = run
+	default:
+		pol.Run.Mode = "deny"
+	}
+
+	if socketPath != "" {
+		pol.FSWrite = append(pol.FSWrite, socketPath)
+	}
+	for _, entry := range spec.Permissions.FS {
+		if entry.Permission != "w" && entry.Permission != "rw" {
+			continue
+		}
+		p := expandHome(entry.Path)
+		if !filepath.IsAbs(p) {
+			p = filepath.Join(spec.TaskDir, p)
+		}
+		pol.FSWrite = append(pol.FSWrite, p)
+	}
+	return pol
+}
+
+// buildGuard renders the audit-hook source with the policy embedded. The
+// policy JSON is double-encoded so it lands as a quoted string literal that
+// is valid Python source (JSON string escapes are a subset of Python's).
+func buildGuard(pol guardPolicy) (string, error) {
+	raw, err := json.Marshal(pol)
+	if err != nil {
+		return "", fmt.Errorf("marshal guard policy: %w", err)
+	}
+	lit, err := json.Marshal(string(raw))
+	if err != nil {
+		return "", fmt.Errorf("encode guard policy literal: %w", err)
+	}
+	out := strings.Replace(guardContent, `"__DICODE_POLICY__"`, string(lit), 1)
+	if out == guardContent {
+		return "", fmt.Errorf("guard template missing policy placeholder")
+	}
+	return out, nil
+}
+
+func expandHome(p string) string {
+	if strings.HasPrefix(p, "~/") || p == "~" {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			return home + p[1:]
+		}
+	}
+	return p
+}

--- a/pkg/runtime/python/guard_integration_test.go
+++ b/pkg/runtime/python/guard_integration_test.go
@@ -109,6 +109,16 @@ func TestGuard_FSRemoveDenied(t *testing.T) {
 	requireDenied(t, out, err, "permissions.fs")
 }
 
+func TestGuard_FSSymlinkDenied(t *testing.T) {
+	link := filepath.Join(t.TempDir(), "link")
+	pol := guardPolicy{Net: guardNet{Mode: "unrestricted"}, Run: guardRun{Mode: "deny"}}
+	out, err := runGuardScript(t, pol, fmt.Sprintf("import os\nos.symlink('/etc/passwd', %q)", link))
+	requireDenied(t, out, err, "permissions.fs")
+	if _, statErr := os.Lstat(link); statErr == nil {
+		t.Error("denied symlink was still created")
+	}
+}
+
 func TestGuard_FSReadAlwaysAllowed(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "readable.txt")

--- a/pkg/runtime/python/guard_integration_test.go
+++ b/pkg/runtime/python/guard_integration_test.go
@@ -1,0 +1,219 @@
+package python
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// pythonForGuardTest locates an interpreter for guard integration tests. The
+// guard only needs the stdlib, so a plain python3 suffices; uv is accepted as
+// a fallback for environments that only ship the managed toolchain. Skips
+// locally when neither is present; on CI it fails loudly (same contract as
+// TestPythonSDK).
+func pythonForGuardTest(t *testing.T) []string {
+	t.Helper()
+	if py, err := exec.LookPath("python3"); err == nil {
+		return []string{py}
+	}
+	if uv, err := exec.LookPath("uv"); err == nil {
+		return []string{uv, "run", "--no-project"}
+	}
+	if os.Getenv("CI") != "" {
+		t.Fatal("neither python3 nor uv on PATH in CI; setup step missing?")
+	}
+	t.Skip("neither python3 nor uv on PATH; skipping guard integration tests")
+	return nil
+}
+
+// runGuardScript renders the guard for pol, appends payload, and executes the
+// result with a real interpreter. Returns the combined output and the exec
+// error (nil on exit 0).
+func runGuardScript(t *testing.T, pol guardPolicy, payload string) (string, error) {
+	t.Helper()
+	guard, err := buildGuard(pol)
+	if err != nil {
+		t.Fatalf("buildGuard: %v", err)
+	}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "guarded.py")
+	if err := os.WriteFile(script, []byte(guard+"\n"+payload+"\n"), 0o600); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	interp := pythonForGuardTest(t)
+	cmd := exec.Command(interp[0], append(interp[1:], script)...) //nolint:gosec
+	out, runErr := cmd.CombinedOutput()
+	return string(out), runErr
+}
+
+func requireDenied(t *testing.T, out string, err error, permField string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected PermissionError exit, got success; output:\n%s", out)
+	}
+	if !strings.Contains(out, "PermissionError") || !strings.Contains(out, permField) {
+		t.Fatalf("expected PermissionError naming %s; output:\n%s", permField, out)
+	}
+}
+
+func requireAllowed(t *testing.T, out string, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("expected success, got %v; output:\n%s", err, out)
+	}
+}
+
+func TestGuard_FSWriteDenied(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "denied.txt")
+	pol := guardPolicy{
+		Net: guardNet{Mode: "unrestricted"},
+		Run: guardRun{Mode: "deny"},
+	}
+	out, err := runGuardScript(t, pol, fmt.Sprintf("open(%q, 'w')", target))
+	requireDenied(t, out, err, "permissions.fs")
+	if _, statErr := os.Stat(target); statErr == nil {
+		t.Error("denied write still created the file")
+	}
+}
+
+func TestGuard_FSWriteAllowedInDeclaredDir(t *testing.T) {
+	dir := t.TempDir()
+	pol := guardPolicy{
+		Net:     guardNet{Mode: "unrestricted"},
+		Run:     guardRun{Mode: "deny"},
+		FSWrite: []string{dir},
+	}
+	payload := fmt.Sprintf(`
+import os
+p = os.path.join(%q, "ok.txt")
+with open(p, "w") as f:
+    f.write("hi")
+os.remove(p)
+os.mkdir(os.path.join(%q, "sub"))
+`, dir, dir)
+	out, err := runGuardScript(t, pol, payload)
+	requireAllowed(t, out, err)
+}
+
+func TestGuard_FSRemoveDenied(t *testing.T) {
+	dir := t.TempDir()
+	victim := filepath.Join(dir, "victim.txt")
+	if err := os.WriteFile(victim, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pol := guardPolicy{Net: guardNet{Mode: "unrestricted"}, Run: guardRun{Mode: "deny"}}
+	out, err := runGuardScript(t, pol, fmt.Sprintf("import os\nos.remove(%q)", victim))
+	requireDenied(t, out, err, "permissions.fs")
+}
+
+func TestGuard_FSReadAlwaysAllowed(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "readable.txt")
+	if err := os.WriteFile(src, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// No fs grants at all: reads must still work (reads are unenforced).
+	pol := guardPolicy{Net: guardNet{Mode: "unrestricted"}, Run: guardRun{Mode: "deny"}}
+	payload := fmt.Sprintf("assert open(%q).read() == 'data'", src)
+	out, err := runGuardScript(t, pol, payload)
+	requireAllowed(t, out, err)
+}
+
+func TestGuard_SubprocessDenied(t *testing.T) {
+	pol := guardPolicy{Net: guardNet{Mode: "unrestricted"}, Run: guardRun{Mode: "deny"}}
+	payload := "import subprocess, sys\nsubprocess.run([sys.executable, '-c', 'pass'])"
+	out, err := runGuardScript(t, pol, payload)
+	requireDenied(t, out, err, "permissions.run")
+}
+
+func TestGuard_SubprocessAllowedByWildcard(t *testing.T) {
+	pol := guardPolicy{Net: guardNet{Mode: "unrestricted"}, Run: guardRun{Mode: "allow"}}
+	payload := "import subprocess, sys\nsubprocess.run([sys.executable, '-c', 'pass'], check=True)"
+	out, err := runGuardScript(t, pol, payload)
+	requireAllowed(t, out, err)
+}
+
+func TestGuard_SubprocessAllowlistMatchesBasename(t *testing.T) {
+	pol := guardPolicy{
+		Net: guardNet{Mode: "unrestricted"},
+		Run: guardRun{Mode: "allowlist", Commands: []string{"true"}},
+	}
+	tru, err := exec.LookPath("true")
+	if err != nil {
+		t.Skip("true not on PATH")
+	}
+	payload := fmt.Sprintf("import subprocess\nsubprocess.run([%q], check=True)", tru)
+	out, runErr := runGuardScript(t, pol, payload)
+	requireAllowed(t, out, runErr)
+
+	payload = "import subprocess, sys\nsubprocess.run([sys.executable, '-c', 'pass'])"
+	out, runErr = runGuardScript(t, pol, payload)
+	requireDenied(t, out, runErr, "permissions.run")
+}
+
+func TestGuard_OsSystemDenied(t *testing.T) {
+	pol := guardPolicy{Net: guardNet{Mode: "unrestricted"}, Run: guardRun{Mode: "deny"}}
+	out, err := runGuardScript(t, pol, "import os\nos.system('true')")
+	requireDenied(t, out, err, "permissions.run")
+}
+
+// localConnectPayload binds a listener on 127.0.0.1 (bind is ungoverned) and
+// connects to it, exercising the socket.connect audit event without any
+// external network dependency.
+const localConnectPayload = `
+import socket
+srv = socket.socket()
+srv.bind(("127.0.0.1", 0))
+srv.listen(1)
+c = socket.socket()
+c.connect(srv.getsockname())
+c.close()
+srv.close()
+`
+
+func TestGuard_NetDenyBlocksConnect(t *testing.T) {
+	pol := guardPolicy{Net: guardNet{Mode: "deny"}, Run: guardRun{Mode: "deny"}}
+	out, err := runGuardScript(t, pol, localConnectPayload)
+	requireDenied(t, out, err, "permissions.net")
+}
+
+func TestGuard_NetUnrestrictedAllowsConnect(t *testing.T) {
+	pol := guardPolicy{Net: guardNet{Mode: "unrestricted"}, Run: guardRun{Mode: "deny"}}
+	out, err := runGuardScript(t, pol, localConnectPayload)
+	requireAllowed(t, out, err)
+}
+
+func TestGuard_NetAllowlistPassesIPLiterals(t *testing.T) {
+	// Hostname vetting happens at getaddrinfo; raw IP connects pass the
+	// allowlist by design (documented guardrail limitation).
+	pol := guardPolicy{
+		Net: guardNet{Mode: "allowlist", Hosts: []string{"api.example.com"}},
+		Run: guardRun{Mode: "deny"},
+	}
+	out, err := runGuardScript(t, pol, localConnectPayload)
+	requireAllowed(t, out, err)
+}
+
+func TestGuard_NetAllowlistGetaddrinfo(t *testing.T) {
+	pol := guardPolicy{
+		Net: guardNet{Mode: "allowlist", Hosts: []string{"localhost"}},
+		Run: guardRun{Mode: "deny"},
+	}
+	// localhost resolves locally (no external DNS); the denied hostname
+	// must raise before any resolution is attempted.
+	payload := `
+import socket
+socket.getaddrinfo("localhost", 80)
+try:
+    socket.getaddrinfo("denied.example.com", 80)
+except PermissionError:
+    pass
+else:
+    raise SystemExit("expected PermissionError for undeclared host")
+`
+	out, err := runGuardScript(t, pol, payload)
+	requireAllowed(t, out, err)
+}

--- a/pkg/runtime/python/guard_test.go
+++ b/pkg/runtime/python/guard_test.go
@@ -1,0 +1,169 @@
+package python
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+func specWithPerms(perms task.Permissions) *task.Spec {
+	return &task.Spec{ID: "t/perm", TaskDir: "/srv/tasks/perm", Permissions: perms}
+}
+
+func TestBuildGuardPolicy_NetModes(t *testing.T) {
+	cases := []struct {
+		name      string
+		net       []string
+		wantMode  string
+		wantHosts []string
+	}{
+		{"omitted is unrestricted", nil, "unrestricted", nil},
+		{"wildcard is unrestricted", []string{"*"}, "unrestricted", nil},
+		{"hosts form an allowlist", []string{"api.github.com", "hooks.slack.com:443"}, "allowlist", []string{"api.github.com", "hooks.slack.com:443"}},
+		{"explicit empty denies all", []string{}, "deny", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pol := buildGuardPolicy(specWithPerms(task.Permissions{Net: tc.net}), "/tmp/dicode.sock")
+			if pol.Net.Mode != tc.wantMode {
+				t.Errorf("net mode = %q, want %q", pol.Net.Mode, tc.wantMode)
+			}
+			if len(pol.Net.Hosts) != len(tc.wantHosts) {
+				t.Fatalf("net hosts = %v, want %v", pol.Net.Hosts, tc.wantHosts)
+			}
+			for i := range tc.wantHosts {
+				if pol.Net.Hosts[i] != tc.wantHosts[i] {
+					t.Errorf("net hosts = %v, want %v", pol.Net.Hosts, tc.wantHosts)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildGuardPolicy_RunModes(t *testing.T) {
+	cases := []struct {
+		name     string
+		run      []string
+		wantMode string
+		wantCmds []string
+	}{
+		{"omitted denies all", nil, "deny", nil},
+		{"wildcard allows all", []string{"*"}, "allow", nil},
+		{"commands form an allowlist", []string{"git", "curl"}, "allowlist", []string{"git", "curl"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pol := buildGuardPolicy(specWithPerms(task.Permissions{Run: tc.run}), "/tmp/dicode.sock")
+			if pol.Run.Mode != tc.wantMode {
+				t.Errorf("run mode = %q, want %q", pol.Run.Mode, tc.wantMode)
+			}
+			if len(pol.Run.Commands) != len(tc.wantCmds) {
+				t.Fatalf("run commands = %v, want %v", pol.Run.Commands, tc.wantCmds)
+			}
+			for i := range tc.wantCmds {
+				if pol.Run.Commands[i] != tc.wantCmds[i] {
+					t.Errorf("run commands = %v, want %v", pol.Run.Commands, tc.wantCmds)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildGuardPolicy_FSWriteResolution(t *testing.T) {
+	spec := specWithPerms(task.Permissions{FS: []task.FSEntry{
+		{Path: "data", Permission: "rw"},        // relative → joined to TaskDir
+		{Path: "/var/log/out", Permission: "w"}, // absolute → kept
+		{Path: "readonly", Permission: "r"},     // read entry → not in write allowlist
+	}})
+	pol := buildGuardPolicy(spec, "/tmp/dicode.sock")
+
+	want := []string{
+		"/tmp/dicode.sock", // IPC socket always writable
+		filepath.Join(spec.TaskDir, "data"),
+		"/var/log/out",
+	}
+	if len(pol.FSWrite) != len(want) {
+		t.Fatalf("fs_write = %v, want %v", pol.FSWrite, want)
+	}
+	for i := range want {
+		if pol.FSWrite[i] != want[i] {
+			t.Errorf("fs_write[%d] = %q, want %q", i, pol.FSWrite[i], want[i])
+		}
+	}
+}
+
+func TestBuildGuard_EmbedsPolicyJSON(t *testing.T) {
+	pol := buildGuardPolicy(specWithPerms(task.Permissions{
+		Net: []string{"api.github.com"},
+		Run: []string{"git"},
+	}), "/tmp/dicode.sock")
+
+	guard, err := buildGuard(pol)
+	if err != nil {
+		t.Fatalf("buildGuard: %v", err)
+	}
+	if strings.Contains(guard, "__DICODE_POLICY__") {
+		t.Error("guard still contains the policy placeholder")
+	}
+
+	// The policy is embedded as a Python string literal containing JSON;
+	// the literal uses JSON string escaping, so unescape and round-trip it.
+	start := strings.Index(guard, `_json.loads(`)
+	if start == -1 {
+		t.Fatal("guard missing _json.loads call")
+	}
+	rest := guard[start+len(`_json.loads(`):]
+	end := strings.Index(rest, ")\n")
+	if end == -1 {
+		t.Fatal("guard missing _json.loads closing paren")
+	}
+	var inner string
+	if err := json.Unmarshal([]byte(rest[:end]), &inner); err != nil {
+		t.Fatalf("embedded literal is not a JSON string: %v", err)
+	}
+	var got guardPolicy
+	if err := json.Unmarshal([]byte(inner), &got); err != nil {
+		t.Fatalf("embedded policy is not valid JSON: %v", err)
+	}
+	if got.Net.Mode != "allowlist" || len(got.Net.Hosts) != 1 || got.Net.Hosts[0] != "api.github.com" {
+		t.Errorf("round-tripped net policy = %+v", got.Net)
+	}
+	if got.Run.Mode != "allowlist" || len(got.Run.Commands) != 1 || got.Run.Commands[0] != "git" {
+		t.Errorf("round-tripped run policy = %+v", got.Run)
+	}
+	if len(got.FSWrite) != 1 || got.FSWrite[0] != "/tmp/dicode.sock" {
+		t.Errorf("round-tripped fs_write = %v", got.FSWrite)
+	}
+}
+
+func TestBuildWrapper_GuardPlacement(t *testing.T) {
+	script := "# /// script\n# dependencies = [\"requests\"]\n# ///\nresult = 1\n"
+	pol := buildGuardPolicy(specWithPerms(task.Permissions{}), "/tmp/dicode.sock")
+
+	wrapped, err := buildWrapper([]byte(script), pol)
+	if err != nil {
+		t.Fatalf("buildWrapper: %v", err)
+	}
+
+	pepIdx := strings.Index(wrapped, "# /// script")
+	sdkIdx := strings.Index(wrapped, "# === dicode SDK ===")
+	guardIdx := strings.Index(wrapped, "# === permission guard ===")
+	bodyIdx := strings.Index(wrapped, "# === task script ===")
+	retIdx := strings.Index(wrapped, "# === return capture ===")
+	for name, idx := range map[string]int{
+		"pep723": pepIdx, "sdk": sdkIdx, "guard": guardIdx, "body": bodyIdx, "return": retIdx,
+	} {
+		if idx == -1 {
+			t.Fatalf("wrapper missing %s section", name)
+		}
+	}
+	// PEP 723 first (uv requirement), then SDK, then guard (so the hook
+	// governs user code but not SDK setup), then task body, then epilogue.
+	if !(pepIdx < sdkIdx && sdkIdx < guardIdx && guardIdx < bodyIdx && bodyIdx < retIdx) {
+		t.Errorf("wrapper sections out of order: pep=%d sdk=%d guard=%d body=%d ret=%d",
+			pepIdx, sdkIdx, guardIdx, bodyIdx, retIdx)
+	}
+}

--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -26,6 +26,13 @@
 //
 // The runtime extracts any such block from task.py and places it at the top of
 // the temporary wrapper file so that uv can parse it correctly.
+//
+// # Permission enforcement
+//
+// Declared permissions.{fs,net,run} are enforced by a PEP 578 audit hook
+// injected into the wrapper (see guard.go and sdk/guard.py). The hook is a
+// guardrail on declared intent, not a security boundary: fs reads and sys
+// are unenforced, and in-process escapes are acceptable.
 package python
 
 import (
@@ -295,7 +302,7 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	defer srv.Stop()
 
 	// Build the temporary wrapper file.
-	wrapped, err := buildWrapper(scriptBytes)
+	wrapped, err := buildWrapper(scriptBytes, buildGuardPolicy(spec, socketPath))
 	if err != nil {
 		result.Error = fmt.Errorf("build wrapper: %w", err)
 		return result, nil
@@ -382,10 +389,19 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 //  1. PEP 723 script block (extracted from the user script, if present) — must
 //     be first so uv can parse inline dependencies.
 //  2. The dicode SDK shim (sdk.py).
-//  3. The user script body (script block stripped out).
-//  4. Return-capture epilogue.
-func buildWrapper(scriptBytes []byte) (string, error) {
+//  3. The permission guard (guard.py) — after the SDK so the hook never
+//     governs the SDK's own socket setup, before the task body so it governs
+//     all user code. uv resolves PEP 723 deps before the script runs, so
+//     dependency installation is ungoverned too.
+//  4. The user script body (script block stripped out).
+//  5. Return-capture epilogue.
+func buildWrapper(scriptBytes []byte, pol guardPolicy) (string, error) {
 	pep723, body := extractPEP723(string(scriptBytes))
+
+	guard, err := buildGuard(pol)
+	if err != nil {
+		return "", err
+	}
 
 	var w strings.Builder
 	if pep723 != "" {
@@ -394,6 +410,8 @@ func buildWrapper(scriptBytes []byte) (string, error) {
 	}
 	w.WriteString("# === dicode SDK ===\n")
 	w.WriteString(sdkContent)
+	w.WriteString("\n# === permission guard ===\n")
+	w.WriteString(guard)
 	w.WriteString("\n# === task script ===\n")
 	w.WriteString(body)
 	w.WriteString("\n# === return capture ===\n")

--- a/pkg/runtime/python/sdk/guard.py
+++ b/pkg/runtime/python/sdk/guard.py
@@ -1,0 +1,184 @@
+# dicode permission guard — PEP 578 audit hook enforcing the task's declared
+# permissions.{fs,net,run}. Injected after the SDK shim (so the SDK's own
+# socket setup is ungoverned) and before the task body.
+#
+# Guardrail, not a security boundary: the task author is trusted. The hook
+# enforces declared intent and catches accidental over-reach; escapability is
+# acceptable.
+#
+# Known limitations:
+#   - fs reads are not enforced: the interpreter, stdlib, and site-packages
+#     read files constantly, so an in-interpreter read allowlist would break
+#     normal execution.
+#   - net checks rely on socket.connect / socket.getaddrinfo audit events;
+#     pooled connections or some async stacks may not re-emit them, and IP
+#     literals pass the allowlist (hostname vetting happens at getaddrinfo,
+#     and the subsequent connect arrives with the resolved IP, which cannot
+#     be correlated back to the hostname).
+#   - C extensions that touch files or sockets without going through os/io
+#     (e.g. sqlite3's own file I/O) do not emit audit events.
+def _dicode_install_guard():
+    import ipaddress as _ipaddress
+    import json as _json
+    import os as _os
+    import socket as _socket
+    import sys as _sys
+
+    policy = _json.loads("__DICODE_POLICY__")
+
+    net_mode = policy["net"]["mode"]  # unrestricted | allowlist | deny
+    run_mode = policy["run"]["mode"]  # allow | allowlist | deny
+
+    net_rules = []  # (lowercase host, port or None)
+    for entry in policy["net"].get("hosts") or []:
+        host, colon, port = entry.rpartition(":")
+        if colon and port.isdigit():
+            net_rules.append((host.lower(), int(port)))
+        else:
+            net_rules.append((entry.lower(), None))
+
+    run_allowed = set(policy["run"].get("commands") or [])
+
+    # The interpreter writes bytecode caches and venv metadata under its own
+    # prefixes during normal imports; those writes are always permitted.
+    write_roots = [_os.path.abspath(p) for p in policy.get("fs_write") or []]
+    for p in (_sys.prefix, _sys.base_prefix, _sys.exec_prefix):
+        if p:
+            write_roots.append(_os.path.abspath(p))
+
+    sep = _os.sep
+    af_unix = getattr(_socket, "AF_UNIX", None)
+    write_flags = (
+        _os.O_WRONLY | _os.O_RDWR | _os.O_APPEND | _os.O_CREAT | _os.O_TRUNC
+    )
+
+    def _to_str(v):
+        if isinstance(v, bytes):
+            return _os.fsdecode(v)
+        return v if isinstance(v, str) else None
+
+    def _write_allowed(p):
+        n = _to_str(p)
+        if n is None:
+            return True  # fd-based op; no path to match against
+        n = _os.path.abspath(n)
+        if n.endswith(".pyc") or (sep + "__pycache__") in n:
+            return True
+        for root in write_roots:
+            if n == root or n.startswith(root + sep):
+                return True
+        return False
+
+    def _check_write(p, op):
+        if not _write_allowed(p):
+            raise PermissionError(
+                f"dicode: {op} on {p!r} denied — declare the path with "
+                f'permission "w" or "rw" under permissions.fs in task.yaml'
+            )
+
+    def _is_ip_literal(h):
+        try:
+            _ipaddress.ip_address(h.strip("[]"))
+            return True
+        except ValueError:
+            return False
+
+    def _host_allowed(host, port):
+        h = _to_str(host)
+        if h is None:
+            return True
+        h = h.lower()
+        if _is_ip_literal(h):
+            return True
+        for rule_host, rule_port in net_rules:
+            if h == rule_host and (
+                rule_port is None or port is None or rule_port == port
+            ):
+                return True
+        return False
+
+    def _deny_net(host, port):
+        raise PermissionError(
+            f"dicode: network access to {host!r} port {port!r} denied — add "
+            f'the host to permissions.net in task.yaml (or use ["*"])'
+        )
+
+    def _check_run(cmd):
+        if run_mode == "allow":
+            return
+        c = _to_str(cmd)
+        if c is not None and (
+            c in run_allowed or _os.path.basename(c) in run_allowed
+        ):
+            return
+        raise PermissionError(
+            f"dicode: spawning {cmd!r} denied — add the command to "
+            f'permissions.run in task.yaml (or use ["*"])'
+        )
+
+    def _hook(event, args):
+        if event == "open":
+            mode, flags = args[1], args[2]
+            if mode is None:
+                is_write = bool((flags or 0) & write_flags)
+            else:
+                is_write = any(c in mode for c in "wax+")
+            if is_write:
+                _check_write(args[0], "open for writing")
+        elif event in (
+            "os.remove",
+            "os.rmdir",
+            "os.mkdir",
+            "os.truncate",
+            "shutil.rmtree",
+        ):
+            _check_write(args[0], event)
+        elif event in ("os.rename", "shutil.move"):
+            _check_write(args[0], event)
+            _check_write(args[1], event)
+        elif event == "socket.connect":
+            if net_mode == "unrestricted":
+                return
+            sock, addr = args[0], args[1]
+            # AF_UNIX (including the dicode IPC socket) is always allowed.
+            if af_unix is not None and getattr(sock, "family", None) == af_unix:
+                return
+            if isinstance(addr, (str, bytes)):
+                return  # unix path address
+            host = addr[0] if isinstance(addr, tuple) and len(addr) > 0 else None
+            port = addr[1] if isinstance(addr, tuple) and len(addr) > 1 else None
+            if net_mode == "deny" or not _host_allowed(host, port):
+                _deny_net(host, port)
+        elif event == "socket.getaddrinfo":
+            if net_mode == "unrestricted":
+                return
+            host, port = args[0], args[1]
+            if host is None:
+                return  # local binds resolve with host=None
+            if net_mode == "deny" or not _host_allowed(
+                host, port if isinstance(port, int) else None
+            ):
+                _deny_net(host, port)
+        elif event == "subprocess.Popen":
+            cmd = args[0]  # the explicit executable= argument, usually None
+            if cmd is None:
+                popen_args = args[1]
+                if isinstance(popen_args, (list, tuple)):
+                    cmd = popen_args[0] if popen_args else None
+                else:
+                    parts = (_to_str(popen_args) or "").split()
+                    cmd = parts[0] if parts else None
+            _check_run(cmd)
+        elif event in ("os.exec", "os.posix_spawn"):
+            _check_run(args[0])
+        elif event == "os.spawn":
+            _check_run(args[1])
+        elif event == "os.system":
+            parts = (_to_str(args[0]) or "").split()
+            _check_run(parts[0] if parts else args[0])
+
+    _sys.addaudithook(_hook)
+
+
+_dicode_install_guard()
+del _dicode_install_guard

--- a/pkg/runtime/python/sdk/guard.py
+++ b/pkg/runtime/python/sdk/guard.py
@@ -31,11 +31,15 @@ def _dicode_install_guard():
 
     net_rules = []  # (lowercase host, port or None)
     for entry in policy["net"].get("hosts") or []:
-        host, colon, port = entry.rpartition(":")
-        if colon and port.isdigit():
-            net_rules.append((host.lower(), int(port)))
+        e = entry.strip()
+        if e.startswith("["):  # [ipv6] or [ipv6]:port
+            host, _, rest = e[1:].partition("]")
+            port = rest[1:] if rest.startswith(":") else ""
+        elif e.count(":") == 1:  # host:port (bare IPv6 has >1 colon)
+            host, _, port = e.partition(":")
         else:
-            net_rules.append((entry.lower(), None))
+            host, port = e, ""
+        net_rules.append((host.lower(), int(port) if port.isdigit() else None))
 
     run_allowed = set(policy["run"].get("commands") or [])
 
@@ -136,6 +140,11 @@ def _dicode_install_guard():
         elif event in ("os.rename", "shutil.move"):
             _check_write(args[0], event)
             _check_write(args[1], event)
+        elif event in ("os.symlink", "os.link"):
+            # The mutation is the new link at the destination (args[1]).
+            _check_write(args[1], event)
+        elif event in ("os.chmod", "os.chown"):
+            _check_write(args[0], event)
         elif event == "socket.connect":
             if net_mode == "unrestricted":
                 return

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -262,16 +262,22 @@ func (e *EnvEntry) UnmarshalYAML(value *yaml.Node) error {
 type Permissions struct {
 	// Env lists env vars the task script may read or that are injected into it.
 	Env []EnvEntry `yaml:"env,omitempty" json:"env,omitempty"`
-	// FS lists filesystem paths and their access modes ("r", "w", "rw"). Deno only.
+	// FS lists filesystem paths and their access modes ("r", "w", "rw").
+	// Deno enforces reads and writes. Python enforces writes only: an
+	// in-interpreter read allowlist would break normal execution (the
+	// interpreter and site-packages read files constantly), so "r" entries
+	// are ignored there and reads stay unrestricted.
 	FS []FSEntry `yaml:"fs,omitempty" json:"fs,omitempty"`
-	// Run lists executables the task may spawn via Deno.Command. Use ["*"] for all. Deno only.
+	// Run lists executables the task may spawn (Deno and Python).
+	// Use ["*"] for all; omit to deny all subprocess execution.
 	Run []string `yaml:"run,omitempty" json:"run,omitempty"`
-	// Net controls outbound network access (Deno only).
-	// Omit or use ["*"] for unrestricted access (--allow-net).
+	// Net controls outbound network access (Deno and Python).
+	// Omit or use ["*"] for unrestricted access.
 	// List specific hosts to restrict: ["api.github.com", "hooks.slack.com"].
 	// Use [] (empty list) to deny all network access.
 	Net []string `yaml:"net,omitempty" json:"net,omitempty"`
-	// Sys lists Deno system-info APIs the task may call (Deno only).
+	// Sys lists Deno system-info APIs the task may call (Deno only; the
+	// names have no usable Python equivalent, so Python ignores this field).
 	// Use ["*"] for all, or list specific names: ["hostname", "osRelease", "networkInterfaces"].
 	// Omit to deny all sys access (default).
 	Sys []string `yaml:"sys,omitempty" json:"sys,omitempty"`


### PR DESCRIPTION
Closes #174.

## Summary

The Python runtime only honored `permissions.env` — declared `fs`, `net`, and `run` permissions were silently ignored, while the Deno runtime enforces all of them. Python tasks now get a PEP 578 audit hook (`sys.addaudithook`, stock CPython 3.8+, Linux/macOS/Windows) injected into the generated wrapper that enforces the declared permissions with the same semantics as `buildDenoArgs`:

- **net**: omit or `["*"]` → unrestricted, host list → allowlist, `[]` → deny all. The omit-means-unrestricted default is deliberate Deno parity; #379 tracks flipping it to deny.
- **run**: `["*"]` → allow all, list → allowlist (matched by command or basename across `subprocess.Popen`, `os.exec*`/`os.spawn*`/`os.posix_spawn`, `os.system`), omit → deny all.
- **fs write**: `"w"`/`"rw"` entries form a write allowlist (`open` in write modes, `os.remove`/`rmdir`/`mkdir`/`rename`/`truncate`, `shutil.rmtree`/`move`). Paths are resolved in Go exactly like Deno's: `~` expansion plus task-dir join for relative paths.

The hook is rendered from an embedded template (`sdk/guard.py`) with the policy serialized as a JSON literal, and is placed after the SDK shim but before the task body — so it governs user code, not the SDK's own IPC socket setup, and not uv's PEP 723 dependency resolution (which runs before the script). AF_UNIX sockets (the dicode IPC channel) are always exempt, as are interpreter-internal writes (bytecode caches, venv prefixes). Violations raise a `PermissionError` naming both the denied resource and the `permissions.*` field that would grant it, matching the feedback a Deno task author gets.

This is a guardrail enforcing declared intent against a trusted task author — not a security boundary. Escapes (C extensions doing raw I/O, pooled connections, in-process hook removal) are acceptable under that model and documented in the guard.

## What was deliberately left behind

- **fs reads are not enforced** (divergence from Deno): the interpreter, stdlib, and site-packages read files constantly, so an in-interpreter read allowlist would break normal execution. `r` entries are ignored by Python; documented in `spec.go` and the task-format docs.
- **sys is not enforced**: Deno's sys permission names (hostname, osRelease, …) map poorly onto Python; the field stays Deno-only.
- **IP-literal connections pass the net allowlist**: hostnames are vetted at `socket.getaddrinfo`, and the subsequent `socket.connect` arrives with the resolved IP, which cannot be correlated back. Deny-all still blocks raw IPs.
- **#379 items untouched**: `buildEnv` still inherits `os.Environ()`, and net's unrestricted default is unchanged.
- **Docker/Podman parity** stays with #214.

## Testing

- Go unit tests cover policy mapping (net/run modes, fs path resolution), policy JSON round-trip through the rendered guard, and wrapper section ordering.
- Integration tests execute rendered guards with a real interpreter (python3, falling back to `uv run`; skipped when neither is present, fail-loud on CI like the existing SDK suite): denied/allowed writes, removes, reads-always-allowed, subprocess deny/wildcard/allowlist, `os.system`, and net deny/unrestricted/allowlist via a loopback listener and local `getaddrinfo` — no external network needed.
- `make test` and `make lint` pass; integration tests ran against Python 3.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)