### PR TITLE
test(deno): make task-test fixtures hermetic (drop jsr.io imports)

### DIFF
--- a/pkg/ipc/control_task_test_test.go
+++ b/pkg/ipc/control_task_test_test.go
@@ -32,20 +32,19 @@ func newControlServerForTaskTest(t *testing.T) (*ControlServer, *registry.Regist
 }
 
 // registerTaskWithTest writes a minimal Deno task + passing test file
-// into a fresh temp dir and registers it.
+// into a fresh temp dir and registers it. assertEquals is defined inline
+// rather than pulled in via tasks/sdk-test.ts (whose jsr:@std/yaml import
+// needs network access) — go test must pass offline.
 func registerTaskWithTest(t *testing.T, reg *registry.Registry, id string) *task.Spec {
 	t.Helper()
 	dir := t.TempDir()
 	_ = os.WriteFile(filepath.Join(dir, "task.yaml"), []byte("name: "+id+"\ntrigger:\n  manual: true\nruntime: deno\n"), 0644)
 	_ = os.WriteFile(filepath.Join(dir, "task.ts"), []byte(`export default async function main() { return { ok: true } }`+"\n"), 0644)
 	_ = os.WriteFile(filepath.Join(dir, "task.test.ts"), []byte(`
-import { setupHarness } from "`+repoRootTasks(t)+`/sdk-test.ts";
-await setupHarness(import.meta.url);
-
-test("smoke", async () => {
-  const r = await runTask();
-  assert.equal(r.ok, true);
-});
+function assertEquals(a: unknown, b: unknown) {
+  if (a !== b) throw new Error("assertEquals: " + String(a) + " !== " + String(b));
+}
+Deno.test("smoke", () => { assertEquals(1, 1); });
 `), 0644)
 
 	spec := &task.Spec{
@@ -60,27 +59,6 @@ test("smoke", async () => {
 		t.Fatalf("register: %v", err)
 	}
 	return spec
-}
-
-// repoRootTasks walks up from the CWD until it finds tasks/sdk-test.ts,
-// so the temp task's test file can import it. Keeps the test self-locating
-// regardless of where `go test` is invoked from.
-func repoRootTasks(t *testing.T) string {
-	t.Helper()
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	for dir := cwd; ; {
-		if _, err := os.Stat(filepath.Join(dir, "tasks", "sdk-test.ts")); err == nil {
-			return "file://" + filepath.Join(dir, "tasks")
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("could not find tasks/sdk-test.ts walking up from %s", cwd)
-		}
-		dir = parent
-	}
 }
 
 func TestControl_TaskTest_MissingTaskID(t *testing.T) {

--- a/pkg/webui/server_task_test_test.go
+++ b/pkg/webui/server_task_test_test.go
@@ -55,8 +55,12 @@ func registerTaskWithTest(t *testing.T, reg *registry.Registry, id, taskScript, 
 }
 
 // passingTest is the canonical Deno test fixture used by the success path.
+// assertEquals is defined inline rather than imported from jsr:@std/assert
+// so the fixture needs no network access — go test must pass offline.
 // Kept short so test runs stay snappy.
-const passingTest = `import { assertEquals } from "jsr:@std/assert@1";
+const passingTest = `function assertEquals(a: unknown, b: unknown) {
+  if (a !== b) throw new Error("assertEquals: " + String(a) + " !== " + String(b));
+}
 Deno.test("ok", () => { assertEquals(1, 1); });
 `
 


### PR DESCRIPTION
## Summary

Makes the Deno task-test unit-test fixtures **hermetic** so the Go suite passes with no network access to `jsr.io`. Pure test-fixture change — no production code touched.

## Problem

Three tests failed in any network-restricted environment (offline runs, sandboxes, Trusted-network CI/routines) because their inline Deno fixtures fetched `@std/*` from jsr.io at runtime:
- `pkg/webui`: `TestAPI_TestTask_Success`, `TestAPI_TestTask_SharedHelperInvariant` — `passingTest` imported `jsr:@std/assert@1`
- `pkg/ipc`: `TestControl_TaskTest_HappyPath` — fixture imported `tasks/sdk-test.ts`, which itself imports `jsr:@std/yaml@1`

Error: `JSR package manifest for '@std/...' failed to load`. The imports were incidental — the tests assert the task-test **harness** reports "1 passed", not that jsr imports work.

## Change

- `pkg/webui/server_task_test_test.go` — replace the `jsr:@std/assert` import in `passingTest` with an inline `assertEquals` (no network). Comment updated.
- `pkg/ipc/control_task_test_test.go` — replace the `sdk-test.ts`/harness import with the same inline `assertEquals` + a plain `Deno.test`; remove the now-unused `repoRootTasks` helper. The shipped `tasks/sdk-test.ts` is unchanged.

Repo-wide sweep confirmed no other Go test fixtures carry network imports; shipped examples under `tasks/` are intentionally left alone (CI exercises them with network).

## Test plan
- [x] `go test ./...` — **every package passes, offline** (previously 3 failed without jsr.io)
- [x] `make build`, `go vet ./...`, `gofmt -l` clean
- [x] The two previously-failing targeted runs now PASS with no network

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJMqv1hzZzUZep13oyKrCD)_