### PR TITLE
security(permissions)!: default net permission flips to deny (#379)

### DIFF
--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -79,7 +79,7 @@ permissions:
 | `permissions.fs[].path` | string | | Absolute or `~`-prefixed path |
 | `permissions.fs[].permission` | string | | `r`, `w`, or `rw` |
 | `permissions.run` | list of strings | | Executables the script may spawn (Deno and Python); use `["*"]` for all |
-| `permissions.net` | list of strings | | Outbound network hosts (Deno and Python); omit = unrestricted, `[]` = deny all |
+| `permissions.net` | list of strings | | Outbound network hosts (Deno and Python); omit or `[]` = deny all, `["*"]` = unrestricted |
 | `permissions.sys` | list of strings | | Deno sys APIs (Deno only); omit = deny all, `["*"]` = all |
 | `permissions.dicode` | object | | Which dicode runtime APIs the task may call (all denied by default) |
 | `permissions.dicode.tasks` | list of strings | | Task IDs the script may invoke via `dicode.run_task()`; use `["*"]` for all |
@@ -908,7 +908,7 @@ permissions:
     - name: DB_PASS             # secret: resolve "db_password" from secrets store
       secret: db_password
   net:
-    - "api.github.com"          # restrict outbound to these hosts (omit = unrestricted)
+    - "api.github.com"          # restrict outbound to these hosts (omit = deny all)
   fs:
     - path: ~/data
       permission: r             # read-only
@@ -1069,9 +1069,12 @@ Controls which hostnames the task may connect to (Deno `--allow-net`; Python aud
 
 | Value | Effect |
 | --- | --- |
-| Omit field (default) | Unrestricted outbound |
+| Omit field (default) | Deny all outbound network |
+| `["*"]` | Unrestricted outbound |
 | `["api.github.com", "hooks.slack.com"]` | Restrict to listed hosts only |
 | `[]` (empty list) | Deny all outbound network |
+
+> **Migration note:** the default used to be unrestricted. Any existing task that makes outbound network calls but omits `permissions.net` must now declare it explicitly — `net: ["*"]` for arbitrary hosts, or a minimal host allowlist.
 
 The Python enforcement is a guardrail, not a security boundary: hostnames are vetted at DNS resolution, so IP-literal connections pass the allowlist (deny-all still blocks them), and pooled or exotic async connections may not re-emit audit events.
 

--- a/docs/deno-runtime.md
+++ b/docs/deno-runtime.md
@@ -402,7 +402,7 @@ Permissions are derived from `task.yaml`:
 
 | Permission | Source |
 | --- | --- |
-| `--allow-net` | Always granted |
+| `--allow-net` / `--allow-net=host1,...` | `net:` entries — omit or `[]` = denied (no flag), `["*"]` = unrestricted, host list = allowlist |
 | `--allow-env=DICODE_SOCKET,DICODE_TOKEN,VAR1,...` | `DICODE_SOCKET`, `DICODE_TOKEN` (IPC handshake) + all `env:` vars |
 | `--allow-read=path1,path2` | `fs:` entries with `r` or `rw` |
 | `--allow-write=path1` | `fs:` entries with `w` or `rw` |

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -513,19 +513,16 @@ func expandHome(p string) string {
 func buildDenoArgs(spec *task.Spec, socketPath, shimPath, runnerPath string) []string {
 	args := []string{"run"}
 
-	// Network: omit = unrestricted (--allow-net); empty list = deny all; named hosts = allowlist.
-	// The IPC socket itself uses a Unix socket (--allow-read/write), not TCP, so net
-	// permission does not affect it.
+	// Network is deny-by-default: omit or [] = deny all; ["*"] = unrestricted;
+	// named hosts = allowlist. The IPC socket itself uses a Unix socket
+	// (--allow-read/write), not TCP, so net permission does not affect it.
 	net := spec.Permissions.Net
-	if net == nil {
-		// no net: field → unrestricted (backward-compatible default)
-		args = append(args, "--allow-net")
-	} else if len(net) == 1 && net[0] == "*" {
+	if len(net) == 1 && net[0] == "*" {
 		args = append(args, "--allow-net")
 	} else if len(net) > 0 {
 		args = append(args, "--allow-net="+strings.Join(net, ","))
 	}
-	// len(net) == 0 (explicit empty list) → no --allow-net flag → network denied
+	// nil or explicit empty list → no --allow-net flag → network denied
 
 	// Env: always allow the internal IPC vars plus HOME/DENO_DIR/XDG_CACHE_HOME
 	// (required by deno.land/x/cache for vendored binary downloads).

--- a/pkg/runtime/deno/runtime_test.go
+++ b/pkg/runtime/deno/runtime_test.go
@@ -367,11 +367,18 @@ func TestRuntime_HTTP(t *testing.T) {
 	defer srv.Close()
 
 	e := newTestEnv(t)
-	r := e.run(t, `
+	spec := &task.Spec{
+		ID: "net-http", Name: "net-http", Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true}, Timeout: 30 * time.Second,
+		Permissions: task.Permissions{
+			Net: []string{"127.0.0.1"},
+		},
+	}
+	r := e.runSpec(t, `export default async function main() {
 		const res = await fetch("`+srv.URL+`")
 		const body = await res.json()
 		return body.ok
-	`)
+	}`, spec)
 	if r.Error != nil {
 		t.Fatalf("error: %v", r.Error)
 	}
@@ -380,8 +387,37 @@ func TestRuntime_HTTP(t *testing.T) {
 	}
 }
 
-func TestRuntime_HTTP_Unrestricted(t *testing.T) {
-	// net: omitted → --allow-net (unrestricted); fetch should succeed.
+// TestRuntime_Net_DefaultDeny: net: omitted → no --allow-net flag; all network blocked.
+func TestRuntime_Net_DefaultDeny(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`{"ok":true}`)) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	e := newTestEnv(t)
+	spec := &task.Spec{
+		ID: "net-default", Name: "net-default", Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true}, Timeout: 30 * time.Second,
+		// Permissions.Net is nil → deny all
+	}
+	r := e.runSpec(t, `export default async function main() {
+		try {
+			await fetch("`+srv.URL+`")
+			return "allowed"
+		} catch (e) {
+			return "blocked"
+		}
+	}`, spec)
+	if r.Error != nil {
+		t.Fatalf("unexpected run error: %v", r.Error)
+	}
+	if r.ReturnValue != "blocked" {
+		t.Errorf("expected omitted net to deny all network, got %v", r.ReturnValue)
+	}
+}
+
+// TestRuntime_Net_Wildcard: net: ["*"] → --allow-net (unrestricted); fetch succeeds.
+func TestRuntime_Net_Wildcard(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`{"ok":true}`)) //nolint:errcheck
 	}))
@@ -391,7 +427,9 @@ func TestRuntime_HTTP_Unrestricted(t *testing.T) {
 	spec := &task.Spec{
 		ID: "net-open", Name: "net-open", Runtime: task.RuntimeDeno,
 		Trigger: task.TriggerConfig{Manual: true}, Timeout: 30 * time.Second,
-		// Permissions.Net is nil → unrestricted
+		Permissions: task.Permissions{
+			Net: []string{"*"},
+		},
 	}
 	r := e.runSpec(t, `export default async function main() {
 		const res = await fetch("`+srv.URL+`")

--- a/pkg/runtime/python/guard.go
+++ b/pkg/runtime/python/guard.go
@@ -44,9 +44,9 @@ type guardRun struct {
 // buildGuardPolicy maps spec.Permissions onto the audit-hook policy with the
 // same semantics as the Deno runtime's buildDenoArgs:
 //
-//	net: omit → unrestricted; ["*"] → unrestricted; [h, ...] → allowlist;
-//	     [] (explicit empty) → deny all. Omit=unrestricted is intentional
-//	     parity with Deno; #379 tracks changing the default to deny.
+//	net: deny by default — omit or [] → deny all; ["*"] → unrestricted;
+//	     [h, ...] → allowlist. A task gets network access only by declaring
+//	     it explicitly.
 //	run: ["*"] → allow all; [c, ...] → allowlist; empty/omit → deny all.
 //	fs:  "w"/"rw" entries form the write allowlist. "~" expands to the user
 //	     home; relative paths resolve against the task dir. "r" entries are
@@ -58,7 +58,7 @@ func buildGuardPolicy(spec *task.Spec, socketPath string) guardPolicy {
 
 	net := spec.Permissions.Net
 	switch {
-	case net == nil, len(net) == 1 && net[0] == "*":
+	case len(net) == 1 && net[0] == "*":
 		pol.Net.Mode = "unrestricted"
 	case len(net) > 0:
 		pol.Net.Mode = "allowlist"

--- a/pkg/runtime/python/guard_test.go
+++ b/pkg/runtime/python/guard_test.go
@@ -20,7 +20,7 @@ func TestBuildGuardPolicy_NetModes(t *testing.T) {
 		wantMode  string
 		wantHosts []string
 	}{
-		{"omitted is unrestricted", nil, "unrestricted", nil},
+		{"omitted denies all", nil, "deny", nil},
 		{"wildcard is unrestricted", []string{"*"}, "unrestricted", nil},
 		{"hosts form an allowlist", []string{"api.github.com", "hooks.slack.com:443"}, "allowlist", []string{"api.github.com", "hooks.slack.com:443"}},
 		{"explicit empty denies all", []string{}, "deny", nil},

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -272,9 +272,9 @@ type Permissions struct {
 	// Use ["*"] for all; omit to deny all subprocess execution.
 	Run []string `yaml:"run,omitempty" json:"run,omitempty"`
 	// Net controls outbound network access (Deno and Python).
-	// Omit or use ["*"] for unrestricted access.
+	// Omit or use [] (empty list) to deny all network access (default).
+	// Use ["*"] for unrestricted access.
 	// List specific hosts to restrict: ["api.github.com", "hooks.slack.com"].
-	// Use [] (empty list) to deny all network access.
 	Net []string `yaml:"net,omitempty" json:"net,omitempty"`
 	// Sys lists Deno system-info APIs the task may call (Deno only; the
 	// names have no usable Python equivalent, so Python ignores this field).

--- a/tasks/buildin/tray/task.yaml
+++ b/tasks/buildin/tray/task.yaml
@@ -17,6 +17,12 @@ permissions:
   fs:
     - path: ~/.cache
       permission: rw
+  # systray-portable binary download: github.com redirects release assets
+  # to *.githubusercontent.com hosts.
+  net:
+    - github.com
+    - objects.githubusercontent.com
+    - release-assets.githubusercontent.com
 
 params:
   tray_version:

--- a/tasks/examples/github-stars/task.yaml
+++ b/tasks/examples/github-stars/task.yaml
@@ -12,4 +12,8 @@ params:
     description: GitHub repo in owner/name format
     default: "denoland/deno"
 
+permissions:
+  net:
+    - api.github.com
+
 timeout: 30s

--- a/tasks/examples/hello-python/task.yaml
+++ b/tasks/examples/hello-python/task.yaml
@@ -17,3 +17,7 @@ params:
   count:
     description: Run count (shown in greeting)
     default: "1"
+
+permissions:
+  net:
+    - httpbin.org


### PR DESCRIPTION
## Summary

Closes the remaining HIGH finding in #379: a task that omitted `permissions.net` got **unrestricted outbound network**. The default now flips to **deny** in both runtimes — the Deno `--allow-net` flag derivation (`buildDenoArgs`) and the Python PEP 578 audit-hook policy (`buildGuardPolicy`) apply identical semantics:

| `permissions.net` | Effect |
| --- | --- |
| omitted | deny all *(was: unrestricted)* |
| `[]` | deny all (unchanged) |
| `["*"]` | unrestricted (explicit opt-in) |
| `["host", ...]` | allowlist (unchanged) |

Only the omit case changes; everything else is untouched. The Python `guard.py` runtime needed no change — the existing `deny` mode already blocks `socket.connect`/`socket.getaddrinfo` while exempting AF_UNIX, so SDK IPC over the unix socket keeps working under deny.

## ⚠️ BREAKING change — migration

Any task that makes outbound network calls but omits `net:` silently loses network. Such tasks must now declare it: `net: ["*"]` for arbitrary hosts, or a minimal host allowlist. A migration note was added to `docs/concepts/task-format.md`.

Shipped tasks audited and fixed (the full breakage surface found in-repo):

- `tasks/buildin/tray/task.yaml` — downloads the systray-portable helper binary from GitHub releases at runtime: `net: [github.com, objects.githubusercontent.com, release-assets.githubusercontent.com]` (release-asset redirects land on the `githubusercontent.com` hosts).
- `tasks/examples/github-stars/task.yaml` — fetches the repo star count: `net: [api.github.com]`.
- `tasks/examples/hello-python/task.yaml` — httpx demo call: `net: [httpbin.org]`.

All other builtins/examples/e2e fixtures/trigger testdata either already declare `net:` or make no outbound calls from the task process (subprocess-based tasks like `git-pr`/`ai-agent-claude-cli` are unaffected — `--allow-run` children aren't governed by Deno net permission). E2e fixtures needed no changes; the suite passes unmodified.

## Deliberately left out

- No registration-time warning for omitted `net:` — the registry has no logger and `Register` is kind-agnostic, so there was no clean low-noise hook; the docs migration note covers it.
- No changes to `pkg/config`, the reconciler, or the daemon (parallel work in #392).

## Testing

- `make test` — full Go suite passes, including Deno and Python integration tests (deno/uv provisioned, zero skips).
- New coverage in both runtimes for all four cases: omit → deny, `["*"]` → unrestricted, list → allowlist, `[]` → deny.
- `make test-e2e` — full Playwright suite passes.
- `make lint` clean.

Refs #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)