### PR TITLE
feat(audit): structured audit log for security-sensitive operations (#45)

### DIFF
--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -1,0 +1,202 @@
+// Package audit provides a structured audit log for security-sensitive
+// operations (issue #45). Events are appended to the `audit_log` SQLite
+// table (created by the standard pkg/db migration) at four boundaries:
+//
+//   - run_triggered — the trigger engine starts a run (cron, webhook,
+//     manual, chain, daemon, …)
+//   - task_called   — a task invokes dicode.run_task over IPC
+//   - mcp_called    — an MCP tools/call invocation (dicode.run_task with
+//     MCP context) or an outbound mcp.call to an external MCP server
+//   - denied        — the web UI rejects an unauthenticated request
+//
+// The store is intentionally dependency-light: it only needs a db.DB
+// handle. All write paths are best-effort — a failed audit insert must
+// never break the operation being audited — and every method is safe to
+// call on a nil *Store (no-op), so callers don't need nil guards.
+package audit
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/google/uuid"
+)
+
+// Event types emitted at the security boundaries.
+const (
+	EventRunTriggered = "run_triggered"
+	EventTaskCalled   = "task_called"
+	EventMCPCalled    = "mcp_called"
+	EventDenied       = "denied"
+)
+
+// tsLayout is the storage format for the ts column. It is prefix-compatible
+// with SQLite's CURRENT_TIMESTAMP / datetime() output ("YYYY-MM-DD HH:MM:SS")
+// so lexicographic comparisons in WHERE/ORDER BY clauses remain correct.
+const tsLayout = "2006-01-02 15:04:05.000"
+
+// Event is a single audit-log row.
+type Event struct {
+	ID         string    `json:"id"`
+	TS         time.Time `json:"ts"`
+	EventType  string    `json:"event_type"`
+	ActorKind  string    `json:"actor_kind"`       // "task" | "ip" | trigger source ("cron", "webhook", …)
+	ActorID    string    `json:"actor_id"`         // task id, client IP, parent run id, …
+	TargetKind string    `json:"target_kind"`      // "task" | "mcp" | "endpoint"
+	TargetID   string    `json:"target_id"`        // task id, mcp name/tool, HTTP "METHOD /path"
+	Params     string    `json:"params,omitempty"` // sanitized JSON (see SanitizeParams) — never raw secrets
+	RunID      string    `json:"run_id,omitempty"` // associated run, when known
+	Allowed    bool      `json:"allowed"`
+	Reason     string    `json:"reason,omitempty"` // denial reason or context note
+}
+
+// Filter selects events for Query. Zero values mean "no constraint".
+type Filter struct {
+	TaskID    string // matches target_id (the task/tool/endpoint acted upon)
+	Actor     string // matches actor_id
+	EventType string // matches event_type
+	Limit     int    // default defaultQueryLimit, capped at maxQueryLimit
+	Offset    int    // pagination offset
+}
+
+const (
+	defaultQueryLimit = 100
+	maxQueryLimit     = 1000
+)
+
+// Store appends and queries audit events. Construct with NewStore. All
+// methods are nil-receiver safe so callers can wire it optionally.
+type Store struct {
+	db db.DB
+}
+
+// NewStore returns a Store backed by the given database. Returns nil when
+// database is nil so the nil-safe no-op behaviour kicks in automatically.
+func NewStore(database db.DB) *Store {
+	if database == nil {
+		return nil
+	}
+	return &Store{db: database}
+}
+
+// Append inserts one event. ID and TS are filled in when empty. Returns
+// an error only for real DB failures; nil receiver is a silent no-op.
+func (s *Store) Append(ctx context.Context, ev Event) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if ev.ID == "" {
+		ev.ID = uuid.New().String()
+	}
+	if ev.TS.IsZero() {
+		ev.TS = time.Now().UTC()
+	}
+	allowed := 0
+	if ev.Allowed {
+		allowed = 1
+	}
+	return s.db.Exec(ctx,
+		`INSERT INTO audit_log
+		   (id, ts, event_type, actor_kind, actor_id, target_kind, target_id, params, run_id, allowed, reason)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		ev.ID, ev.TS.UTC().Format(tsLayout), ev.EventType,
+		ev.ActorKind, ev.ActorID, ev.TargetKind, ev.TargetID,
+		ev.Params, ev.RunID, allowed, ev.Reason,
+	)
+}
+
+// Emit is the fire-and-forget variant of Append used on hot paths where a
+// failed audit insert must never break the audited operation. The error is
+// intentionally discarded — the audited operation already has its own
+// logging, and Append failures are limited to DB-level problems that the
+// daemon surfaces elsewhere.
+func (s *Store) Emit(ctx context.Context, ev Event) {
+	_ = s.Append(ctx, ev)
+}
+
+// Query returns events matching the filter, newest first.
+func (s *Store) Query(ctx context.Context, f Filter) ([]Event, error) {
+	if s == nil || s.db == nil {
+		return []Event{}, nil
+	}
+	limit := f.Limit
+	if limit <= 0 {
+		limit = defaultQueryLimit
+	}
+	if limit > maxQueryLimit {
+		limit = maxQueryLimit
+	}
+	offset := f.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	var where []string
+	var args []any
+	if f.TaskID != "" {
+		where = append(where, "target_id = ?")
+		args = append(args, f.TaskID)
+	}
+	if f.Actor != "" {
+		where = append(where, "actor_id = ?")
+		args = append(args, f.Actor)
+	}
+	if f.EventType != "" {
+		where = append(where, "event_type = ?")
+		args = append(args, f.EventType)
+	}
+	q := `SELECT id, ts, event_type, actor_kind, actor_id, target_kind, target_id, params, run_id, allowed, reason
+	      FROM audit_log`
+	if len(where) > 0 {
+		q += " WHERE " + strings.Join(where, " AND ")
+	}
+	q += " ORDER BY ts DESC, id DESC LIMIT ? OFFSET ?"
+	args = append(args, limit, offset)
+
+	events := []Event{}
+	err := s.db.Query(ctx, q, args, func(rows db.Scanner) error {
+		for rows.Next() {
+			var ev Event
+			var ts string
+			var allowed int
+			if err := rows.Scan(&ev.ID, &ts, &ev.EventType, &ev.ActorKind, &ev.ActorID,
+				&ev.TargetKind, &ev.TargetID, &ev.Params, &ev.RunID, &allowed, &ev.Reason); err != nil {
+				return err
+			}
+			ev.TS = parseTS(ts)
+			ev.Allowed = allowed != 0
+			events = append(events, ev)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("audit query: %w", err)
+	}
+	return events, nil
+}
+
+// parseTS decodes a stored ts column value. Accepts both the fractional
+// layout this package writes and SQLite's plain CURRENT_TIMESTAMP format
+// (rows inserted by hand or by future writers).
+func parseTS(s string) time.Time {
+	for _, layout := range []string{tsLayout, "2006-01-02 15:04:05", time.RFC3339Nano, time.RFC3339} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+// Prune deletes events older than retentionDays. retentionDays <= 0 means
+// retention is disabled and Prune is a guaranteed no-op — it can never
+// wipe the table by accident when the config value is 0/unset.
+func (s *Store) Prune(ctx context.Context, retentionDays int) error {
+	if s == nil || s.db == nil || retentionDays <= 0 {
+		return nil
+	}
+	cutoff := time.Now().UTC().AddDate(0, 0, -retentionDays).Format(tsLayout)
+	return s.db.Exec(ctx, `DELETE FROM audit_log WHERE ts < ?`, cutoff)
+}

--- a/pkg/audit/sanitize.go
+++ b/pkg/audit/sanitize.go
@@ -1,0 +1,163 @@
+package audit
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Redacted is the placeholder substituted for any sanitized value.
+// Audit rows must NEVER contain secret values — only the fact that a
+// (redacted) value was passed.
+const Redacted = "[REDACTED]"
+
+// denyExact is the case-insensitive set of param names whose values are
+// always redacted, mirroring the run-input redaction deny-list in
+// pkg/registry/inputredact.go.
+var denyExact = map[string]struct{}{
+	"authorization": {},
+	"cookie":        {},
+	"password":      {},
+	"passphrase":    {},
+	"api_key":       {},
+	"apikey":        {},
+	"api-key":       {},
+	"secret":        {},
+	"token":         {},
+	"bearer":        {},
+	"credential":    {},
+	"credentials":   {},
+}
+
+// denySubstrings is matched case-insensitively as a substring of the param
+// name. Over-redaction (e.g. "tokens_per_minute") is the safe failure mode.
+var denySubstrings = []string{
+	"signature",
+	"token",
+	"secret",
+	"password",
+	"passphrase",
+	"credential",
+	"key",
+}
+
+// refPrefixes are value prefixes that reference daemon-resolved material —
+// `env:` fields and `secret:`/`secrets:` references from task.yaml. The
+// reference itself names the secret, and the value the daemon resolves it
+// to must never reach the audit log, so the whole value is redacted.
+var refPrefixes = []string{"env:", "secret:", "secrets:"}
+
+// shouldRedactName reports whether a param name matches the deny-list.
+func shouldRedactName(name string) bool {
+	lower := strings.ToLower(name)
+	if _, ok := denyExact[lower]; ok {
+		return true
+	}
+	for _, sub := range denySubstrings {
+		if strings.Contains(lower, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// isSecretRef reports whether a string value is an env:/secret(s): reference.
+func isSecretRef(v string) bool {
+	lower := strings.ToLower(strings.TrimSpace(v))
+	for _, p := range refPrefixes {
+		if strings.HasPrefix(lower, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// SanitizeParams sanitizes a flat string param map (the shape used by task
+// triggers) and returns it as a deterministic JSON object string. Values
+// are replaced with Redacted when either the key name matches the
+// deny-list or the value is an env:/secret(s): reference. Returns "" for
+// an empty/nil map so callers can store NULL-ish params cheaply.
+func SanitizeParams(params map[string]string) string {
+	if len(params) == 0 {
+		return ""
+	}
+	out := make(map[string]string, len(params))
+	for k, v := range params {
+		if shouldRedactName(k) || isSecretRef(v) {
+			out[k] = Redacted
+			continue
+		}
+		out[k] = v
+	}
+	raw, err := json.Marshal(out) // map keys are sorted by encoding/json
+	if err != nil {
+		return ""
+	}
+	return string(raw)
+}
+
+// maxSanitizeDepth caps recursion on adversarially deep structures.
+const maxSanitizeDepth = 64
+
+// SanitizeAny sanitizes an arbitrary JSON-shaped value (used for MCP tool
+// arguments) and returns its JSON encoding. Same redaction rules as
+// SanitizeParams, applied recursively. Returns "" for nil.
+func SanitizeAny(v any) string {
+	if v == nil {
+		return ""
+	}
+	raw, err := json.Marshal(sanitizeValue(v, 0))
+	if err != nil {
+		return ""
+	}
+	return string(raw)
+}
+
+func sanitizeValue(v any, depth int) any {
+	if depth >= maxSanitizeDepth {
+		return Redacted
+	}
+	switch x := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, child := range x {
+			if shouldRedactName(k) {
+				out[k] = Redacted
+				continue
+			}
+			out[k] = sanitizeValue(child, depth+1)
+		}
+		return out
+	case map[string]string:
+		out := make(map[string]any, len(x))
+		for k, child := range x {
+			if shouldRedactName(k) || isSecretRef(child) {
+				out[k] = Redacted
+				continue
+			}
+			out[k] = child
+		}
+		return out
+	case []any:
+		out := make([]any, len(x))
+		for i, child := range x {
+			out[i] = sanitizeValue(child, depth+1)
+		}
+		return out
+	case string:
+		if isSecretRef(x) {
+			return Redacted
+		}
+		return x
+	case nil, bool, float64, float32, int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64, json.Number:
+		return x
+	default:
+		// Unknown Go type — fall back to its string form, redacting refs.
+		s := fmt.Sprintf("%v", x)
+		if isSecretRef(s) {
+			return Redacted
+		}
+		return s
+	}
+}

--- a/pkg/audit/sanitize_test.go
+++ b/pkg/audit/sanitize_test.go
@@ -1,0 +1,124 @@
+package audit
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeParams_RedactsByName(t *testing.T) {
+	got := SanitizeParams(map[string]string{
+		"api_key":           "sk-live-12345",
+		"GITHUB_TOKEN":      "ghp_abcdef",
+		"slack_secret":      "xoxb-1111",
+		"password":          "hunter2",
+		"webhook_signature": "sha256=deadbeef",
+		"channel":           "#alerts",
+	})
+
+	var m map[string]string
+	if err := json.Unmarshal([]byte(got), &m); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, got)
+	}
+	for _, k := range []string{"api_key", "GITHUB_TOKEN", "slack_secret", "password", "webhook_signature"} {
+		if m[k] != Redacted {
+			t.Errorf("key %q: got %q, want %q", k, m[k], Redacted)
+		}
+	}
+	if m["channel"] != "#alerts" {
+		t.Errorf("non-sensitive key was altered: got %q", m["channel"])
+	}
+	for _, leaked := range []string{"sk-live-12345", "ghp_abcdef", "xoxb-1111", "hunter2", "deadbeef"} {
+		if strings.Contains(got, leaked) {
+			t.Errorf("sanitized output leaks secret value %q: %s", leaked, got)
+		}
+	}
+}
+
+func TestSanitizeParams_RedactsEnvAndSecretRefs(t *testing.T) {
+	got := SanitizeParams(map[string]string{
+		"target":  "env:GH_TOKEN",
+		"webhook": "secret:slack_webhook_url",
+		"other":   "secrets:db_password",
+		"mixed":   "  ENV:UPPER_CASE_REF",
+		"plain":   "environment-name", // does not start with env: — must survive
+	})
+
+	var m map[string]string
+	if err := json.Unmarshal([]byte(got), &m); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, got)
+	}
+	for _, k := range []string{"target", "webhook", "other", "mixed"} {
+		if m[k] != Redacted {
+			t.Errorf("key %q: got %q, want %q", k, m[k], Redacted)
+		}
+	}
+	if m["plain"] != "environment-name" {
+		t.Errorf("plain value was altered: got %q", m["plain"])
+	}
+}
+
+func TestSanitizeParams_Empty(t *testing.T) {
+	if got := SanitizeParams(nil); got != "" {
+		t.Errorf("nil map: got %q, want empty string", got)
+	}
+	if got := SanitizeParams(map[string]string{}); got != "" {
+		t.Errorf("empty map: got %q, want empty string", got)
+	}
+}
+
+func TestSanitizeAny_Nested(t *testing.T) {
+	got := SanitizeAny(map[string]any{
+		"query": "list issues",
+		"auth": map[string]any{
+			"token": "ghp_secretvalue",
+		},
+		"items": []any{
+			map[string]any{"apiKey": "sk-12345", "name": "ok"},
+			"env:SOME_VAR",
+			float64(42),
+		},
+	})
+
+	if strings.Contains(got, "ghp_secretvalue") || strings.Contains(got, "sk-12345") {
+		t.Fatalf("nested secret leaked: %s", got)
+	}
+	if strings.Contains(got, "env:SOME_VAR") {
+		t.Fatalf("env ref leaked: %s", got)
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(got), &m); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, got)
+	}
+	if m["query"] != "list issues" {
+		t.Errorf("non-sensitive value altered: %v", m["query"])
+	}
+	items := m["items"].([]any)
+	if items[1] != Redacted {
+		t.Errorf("string ref in list: got %v, want %q", items[1], Redacted)
+	}
+	if items[2] != float64(42) {
+		t.Errorf("number in list altered: %v", items[2])
+	}
+}
+
+func TestSanitizeAny_DepthCap(t *testing.T) {
+	// Build a structure deeper than maxSanitizeDepth — must not panic.
+	v := any("leaf")
+	for i := 0; i < maxSanitizeDepth+10; i++ {
+		v = map[string]any{"nested": v}
+	}
+	got := SanitizeAny(v)
+	if got == "" {
+		t.Fatal("expected non-empty output for deep structure")
+	}
+	if !strings.Contains(got, Redacted) {
+		t.Errorf("expected depth cap to redact the innermost levels: %s", got)
+	}
+}
+
+func TestSanitizeAny_Nil(t *testing.T) {
+	if got := SanitizeAny(nil); got != "" {
+		t.Errorf("nil: got %q, want empty string", got)
+	}
+}

--- a/pkg/audit/store_test.go
+++ b/pkg/audit/store_test.go
@@ -1,0 +1,178 @@
+package audit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return NewStore(d)
+}
+
+func TestStore_AppendAndQuery(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	events := []Event{
+		{EventType: EventRunTriggered, ActorKind: "cron", ActorID: "", TargetKind: "task", TargetID: "ns/task-a", RunID: "run-1", Allowed: true},
+		{EventType: EventTaskCalled, ActorKind: "task", ActorID: "ns/caller", TargetKind: "task", TargetID: "ns/task-b", RunID: "run-2", Allowed: true},
+		{EventType: EventTaskCalled, ActorKind: "task", ActorID: "ns/caller", TargetKind: "task", TargetID: "ns/task-c", Allowed: false, Reason: "not in security.allowed_tasks"},
+		{EventType: EventDenied, ActorKind: "ip", ActorID: "10.0.0.7", TargetKind: "endpoint", TargetID: "GET /api/tasks", Allowed: false, Reason: "unauthorized"},
+	}
+	for i, ev := range events {
+		// Spread timestamps so ordering is deterministic.
+		ev.TS = time.Date(2026, 6, 1, 12, 0, i, 0, time.UTC)
+		if err := s.Append(ctx, ev); err != nil {
+			t.Fatalf("Append[%d]: %v", i, err)
+		}
+	}
+
+	// Unfiltered: newest first.
+	all, err := s.Query(ctx, Filter{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(all) != 4 {
+		t.Fatalf("got %d events, want 4", len(all))
+	}
+	if all[0].EventType != EventDenied || all[3].EventType != EventRunTriggered {
+		t.Errorf("expected newest-first ordering, got %s … %s", all[0].EventType, all[3].EventType)
+	}
+	if all[0].Allowed {
+		t.Error("denied event must have Allowed=false")
+	}
+	if all[0].ID == "" || all[0].TS.IsZero() {
+		t.Error("Append must fill ID and TS")
+	}
+
+	// Filter by task (target_id).
+	byTask, err := s.Query(ctx, Filter{TaskID: "ns/task-b"})
+	if err != nil {
+		t.Fatalf("Query by task: %v", err)
+	}
+	if len(byTask) != 1 || byTask[0].RunID != "run-2" {
+		t.Errorf("task filter: got %+v", byTask)
+	}
+
+	// Filter by actor.
+	byActor, err := s.Query(ctx, Filter{Actor: "ns/caller"})
+	if err != nil {
+		t.Fatalf("Query by actor: %v", err)
+	}
+	if len(byActor) != 2 {
+		t.Errorf("actor filter: got %d events, want 2", len(byActor))
+	}
+
+	// Filter by event type.
+	byType, err := s.Query(ctx, Filter{EventType: EventDenied})
+	if err != nil {
+		t.Fatalf("Query by type: %v", err)
+	}
+	if len(byType) != 1 || byType[0].ActorID != "10.0.0.7" {
+		t.Errorf("event_type filter: got %+v", byType)
+	}
+
+	// Combined filters.
+	combined, err := s.Query(ctx, Filter{Actor: "ns/caller", TaskID: "ns/task-c"})
+	if err != nil {
+		t.Fatalf("Query combined: %v", err)
+	}
+	if len(combined) != 1 || combined[0].Reason != "not in security.allowed_tasks" {
+		t.Errorf("combined filter: got %+v", combined)
+	}
+}
+
+func TestStore_QueryPagination(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		err := s.Append(ctx, Event{
+			EventType: EventRunTriggered,
+			TargetID:  "t",
+			TS:        time.Date(2026, 6, 1, 12, 0, i, 0, time.UTC),
+			Allowed:   true,
+		})
+		if err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+	}
+	page1, err := s.Query(ctx, Filter{Limit: 2})
+	if err != nil {
+		t.Fatalf("page1: %v", err)
+	}
+	page2, err := s.Query(ctx, Filter{Limit: 2, Offset: 2})
+	if err != nil {
+		t.Fatalf("page2: %v", err)
+	}
+	if len(page1) != 2 || len(page2) != 2 {
+		t.Fatalf("page sizes: %d, %d, want 2, 2", len(page1), len(page2))
+	}
+	if page1[0].ID == page2[0].ID || page1[1].ID == page2[0].ID {
+		t.Error("pages overlap")
+	}
+	if !page1[1].TS.After(page2[0].TS) && !page1[1].TS.Equal(page2[0].TS) {
+		t.Errorf("expected page1 to be newer than page2: %v vs %v", page1[1].TS, page2[0].TS)
+	}
+}
+
+func TestStore_Prune(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	old := Event{EventType: EventDenied, TargetID: "old", TS: time.Now().UTC().AddDate(0, 0, -45)}
+	fresh := Event{EventType: EventDenied, TargetID: "fresh", TS: time.Now().UTC()}
+	if err := s.Append(ctx, old); err != nil {
+		t.Fatalf("append old: %v", err)
+	}
+	if err := s.Append(ctx, fresh); err != nil {
+		t.Fatalf("append fresh: %v", err)
+	}
+
+	// retentionDays <= 0 must be a no-op (never wipes the table).
+	if err := s.Prune(ctx, 0); err != nil {
+		t.Fatalf("Prune(0): %v", err)
+	}
+	if err := s.Prune(ctx, -3); err != nil {
+		t.Fatalf("Prune(-3): %v", err)
+	}
+	all, _ := s.Query(ctx, Filter{})
+	if len(all) != 2 {
+		t.Fatalf("Prune(0/-3) must not delete anything: %d rows left", len(all))
+	}
+
+	if err := s.Prune(ctx, 30); err != nil {
+		t.Fatalf("Prune(30): %v", err)
+	}
+	after, _ := s.Query(ctx, Filter{})
+	if len(after) != 1 || after[0].TargetID != "fresh" {
+		t.Fatalf("expected only the fresh row to survive, got %+v", after)
+	}
+}
+
+func TestStore_NilSafe(t *testing.T) {
+	var s *Store
+	ctx := context.Background()
+	if err := s.Append(ctx, Event{EventType: EventDenied}); err != nil {
+		t.Errorf("nil store Append: %v", err)
+	}
+	s.Emit(ctx, Event{EventType: EventDenied}) // must not panic
+	evs, err := s.Query(ctx, Filter{})
+	if err != nil || len(evs) != 0 {
+		t.Errorf("nil store Query: %v, %v", evs, err)
+	}
+	if err := s.Prune(ctx, 30); err != nil {
+		t.Errorf("nil store Prune: %v", err)
+	}
+	if NewStore(nil) != nil {
+		t.Error("NewStore(nil) must return nil")
+	}
+}

--- a/pkg/config/auditlog_test.go
+++ b/pkg/config/auditlog_test.go
@@ -1,21 +1,11 @@
 package config
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func loadConfigString(t *testing.T, content string) (*Config, error) {
-	t.Helper()
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "dicode.yaml")
-	if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
-		t.Fatal(err)
-	}
-	return Load(cfgPath)
-}
+// loadConfigString is shared with approval_test.go (same package).
 
 func TestAuditLogConfig_DefaultRetention(t *testing.T) {
 	cfg, err := loadConfigString(t, "spec:\n  entries: {}\n")

--- a/pkg/config/auditlog_test.go
+++ b/pkg/config/auditlog_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func loadConfigString(t *testing.T, content string) (*Config, error) {
+	t.Helper()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dicode.yaml")
+	if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return Load(cfgPath)
+}
+
+func TestAuditLogConfig_DefaultRetention(t *testing.T) {
+	cfg, err := loadConfigString(t, "spec:\n  entries: {}\n")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.AuditLog.RetentionDays != nil {
+		t.Errorf("unset retention_days should stay nil, got %d", *cfg.AuditLog.RetentionDays)
+	}
+	if got := cfg.AuditLog.EffectiveRetentionDays(); got != 30 {
+		t.Errorf("EffectiveRetentionDays: got %d, want 30 (default)", got)
+	}
+}
+
+func TestAuditLogConfig_ExplicitValues(t *testing.T) {
+	cfg, err := loadConfigString(t, "spec:\n  entries: {}\naudit_log:\n  retention_days: 7\n")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.AuditLog.EffectiveRetentionDays(); got != 7 {
+		t.Errorf("EffectiveRetentionDays: got %d, want 7", got)
+	}
+
+	// Explicit 0 disables pruning — must NOT fall back to the 30-day default.
+	cfg, err = loadConfigString(t, "spec:\n  entries: {}\naudit_log:\n  retention_days: 0\n")
+	if err != nil {
+		t.Fatalf("Load with 0: %v", err)
+	}
+	if got := cfg.AuditLog.EffectiveRetentionDays(); got != 0 {
+		t.Errorf("explicit 0: EffectiveRetentionDays got %d, want 0", got)
+	}
+}
+
+func TestAuditLogConfig_NegativeRejected(t *testing.T) {
+	_, err := loadConfigString(t, "spec:\n  entries: {}\naudit_log:\n  retention_days: -1\n")
+	if err == nil {
+		t.Fatal("expected error for negative retention_days")
+	}
+	if !strings.Contains(err.Error(), "audit_log.retention_days") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -216,6 +216,27 @@ func (a ApprovalConfig) IsEnabled() bool {
 	return *a.Enabled
 }
 
+// AuditLogConfig tunes the structured security audit log (#45).
+type AuditLogConfig struct {
+	// RetentionDays is how long audit_log rows are kept before the daemon
+	// prunes them. nil (unset) defaults to 30 days; an explicit 0 disables
+	// pruning entirely (rows are kept forever). Negative values are
+	// rejected by validate.
+	RetentionDays *int `yaml:"retention_days,omitempty"`
+}
+
+// defaultAuditRetentionDays is applied when audit_log.retention_days is unset.
+const defaultAuditRetentionDays = 30
+
+// EffectiveRetentionDays resolves the retention window: nil → 30 (default),
+// explicit 0 → 0 (pruning disabled).
+func (c AuditLogConfig) EffectiveRetentionDays() int {
+	if c.RetentionDays == nil {
+		return defaultAuditRetentionDays
+	}
+	return *c.RetentionDays
+}
+
 type Config struct {
 	// Spec is the root TaskSet defined inline in dicode.yaml. Its entries
 	// declare every source the daemon loads. Overrides on these entries
@@ -244,6 +265,7 @@ type Config struct {
 	Relay     RelayConfig              `yaml:"relay,omitempty"`
 	AI        AIConfig                 `yaml:"ai,omitempty"`
 	Approval  ApprovalConfig           `yaml:"approval,omitempty"`
+	AuditLog  AuditLogConfig           `yaml:"audit_log,omitempty"`
 	LogLevel  string                   `yaml:"log_level"`
 	DataDir   string                   `yaml:"data_dir"`
 	// ContainerSecurity is the operator opt-out for the container runtime
@@ -581,6 +603,9 @@ func (cfg *Config) validate() error {
 	case "", "off", "warn", "strict":
 	default:
 		return fmt.Errorf("server.device_binding: must be one of off, warn, strict, got %q", cfg.Server.DeviceBinding)
+	}
+	if cfg.AuditLog.RetentionDays != nil && *cfg.AuditLog.RetentionDays < 0 {
+		return fmt.Errorf("audit_log.retention_days: must be >= 0 (0 disables pruning), got %d", *cfg.AuditLog.RetentionDays)
 	}
 	if err := cfg.Defaults.OnFailureChain.ValidateAtDefaults(); err != nil {
 		return fmt.Errorf("defaults.on_failure_chain: %w", err)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/dicode/dicode/pkg/approval"
+	"github.com/dicode/dicode/pkg/audit"
 	"github.com/dicode/dicode/pkg/config"
 	"github.com/dicode/dicode/pkg/db"
 	"github.com/dicode/dicode/pkg/ipc"
@@ -570,8 +571,41 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 		}
 	}
 
+	// 9.5. Audit-log retention (#45). Event emission is wired implicitly —
+	// the trigger engine (SetDB), per-run IPC servers, and webui all build
+	// their own audit.Store over the shared database handle. The daemon
+	// only owns pruning: once at startup, then periodically. retention 0
+	// (explicit opt-out) disables pruning entirely; Prune itself also
+	// refuses to run with a non-positive window.
+	auditStore := audit.NewStore(database)
+	auditRetentionDays := cfg.AuditLog.EffectiveRetentionDays()
+	if auditRetentionDays > 0 {
+		if err := auditStore.Prune(ctx, auditRetentionDays); err != nil {
+			log.Warn("audit log prune failed", zap.Error(err))
+		}
+		log.Info("audit log retention enabled", zap.Int("retention_days", auditRetentionDays))
+	} else {
+		log.Info("audit log pruning disabled (audit_log.retention_days: 0)")
+	}
+
 	// 10. Run everything concurrently.
 	g, ctx := errgroup.WithContext(ctx)
+	if auditRetentionDays > 0 {
+		g.Go(func() error {
+			ticker := time.NewTicker(6 * time.Hour)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-ticker.C:
+					if err := auditStore.Prune(ctx, auditRetentionDays); err != nil {
+						log.Warn("audit log prune failed", zap.Error(err))
+					}
+				}
+			}
+		})
+	}
 	g.Go(func() error { return rec.Run(ctx) })
 	g.Go(func() error { return eng.Start(ctx) })
 	g.Go(func() error { return srv.Start(ctx) })

--- a/pkg/db/sqlite.go
+++ b/pkg/db/sqlite.go
@@ -257,6 +257,30 @@ func (s *SQLiteDB) migrate() error {
 	if err != nil {
 		return fmt.Errorf("migrate approval_tokens: %w", err)
 	}
+	// audit_log — structured audit log for security-sensitive operations
+	// (#45). Appended by pkg/audit at the trigger-engine, IPC (run_task /
+	// mcp.call), and webui denied-auth boundaries. params holds sanitized
+	// JSON only — secret values are redacted before insert.
+	_, err = s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS audit_log (
+			id          TEXT PRIMARY KEY,
+			ts          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			event_type  TEXT NOT NULL DEFAULT '',
+			actor_kind  TEXT NOT NULL DEFAULT '',
+			actor_id    TEXT NOT NULL DEFAULT '',
+			target_kind TEXT NOT NULL DEFAULT '',
+			target_id   TEXT NOT NULL DEFAULT '',
+			params      TEXT NOT NULL DEFAULT '',
+			run_id      TEXT NOT NULL DEFAULT '',
+			allowed     BOOLEAN NOT NULL,
+			reason      TEXT NOT NULL DEFAULT ''
+		);
+		CREATE INDEX IF NOT EXISTS idx_audit_log_ts ON audit_log(ts DESC);
+		CREATE INDEX IF NOT EXISTS idx_audit_log_actor_ts ON audit_log(actor_id, ts DESC);
+	`)
+	if err != nil {
+		return fmt.Errorf("migrate audit_log: %w", err)
+	}
 
 	return nil
 }

--- a/pkg/db/sqlite_test.go
+++ b/pkg/db/sqlite_test.go
@@ -142,7 +142,7 @@ func TestSQLiteDB_Schema(t *testing.T) {
 	db := newTestDB(t)
 	ctx := context.Background()
 
-	tables := []string{"runs", "run_logs", "kv", "secrets"}
+	tables := []string{"runs", "run_logs", "kv", "secrets", "audit_log"}
 	for _, tbl := range tables {
 		var name string
 		_ = db.Query(ctx,
@@ -157,6 +157,28 @@ func TestSQLiteDB_Schema(t *testing.T) {
 		)
 		if name != tbl {
 			t.Errorf("table %q not found", tbl)
+		}
+	}
+}
+
+func TestSQLiteDB_AuditLogIndexes(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	for _, idx := range []string{"idx_audit_log_ts", "idx_audit_log_actor_ts"} {
+		var name string
+		_ = db.Query(ctx,
+			`SELECT name FROM sqlite_master WHERE type='index' AND name=?`,
+			[]any{idx},
+			func(rows Scanner) error {
+				if rows.Next() {
+					return rows.Scan(&name)
+				}
+				return nil
+			},
+		)
+		if name != idx {
+			t.Errorf("index %q not found", idx)
 		}
 	}
 }

--- a/pkg/ipc/audit_test.go
+++ b/pkg/ipc/audit_test.go
@@ -1,0 +1,161 @@
+package ipc
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/audit"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// auditEvents queries all audit rows recorded against the test env's DB.
+func auditEvents(t *testing.T, e *testEnv, f audit.Filter) []audit.Event {
+	t.Helper()
+	events, err := audit.NewStore(e.db).Query(context.Background(), f)
+	if err != nil {
+		t.Fatalf("audit query: %v", err)
+	}
+	return events
+}
+
+func TestAudit_RunTask_DeniedNoCap(t *testing.T) {
+	e := newTestEnv(t)
+	conn, _ := e.start(t, nil, nil) // no spec → no tasks.trigger cap
+
+	sendMsg(t, conn, map[string]any{"id": "1", "method": "dicode.run_task", "taskID": "some-task"})
+	if resp := recvMsg(t, conn); resp["error"] == nil {
+		t.Fatal("expected permission denied")
+	}
+
+	events := auditEvents(t, e, audit.Filter{EventType: audit.EventTaskCalled})
+	if len(events) != 1 {
+		t.Fatalf("got %d task_called events, want 1", len(events))
+	}
+	ev := events[0]
+	if ev.Allowed {
+		t.Error("denied call must record allowed=false")
+	}
+	if ev.Reason != "permission denied (tasks.trigger)" {
+		t.Errorf("reason: %q", ev.Reason)
+	}
+	if ev.ActorKind != "task" || ev.ActorID != "test-task" {
+		t.Errorf("actor: %s/%s", ev.ActorKind, ev.ActorID)
+	}
+	if ev.TargetID != "some-task" {
+		t.Errorf("target: %q", ev.TargetID)
+	}
+}
+
+func TestAudit_RunTask_DeniedNotAllowedAndParamsSanitized(t *testing.T) {
+	e := newTestEnv(t)
+	spec := specWithDicode("caller", &task.DicodePermissions{Tasks: []string{"permitted-task"}})
+	conn, _ := e.startWithSpec(t, nil, nil, spec, &mockEngine{})
+
+	sendMsg(t, conn, map[string]any{
+		"id": "1", "method": "dicode.run_task", "taskID": "forbidden-task",
+		"params": map[string]string{"api_key": "sk-live-supersecret", "channel": "#ops"},
+	})
+	if resp := recvMsg(t, conn); resp["error"] == nil {
+		t.Fatal("expected security error for unlisted task")
+	}
+
+	events := auditEvents(t, e, audit.Filter{TaskID: "forbidden-task"})
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	ev := events[0]
+	if ev.Allowed || ev.Reason != "not in security.allowed_tasks" {
+		t.Errorf("allowed=%v reason=%q", ev.Allowed, ev.Reason)
+	}
+	if strings.Contains(ev.Params, "sk-live-supersecret") {
+		t.Errorf("audit params leaked secret value: %s", ev.Params)
+	}
+	if !strings.Contains(ev.Params, audit.Redacted) {
+		t.Errorf("expected redaction placeholder in params: %s", ev.Params)
+	}
+	if !strings.Contains(ev.Params, "#ops") {
+		t.Errorf("non-sensitive param missing: %s", ev.Params)
+	}
+}
+
+func TestAudit_RunTask_Allowed(t *testing.T) {
+	e := newTestEnv(t)
+	eng := &mockEngine{runID: "run-abc", result: RunResult{RunID: "run-abc", Status: "success"}}
+	spec := specWithDicode("caller", &task.DicodePermissions{Tasks: []string{"target-task"}})
+	conn, _ := e.startWithSpec(t, nil, nil, spec, eng)
+
+	sendMsg(t, conn, map[string]any{"id": "1", "method": "dicode.run_task", "taskID": "target-task"})
+	if resp := recvMsg(t, conn); resp["error"] != nil {
+		t.Fatalf("unexpected error: %v", resp["error"])
+	}
+
+	events := auditEvents(t, e, audit.Filter{TaskID: "target-task"})
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	ev := events[0]
+	if !ev.Allowed || ev.Reason != "" {
+		t.Errorf("allowed=%v reason=%q, want allowed with empty reason", ev.Allowed, ev.Reason)
+	}
+	if ev.RunID != "run-abc" {
+		t.Errorf("run_id: got %q, want the fired run id", ev.RunID)
+	}
+	if ev.EventType != audit.EventTaskCalled {
+		t.Errorf("event_type: %q", ev.EventType)
+	}
+}
+
+func TestAudit_RunTask_MCPContextEmitsMCPCalled(t *testing.T) {
+	e := newTestEnv(t)
+	spec := specWithDicode("caller", &task.DicodePermissions{Tasks: []string{"*"}})
+	conn, _ := e.startWithSpec(t, nil, nil, spec, &mockEngine{})
+
+	// MCP-context call against a task that is not registered → denied with
+	// "task not found", recorded as mcp_called (the tools/call boundary).
+	sendMsg(t, conn, map[string]any{
+		"id": "1", "method": "dicode.run_task", "taskID": "ghost-task", "mcpContext": true,
+	})
+	if resp := recvMsg(t, conn); resp["error"] == nil {
+		t.Fatal("expected error for unknown MCP-exposed task")
+	}
+
+	events := auditEvents(t, e, audit.Filter{EventType: audit.EventMCPCalled})
+	if len(events) != 1 {
+		t.Fatalf("got %d mcp_called events, want 1", len(events))
+	}
+	if events[0].Allowed || events[0].Reason != "task not found" {
+		t.Errorf("allowed=%v reason=%q", events[0].Allowed, events[0].Reason)
+	}
+}
+
+func TestAudit_MCPCall_Denied(t *testing.T) {
+	e := newTestEnv(t)
+	conn, _ := e.start(t, nil, nil) // no spec → no mcp.call cap
+
+	sendMsg(t, conn, map[string]any{
+		"id": "1", "method": "mcp.call", "mcpName": "github", "tool": "list_issues",
+		"args": map[string]any{"token": "ghp_secret", "repo": "dicode-core"},
+	})
+	if resp := recvMsg(t, conn); resp["error"] == nil {
+		t.Fatal("expected permission denied")
+	}
+
+	events := auditEvents(t, e, audit.Filter{EventType: audit.EventMCPCalled})
+	if len(events) != 1 {
+		t.Fatalf("got %d mcp_called events, want 1", len(events))
+	}
+	ev := events[0]
+	if ev.Allowed {
+		t.Error("denied mcp.call must record allowed=false")
+	}
+	if ev.TargetKind != "mcp" || ev.TargetID != "github/list_issues" {
+		t.Errorf("target: %s/%s", ev.TargetKind, ev.TargetID)
+	}
+	if strings.Contains(ev.Params, "ghp_secret") {
+		t.Errorf("audit params leaked secret arg: %s", ev.Params)
+	}
+	if !strings.Contains(ev.Params, "dicode-core") {
+		t.Errorf("non-sensitive arg missing: %s", ev.Params)
+	}
+}

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/dicode/dicode/pkg/audit"
 	"github.com/dicode/dicode/pkg/db"
 	mcpclient "github.com/dicode/dicode/pkg/mcp/client"
 	"github.com/dicode/dicode/pkg/registry"
@@ -41,6 +42,7 @@ type Server struct {
 	engine   EngineRunner
 	secrets  secrets.Manager // optional; enables dicode.secrets_set / dicode.secrets_delete
 	log      *zap.Logger
+	audit    *audit.Store // best-effort task_called / mcp_called emission (#45); nil-safe
 
 	// redactor strips secret values from inbound log messages before they
 	// hit the run log. Nil load is safe (no redaction; RedactString is
@@ -129,6 +131,7 @@ func New(
 		secret:       secret,
 		registry:     reg,
 		db:           database,
+		audit:        audit.NewStore(database),
 		params:       params,
 		input:        input,
 		spec:         spec,
@@ -653,6 +656,7 @@ func (s *Server) handleConn(conn net.Conn) {
 
 		case "dicode.run_task":
 			if !hasCap(caps, CapTaskTrigger) {
+				s.auditTaskCall(req, false, "permission denied (tasks.trigger)", "")
 				reply(req.ID, nil, "ipc: permission denied (tasks.trigger)")
 				continue
 			}
@@ -661,6 +665,7 @@ func (s *Server) handleConn(conn net.Conn) {
 				continue
 			}
 			if !s.taskAllowed(req.TaskID) {
+				s.auditTaskCall(req, false, "not in security.allowed_tasks", "")
 				reply(req.ID, nil, fmt.Sprintf("ipc: task %q not in security.allowed_tasks", req.TaskID))
 				continue
 			}
@@ -668,9 +673,11 @@ func (s *Server) handleConn(conn net.Conn) {
 			// tasks that have explicitly opted in via mcp_exposed: true.
 			if req.MCPContext {
 				if targetSpec, ok := s.registry.Get(req.TaskID); !ok {
+					s.auditTaskCall(req, false, "task not found", "")
 					reply(req.ID, nil, fmt.Sprintf("ipc: task %q not found", req.TaskID))
 					continue
 				} else if !targetSpec.MCPExposed {
+					s.auditTaskCall(req, false, "not exposed via MCP", "")
 					reply(req.ID, nil, fmt.Sprintf("ipc: task %q is not exposed via MCP", req.TaskID))
 					continue
 				}
@@ -684,9 +691,11 @@ func (s *Server) handleConn(conn net.Conn) {
 			// s.runID is "" and FireFromTask falls back to a plain manual.
 			runID, err := s.engine.FireFromTask(s.ctx, req.TaskID, s.runID, callParams)
 			if err != nil {
+				s.auditTaskCall(req, true, "fire failed: "+err.Error(), "")
 				reply(req.ID, nil, err.Error())
 				continue
 			}
+			s.auditTaskCall(req, true, "", runID)
 			result, err := s.engine.WaitRun(s.ctx, runID)
 			if err != nil {
 				reply(req.ID, nil, err.Error())
@@ -1096,10 +1105,12 @@ func (s *Server) handleConn(conn net.Conn) {
 
 		case "mcp.call":
 			if !hasCap(caps, CapMCPCall) {
+				s.auditMCPCall(req, false, "permission denied (mcp.call)")
 				reply(req.ID, nil, "ipc: permission denied (mcp.call)")
 				continue
 			}
 			if !s.mcpAllowed(req.MCPName) {
+				s.auditMCPCall(req, false, "not in security.allowed_mcp")
 				reply(req.ID, nil, fmt.Sprintf("ipc: %q not in security.allowed_mcp", req.MCPName))
 				continue
 			}
@@ -1112,6 +1123,9 @@ func (s *Server) handleConn(conn net.Conn) {
 			if len(req.Args) > 0 {
 				_ = json.Unmarshal(req.Args, &args)
 			}
+			// Audit before the network round-trip so every authorized
+			// invocation is recorded even when the MCP server errors.
+			s.auditMCPCall(req, true, "")
 			result, err := mcpclient.New(port).Call(context.Background(), req.Tool, args)
 			if err != nil {
 				reply(req.ID, nil, err.Error())
@@ -1214,6 +1228,62 @@ func (s *Server) handleConn(conn net.Conn) {
 			}
 		}
 	}
+}
+
+// auditTaskCall records a dicode.run_task invocation (#45). The event type
+// is mcp_called when the caller signalled MCP context (i.e. the buildin/mcp
+// task forwarding a tools/call), task_called otherwise. firedRunID is the
+// newly fired run when the call succeeded; the event otherwise falls back
+// to the caller's own run ID for correlation. Best-effort and nil-safe.
+func (s *Server) auditTaskCall(req Request, allowed bool, reason, firedRunID string) {
+	eventType := audit.EventTaskCalled
+	if req.MCPContext {
+		eventType = audit.EventMCPCalled
+	}
+	var callParams map[string]string
+	if len(req.Params) > 0 {
+		_ = json.Unmarshal(req.Params, &callParams)
+	}
+	runID := firedRunID
+	if runID == "" {
+		runID = s.runID
+	}
+	s.audit.Emit(context.Background(), audit.Event{
+		EventType:  eventType,
+		ActorKind:  "task",
+		ActorID:    s.taskID,
+		TargetKind: "task",
+		TargetID:   req.TaskID,
+		Params:     audit.SanitizeParams(callParams),
+		RunID:      runID,
+		Allowed:    allowed,
+		Reason:     reason,
+	})
+}
+
+// auditMCPCall records an outbound mcp.call to an external MCP server (#45).
+// Tool arguments are sanitized recursively before storage. Best-effort and
+// nil-safe.
+func (s *Server) auditMCPCall(req Request, allowed bool, reason string) {
+	var args map[string]any
+	if len(req.Args) > 0 {
+		_ = json.Unmarshal(req.Args, &args)
+	}
+	var params string
+	if args != nil {
+		params = audit.SanitizeAny(args)
+	}
+	s.audit.Emit(context.Background(), audit.Event{
+		EventType:  audit.EventMCPCalled,
+		ActorKind:  "task",
+		ActorID:    s.taskID,
+		TargetKind: "mcp",
+		TargetID:   req.MCPName + "/" + req.Tool,
+		Params:     params,
+		RunID:      s.runID,
+		Allowed:    allowed,
+		Reason:     reason,
+	})
 }
 
 // dicodePerms returns the Dicode permission block for the current spec, or nil.

--- a/pkg/runtime/executor.go
+++ b/pkg/runtime/executor.go
@@ -30,6 +30,12 @@ type RunOptions struct {
 	Params      map[string]string
 	Input       interface{}
 
+	// TriggerActor identifies the operator principal that initiated this
+	// run (e.g. the authenticated web session's client IP for manual API
+	// runs). Empty for cron/webhook/chain runs. The trigger engine prefers
+	// it over ParentRunID as the run_triggered audit actor_id (#45).
+	TriggerActor string
+
 	// PreResolvedEnv, when set, is the result of an env-resolver pass run
 	// by the trigger engine before dispatch. The runtime uses these values
 	// directly instead of calling the resolver itself, avoiding the

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -878,12 +878,20 @@ func (e *Engine) getShutdownCtx() context.Context {
 
 // FireManual triggers a task by ID with optional param overrides.
 func (e *Engine) FireManual(ctx context.Context, taskID string, params map[string]string) (string, error) {
+	return e.FireManualWithActor(ctx, taskID, params, "")
+}
+
+// FireManualWithActor is FireManual carrying the identity of the operator
+// principal (e.g. the authenticated web session's client IP) that requested
+// the run. The actor flows into the run_triggered audit event (#45) as
+// actor_id; an empty actor preserves plain FireManual behaviour.
+func (e *Engine) FireManualWithActor(ctx context.Context, taskID string, params map[string]string, actor string) (string, error) {
 	k, ok := e.registry.GetKinded(taskID)
 	if !ok {
 		return "", fmt.Errorf("task %q not found", taskID)
 	}
 	e.log.Info("manual trigger", zap.String("task", taskID))
-	return e.fireKinded(context.Background(), k, pkgruntime.RunOptions{Params: params}, registry.TriggerManual)
+	return e.fireKinded(context.Background(), k, pkgruntime.RunOptions{Params: params, TriggerActor: actor}, registry.TriggerManual)
 }
 
 // FireFromTask triggers a task as a child of an in-flight run. Used by the
@@ -2043,12 +2051,18 @@ func (e *Engine) startRun(spec *task.Spec, opts *pkgruntime.RunOptions, source r
 	}
 
 	// Audit boundary (#45): one best-effort run_triggered event per run.
-	// actor_kind is the trigger source; actor_id is the parent run for
-	// chain/task-fired runs (empty for cron/webhook/manual).
+	// actor_kind is the trigger source; actor_id is the operator principal
+	// (opts.TriggerActor — e.g. the web session's client IP for manual API
+	// runs) when known, falling back to the parent run for chain/task-fired
+	// runs (empty for cron/webhook).
+	actorID := opts.TriggerActor
+	if actorID == "" {
+		actorID = opts.ParentRunID
+	}
 	e.audit.Emit(context.Background(), audit.Event{
 		EventType:  audit.EventRunTriggered,
 		ActorKind:  string(source),
-		ActorID:    opts.ParentRunID,
+		ActorID:    actorID,
 		TargetKind: "task",
 		TargetID:   spec.ID,
 		Params:     audit.SanitizeParams(opts.Params),

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/dicode/dicode/pkg/audit"
 	"github.com/dicode/dicode/pkg/db"
 	"github.com/dicode/dicode/pkg/ipc"
 	"github.com/dicode/dicode/pkg/registry"
@@ -54,6 +55,7 @@ type Engine struct {
 	executors map[task.Runtime]pkgruntime.Executor
 	cron      *cron.Cron
 	log       *zap.Logger
+	audit     *audit.Store // best-effort audit emission; nil-safe, wired by SetDB
 
 	mu                 sync.Mutex
 	cronEntries        map[string]cron.EntryID // taskID → cron entry
@@ -233,6 +235,9 @@ func New(r *registry.Registry, defaultExec pkgruntime.Executor, log *zap.Logger)
 // detects missed runs on startup (e.g. after a process restart).
 func (e *Engine) SetDB(d db.DB) {
 	e.db = d
+	// Audit emission piggybacks on the same handle — one wiring point keeps
+	// the #45 footprint minimal. NewStore(nil) → nil → Emit is a no-op.
+	e.audit = audit.NewStore(d)
 }
 
 // SetSecrets wires the secrets chain into the engine. Required for the
@@ -2036,6 +2041,20 @@ func (e *Engine) startRun(spec *task.Spec, opts *pkgruntime.RunOptions, source r
 	if _, err = e.registry.StartRunWithID(context.Background(), opts.RunID, spec.ID, opts.ParentRunID, string(source), registry.RunKindTask); err != nil {
 		return nil, nil, fmt.Errorf("start run record: %w", err)
 	}
+
+	// Audit boundary (#45): one best-effort run_triggered event per run.
+	// actor_kind is the trigger source; actor_id is the parent run for
+	// chain/task-fired runs (empty for cron/webhook/manual).
+	e.audit.Emit(context.Background(), audit.Event{
+		EventType:  audit.EventRunTriggered,
+		ActorKind:  string(source),
+		ActorID:    opts.ParentRunID,
+		TargetKind: "task",
+		TargetID:   spec.ID,
+		Params:     audit.SanitizeParams(opts.Params),
+		RunID:      opts.RunID,
+		Allowed:    true,
+	})
 
 	// Best-effort input persistence. Failures do not block the run — the
 	// auto-fix loop (#234) handles missing inputs via ErrInputUnavailable.

--- a/pkg/trigger/engine_audit_actor_test.go
+++ b/pkg/trigger/engine_audit_actor_test.go
@@ -1,0 +1,102 @@
+package trigger
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/audit"
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
+)
+
+// newAuditActorEnv builds an engine with the audit store wired (SetDB) but no
+// executor — these tests only assert on the run_triggered event emitted by
+// startRun, which fires before dispatch, so the run itself failing with
+// "no executor" is irrelevant.
+func newAuditActorEnv(t *testing.T) (*Engine, *registry.Registry) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+	eng := New(reg, nil, zap.NewNop())
+	eng.SetDB(d)
+	return eng, reg
+}
+
+// fireAndWait fires the manual run and blocks until it reaches a terminal
+// state so the background goroutine cannot race the test's DB teardown.
+func fireAndWait(t *testing.T, eng *Engine, taskID, actor string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var runID string
+	var err error
+	if actor != "" {
+		runID, err = eng.FireManualWithActor(ctx, taskID, nil, actor)
+	} else {
+		runID, err = eng.FireManual(ctx, taskID, nil)
+	}
+	if err != nil {
+		t.Fatalf("fire %s: %v", taskID, err)
+	}
+	if _, err := eng.WaitRun(ctx, runID); err != nil {
+		t.Fatalf("WaitRun %s: %v", runID, err)
+	}
+	return runID
+}
+
+// TestFireManualWithActor_RecordsAuditActor verifies the run_triggered audit
+// event (#45) carries the operator principal: actor_id is the TriggerActor
+// for actor-carrying manual fires, and stays empty for plain FireManual
+// (where there is no parent run either).
+func TestFireManualWithActor_RecordsAuditActor(t *testing.T) {
+	eng, reg := newAuditActorEnv(t)
+	spec := &task.Spec{
+		ID:      "actor-task",
+		Name:    "actor-task",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Timeout: 5 * time.Second,
+		Enabled: true,
+	}
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	withActor := fireAndWait(t, eng, "actor-task", "203.0.113.7")
+	plain := fireAndWait(t, eng, "actor-task", "")
+
+	events, err := eng.audit.Query(context.Background(), audit.Filter{EventType: audit.EventRunTriggered})
+	if err != nil {
+		t.Fatalf("audit query: %v", err)
+	}
+	byRun := map[string]audit.Event{}
+	for _, ev := range events {
+		byRun[ev.RunID] = ev
+	}
+
+	ev, ok := byRun[withActor]
+	if !ok {
+		t.Fatalf("no run_triggered event for actor run %s", withActor)
+	}
+	if ev.ActorKind != string(registry.TriggerManual) {
+		t.Errorf("actor run actor_kind = %q, want %q", ev.ActorKind, registry.TriggerManual)
+	}
+	if ev.ActorID != "203.0.113.7" {
+		t.Errorf("actor run actor_id = %q, want %q", ev.ActorID, "203.0.113.7")
+	}
+
+	ev, ok = byRun[plain]
+	if !ok {
+		t.Fatalf("no run_triggered event for plain run %s", plain)
+	}
+	if ev.ActorID != "" {
+		t.Errorf("plain FireManual actor_id = %q, want empty", ev.ActorID)
+	}
+}

--- a/pkg/webui/apikeys.go
+++ b/pkg/webui/apikeys.go
@@ -170,6 +170,7 @@ func (s *Server) requireAPIKey(next http.Handler) http.Handler {
 		}
 		raw := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
 		if raw == "" || !s.apiKeys.validate(r.Context(), raw) {
+			s.auditDenied(r, "invalid or missing API key")
 			w.Header().Set("WWW-Authenticate", `Bearer realm="dicode"`)
 			jsonErr(w, "invalid or missing API key", http.StatusUnauthorized)
 			return

--- a/pkg/webui/audit_api.go
+++ b/pkg/webui/audit_api.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/dicode/dicode/pkg/audit"
+	"go.uber.org/zap"
 )
 
 // apiQueryAudit serves GET /api/audit?task_id=&actor=&event_type=&limit=&offset=
@@ -29,7 +30,7 @@ func (s *Server) apiQueryAudit(w http.ResponseWriter, r *http.Request) {
 		Offset:    offset,
 	})
 	if err != nil {
-		s.log.Error("audit query failed")
+		s.log.Error("audit query failed", zap.Error(err))
 		jsonErr(w, "audit query failed", http.StatusInternalServerError)
 		return
 	}

--- a/pkg/webui/audit_api.go
+++ b/pkg/webui/audit_api.go
@@ -1,0 +1,40 @@
+package webui
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/dicode/dicode/pkg/audit"
+)
+
+// apiQueryAudit serves GET /api/audit?task_id=&actor=&event_type=&limit=&offset=
+// — the paginated, filterable view over the security audit log (#45).
+// Registered inside the /api route group, so it sits behind requireAuth
+// like every other API route. Events are returned newest first; limit
+// defaults to 100 and is capped by the store.
+func (s *Server) apiQueryAudit(w http.ResponseWriter, r *http.Request) {
+	if s.audit == nil {
+		jsonErr(w, "audit log unavailable (no database)", http.StatusServiceUnavailable)
+		return
+	}
+	q := r.URL.Query()
+	limit, _ := strconv.Atoi(q.Get("limit"))
+	offset, _ := strconv.Atoi(q.Get("offset"))
+
+	events, err := s.audit.Query(r.Context(), audit.Filter{
+		TaskID:    q.Get("task_id"),
+		Actor:     q.Get("actor"),
+		EventType: q.Get("event_type"),
+		Limit:     limit,
+		Offset:    offset,
+	})
+	if err != nil {
+		s.log.Error("audit query failed")
+		jsonErr(w, "audit query failed", http.StatusInternalServerError)
+		return
+	}
+	jsonOK(w, map[string]any{
+		"events": events,
+		"count":  len(events),
+	})
+}

--- a/pkg/webui/audit_api_test.go
+++ b/pkg/webui/audit_api_test.go
@@ -1,0 +1,159 @@
+package webui
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/audit"
+	"github.com/dicode/dicode/pkg/config"
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/ipc"
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/trigger"
+	"go.uber.org/zap"
+)
+
+// newAuditTestServer builds a Server without the deno runtime so these
+// tests run on machines where the deno binary is unavailable.
+func newAuditTestServer(t *testing.T, cfg *config.Config) *Server {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+	eng := trigger.New(reg, nil, zap.NewNop())
+	srv, err := New(cfg.Server.Port, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return srv
+}
+
+func TestAudit_DeniedAuthEmitsEvent(t *testing.T) {
+	cfg := &config.Config{Server: config.ServerConfig{Port: 8080, Auth: true, BcryptCost: 4}}
+	srv := newAuditTestServer(t, cfg)
+	h := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks", nil)
+	req.RemoteAddr = "203.0.113.9:50000"
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+
+	events, err := srv.audit.Query(context.Background(), audit.Filter{EventType: audit.EventDenied})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d denied events, want 1", len(events))
+	}
+	ev := events[0]
+	if ev.Allowed {
+		t.Error("denied event must have allowed=false")
+	}
+	if ev.ActorKind != "ip" || ev.ActorID != "203.0.113.9" {
+		t.Errorf("actor: %s/%s", ev.ActorKind, ev.ActorID)
+	}
+	if ev.TargetKind != "endpoint" || ev.TargetID != "GET /api/tasks" {
+		t.Errorf("target: %s/%s", ev.TargetKind, ev.TargetID)
+	}
+}
+
+func TestAudit_NoEventWhenAuthDisabled(t *testing.T) {
+	cfg := &config.Config{Server: config.ServerConfig{Port: 8080}}
+	srv := newAuditTestServer(t, cfg)
+	h := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 with auth disabled, got %d", w.Code)
+	}
+	events, err := srv.audit.Query(context.Background(), audit.Filter{EventType: audit.EventDenied})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected no denied events with auth off, got %d", len(events))
+	}
+}
+
+func TestAPIAudit_QueryAndFilter(t *testing.T) {
+	cfg := &config.Config{Server: config.ServerConfig{Port: 8080}} // auth off → endpoint reachable
+	srv := newAuditTestServer(t, cfg)
+	h := srv.Handler()
+	ctx := context.Background()
+
+	seed := []audit.Event{
+		{EventType: audit.EventRunTriggered, ActorKind: "cron", TargetKind: "task", TargetID: "ns/a", RunID: "r1", Allowed: true},
+		{EventType: audit.EventTaskCalled, ActorKind: "task", ActorID: "ns/caller", TargetKind: "task", TargetID: "ns/b", Allowed: true},
+		{EventType: audit.EventTaskCalled, ActorKind: "task", ActorID: "ns/caller", TargetKind: "task", TargetID: "ns/a", Allowed: false, Reason: "denied"},
+	}
+	for i, ev := range seed {
+		if err := srv.audit.Append(ctx, ev); err != nil {
+			t.Fatalf("seed[%d]: %v", i, err)
+		}
+	}
+
+	get := func(url string) map[string]any {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET %s: status %d: %s", url, w.Code, w.Body.String())
+		}
+		var body map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("GET %s: bad JSON: %v", url, err)
+		}
+		return body
+	}
+
+	// Unfiltered.
+	body := get("/api/audit")
+	if int(body["count"].(float64)) != 3 {
+		t.Errorf("unfiltered count: %v", body["count"])
+	}
+
+	// task_id filter.
+	body = get("/api/audit?task_id=ns/a")
+	if int(body["count"].(float64)) != 2 {
+		t.Errorf("task_id filter count: %v", body["count"])
+	}
+
+	// actor filter.
+	body = get("/api/audit?actor=ns/caller")
+	if int(body["count"].(float64)) != 2 {
+		t.Errorf("actor filter count: %v", body["count"])
+	}
+
+	// combined + event_type.
+	body = get("/api/audit?actor=ns/caller&task_id=ns/a&event_type=task_called")
+	if int(body["count"].(float64)) != 1 {
+		t.Fatalf("combined filter count: %v", body["count"])
+	}
+	events := body["events"].([]any)
+	first := events[0].(map[string]any)
+	if first["reason"] != "denied" || first["allowed"] != false {
+		t.Errorf("combined filter event: %v", first)
+	}
+
+	// limit pagination.
+	body = get("/api/audit?limit=1")
+	if int(body["count"].(float64)) != 1 {
+		t.Errorf("limit=1 count: %v", body["count"])
+	}
+	body = get("/api/audit?limit=1&offset=2")
+	if int(body["count"].(float64)) != 1 {
+		t.Errorf("limit=1 offset=2 count: %v", body["count"])
+	}
+}

--- a/pkg/webui/audit_api_test.go
+++ b/pkg/webui/audit_api_test.go
@@ -6,12 +6,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/dicode/dicode/pkg/audit"
 	"github.com/dicode/dicode/pkg/config"
 	"github.com/dicode/dicode/pkg/db"
 	"github.com/dicode/dicode/pkg/ipc"
 	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
 	"github.com/dicode/dicode/pkg/trigger"
 	"go.uber.org/zap"
 )
@@ -83,6 +85,89 @@ func TestAudit_NoEventWhenAuthDisabled(t *testing.T) {
 	}
 	if len(events) != 0 {
 		t.Fatalf("expected no denied events with auth off, got %d", len(events))
+	}
+}
+
+// TestAPIAudit_ManualRunRecordsActor verifies the manual-run API path
+// (POST /api/tasks/{id}/run) stamps the operator principal — the session's
+// client IP — into the run_triggered audit event's actor_id (#45).
+func TestAPIAudit_ManualRunRecordsActor(t *testing.T) {
+	cfg := &config.Config{Server: config.ServerConfig{Port: 8080}} // auth off → endpoint reachable
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+	eng := trigger.New(reg, nil, zap.NewNop())
+	eng.SetDB(d) // wire the engine's audit store, as daemon.go does in production
+	srv, err := New(cfg.Server.Port, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := reg.Register(&task.Spec{
+		ID:      "actor-task",
+		Name:    "actor-task",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Timeout: 5 * time.Second,
+		Enabled: true,
+	}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/actor-task/run", nil)
+	req.RemoteAddr = "203.0.113.9:50000"
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("run: status %d: %s", w.Code, w.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("bad JSON: %v", err)
+	}
+
+	// Wait for the (executor-less, immediately failing) run to finish so its
+	// background goroutine cannot race the test's DB teardown.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := eng.WaitRun(ctx, body["runId"]); err != nil {
+		t.Fatalf("WaitRun: %v", err)
+	}
+
+	events, err := srv.audit.Query(ctx, audit.Filter{EventType: audit.EventRunTriggered})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d run_triggered events, want 1", len(events))
+	}
+	ev := events[0]
+	if ev.ActorKind != "manual" || ev.ActorID != "203.0.113.9" {
+		t.Errorf("actor: %s/%s, want manual/203.0.113.9", ev.ActorKind, ev.ActorID)
+	}
+	if ev.TargetKind != "task" || ev.TargetID != "actor-task" {
+		t.Errorf("target: %s/%s", ev.TargetKind, ev.TargetID)
+	}
+	if ev.RunID != body["runId"] {
+		t.Errorf("run_id: %s, want %s", ev.RunID, body["runId"])
+	}
+}
+
+// TestAPIAudit_RequiresAuth verifies GET /api/audit sits behind requireAuth:
+// with server.auth enabled, an unauthenticated request (no session, no
+// cookie) must be rejected with 401 instead of leaking audit events.
+func TestAPIAudit_RequiresAuth(t *testing.T) {
+	cfg := &config.Config{Server: config.ServerConfig{Port: 8080, Auth: true, BcryptCost: 4}}
+	srv := newAuditTestServer(t, cfg)
+	h := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/audit", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/pkg/webui/auth.go
+++ b/pkg/webui/auth.go
@@ -1,15 +1,31 @@
 package webui
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
 
+	"github.com/dicode/dicode/pkg/audit"
 	"github.com/dicode/dicode/pkg/ipc"
 	"github.com/dicode/dicode/pkg/task"
 	"go.uber.org/zap"
 )
+
+// auditDenied records a denied-auth event (#45). Best-effort and nil-safe;
+// uses a background context so a client disconnect cannot cancel the insert.
+func (s *Server) auditDenied(r *http.Request, reason string) {
+	s.audit.Emit(context.Background(), audit.Event{
+		EventType:  audit.EventDenied,
+		ActorKind:  "ip",
+		ActorID:    clientIP(r, s.cfg.Server.TrustProxy),
+		TargetKind: "endpoint",
+		TargetID:   r.Method + " " + r.URL.Path,
+		Allowed:    false,
+		Reason:     reason,
+	})
+}
 
 // webhookAuthGuard checks whether the task associated with the requested webhook
 // path has trigger.auth: true. If it does, and the request carries no valid
@@ -61,6 +77,8 @@ func (s *Server) webhookAuthGuard(w http.ResponseWriter, r *http.Request, next h
 		next.ServeHTTP(w, r)
 		return
 	}
+
+	s.auditDenied(r, "webhook requires authenticated session")
 
 	// For webhook paths, a GET from a browser includes "text/html" in Accept.
 	// API clients (curl, fetch without custom headers, etc.) typically don't,
@@ -140,6 +158,7 @@ func (s *Server) requireSessionOrAPIKey(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
+		s.auditDenied(r, "no valid session or API key")
 		w.Header().Set("WWW-Authenticate", `Bearer realm="dicode"`)
 		jsonErr(w, "unauthorized", http.StatusUnauthorized)
 	})
@@ -187,6 +206,7 @@ func (s *Server) requireAuth(next http.Handler) http.Handler {
 			}
 		}
 
+		s.auditDenied(r, "no valid session")
 		if isAPIRequest(r) {
 			jsonErr(w, "unauthorized", http.StatusUnauthorized)
 			return

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -1528,7 +1528,10 @@ func (s *Server) writePipelineDetail(w http.ResponseWriter, p *task.PipelineTask
 func (s *Server) apiRunTask(w http.ResponseWriter, r *http.Request) {
 	id := taskIDParam(r)
 	s.log.Info("run requested via API", zap.String("task", id))
-	runID, err := s.engine.FireManual(r.Context(), id, nil)
+	// Record the operator principal (the session's client IP — the best
+	// identity available under single-passphrase auth) so the run_triggered
+	// audit event (#45) can answer "who triggered this manual run".
+	runID, err := s.engine.FireManualWithActor(r.Context(), id, nil, clientIP(r, s.cfg.Server.TrustProxy))
 	if err != nil {
 		jsonErr(w, err.Error(), http.StatusBadRequest)
 		return

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/dicode/dicode/pkg/approval"
+	"github.com/dicode/dicode/pkg/audit"
 	"github.com/dicode/dicode/pkg/config"
 	"github.com/dicode/dicode/pkg/db"
 	"github.com/dicode/dicode/pkg/ipc"
@@ -163,6 +164,9 @@ type Server struct {
 	// (SetApprovalTokenStore); nil disables the /approve/{token} link flow.
 	approvalGate   ApprovalGate
 	approvalTokens *approval.TokenStore
+	// audit records denied-auth events and serves GET /api/audit (#45).
+	// Nil when no database is wired (tests); all emission is nil-safe.
+	audit *audit.Store
 }
 
 // SetReplayer wires a Replayer for the POST /api/runs/{runID}/replay
@@ -256,6 +260,7 @@ func New(port int, r *registry.Registry, eng *trigger.Engine, cfg *config.Config
 		gateway:           gateway,
 		csrfKey:           csrfKey,
 		db:                database,
+		audit:             audit.NewStore(database),
 	}
 
 	// Wire run started hook → broadcast run:started
@@ -516,6 +521,9 @@ func (s *Server) Handler() http.Handler {
 			// (group + task), per #116. /api/tasks/{id}/runs above remains
 			// the canonical "list a task's runs" endpoint.
 			r.Get("/runs", s.apiQueryRuns)
+
+			// Security audit log (#45) — protected by requireAuth above.
+			r.Get("/audit", s.apiQueryAudit)
 			r.Get("/runs/{runID}", s.apiGetRun)
 			r.Get("/runs/{runID}/logs", s.apiGetLogs)
 			r.Post("/runs/{runID}/kill", s.apiKillRun)
@@ -1037,6 +1045,7 @@ func (s *Server) apiSecretsUnlock(w http.ResponseWriter, r *http.Request) {
 	}
 	if src != passphraseSourceNone {
 		if !s.verifyPassphrase(r.Context(), password) {
+			s.auditDenied(r, "incorrect password")
 			s.loginError(w, r, "incorrect password", http.StatusUnauthorized, safeNext)
 			return
 		}


### PR DESCRIPTION
## Summary

Implements #45 — a structured audit log that records security-sensitive operations at the system's trust boundaries. Closes #45.

A new `audit_log` table captures who triggered what, which tasks/MCP tools were invoked (allowed **and** denied), and denied auth attempts — with secret/env values redacted.

## Design as built

**Emission boundaries** (the prompt assumed per-runtime `server.go` files + a `pkg/mcp` server; in this codebase both the Deno and Python runtimes dispatch `dicode.run_task`/`mcp.call` through the single shared `pkg/ipc/server.go`, and MCP `tools/call` arrives as `dicode.run_task` with `MCPContext=true` from the buildin/mcp task — so instrumenting `pkg/ipc` covers all those paths at once):

1. **`run_triggered`** — `trigger.Engine.startRun()`, the single choke point all sources (cron/webhook/manual/chain/daemon/replay) flow through. Surgical one-line emit + one struct field to minimize conflict surface against the open #393.
2. **`task_called`** — `pkg/ipc/server.go` `dicode.run_task`: emits on capability / `allowed_tasks` / MCP-exposure denials (allowed=false + reason) and on allowed fires (allowed=true + run_id). Covers Deno and Python identically.
3. **`mcp_called`** — `pkg/ipc/server.go`: the buildin/mcp `tools/call` forwarder and outbound `mcp.call` to external servers (emitted after authz, before the network round-trip).
4. **`denied`** — `pkg/webui`: `requireAuth`, `requireSessionOrAPIKey`, `requireAPIKey`, `webhookAuthGuard`, and failed passphrase logins.

**Sanitization** (`pkg/audit/sanitize.go`): params stored as deterministic JSON; values replaced with `[REDACTED]` when the key matches a deny-list (mirroring `pkg/registry/inputredact.go`) or the value is an `env:`/`secret:`/`secrets:` reference. Nested MCP args walked recursively with a depth cap.

**Schema / API / retention**:
- `audit_log` table via the existing `CREATE TABLE IF NOT EXISTS` migration in `pkg/db/sqlite.go` (no goose — #42 is not merged), with indexes on `(ts DESC)` and `(actor_id, ts DESC)`.
- `GET /api/audit?task_id=&actor=&event_type=&limit=&offset=` behind `requireAuth`, newest-first, limit capped at 1000.
- `audit_log.retention_days`: unset→30, 0→disabled, negative→config error. Daemon prunes at startup + every 6h.

## Test plan
- [x] `make build`, `go vet ./...`, `gofmt -l` clean
- [x] New `pkg/audit` / `pkg/config` / `pkg/db` / `pkg/ipc` / `pkg/webui` audit tests pass
- [x] 3 pre-existing failures (`TestControl_TaskTest_HappyPath`, `TestAPI_TestTask_Success`, `TestAPI_TestTask_SharedHelperInvariant`) fail identically on pristine `origin/main` — sandbox has no route to jsr.io for deno deps; unrelated to this change.

This PR is opened as a draft and will be driven through an automated security + code review loop before being marked ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJMqv1hzZzUZep13oyKrCD)_