### PR TITLE
security(runtime): isolate task subprocess env from the daemon environment (#379)

### DIFF
--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -391,7 +391,7 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 
 	args := buildDenoArgs(spec, socketPath, shimPath, runnerPath)
 	cmd := exec.CommandContext(execCtx, rt.denoPath, args...) //nolint:gosec
-	cmd.Env = buildEnv(resolved, socketPath, token)
+	cmd.Env = pkgruntime.SubprocessEnv(spec, resolved, socketPath, token)
 
 	var wg sync.WaitGroup
 	if spec.Silent {
@@ -575,16 +575,6 @@ func buildDenoArgs(spec *task.Spec, socketPath, shimPath, runnerPath string) []s
 
 	args = append(args, runnerPath)
 	return args
-}
-
-func buildEnv(resolved map[string]string, socketPath, token string) []string {
-	// Inherit the host environment so Deno can locate its cache (DENO_DIR etc).
-	// The --allow-env flag separately controls which vars the JS script can read.
-	env := append(os.Environ(), "DICODE_SOCKET="+socketPath, "DICODE_TOKEN="+token)
-	for k, v := range resolved {
-		env = append(env, k+"="+v)
-	}
-	return env
 }
 
 // envresolver returns the env resolver to use for a Run. When a

--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -316,7 +316,7 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	tmpFile.Close()
 
 	cmd := exec.CommandContext(execCtx, e.uvPath, "run", tmpFile.Name()) //nolint:gosec
-	cmd.Env = buildEnv(resolved, socketPath, token)
+	cmd.Env = pkgruntime.SubprocessEnv(spec, resolved, socketPath, token)
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
@@ -453,12 +453,4 @@ func mergeParams(specParams []task.Param, overrides map[string]string) map[strin
 		out[k] = v
 	}
 	return out
-}
-
-func buildEnv(resolved map[string]string, socketPath, token string) []string {
-	env := append(os.Environ(), "DICODE_SOCKET="+socketPath, "DICODE_TOKEN="+token)
-	for k, v := range resolved {
-		env = append(env, k+"="+v)
-	}
-	return env
 }

--- a/pkg/runtime/subprocenv.go
+++ b/pkg/runtime/subprocenv.go
@@ -32,6 +32,15 @@ var hostPassthroughVars = []string{
 	"UV_CACHE_DIR", "UV_PYTHON", "UV_PYTHON_INSTALL_DIR", "VIRTUAL_ENV",
 }
 
+// neverForwardEnv are daemon-only credentials that a bare permissions.env
+// entry must never forward to a task subprocess, regardless of what a
+// task.yaml declares.
+var neverForwardEnv = map[string]bool{
+	"DICODE_MASTER_KEY":  true, // root key deriving every secret
+	"DICODE_API_KEY":     true, // daemon admin control-plane credential
+	"DICODE_MCP_API_KEY": true, // daemon MCP control-plane credential
+}
+
 // SubprocessEnv builds the full environment for a task subprocess:
 // allowlisted host vars (only those actually set in the daemon env), host
 // values for bare permissions.env entries (a name-only entry allowlists a
@@ -51,9 +60,11 @@ func SubprocessEnv(spec *task.Spec, resolved map[string]string, socketPath, toke
 			if e.Name == "" || e.Value != "" || e.Secret != "" || e.From != "" {
 				continue
 			}
-			// The master key must never reach a task, even if a task.yaml
-			// names it.
-			if e.Name == "DICODE_MASTER_KEY" {
+			// Daemon-only credentials must never reach a task, even if a
+			// task.yaml names them: the master key derives every secret, and
+			// the API keys authenticate to the daemon's own admin/MCP control
+			// plane — a task has no legitimate need for any of them.
+			if neverForwardEnv[e.Name] {
 				continue
 			}
 			if _, ok := resolved[e.Name]; ok {

--- a/pkg/runtime/subprocenv.go
+++ b/pkg/runtime/subprocenv.go
@@ -1,0 +1,72 @@
+package runtime
+
+import (
+	"os"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// hostPassthroughVars are the only daemon env vars a task subprocess
+// inherits. The daemon environment can carry secrets (operator-exported
+// credentials, deploy tokens), so everything not on this list is withheld.
+// This list covers what the runtime binaries themselves (deno, uv, the
+// provisioned Python) need to locate caches, trust stores, and proxies —
+// the script-visible env is restricted separately (Deno --allow-env,
+// Python SDK env.get).
+var hostPassthroughVars = []string{
+	// Process basics.
+	"PATH", "HOME", "USER", "LOGNAME", "TMPDIR",
+	// Locale / timezone.
+	"LANG", "LC_ALL", "LC_CTYPE", "TZ",
+	// Cache, data, and config roots (deno and uv both derive default
+	// cache locations from these).
+	"XDG_CACHE_HOME", "XDG_DATA_HOME", "XDG_CONFIG_HOME",
+	// TLS trust store overrides.
+	"SSL_CERT_FILE", "SSL_CERT_DIR",
+	// Proxies, honored by both deno and uv/requests.
+	"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+	"http_proxy", "https_proxy", "no_proxy",
+	// Deno cache location.
+	"DENO_DIR",
+	// uv interpreter and cache locations.
+	"UV_CACHE_DIR", "UV_PYTHON", "UV_PYTHON_INSTALL_DIR", "VIRTUAL_ENV",
+}
+
+// SubprocessEnv builds the full environment for a task subprocess:
+// allowlisted host vars (only those actually set in the daemon env), host
+// values for bare permissions.env entries (a name-only entry allowlists a
+// host var, so its value must be forwarded explicitly now that the daemon
+// env is not inherited wholesale), the per-run IPC coordinates, and the
+// resolved task env. Later entries win on duplicate names (os/exec dedupes
+// keeping the last), so resolved values override any host passthrough.
+func SubprocessEnv(spec *task.Spec, resolved map[string]string, socketPath, token string) []string {
+	env := make([]string, 0, len(hostPassthroughVars)+len(resolved)+8)
+	for _, name := range hostPassthroughVars {
+		if v, ok := os.LookupEnv(name); ok {
+			env = append(env, name+"="+v)
+		}
+	}
+	if spec != nil {
+		for _, e := range spec.Permissions.Env {
+			if e.Name == "" || e.Value != "" || e.Secret != "" || e.From != "" {
+				continue
+			}
+			// The master key must never reach a task, even if a task.yaml
+			// names it.
+			if e.Name == "DICODE_MASTER_KEY" {
+				continue
+			}
+			if _, ok := resolved[e.Name]; ok {
+				continue
+			}
+			if v, ok := os.LookupEnv(e.Name); ok {
+				env = append(env, e.Name+"="+v)
+			}
+		}
+	}
+	env = append(env, "DICODE_SOCKET="+socketPath, "DICODE_TOKEN="+token)
+	for k, v := range resolved {
+		env = append(env, k+"="+v)
+	}
+	return env
+}

--- a/pkg/runtime/subprocenv_test.go
+++ b/pkg/runtime/subprocenv_test.go
@@ -1,0 +1,103 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+func envMap(env []string) map[string]string {
+	// Last occurrence wins, matching os/exec dedupe semantics.
+	out := make(map[string]string, len(env))
+	for _, kv := range env {
+		k, v, _ := strings.Cut(kv, "=")
+		out[k] = v
+	}
+	return out
+}
+
+func TestSubprocessEnv_ExcludesDaemonEnv(t *testing.T) {
+	t.Setenv("DICODE_MASTER_KEY", "super-secret")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "leaky")
+	t.Setenv("PATH", "/usr/bin")
+
+	env := envMap(SubprocessEnv(&task.Spec{}, nil, "/tmp/sock", "tok"))
+
+	if _, ok := env["DICODE_MASTER_KEY"]; ok {
+		t.Error("DICODE_MASTER_KEY leaked into subprocess env")
+	}
+	if _, ok := env["AWS_SECRET_ACCESS_KEY"]; ok {
+		t.Error("arbitrary daemon env var leaked into subprocess env")
+	}
+	if env["PATH"] != "/usr/bin" {
+		t.Errorf("PATH not passed through, got %q", env["PATH"])
+	}
+	if env["DICODE_SOCKET"] != "/tmp/sock" || env["DICODE_TOKEN"] != "tok" {
+		t.Errorf("IPC vars missing: socket=%q token=%q", env["DICODE_SOCKET"], env["DICODE_TOKEN"])
+	}
+}
+
+func TestSubprocessEnv_PassthroughOnlyWhenSet(t *testing.T) {
+	t.Setenv("DENO_DIR", "/custom/deno")
+	// UV_CACHE_DIR deliberately not set.
+	env := SubprocessEnv(nil, nil, "/tmp/sock", "tok")
+	m := envMap(env)
+	if m["DENO_DIR"] != "/custom/deno" {
+		t.Errorf("DENO_DIR not passed through, got %q", m["DENO_DIR"])
+	}
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "UV_CACHE_DIR=") {
+			t.Error("unset allowlist var injected with empty value")
+		}
+	}
+}
+
+func TestSubprocessEnv_ResolvedVarsIncluded(t *testing.T) {
+	env := envMap(SubprocessEnv(&task.Spec{}, map[string]string{"API_KEY": "abc123"}, "/tmp/sock", "tok"))
+	if env["API_KEY"] != "abc123" {
+		t.Errorf("resolved var missing, got %q", env["API_KEY"])
+	}
+}
+
+func TestSubprocessEnv_BareAllowlistEntryForwardsHostValue(t *testing.T) {
+	t.Setenv("UPSTREAM_URL", "http://example.test")
+	t.Setenv("OTHER_HOST_VAR", "nope")
+
+	spec := &task.Spec{}
+	spec.Permissions.Env = []task.EnvEntry{
+		{Name: "UPSTREAM_URL"},                     // bare → forward host value
+		{Name: "FROM_VAR", From: "env:SOMEWHERE"},  // resolver-handled, not forwarded here
+		{Name: "SECRET_VAR", Secret: "secret-key"}, // resolver-handled
+		{Name: "DICODE_MASTER_KEY"},                // never forwarded
+		{Name: "UNSET_BARE"},                       // not set on host → omitted
+	}
+
+	env := SubprocessEnv(spec, nil, "/tmp/sock", "tok")
+	m := envMap(env)
+
+	if m["UPSTREAM_URL"] != "http://example.test" {
+		t.Errorf("bare allowlist host value not forwarded, got %q", m["UPSTREAM_URL"])
+	}
+	if _, ok := m["OTHER_HOST_VAR"]; ok {
+		t.Error("undeclared host var forwarded")
+	}
+	for _, name := range []string{"FROM_VAR", "SECRET_VAR", "DICODE_MASTER_KEY", "UNSET_BARE"} {
+		for _, kv := range env {
+			if strings.HasPrefix(kv, name+"=") {
+				t.Errorf("%s should not be present in subprocess env", name)
+			}
+		}
+	}
+}
+
+func TestSubprocessEnv_ResolvedWinsOverBareHostValue(t *testing.T) {
+	t.Setenv("DUAL_VAR", "host-value")
+	spec := &task.Spec{}
+	spec.Permissions.Env = []task.EnvEntry{{Name: "DUAL_VAR"}}
+
+	env := envMap(SubprocessEnv(spec, map[string]string{"DUAL_VAR": "resolved-value"}, "/tmp/sock", "tok"))
+	if env["DUAL_VAR"] != "resolved-value" {
+		t.Errorf("resolved value should win over host value, got %q", env["DUAL_VAR"])
+	}
+}

--- a/pkg/runtime/subprocenv_test.go
+++ b/pkg/runtime/subprocenv_test.go
@@ -63,13 +63,18 @@ func TestSubprocessEnv_ResolvedVarsIncluded(t *testing.T) {
 func TestSubprocessEnv_BareAllowlistEntryForwardsHostValue(t *testing.T) {
 	t.Setenv("UPSTREAM_URL", "http://example.test")
 	t.Setenv("OTHER_HOST_VAR", "nope")
+	t.Setenv("DICODE_MASTER_KEY", "root-key")
+	t.Setenv("DICODE_API_KEY", "admin-key")
+	t.Setenv("DICODE_MCP_API_KEY", "mcp-key")
 
 	spec := &task.Spec{}
 	spec.Permissions.Env = []task.EnvEntry{
 		{Name: "UPSTREAM_URL"},                     // bare → forward host value
 		{Name: "FROM_VAR", From: "env:SOMEWHERE"},  // resolver-handled, not forwarded here
 		{Name: "SECRET_VAR", Secret: "secret-key"}, // resolver-handled
-		{Name: "DICODE_MASTER_KEY"},                // never forwarded
+		{Name: "DICODE_MASTER_KEY"},                // daemon-only → never forwarded
+		{Name: "DICODE_API_KEY"},                   // daemon-only → never forwarded
+		{Name: "DICODE_MCP_API_KEY"},               // daemon-only → never forwarded
 		{Name: "UNSET_BARE"},                       // not set on host → omitted
 	}
 
@@ -82,7 +87,7 @@ func TestSubprocessEnv_BareAllowlistEntryForwardsHostValue(t *testing.T) {
 	if _, ok := m["OTHER_HOST_VAR"]; ok {
 		t.Error("undeclared host var forwarded")
 	}
-	for _, name := range []string{"FROM_VAR", "SECRET_VAR", "DICODE_MASTER_KEY", "UNSET_BARE"} {
+	for _, name := range []string{"FROM_VAR", "SECRET_VAR", "DICODE_MASTER_KEY", "DICODE_API_KEY", "DICODE_MCP_API_KEY", "UNSET_BARE"} {
 		for _, kv := range env {
 			if strings.HasPrefix(kv, name+"=") {
 				t.Errorf("%s should not be present in subprocess env", name)

--- a/pkg/secrets/local.go
+++ b/pkg/secrets/local.go
@@ -16,7 +16,8 @@ import (
 // The encryption key is derived from a master key via Argon2id.
 //
 // Master key resolution order:
-//  1. DICODE_MASTER_KEY env var (base64-encoded 32 bytes)
+//  1. DICODE_MASTER_KEY env var (base64-encoded 32 bytes; unset from the
+//     process env after a successful load so children cannot inherit it)
 //  2. ~/.dicode/master.key file (auto-generated on first run, chmod 600)
 //
 // The raw master is retained (in `masterKey`) so DeriveSubKey can derive
@@ -153,6 +154,11 @@ func loadOrCreateMasterKey(dataDir string) ([]byte, error) {
 		if len(key) != 32 {
 			return nil, fmt.Errorf("DICODE_MASTER_KEY must be 32 bytes (base64-encoded)")
 		}
+		// Remove the key from the process env so child processes (task
+		// subprocesses inherit a subset of the daemon env) can never see it.
+		// The raw bytes are retained in LocalProvider.masterKey for
+		// DeriveSubKey, so derivation is unaffected.
+		os.Unsetenv("DICODE_MASTER_KEY")
 		return key, nil
 	}
 

--- a/pkg/secrets/local_test.go
+++ b/pkg/secrets/local_test.go
@@ -2,6 +2,8 @@ package secrets
 
 import (
 	"bytes"
+	"encoding/base64"
+	"os"
 	"testing"
 )
 
@@ -67,6 +69,29 @@ func TestLocalProvider_DeriveSubKey_RejectsEmptyContext(t *testing.T) {
 	_, err := p.DeriveSubKey("")
 	if err == nil {
 		t.Error("expected error for empty context")
+	}
+}
+
+func TestNewLocalProvider_UnsetsMasterKeyEnvVar(t *testing.T) {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	t.Setenv("DICODE_MASTER_KEY", base64.StdEncoding.EncodeToString(key))
+
+	p, err := NewLocalProvider(t.TempDir(), newTestSecretDB(t))
+	if err != nil {
+		t.Fatalf("NewLocalProvider: %v", err)
+	}
+
+	if v, ok := os.LookupEnv("DICODE_MASTER_KEY"); ok {
+		t.Errorf("DICODE_MASTER_KEY still in process env after provider init: %q", v)
+	}
+	if !bytes.Equal(p.masterKey, key) {
+		t.Error("master key bytes not retained after env unset")
+	}
+	if _, err := p.DeriveSubKey("dicode/run-inputs/v1"); err != nil {
+		t.Errorf("DeriveSubKey after env unset: %v", err)
 	}
 }
 

--- a/pkg/trigger/e2e_secret_provider_test.go
+++ b/pkg/trigger/e2e_secret_provider_test.go
@@ -102,8 +102,8 @@ func TestE2E_SecretProvider_FullChain(t *testing.T) {
 	}
 
 	// UPSTREAM_URL is host-env-allowlisted in the provider's permissions.env;
-	// the runtime inherits os.Environ() so t.Setenv flows through to the
-	// Deno subprocess.
+	// bare allowlist entries are forwarded from the host env into the
+	// subprocess env, so t.Setenv flows through to the Deno subprocess.
 	t.Setenv("UPSTREAM_URL", ts.URL)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)


### PR DESCRIPTION
## Summary

Addresses the env-isolation BLOCKER from #379. Task subprocesses (Deno and Python/uv) were launched with `append(os.Environ(), ...)`, so untrusted task code inherited the entire daemon environment. Worst case: when the master key is supplied via `DICODE_MASTER_KEY`, any task could read it from its own process env and decrypt the whole secrets store — Deno's `--allow-env` gates `Deno.env.get`, but not fs reads of `/proc/self/environ`, and the Python guard is a guardrail, not a boundary. The env itself has to be clean.

Two layers of fix:

- **Master key never lingers in the env.** `loadOrCreateMasterKey` unsets `DICODE_MASTER_KEY` as soon as the key bytes are decoded. The raw key is already retained in `LocalProvider.masterKey`, so `DeriveSubKey` and all derivation paths are unaffected; this was the only place the var is read.
- **Subprocess env is built from an explicit allowlist** (shared `pkg/runtime.SubprocessEnv`, used by both runtimes so they can't drift), following the precedent of the Docker runtime which already sets an explicit `Env` list. The child gets: allowlisted host vars (only if actually set — no empty injections), the per-run IPC coordinates, and the resolved task env. Resolved values win on name collisions (appended last; `os/exec` dedupes keeping the last occurrence).

The allowlist: `PATH`, `HOME`, `USER`, `LOGNAME`, `TMPDIR`; locale/TZ (`LANG`, `LC_ALL`, `LC_CTYPE`, `TZ`); cache roots (`XDG_CACHE_HOME`, `XDG_DATA_HOME`, `XDG_CONFIG_HOME`); TLS overrides (`SSL_CERT_FILE`, `SSL_CERT_DIR`); proxy vars (`HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` + lowercase — both deno and uv honor them, and dropping them would break corporate networks); `DENO_DIR`; `UV_CACHE_DIR`, `UV_PYTHON`, `UV_PYTHON_INSTALL_DIR`, `VIRTUAL_ENV`. Deliberately excluded: `DENO_AUTH_TOKENS` and uv index URLs, since those can carry credentials — operators who need them can revisit explicitly.

One behavioral subtlety: bare `permissions.env` entries (name-only, e.g. `- UPSTREAM_URL`) are documented as "script reads it from host env" and previously worked only because of wholesale inheritance — the resolver deliberately leaves them unset. `SubprocessEnv` now forwards those host values explicitly (never `DICODE_MASTER_KEY`, even if declared), preserving the feature while keeping the rest of the daemon env out. `TestRuntime_Env_BarePassthrough` and the secret-provider e2e test cover this end-to-end.

The script-visible env layer (Deno `--allow-env` allowlist, Python SDK `env.get`) is untouched — this PR hardens the inheritance layer below it. The remaining #379 items (net default-deny, `run` opt-in gate) go in a separate PR.

## Validation

`make test` passes with real `deno` and `uv` on PATH — the integration tests that spawn actual subprocesses (`TestPythonSDK`, the Deno enforcement/env suites, the trigger e2e secret-provider test) all ran (zero skips), so the minimal env is validated against real runtime binaries on the warm-cache path. A cold-cache run (first-ever deno module download / uv interpreter provisioning) wasn't exercised here; the cache/TLS/proxy vars above are included to cover it, but worth a sanity run on a fresh host.

Fixes the env half of #379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
