### PR TITLE
feat(runtime): enforce container security floor for docker/podman (#380)

### DIFF
--- a/docs/podman-runtime.md
+++ b/docs/podman-runtime.md
@@ -129,7 +129,26 @@ The `docker:` section supports container-isolation fields that map to podman CLI
 | `read_only` | `--read-only` |
 | `user` | `--user` |
 
-A startup warning is emitted for values that visibly weaken isolation — `network_mode: host`, `cap_add` of `SYS_ADMIN`/`SYS_PTRACE`/`SYS_MODULE`/`ALL`, and `security_opt` disabling seccomp/AppArmor/SELinux. The task still runs; the warning surfaces in the UI so reviewers notice.
+A startup warning is emitted for values that visibly weaken isolation — `network_mode: host`, `cap_add` of `SYS_ADMIN`/`SYS_PTRACE`/`SYS_MODULE`/`ALL`, and `security_opt` disabling seccomp/AppArmor/SELinux.
+
+On top of the warning, a **security floor is enforced at dispatch** (issue #380): the run is **aborted with an error** — in both the docker and podman runtimes — when a task requests a dangerous escape:
+
+- `network_mode: host` (or `container:<id>` / `ns:<path>`),
+- `cap_add` of escape-capable capabilities (`ALL`, `SYS_ADMIN`, `SYS_PTRACE`, `SYS_MODULE`, `NET_ADMIN`, `DAC_READ_SEARCH`, …),
+- `security_opt` that disables a kernel sandbox layer (`seccomp=unconfined`, `apparmor=unconfined`, `label=disable`, `systempaths=unconfined`, `unmask=…`),
+- bind mounts of sensitive host paths — `/`, `/proc`, `/sys`, `/etc`, `/dev`, `/run` (including the docker/podman control sockets), container-runtime state dirs — or sources that traverse (`..`/symlinks) into them.
+
+Operators opt in to specific escapes via the `container_security` block in `dicode.yaml`:
+
+```yaml
+container_security:
+  allow_host_network: true                  # permit network_mode: host
+  allow_insecure_security_opt: true         # permit seccomp/apparmor/label weakening
+  allowed_cap_add: [SYS_PTRACE]             # caps tasks may add despite the deny list ("ALL" = any)
+  allowed_volume_roots: [/srv/dicode-data]  # strict allowlist for bind-mount sources
+```
+
+When `allowed_volume_roots` is set, every bind-mount source must resolve inside one of the listed roots (an explicitly listed root also overrides the built-in sensitive-path denylist).
 
 See [Task Format → Container fields reference](./concepts/task-format.md#container-fields-reference) for the full schema and a hardened-defaults example.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dicode/dicode/pkg/runtime/containersec"
 	"github.com/dicode/dicode/pkg/task"
 	"github.com/dicode/dicode/pkg/taskset"
 	"gopkg.in/yaml.v3"
@@ -242,6 +243,46 @@ type Config struct {
 	Approval  ApprovalConfig           `yaml:"approval,omitempty"`
 	LogLevel  string                   `yaml:"log_level"`
 	DataDir   string                   `yaml:"data_dir"`
+	// ContainerSecurity is the operator opt-out for the container runtime
+	// security floor (issue #380). By default every dangerous host-config
+	// request from a task.yaml (host network namespace, dangerous cap_add,
+	// isolation-weakening security_opt, bind mounts of sensitive host paths)
+	// is rejected at dispatch; this block lets an operator explicitly allow
+	// specific escapes. Appended last to minimize merge conflicts.
+	ContainerSecurity ContainerSecurityConfig `yaml:"container_security,omitempty"`
+}
+
+// ContainerSecurityConfig configures the security floor enforced on
+// docker/podman task host configuration (issue #380). The zero value —
+// no block in dicode.yaml — denies everything dangerous.
+//
+// Example:
+//
+//	container_security:
+//	  allow_host_network: true                 # permit network_mode: host / container:<id>
+//	  allow_insecure_security_opt: false       # seccomp/apparmor/label/unmask weakening
+//	  allowed_cap_add: [SYS_PTRACE]            # caps tasks may add despite the deny list ("ALL" = any)
+//	  allowed_volume_roots: [/srv/dicode-data] # strict allowlist for bind-mount sources
+//
+// When allowed_volume_roots is non-empty, EVERY bind-mount source must
+// resolve (after symlink/".." cleaning) inside one of the listed roots;
+// an explicitly listed root also overrides the built-in sensitive-path
+// denylist (/, /proc, /sys, /etc, /dev, /run, the docker/podman sockets, …).
+type ContainerSecurityConfig struct {
+	AllowHostNetwork         bool     `yaml:"allow_host_network,omitempty"`
+	AllowInsecureSecurityOpt bool     `yaml:"allow_insecure_security_opt,omitempty"`
+	AllowedCapAdd            []string `yaml:"allowed_cap_add,omitempty"`
+	AllowedVolumeRoots       []string `yaml:"allowed_volume_roots,omitempty"`
+}
+
+// Policy converts the operator config into the runtime-enforced policy.
+func (c ContainerSecurityConfig) Policy() containersec.Policy {
+	return containersec.Policy{
+		AllowHostNetwork:         c.AllowHostNetwork,
+		AllowInsecureSecurityOpt: c.AllowInsecureSecurityOpt,
+		AllowedCapAdd:            c.AllowedCapAdd,
+		AllowedVolumeRoots:       c.AllowedVolumeRoots,
+	}
 }
 
 // DatabaseConfig selects the storage backend.
@@ -549,6 +590,19 @@ func (cfg *Config) validate() error {
 	for id, p := range cfg.Approval.Tasks {
 		if p.Trust != "" && p.Trust != "always" {
 			return fmt.Errorf("approval.tasks[%q].trust: must be \"always\" or unset, got %q", id, p.Trust)
+		}
+	}
+	// container_security (issue #380): roots must be absolute so the
+	// runtime's resolve-then-prefix check is well-defined; caps must be
+	// non-empty names.
+	for _, root := range cfg.ContainerSecurity.AllowedVolumeRoots {
+		if !filepath.IsAbs(root) {
+			return fmt.Errorf("container_security.allowed_volume_roots: %q must be an absolute path", root)
+		}
+	}
+	for _, c := range cfg.ContainerSecurity.AllowedCapAdd {
+		if strings.TrimSpace(c) == "" {
+			return fmt.Errorf("container_security.allowed_cap_add: entries must be non-empty capability names")
 		}
 	}
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -895,3 +895,79 @@ spec:
 		t.Errorf("AI.CreateSessionTTL = %v, want %v", cfg.AI.CreateSessionTTL, time.Hour)
 	}
 }
+
+// TestLoad_ContainerSecurity covers the issue #380 operator opt-out block:
+// default deny when absent, parsed values when present, and validation of
+// allowed_volume_roots / allowed_cap_add entries.
+func TestLoad_ContainerSecurity(t *testing.T) {
+	writeCfg := func(t *testing.T, body string) string {
+		t.Helper()
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "dicode.yaml")
+		content := `
+spec:
+  entries:
+    local:
+      ref:
+        path: ${CONFIGDIR}/tasks
+` + body
+		if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return cfgPath
+	}
+
+	t.Run("absent block is default deny", func(t *testing.T) {
+		cfg, err := Load(writeCfg(t, ""))
+		if err != nil {
+			t.Fatal(err)
+		}
+		p := cfg.ContainerSecurity.Policy()
+		if p.AllowHostNetwork || p.AllowInsecureSecurityOpt || len(p.AllowedCapAdd) != 0 || len(p.AllowedVolumeRoots) != 0 {
+			t.Errorf("absent container_security must yield the strict zero policy, got %+v", p)
+		}
+	})
+
+	t.Run("explicit opt-ins parse into the policy", func(t *testing.T) {
+		cfg, err := Load(writeCfg(t, `
+container_security:
+  allow_host_network: true
+  allow_insecure_security_opt: true
+  allowed_cap_add: [SYS_PTRACE, CAP_NET_ADMIN]
+  allowed_volume_roots: [/srv/dicode-data, /opt/shared]
+`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		p := cfg.ContainerSecurity.Policy()
+		if !p.AllowHostNetwork || !p.AllowInsecureSecurityOpt {
+			t.Errorf("booleans not propagated: %+v", p)
+		}
+		if len(p.AllowedCapAdd) != 2 || p.AllowedCapAdd[0] != "SYS_PTRACE" {
+			t.Errorf("AllowedCapAdd = %v", p.AllowedCapAdd)
+		}
+		if len(p.AllowedVolumeRoots) != 2 || p.AllowedVolumeRoots[0] != "/srv/dicode-data" {
+			t.Errorf("AllowedVolumeRoots = %v", p.AllowedVolumeRoots)
+		}
+	})
+
+	t.Run("relative allowed_volume_roots rejected", func(t *testing.T) {
+		_, err := Load(writeCfg(t, `
+container_security:
+  allowed_volume_roots: [relative/path]
+`))
+		if err == nil || !strings.Contains(err.Error(), "allowed_volume_roots") {
+			t.Errorf("expected allowed_volume_roots validation error, got %v", err)
+		}
+	})
+
+	t.Run("empty allowed_cap_add entry rejected", func(t *testing.T) {
+		_, err := Load(writeCfg(t, `
+container_security:
+  allowed_cap_add: ["", SYS_PTRACE]
+`))
+		if err == nil || !strings.Contains(err.Error(), "allowed_cap_add") {
+			t.Errorf("expected allowed_cap_add validation error, got %v", err)
+		}
+	})
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -540,6 +540,27 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	g.Go(func() error { return srv.Start(ctx) })
 	g.Go(func() error { return ctrlSrv.Start(ctx) })
 
+	// Best-effort container image GC (issue #380): reclaim dicode-built
+	// images whose task is gone or whose Dockerfile hash moved on. The
+	// first pass is delayed so the reconciler has populated the registry
+	// (an empty registry would treat every dicode image as orphaned);
+	// later passes run daily.
+	g.Go(func() error {
+		timer := time.NewTimer(2 * time.Minute)
+		defer timer.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-timer.C:
+			}
+			specs := reg.All()
+			dockerruntime.ReclaimOrphanedImages(ctx, log, specs)
+			podmanruntime.ReclaimOrphanedImages(ctx, log, specs)
+			timer.Reset(24 * time.Hour)
+		}
+	})
+
 	// Relay client now runs as the buildin/relay-client daemon task, which
 	// reconciler-launches automatically when cfg.Relay.Enabled = true.
 	// Daemon-level wiring (env vars + crypto handler) is set above; nothing
@@ -616,9 +637,19 @@ func buildRuntimes(
 		}
 	}
 
-	eng.RegisterExecutor(task.RuntimeDocker, dockerruntime.New(reg, log))
+	// Container security floor (issue #380): both container runtimes
+	// validate untrusted task host config against the operator policy
+	// before creating containers. The zero-value policy (no
+	// container_security block in dicode.yaml) denies every dangerous
+	// escape.
+	secPolicy := cfg.ContainerSecurity.Policy()
+
+	dockerRT := dockerruntime.New(reg, log)
+	dockerRT.SetPolicy(secPolicy)
+	eng.RegisterExecutor(task.RuntimeDocker, dockerRT)
 
 	podmanMgr := podmanruntime.New(reg, log)
+	podmanMgr.SetPolicy(secPolicy)
 	managed = append(managed, podmanMgr)
 	if podmanMgr.IsInstalled("") {
 		if p, err := podmanMgr.BinaryPath(""); err == nil {

--- a/pkg/runtime/containersec/policy.go
+++ b/pkg/runtime/containersec/policy.go
@@ -1,0 +1,258 @@
+// Package containersec enforces a security floor on container host
+// configuration coming from untrusted task.yaml files (issue #380).
+//
+// Task specs live in watched git repos: anyone who can push a task can
+// request arbitrary host config. PR #296 made network_mode, cap_add,
+// security_opt, volumes, read_only and user configurable per task; without
+// a floor, a malicious task escapes to the host trivially — bind-mount /,
+// mount the docker/podman control socket, join the host network namespace,
+// add CAP_SYS_ADMIN, or disable seccomp/AppArmor/SELinux.
+//
+// Validate rejects such configs before container creation, in both the
+// docker and podman runtimes. The zero-value Policy denies everything
+// dangerous (default-deny); operators opt in explicitly via the
+// container_security block in dicode.yaml (see pkg/config).
+package containersec
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// Policy describes which dangerous container host-config escapes an
+// operator has explicitly allowed. The zero value denies everything.
+type Policy struct {
+	// AllowHostNetwork permits network_mode values that join the host's (or
+	// another container's) network namespace: "host", "container:<id>",
+	// "ns:<path>".
+	AllowHostNetwork bool
+
+	// AllowInsecureSecurityOpt permits security_opt entries that disable a
+	// kernel sandbox layer: seccomp=unconfined, apparmor=unconfined,
+	// label=disable, systempaths=unconfined, unmask=…
+	AllowInsecureSecurityOpt bool
+
+	// AllowedCapAdd lists Linux capabilities (case-insensitive, with or
+	// without the CAP_ prefix) that tasks may cap_add even though they are
+	// on the dangerous list. "ALL" permits every capability, including
+	// cap_add: ["ALL"] itself.
+	AllowedCapAdd []string
+
+	// AllowedVolumeRoots lists host directories under which bind-mount
+	// sources are allowed. When non-empty the policy switches to strict
+	// allowlist mode: every bind-mount source must resolve — after symlink
+	// and ".." cleaning — inside one of these roots (an explicitly listed
+	// root overrides the built-in denylist). When empty (the default),
+	// bind mounts are allowed except for the built-in sensitive-path
+	// denylist: /, /proc, /sys, /etc, /dev, /boot, /root, /run, /var/run,
+	// container-runtime state dirs, and the docker/podman control sockets.
+	AllowedVolumeRoots []string
+}
+
+// dangerousCapAdd lists capabilities that enable container escape or host
+// tampering. Names are normalized (upper-case, no CAP_ prefix).
+var dangerousCapAdd = map[string]bool{
+	"ALL":             true,
+	"SYS_ADMIN":       true, // mount, namespaces — the classic escape cap
+	"SYS_PTRACE":      true, // trace/inject into host pids
+	"SYS_MODULE":      true, // load kernel modules
+	"SYS_RAWIO":       true, // raw device access
+	"SYS_BOOT":        true, // reboot the host
+	"SYS_TIME":        true, // change host clock
+	"NET_ADMIN":       true, // reconfigure host networking (with host netns)
+	"DAC_READ_SEARCH": true, // bypass read permission checks (open_by_handle_at escape)
+	"DAC_OVERRIDE":    true, // bypass file permission checks
+	"BPF":             true, // load eBPF programs
+	"SYSLOG":          true, // read kernel logs (kaslr leaks)
+}
+
+// sensitiveVolumeRoots are host paths (and everything under them) that must
+// never be bind-mounted into a task container unless the operator lists an
+// explicit allowed root that covers them.
+var sensitiveVolumeRoots = []string{
+	"/",
+	"/proc",
+	"/sys",
+	"/etc",
+	"/dev",
+	"/boot",
+	"/root",
+	"/run",     // docker.sock, podman.sock, dbus, sshd agent sockets, …
+	"/var/run", // symlink to /run on modern systems; listed for hosts where EvalSymlinks can't resolve it
+	"/var/lib/docker",
+	"/var/lib/containers",
+}
+
+// namedVolumeRe matches a docker/podman named volume (as opposed to a host
+// path bind mount). Named volumes are runtime-managed and safe.
+var namedVolumeRe = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*$`)
+
+// Validate checks the task's container host configuration against the
+// policy and returns an error describing every violation when the config
+// requests a dangerous escape that the operator has not allowed. A nil
+// DockerConfig validates trivially. Both the docker and podman runtimes
+// call this before creating a container; a non-nil error aborts the run.
+func Validate(cfg *task.DockerConfig, p Policy) error {
+	if cfg == nil {
+		return nil
+	}
+	var violations []string
+
+	if v := checkNetworkMode(cfg.NetworkMode, p); v != "" {
+		violations = append(violations, v)
+	}
+	violations = append(violations, checkCapAdd(cfg.CapAdd, p)...)
+	violations = append(violations, checkSecurityOpt(cfg.SecurityOpt, p)...)
+	violations = append(violations, checkVolumes(cfg.Volumes, p)...)
+
+	if len(violations) == 0 {
+		return nil
+	}
+	return fmt.Errorf("container security policy: %s — dangerous host config is denied by default; an operator can opt in via the container_security block in dicode.yaml",
+		strings.Join(violations, "; "))
+}
+
+func checkNetworkMode(mode string, p Policy) string {
+	m := strings.ToLower(strings.TrimSpace(mode))
+	dangerous := m == "host" || strings.HasPrefix(m, "container:") || strings.HasPrefix(m, "ns:")
+	if dangerous && !p.AllowHostNetwork {
+		return fmt.Sprintf("docker.network_mode %q joins a host/container namespace (allow with container_security.allow_host_network)", mode)
+	}
+	return ""
+}
+
+// NormalizeCap upper-cases a capability name and strips an optional CAP_
+// prefix so CAP_SYS_ADMIN, sys_admin and SYS_ADMIN compare equal.
+func NormalizeCap(c string) string {
+	return strings.TrimPrefix(strings.ToUpper(strings.TrimSpace(c)), "CAP_")
+}
+
+func checkCapAdd(caps []string, p Policy) []string {
+	allowed := make(map[string]bool, len(p.AllowedCapAdd))
+	for _, a := range p.AllowedCapAdd {
+		allowed[NormalizeCap(a)] = true
+	}
+	var violations []string
+	for _, c := range caps {
+		n := NormalizeCap(c)
+		if !dangerousCapAdd[n] {
+			continue
+		}
+		if allowed[n] || allowed["ALL"] {
+			continue
+		}
+		violations = append(violations, fmt.Sprintf("docker.cap_add %q can enable container escape (allow with container_security.allowed_cap_add)", c))
+	}
+	return violations
+}
+
+func checkSecurityOpt(opts []string, p Policy) []string {
+	var violations []string
+	for _, o := range opts {
+		// Docker historically accepted ":" as the key/value separator;
+		// normalize the first one to "=" so seccomp:unconfined is caught.
+		canon := strings.Replace(strings.ToLower(strings.TrimSpace(o)), ":", "=", 1)
+		dangerous := canon == "seccomp=unconfined" ||
+			canon == "apparmor=unconfined" ||
+			canon == "label=disable" ||
+			canon == "systempaths=unconfined" ||
+			strings.HasPrefix(canon, "unmask=")
+		if dangerous && !p.AllowInsecureSecurityOpt {
+			violations = append(violations, fmt.Sprintf("docker.security_opt %q disables a kernel sandbox layer (allow with container_security.allow_insecure_security_opt)", o))
+		}
+	}
+	return violations
+}
+
+func checkVolumes(volumes []string, p Policy) []string {
+	var violations []string
+	for _, v := range volumes {
+		if msg := checkVolume(v, p); msg != "" {
+			violations = append(violations, msg)
+		}
+	}
+	return violations
+}
+
+// checkVolume validates a single "source:container[:opts]" volume spec.
+// Returns "" when the spec is allowed, otherwise a violation message.
+func checkVolume(spec string, p Policy) string {
+	parts := strings.Split(spec, ":")
+	src := strings.TrimSpace(parts[0])
+	if len(parts) == 1 || src == "" {
+		// Anonymous volume ("/data") or malformed empty source — the
+		// runtime manages storage itself; no host path is exposed.
+		return ""
+	}
+	if !strings.HasPrefix(src, "/") {
+		if namedVolumeRe.MatchString(src) {
+			return "" // named volume, runtime-managed
+		}
+		// Relative path (./x, ../x, ~/x). Podman bind-mounts these relative
+		// to the daemon CWD — reject so traversal can't sidestep the
+		// absolute-path checks below.
+		return fmt.Sprintf("docker.volumes source %q is a relative host path; bind-mount sources must be absolute", src)
+	}
+
+	resolved := resolveHostPath(src)
+
+	if len(p.AllowedVolumeRoots) > 0 {
+		for _, root := range p.AllowedVolumeRoots {
+			if pathWithin(resolved, filepath.Clean(root)) {
+				return ""
+			}
+		}
+		return fmt.Sprintf("docker.volumes source %q (resolved %q) is outside the configured container_security.allowed_volume_roots", src, resolved)
+	}
+
+	for _, root := range sensitiveVolumeRoots {
+		// "/" only blocks bind-mounting the root itself; everything else
+		// blocks the path and its whole subtree.
+		if root == "/" {
+			if resolved == "/" {
+				return fmt.Sprintf("docker.volumes source %q bind-mounts the host root filesystem (allow specific paths with container_security.allowed_volume_roots)", src)
+			}
+			continue
+		}
+		if pathWithin(resolved, root) {
+			return fmt.Sprintf("docker.volumes source %q resolves to sensitive host path %q (allow explicitly with container_security.allowed_volume_roots)", src, resolved)
+		}
+	}
+	// Control sockets relocated outside the standard dirs (e.g. a custom
+	// DOCKER_HOST socket path) are still recognizable by name.
+	switch filepath.Base(resolved) {
+	case "docker.sock", "podman.sock":
+		return fmt.Sprintf("docker.volumes source %q resolves to a container-runtime control socket (%q)", src, resolved)
+	}
+	return ""
+}
+
+// resolveHostPath cleans ".." segments and resolves symlinks best-effort so
+// a source like /home/user/../../etc or a symlink pointing at /proc cannot
+// dodge the sensitive-path checks. Paths that do not exist on the host fall
+// back to the lexically cleaned form.
+func resolveHostPath(src string) string {
+	cleaned := filepath.Clean(src)
+	if !filepath.IsAbs(cleaned) {
+		if abs, err := filepath.Abs(cleaned); err == nil {
+			cleaned = abs
+		}
+	}
+	if resolved, err := filepath.EvalSymlinks(cleaned); err == nil {
+		return resolved
+	}
+	return cleaned
+}
+
+// pathWithin reports whether path equals root or lives inside root's subtree.
+// Both arguments must already be cleaned absolute paths.
+func pathWithin(path, root string) bool {
+	if root == "/" {
+		return true
+	}
+	return path == root || strings.HasPrefix(path, root+"/")
+}

--- a/pkg/runtime/containersec/policy.go
+++ b/pkg/runtime/containersec/policy.go
@@ -153,9 +153,12 @@ func checkCapAdd(caps []string, p Policy) []string {
 func checkSecurityOpt(opts []string, p Policy) []string {
 	var violations []string
 	for _, o := range opts {
-		// Docker historically accepted ":" as the key/value separator;
-		// normalize the first one to "=" so seccomp:unconfined is caught.
-		canon := strings.Replace(strings.ToLower(strings.TrimSpace(o)), ":", "=", 1)
+		// Canonicalize: lower-case, strip all internal whitespace (so
+		// "seccomp = unconfined" can't slip past the exact match), then
+		// normalize the first ":" to "=" (Docker historically accepted ":"
+		// as the key/value separator) so seccomp:unconfined is caught.
+		canon := strings.ReplaceAll(strings.ToLower(strings.TrimSpace(o)), " ", "")
+		canon = strings.Replace(canon, ":", "=", 1)
 		dangerous := canon == "seccomp=unconfined" ||
 			canon == "apparmor=unconfined" ||
 			canon == "label=disable" ||

--- a/pkg/runtime/containersec/policy_test.go
+++ b/pkg/runtime/containersec/policy_test.go
@@ -79,6 +79,11 @@ func TestValidate_DefaultDeny(t *testing.T) {
 			wantSub: "security_opt",
 		},
 		{
+			name:    "seccomp unconfined with internal whitespace",
+			cfg:     &task.DockerConfig{SecurityOpt: []string{"seccomp = unconfined"}},
+			wantSub: "security_opt",
+		},
+		{
 			name:    "apparmor unconfined",
 			cfg:     &task.DockerConfig{SecurityOpt: []string{"apparmor=unconfined"}},
 			wantSub: "security_opt",

--- a/pkg/runtime/containersec/policy_test.go
+++ b/pkg/runtime/containersec/policy_test.go
@@ -1,0 +1,351 @@
+package containersec
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+func TestValidate_NilConfig(t *testing.T) {
+	if err := Validate(nil, Policy{}); err != nil {
+		t.Fatalf("nil config must validate, got %v", err)
+	}
+}
+
+// TestValidate_DefaultDeny pins the security floor: every dangerous config
+// is rejected by the zero-value (default) policy.
+func TestValidate_DefaultDeny(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *task.DockerConfig
+		wantSub string // substring expected in the error
+	}{
+		{
+			name:    "host network",
+			cfg:     &task.DockerConfig{NetworkMode: "host"},
+			wantSub: "network_mode",
+		},
+		{
+			name:    "host network case-insensitive",
+			cfg:     &task.DockerConfig{NetworkMode: "HOST"},
+			wantSub: "network_mode",
+		},
+		{
+			name:    "container network namespace",
+			cfg:     &task.DockerConfig{NetworkMode: "container:abc"},
+			wantSub: "network_mode",
+		},
+		{
+			name:    "ns path network namespace",
+			cfg:     &task.DockerConfig{NetworkMode: "ns:/proc/1/ns/net"},
+			wantSub: "network_mode",
+		},
+		{
+			name:    "cap_add SYS_ADMIN",
+			cfg:     &task.DockerConfig{CapAdd: []string{"SYS_ADMIN"}},
+			wantSub: "cap_add",
+		},
+		{
+			name:    "cap_add CAP_ prefixed lowercase",
+			cfg:     &task.DockerConfig{CapAdd: []string{"cap_sys_admin"}},
+			wantSub: "cap_add",
+		},
+		{
+			name:    "cap_add SYS_PTRACE",
+			cfg:     &task.DockerConfig{CapAdd: []string{"SYS_PTRACE"}},
+			wantSub: "cap_add",
+		},
+		{
+			name:    "cap_add NET_ADMIN",
+			cfg:     &task.DockerConfig{CapAdd: []string{"NET_ADMIN"}},
+			wantSub: "cap_add",
+		},
+		{
+			name:    "cap_add ALL",
+			cfg:     &task.DockerConfig{CapAdd: []string{"ALL"}},
+			wantSub: "cap_add",
+		},
+		{
+			name:    "seccomp unconfined",
+			cfg:     &task.DockerConfig{SecurityOpt: []string{"seccomp=unconfined"}},
+			wantSub: "security_opt",
+		},
+		{
+			name:    "seccomp unconfined legacy colon separator",
+			cfg:     &task.DockerConfig{SecurityOpt: []string{"seccomp:unconfined"}},
+			wantSub: "security_opt",
+		},
+		{
+			name:    "apparmor unconfined",
+			cfg:     &task.DockerConfig{SecurityOpt: []string{"apparmor=unconfined"}},
+			wantSub: "security_opt",
+		},
+		{
+			name:    "selinux label disable",
+			cfg:     &task.DockerConfig{SecurityOpt: []string{"label=disable"}},
+			wantSub: "security_opt",
+		},
+		{
+			name:    "systempaths unconfined",
+			cfg:     &task.DockerConfig{SecurityOpt: []string{"systempaths=unconfined"}},
+			wantSub: "security_opt",
+		},
+		{
+			name:    "podman unmask",
+			cfg:     &task.DockerConfig{SecurityOpt: []string{"unmask=ALL"}},
+			wantSub: "security_opt",
+		},
+		{
+			name:    "bind mount host root",
+			cfg:     &task.DockerConfig{Volumes: []string{"/:/host"}},
+			wantSub: "volumes",
+		},
+		{
+			name:    "bind mount docker socket",
+			cfg:     &task.DockerConfig{Volumes: []string{"/var/run/docker.sock:/var/run/docker.sock"}},
+			wantSub: "volumes",
+		},
+		{
+			name:    "bind mount podman socket",
+			cfg:     &task.DockerConfig{Volumes: []string{"/run/podman/podman.sock:/sock"}},
+			wantSub: "volumes",
+		},
+		{
+			name:    "bind mount rootless podman socket",
+			cfg:     &task.DockerConfig{Volumes: []string{"/run/user/1000/podman/podman.sock:/sock"}},
+			wantSub: "volumes",
+		},
+		{
+			name:    "bind mount relocated docker socket by name",
+			cfg:     &task.DockerConfig{Volumes: []string{"/srv/sockets/docker.sock:/sock"}},
+			wantSub: "control socket",
+		},
+		{
+			name:    "bind mount /proc",
+			cfg:     &task.DockerConfig{Volumes: []string{"/proc:/host-proc"}},
+			wantSub: "volumes",
+		},
+		{
+			name:    "bind mount /sys",
+			cfg:     &task.DockerConfig{Volumes: []string{"/sys:/host-sys"}},
+			wantSub: "volumes",
+		},
+		{
+			name:    "bind mount /etc",
+			cfg:     &task.DockerConfig{Volumes: []string{"/etc:/host-etc:ro"}},
+			wantSub: "volumes",
+		},
+		{
+			name:    "bind mount under /etc",
+			cfg:     &task.DockerConfig{Volumes: []string{"/etc/shadow:/x:ro"}},
+			wantSub: "volumes",
+		},
+		{
+			name:    "bind mount docker state dir",
+			cfg:     &task.DockerConfig{Volumes: []string{"/var/lib/docker:/d"}},
+			wantSub: "volumes",
+		},
+		{
+			name:    "traversal escapes into /etc",
+			cfg:     &task.DockerConfig{Volumes: []string{"/srv/data/../../etc:/x"}},
+			wantSub: "volumes",
+		},
+		{
+			name:    "traversal to host root",
+			cfg:     &task.DockerConfig{Volumes: []string{"/srv/..:/x"}},
+			wantSub: "volumes",
+		},
+		{
+			name:    "relative bind mount source",
+			cfg:     &task.DockerConfig{Volumes: []string{"../secrets:/x"}},
+			wantSub: "relative",
+		},
+		{
+			name: "multiple violations all reported",
+			cfg: &task.DockerConfig{
+				NetworkMode: "host",
+				CapAdd:      []string{"SYS_ADMIN"},
+				Volumes:     []string{"/:/host"},
+			},
+			wantSub: "network_mode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Validate(tt.cfg, Policy{})
+			if err == nil {
+				t.Fatalf("expected rejection, got nil error")
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("error %q does not mention %q", err.Error(), tt.wantSub)
+			}
+		})
+	}
+}
+
+// TestValidate_OperatorOptIn pins that each dangerous config passes when the
+// operator explicitly allows it.
+func TestValidate_OperatorOptIn(t *testing.T) {
+	tests := []struct {
+		name   string
+		cfg    *task.DockerConfig
+		policy Policy
+	}{
+		{
+			name:   "host network allowed",
+			cfg:    &task.DockerConfig{NetworkMode: "host"},
+			policy: Policy{AllowHostNetwork: true},
+		},
+		{
+			name:   "cap_add allowed by list",
+			cfg:    &task.DockerConfig{CapAdd: []string{"SYS_PTRACE"}},
+			policy: Policy{AllowedCapAdd: []string{"sys_ptrace"}},
+		},
+		{
+			name:   "cap_add allowed with CAP_ prefix in policy",
+			cfg:    &task.DockerConfig{CapAdd: []string{"NET_ADMIN"}},
+			policy: Policy{AllowedCapAdd: []string{"CAP_NET_ADMIN"}},
+		},
+		{
+			name:   "cap_add ALL allowed when policy allows ALL",
+			cfg:    &task.DockerConfig{CapAdd: []string{"ALL", "SYS_ADMIN"}},
+			policy: Policy{AllowedCapAdd: []string{"ALL"}},
+		},
+		{
+			name:   "insecure security_opt allowed",
+			cfg:    &task.DockerConfig{SecurityOpt: []string{"seccomp=unconfined"}},
+			policy: Policy{AllowInsecureSecurityOpt: true},
+		},
+		{
+			name:   "bind mount inside allowed root",
+			cfg:    &task.DockerConfig{Volumes: []string{"/srv/shared/data:/data"}},
+			policy: Policy{AllowedVolumeRoots: []string{"/srv/shared"}},
+		},
+		{
+			name:   "allowed root overrides built-in denylist",
+			cfg:    &task.DockerConfig{Volumes: []string{"/etc/myapp:/cfg:ro"}},
+			policy: Policy{AllowedVolumeRoots: []string{"/etc/myapp"}},
+		},
+		{
+			name:   "allowed root slash allows everything",
+			cfg:    &task.DockerConfig{Volumes: []string{"/var/lib/docker:/d"}},
+			policy: Policy{AllowedVolumeRoots: []string{"/"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := Validate(tt.cfg, tt.policy); err != nil {
+				t.Errorf("expected pass with opt-in, got %v", err)
+			}
+		})
+	}
+}
+
+// TestValidate_PartialOptInStillDeniesOthers ensures opting in to one escape
+// does not loosen the rest of the floor.
+func TestValidate_PartialOptInStillDeniesOthers(t *testing.T) {
+	cfg := &task.DockerConfig{
+		NetworkMode: "host",
+		CapAdd:      []string{"SYS_ADMIN"},
+	}
+	err := Validate(cfg, Policy{AllowHostNetwork: true})
+	if err == nil {
+		t.Fatalf("cap_add SYS_ADMIN must still be rejected when only host network is allowed")
+	}
+	if strings.Contains(err.Error(), "network_mode") {
+		t.Errorf("allowed host network must not appear as a violation: %v", err)
+	}
+	if !strings.Contains(err.Error(), "cap_add") {
+		t.Errorf("expected cap_add violation in %v", err)
+	}
+}
+
+// TestValidate_SafeConfigsPass pins that ordinary configs are untouched by
+// the floor.
+func TestValidate_SafeConfigsPass(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *task.DockerConfig
+	}{
+		{name: "empty config", cfg: &task.DockerConfig{Image: "alpine"}},
+		{name: "bridge network", cfg: &task.DockerConfig{NetworkMode: "bridge"}},
+		{name: "none network", cfg: &task.DockerConfig{NetworkMode: "none"}},
+		{name: "custom network", cfg: &task.DockerConfig{NetworkMode: "my-net"}},
+		{name: "benign cap_add", cfg: &task.DockerConfig{CapAdd: []string{"NET_BIND_SERVICE", "CHOWN"}}},
+		{name: "cap_drop ALL", cfg: &task.DockerConfig{CapDrop: []string{"ALL"}}},
+		{name: "hardening security_opt", cfg: &task.DockerConfig{SecurityOpt: []string{"no-new-privileges:true"}}},
+		{name: "named volume", cfg: &task.DockerConfig{Volumes: []string{"mydata:/data"}}},
+		{name: "named volume with opts", cfg: &task.DockerConfig{Volumes: []string{"my_vol.2:/data:ro"}}},
+		{name: "anonymous volume", cfg: &task.DockerConfig{Volumes: []string{"/data"}}},
+		{name: "benign bind mount", cfg: &task.DockerConfig{Volumes: []string{"/srv/app-data:/data:ro"}}},
+		{name: "read only and user", cfg: &task.DockerConfig{ReadOnly: true, User: "65532:65532"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := Validate(tt.cfg, Policy{}); err != nil {
+				t.Errorf("safe config rejected: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidate_SymlinkEscape ensures a symlink inside an allowed root that
+// points at a sensitive path is resolved before the allow-root check.
+func TestValidate_SymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	link := filepath.Join(root, "etc-link")
+	if err := os.Symlink("/etc", link); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	cfg := &task.DockerConfig{Volumes: []string{link + ":/x"}}
+
+	// Allowlist mode: the symlink resolves to /etc, outside the allowed root.
+	err := Validate(cfg, Policy{AllowedVolumeRoots: []string{root}})
+	if err == nil {
+		t.Fatalf("symlink escaping the allowed root must be rejected")
+	}
+
+	// Denylist mode: the symlink resolves to /etc, which is sensitive.
+	err = Validate(cfg, Policy{})
+	if err == nil {
+		t.Fatalf("symlink pointing at /etc must be rejected by the default denylist")
+	}
+}
+
+// TestValidate_TraversalOutsideAllowedRoot covers ".." escapes when
+// allowed_volume_roots is configured.
+func TestValidate_TraversalOutsideAllowedRoot(t *testing.T) {
+	cfg := &task.DockerConfig{Volumes: []string{"/srv/shared/../../etc/shadow:/x"}}
+	err := Validate(cfg, Policy{AllowedVolumeRoots: []string{"/srv/shared"}})
+	if err == nil {
+		t.Fatalf("traversal escaping the allowed root must be rejected")
+	}
+
+	// A sibling directory that merely shares the root as a string prefix
+	// must not pass ("/srv/shared-evil" is not within "/srv/shared").
+	cfg = &task.DockerConfig{Volumes: []string{"/srv/shared-evil/data:/x"}}
+	if err := Validate(cfg, Policy{AllowedVolumeRoots: []string{"/srv/shared"}}); err == nil {
+		t.Fatalf("string-prefix sibling of an allowed root must be rejected")
+	}
+}
+
+func TestNormalizeCap(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"SYS_ADMIN", "SYS_ADMIN"},
+		{"sys_admin", "SYS_ADMIN"},
+		{"CAP_SYS_ADMIN", "SYS_ADMIN"},
+		{"cap_net_admin", "NET_ADMIN"},
+		{" all ", "ALL"},
+	}
+	for _, tt := range tests {
+		if got := NormalizeCap(tt.in); got != tt.want {
+			t.Errorf("NormalizeCap(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/pkg/runtime/docker/docker.go
+++ b/pkg/runtime/docker/docker.go
@@ -8,7 +8,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -19,6 +18,8 @@ import (
 
 	"github.com/dicode/dicode/pkg/registry"
 	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+	"github.com/dicode/dicode/pkg/runtime/containersec"
+	"github.com/dicode/dicode/pkg/runtime/imagegc"
 	"github.com/dicode/dicode/pkg/task"
 	dockerbuild "github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
@@ -45,12 +46,19 @@ type RunResult struct {
 type Runtime struct {
 	registry *registry.Registry
 	log      *zap.Logger
+	// policy is the container host-config security floor (issue #380).
+	// The zero value is the strict default: every dangerous escape denied.
+	policy containersec.Policy
 }
 
 // New creates a Docker Runtime.
 func New(r *registry.Registry, log *zap.Logger) *Runtime {
 	return &Runtime{registry: r, log: log}
 }
+
+// SetPolicy installs the operator-configured container security policy.
+// Call before the first Run; without it the strict default applies.
+func (rt *Runtime) SetPolicy(p containersec.Policy) { rt.policy = p }
 
 // fail marks a run as failed and returns the result.
 func (rt *Runtime) fail(runID string, err error) (*RunResult, error) {
@@ -72,6 +80,16 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	defer dc.Close()
 
 	cfg := spec.Docker
+
+	// Security floor (issue #380): task.yaml is untrusted input. Reject
+	// dangerous host config (host network namespace, dangerous cap_add,
+	// isolation-weakening security_opt, bind mounts of sensitive host paths)
+	// before any image is built or any container is created, unless the
+	// operator opted in via container_security in dicode.yaml.
+	if err := containersec.Validate(cfg, rt.policy); err != nil {
+		_ = rt.registry.AppendLog(ctx, runID, "error", err.Error())
+		return rt.fail(runID, err)
+	}
 
 	// Resolve the image: build from Dockerfile or pull.
 	imageTag := cfg.Image
@@ -246,8 +264,7 @@ func (rt *Runtime) buildImage(ctx context.Context, dc *dockerclient.Client, spec
 	if err != nil {
 		return "", fmt.Errorf("read Dockerfile: %w", err)
 	}
-	h := sha256.Sum256(content)
-	tag := fmt.Sprintf("dicode-%s:%x", spec.ID, h[:6])
+	tag := imagegc.Tag(spec.ID, content)
 
 	// Cache hit: image with this tag already exists.
 	if _, _, err := dc.ImageInspectWithRaw(ctx, tag); err == nil {

--- a/pkg/runtime/docker/imagegc.go
+++ b/pkg/runtime/docker/imagegc.go
@@ -1,0 +1,65 @@
+package docker
+
+import (
+	"context"
+	"strings"
+
+	"github.com/dicode/dicode/pkg/runtime/imagegc"
+	"github.com/dicode/dicode/pkg/task"
+	"github.com/docker/docker/api/types/image"
+	dockerclient "github.com/docker/docker/client"
+	"go.uber.org/zap"
+)
+
+// ReclaimOrphanedImages removes locally built dicode-<taskID>:<hash> images
+// that no longer correspond to a registered task with that Dockerfile hash
+// (issue #380 / TODO in pkg/task/spec.go). Best effort: if Docker is
+// unavailable or an image is still in use, the function logs and moves on.
+// specs should be the registry's current task list (registry.All()).
+func ReclaimOrphanedImages(ctx context.Context, log *zap.Logger, specs []*task.Spec) {
+	dc, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithAPIVersionNegotiation())
+	if err != nil {
+		log.Debug("docker unavailable, skipping image GC", zap.Error(err))
+		return
+	}
+	defer dc.Close()
+
+	list, err := dc.ImageList(ctx, image.ListOptions{})
+	if err != nil {
+		log.Debug("docker image list failed, skipping image GC", zap.Error(err))
+		return
+	}
+
+	var candidates []imagegc.Candidate
+	for _, summary := range list {
+		for _, repoTag := range summary.RepoTags {
+			repo, tag, ok := splitRepoTag(repoTag)
+			if !ok {
+				continue
+			}
+			candidates = append(candidates, imagegc.Candidate{Repository: repo, Tag: tag})
+		}
+	}
+
+	current, skip := imagegc.CurrentTags(specs)
+	orphans := imagegc.SelectOrphans(candidates, current, skip)
+	for _, ref := range orphans {
+		// No Force: an image backing a running container fails removal,
+		// which is exactly the safe behaviour we want.
+		if _, err := dc.ImageRemove(ctx, ref, image.RemoveOptions{PruneChildren: true}); err != nil {
+			log.Debug("could not remove orphaned dicode image", zap.String("image", ref), zap.Error(err))
+			continue
+		}
+		log.Info("reclaimed orphaned dicode image", zap.String("image", ref))
+	}
+}
+
+// splitRepoTag splits "repo:tag" at the last colon that belongs to the tag
+// (a colon followed by a "/" is a registry port, not a tag separator).
+func splitRepoTag(ref string) (repo, tag string, ok bool) {
+	i := strings.LastIndex(ref, ":")
+	if i < 0 || strings.Contains(ref[i+1:], "/") {
+		return "", "", false
+	}
+	return ref[:i], ref[i+1:], true
+}

--- a/pkg/runtime/imagegc/imagegc.go
+++ b/pkg/runtime/imagegc/imagegc.go
@@ -1,0 +1,104 @@
+// Package imagegc selects orphaned dicode-built container images for
+// garbage collection.
+//
+// The docker and podman runtimes build local task images tagged
+// "dicode-<taskID>:<dockerfile-hash>" (see Tag). When a task is removed or
+// its Dockerfile changes, the previously built image lingers forever —
+// the TODOs in pkg/task/spec.go and pkg/runtime/podman/runtime.go.
+//
+// This package holds the pure, unit-testable selection logic; the
+// runtime-specific reclaim wiring (docker SDK / podman CLI calls) lives in
+// pkg/runtime/docker and pkg/runtime/podman and is best-effort.
+package imagegc
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// Repository returns the image repository used for a task's locally built
+// image: "dicode-<taskID>".
+func Repository(taskID string) string { return "dicode-" + taskID }
+
+// TagSuffix returns the tag component derived from Dockerfile content.
+func TagSuffix(dockerfile []byte) string {
+	h := sha256.Sum256(dockerfile)
+	return fmt.Sprintf("%x", h[:6])
+}
+
+// Tag returns the full image reference for a task's locally built image:
+// "dicode-<taskID>:<hash>". Both container runtimes use this when building,
+// so GC selection and build caching can never disagree on the format.
+func Tag(taskID string, dockerfile []byte) string {
+	return Repository(taskID) + ":" + TagSuffix(dockerfile)
+}
+
+// Candidate is one locally present image, as listed by the container runtime.
+type Candidate struct {
+	Repository string // e.g. "dicode-mytask" or "localhost/dicode-mytask"
+	Tag        string // e.g. "a1b2c3d4e5f6"
+}
+
+// CurrentTags computes, for every registered task that builds a local image,
+// the repository → expected-tag mapping currently in use.
+//
+// Tasks whose Dockerfile cannot be read land in skip instead — their images
+// are never collected (fail safe: a transient read error must not delete an
+// image that may still be in use).
+func CurrentTags(specs []*task.Spec) (current map[string]string, skip map[string]bool) {
+	current = make(map[string]string)
+	skip = make(map[string]bool)
+	for _, spec := range specs {
+		if spec == nil || spec.Docker == nil || spec.Docker.Build == nil {
+			continue
+		}
+		if spec.Runtime != task.RuntimeDocker && spec.Runtime != task.RuntimePodman {
+			continue
+		}
+		repo := Repository(spec.ID)
+		dockerfilePath, _ := spec.Docker.Build.ResolvePaths(spec.TaskDir)
+		content, err := os.ReadFile(dockerfilePath) //nolint:gosec
+		if err != nil {
+			skip[repo] = true
+			continue
+		}
+		current[repo] = TagSuffix(content)
+	}
+	return current, skip
+}
+
+// SelectOrphans returns the references ("repository:tag", as listed) of
+// dicode-built images that are orphaned and safe to remove:
+//
+//   - the repository is "dicode-*" (or "localhost/dicode-*", podman's local
+//     prefix) — images from real registries are never touched, even if the
+//     basename happens to start with "dicode-";
+//   - the repository is not in skip (Dockerfile unreadable → keep all);
+//   - no registered task currently expects this exact tag — either the task
+//     is gone, or its Dockerfile hash moved on.
+//
+// Untagged ("<none>") images are left for the runtime's own prune tooling.
+func SelectOrphans(images []Candidate, current map[string]string, skip map[string]bool) []string {
+	var orphans []string
+	for _, img := range images {
+		repo := strings.TrimPrefix(img.Repository, "localhost/")
+		if !strings.HasPrefix(repo, "dicode-") {
+			continue
+		}
+		if img.Tag == "" || img.Tag == "<none>" {
+			continue
+		}
+		if skip[repo] {
+			continue
+		}
+		if expected, ok := current[repo]; ok && expected == img.Tag {
+			continue
+		}
+		orphans = append(orphans, img.Repository+":"+img.Tag)
+	}
+	return orphans
+}

--- a/pkg/runtime/imagegc/imagegc_test.go
+++ b/pkg/runtime/imagegc/imagegc_test.go
@@ -1,0 +1,158 @@
+package imagegc
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+func TestTag_Format(t *testing.T) {
+	dockerfile := []byte("FROM alpine\n")
+	tag := Tag("mytask", dockerfile)
+	want := Repository("mytask") + ":" + TagSuffix(dockerfile)
+	if tag != want {
+		t.Errorf("Tag = %q, want %q", tag, want)
+	}
+	if Repository("mytask") != "dicode-mytask" {
+		t.Errorf("Repository = %q", Repository("mytask"))
+	}
+	if len(TagSuffix(dockerfile)) != 12 { // 6 bytes hex-encoded
+		t.Errorf("TagSuffix length = %d, want 12", len(TagSuffix(dockerfile)))
+	}
+	// Same content → same tag; different content → different tag.
+	if Tag("mytask", dockerfile) != tag {
+		t.Errorf("Tag not deterministic")
+	}
+	if Tag("mytask", []byte("FROM debian\n")) == tag {
+		t.Errorf("different Dockerfile content must yield a different tag")
+	}
+}
+
+func TestSelectOrphans(t *testing.T) {
+	current := map[string]string{
+		"dicode-alive":   "aaaaaaaaaaaa",
+		"dicode-rotated": "bbbbbbbbbbbb",
+	}
+	skip := map[string]bool{
+		"dicode-unreadable": true,
+	}
+	images := []Candidate{
+		{Repository: "dicode-alive", Tag: "aaaaaaaaaaaa"},             // in use → keep
+		{Repository: "dicode-alive", Tag: "000000000000"},             // stale hash → orphan
+		{Repository: "localhost/dicode-rotated", Tag: "cccccc"},       // stale hash, podman prefix → orphan
+		{Repository: "localhost/dicode-rotated", Tag: "bbbbbbbbbbbb"}, // current, podman prefix → keep
+		{Repository: "dicode-removed", Tag: "dddddddddddd"},           // task gone → orphan
+		{Repository: "dicode-unreadable", Tag: "eeeeeeeeeeee"},        // Dockerfile unreadable → keep (fail safe)
+		{Repository: "dicode-alive", Tag: "<none>"},                   // dangling → leave for prune
+		{Repository: "dicode-alive", Tag: ""},                         // malformed → leave
+		{Repository: "alpine", Tag: "latest"},                         // not ours → keep
+		{Repository: "someorg/dicode-tool", Tag: "v1"},                // registry image with dicode- basename → keep
+		{Repository: "docker.io/library/redis", Tag: "7"},             // not ours → keep
+	}
+
+	got := SelectOrphans(images, current, skip)
+	want := []string{
+		"dicode-alive:000000000000",
+		"localhost/dicode-rotated:cccccc",
+		"dicode-removed:dddddddddddd",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("SelectOrphans = %v, want %v", got, want)
+	}
+}
+
+func TestSelectOrphans_EmptyInputs(t *testing.T) {
+	if got := SelectOrphans(nil, nil, nil); len(got) != 0 {
+		t.Errorf("expected no orphans for empty input, got %v", got)
+	}
+	// No registered tasks at all: every dicode-* image is orphaned.
+	got := SelectOrphans([]Candidate{{Repository: "dicode-x", Tag: "abc"}}, map[string]string{}, map[string]bool{})
+	if len(got) != 1 || got[0] != "dicode-x:abc" {
+		t.Errorf("expected dicode-x:abc orphaned, got %v", got)
+	}
+}
+
+func TestCurrentTags(t *testing.T) {
+	dir := t.TempDir()
+
+	buildTask := filepath.Join(dir, "buildtask")
+	if err := os.MkdirAll(buildTask, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dockerfile := []byte("FROM alpine\nRUN echo hi\n")
+	if err := os.WriteFile(filepath.Join(buildTask, "Dockerfile"), dockerfile, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	specs := []*task.Spec{
+		nil, // tolerated
+		{ // docker build task → contributes to current
+			ID:      "buildtask",
+			Runtime: task.RuntimeDocker,
+			TaskDir: buildTask,
+			Docker:  &task.DockerConfig{Build: &task.DockerBuild{}},
+		},
+		{ // podman build task with missing Dockerfile → skip (fail safe)
+			ID:      "broken",
+			Runtime: task.RuntimePodman,
+			TaskDir: filepath.Join(dir, "does-not-exist"),
+			Docker:  &task.DockerConfig{Build: &task.DockerBuild{}},
+		},
+		{ // image-based task → no local build, ignored
+			ID:      "pulled",
+			Runtime: task.RuntimeDocker,
+			Docker:  &task.DockerConfig{Image: "alpine"},
+		},
+		{ // deno task → ignored
+			ID:      "script",
+			Runtime: task.RuntimeDeno,
+		},
+	}
+
+	current, skip := CurrentTags(specs)
+
+	if got, want := current["dicode-buildtask"], TagSuffix(dockerfile); got != want {
+		t.Errorf("current[dicode-buildtask] = %q, want %q", got, want)
+	}
+	if !skip["dicode-broken"] {
+		t.Errorf("unreadable Dockerfile must land in skip; skip=%v", skip)
+	}
+	if _, ok := current["dicode-pulled"]; ok {
+		t.Errorf("image-based task must not contribute a current tag")
+	}
+	if len(current) != 1 {
+		t.Errorf("unexpected current map: %v", current)
+	}
+}
+
+// TestCurrentTags_SelectOrphans_EndToEnd ties the two halves together: after
+// a Dockerfile change, the old tag is orphaned and the new tag is kept.
+func TestCurrentTags_SelectOrphans_EndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM alpine:3.20\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	spec := &task.Spec{
+		ID:      "web",
+		Runtime: task.RuntimePodman,
+		TaskDir: dir,
+		Docker:  &task.DockerConfig{Build: &task.DockerBuild{}},
+	}
+
+	oldTag := TagSuffix([]byte("FROM alpine:3.19\n"))
+	newTag := TagSuffix([]byte("FROM alpine:3.20\n"))
+
+	current, skip := CurrentTags([]*task.Spec{spec})
+	images := []Candidate{
+		{Repository: "localhost/dicode-web", Tag: oldTag},
+		{Repository: "localhost/dicode-web", Tag: newTag},
+	}
+	got := SelectOrphans(images, current, skip)
+	want := []string{"localhost/dicode-web:" + oldTag}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("SelectOrphans = %v, want %v", got, want)
+	}
+}

--- a/pkg/runtime/podman/argv.go
+++ b/pkg/runtime/podman/argv.go
@@ -1,0 +1,108 @@
+package podman
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// envNameRe matches a sane environment variable name. Anything else —
+// in particular names containing "=" — would let a task smuggle extra
+// KEY=VALUE pairs through the single "-e", k+"="+v argv token.
+var envNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// validateArgvSafety rejects task-controlled values that could corrupt the
+// podman CLI invocation built by buildArgs (issue #380).
+//
+// exec.Command passes each slice element as one argv entry, so classic shell
+// injection is impossible. The remaining hazards are targeted here:
+//
+//   - the image reference is the first positional argument after the flags;
+//     a value starting with "-" would be parsed as a podman flag,
+//   - NUL bytes make execve fail with a cryptic error (and signal tampering),
+//   - CR/LF in single-token flag values (ports, volumes, hosts, caps,
+//     security opts, network, workdir, user) have no legitimate use and
+//     make injected values hard to spot in logs,
+//   - env var names must be well-formed so "-e NAME=VALUE" stays one pair.
+func validateArgvSafety(cfg *task.DockerConfig, imageRef string) error {
+	if imageRef == "" {
+		return fmt.Errorf("podman argv: image reference is empty")
+	}
+	if strings.HasPrefix(imageRef, "-") {
+		return fmt.Errorf("podman argv: image reference %q starts with '-' and would be parsed as a flag", imageRef)
+	}
+	if strings.ContainsAny(imageRef, "\x00\n\r\t ") {
+		return fmt.Errorf("podman argv: image reference %q contains whitespace or control characters", imageRef)
+	}
+
+	checkToken := func(field, v string) error {
+		if strings.ContainsAny(v, "\x00\n\r") {
+			return fmt.Errorf("podman argv: docker.%s value %q contains control characters", field, v)
+		}
+		return nil
+	}
+	for _, v := range cfg.Ports {
+		if err := checkToken("ports", v); err != nil {
+			return err
+		}
+	}
+	for _, v := range cfg.Volumes {
+		if err := checkToken("volumes", v); err != nil {
+			return err
+		}
+	}
+	for _, v := range cfg.ExtraHosts {
+		if err := checkToken("extra_hosts", v); err != nil {
+			return err
+		}
+	}
+	for _, v := range cfg.CapAdd {
+		if err := checkToken("cap_add", v); err != nil {
+			return err
+		}
+	}
+	for _, v := range cfg.CapDrop {
+		if err := checkToken("cap_drop", v); err != nil {
+			return err
+		}
+	}
+	for _, v := range cfg.SecurityOpt {
+		if err := checkToken("security_opt", v); err != nil {
+			return err
+		}
+	}
+	for _, fv := range []struct{ field, value string }{
+		{"network_mode", cfg.NetworkMode},
+		{"working_dir", cfg.WorkingDir},
+		{"user", cfg.User},
+	} {
+		if err := checkToken(fv.field, fv.value); err != nil {
+			return err
+		}
+	}
+
+	for k, v := range cfg.EnvVars {
+		if !envNameRe.MatchString(k) {
+			return fmt.Errorf("podman argv: docker.env_vars key %q is not a valid environment variable name", k)
+		}
+		if strings.ContainsRune(v, '\x00') {
+			return fmt.Errorf("podman argv: docker.env_vars[%s] value contains a NUL byte", k)
+		}
+	}
+
+	// Command and entrypoint tokens land after the image reference, where
+	// podman hands them to the container verbatim — only NUL is fatal.
+	for _, v := range cfg.Command {
+		if strings.ContainsRune(v, '\x00') {
+			return fmt.Errorf("podman argv: docker.command token %q contains a NUL byte", v)
+		}
+	}
+	for _, v := range cfg.Entrypoint {
+		if strings.ContainsRune(v, '\x00') {
+			return fmt.Errorf("podman argv: docker.entrypoint token %q contains a NUL byte", v)
+		}
+	}
+	return nil
+}

--- a/pkg/runtime/podman/imagegc.go
+++ b/pkg/runtime/podman/imagegc.go
@@ -1,0 +1,59 @@
+package podman
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+
+	podmanpkg "github.com/dicode/dicode/pkg/podman"
+	"github.com/dicode/dicode/pkg/runtime/imagegc"
+	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
+)
+
+// ReclaimOrphanedImages removes locally built dicode-<taskID>:<hash> images
+// that no longer correspond to a registered task with that Dockerfile hash
+// (issue #380 / the long-standing build-cache TODO). Best effort: if podman
+// is unavailable or an image is still in use, the function logs and moves
+// on. specs should be the registry's current task list (registry.All()).
+func ReclaimOrphanedImages(ctx context.Context, log *zap.Logger, specs []*task.Spec) {
+	podmanPath, err := podmanpkg.BinaryPath()
+	if err != nil {
+		log.Debug("podman unavailable, skipping image GC", zap.Error(err))
+		return
+	}
+
+	listCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(listCtx, podmanPath, "images", //nolint:gosec
+		"--format", "{{.Repository}}|{{.Tag}}",
+	).Output()
+	if err != nil {
+		log.Debug("podman image list failed, skipping image GC", zap.Error(err))
+		return
+	}
+
+	var candidates []imagegc.Candidate
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		repo, tag, ok := strings.Cut(strings.TrimSpace(line), "|")
+		if !ok || repo == "" {
+			continue
+		}
+		candidates = append(candidates, imagegc.Candidate{Repository: repo, Tag: tag})
+	}
+
+	current, skip := imagegc.CurrentTags(specs)
+	for _, ref := range imagegc.SelectOrphans(candidates, current, skip) {
+		rmCtx, rmCancel := context.WithTimeout(ctx, 30*time.Second)
+		// No -f: an image backing a running container fails removal, which
+		// is exactly the safe behaviour we want.
+		err := exec.CommandContext(rmCtx, podmanPath, "rmi", ref).Run() //nolint:gosec
+		rmCancel()
+		if err != nil {
+			log.Debug("could not remove orphaned dicode image", zap.String("image", ref), zap.Error(err))
+			continue
+		}
+		log.Info("reclaimed orphaned dicode image", zap.String("image", ref))
+	}
+}

--- a/pkg/runtime/podman/runtime.go
+++ b/pkg/runtime/podman/runtime.go
@@ -25,13 +25,14 @@
 // Images are tagged dicode-<taskID>:<hash> where hash is derived from the
 // Dockerfile content. If the image already exists, the build is skipped.
 //
-// TODO: clean up old dicode-<taskID>:* images when a task is removed or the Dockerfile changes.
+// Old dicode-<taskID>:* images (task removed, or Dockerfile changed) are
+// reclaimed best-effort by ReclaimOrphanedImages (see imagegc.go), which the
+// daemon calls periodically with the registry's current task list.
 package podman
 
 import (
 	"bufio"
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -42,6 +43,8 @@ import (
 	podmanpkg "github.com/dicode/dicode/pkg/podman"
 	"github.com/dicode/dicode/pkg/registry"
 	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+	"github.com/dicode/dicode/pkg/runtime/containersec"
+	"github.com/dicode/dicode/pkg/runtime/imagegc"
 	"github.com/dicode/dicode/pkg/task"
 	"go.uber.org/zap"
 )
@@ -50,12 +53,19 @@ import (
 type Runtime struct {
 	reg *registry.Registry
 	log *zap.Logger
+	// policy is the container host-config security floor (issue #380).
+	// The zero value is the strict default: every dangerous escape denied.
+	policy containersec.Policy
 }
 
 // New creates a Podman Runtime manager.
 func New(reg *registry.Registry, log *zap.Logger) *Runtime {
 	return &Runtime{reg: reg, log: log}
 }
+
+// SetPolicy installs the operator-configured container security policy.
+// Call before NewExecutor; executors copy the policy at creation time.
+func (rt *Runtime) SetPolicy(p containersec.Policy) { rt.policy = p }
 
 // --- ManagedRuntime interface ---
 
@@ -80,7 +90,7 @@ func (rt *Runtime) Install(_ context.Context, _ string) error {
 }
 
 func (rt *Runtime) NewExecutor(binaryPath string) pkgruntime.Executor {
-	return &executor{podmanPath: binaryPath, reg: rt.reg, log: rt.log}
+	return &executor{podmanPath: binaryPath, reg: rt.reg, log: rt.log, policy: rt.policy}
 }
 
 // --- executor ---
@@ -89,6 +99,7 @@ type executor struct {
 	podmanPath string
 	reg        *registry.Registry
 	log        *zap.Logger
+	policy     containersec.Policy
 }
 
 // Execute implements runtime.Executor.
@@ -99,6 +110,17 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	cfg := spec.Docker
 	containerName := "dicode-" + runID
 
+	// Security floor (issue #380): task.yaml is untrusted input. Reject
+	// dangerous host config (host network namespace, dangerous cap_add,
+	// isolation-weakening security_opt, bind mounts of sensitive host paths)
+	// before any image is built or any container is created, unless the
+	// operator opted in via container_security in dicode.yaml.
+	if err := containersec.Validate(cfg, e.policy); err != nil {
+		_ = e.reg.AppendLog(ctx, runID, "error", err.Error())
+		result.Error = err
+		return result, nil
+	}
+
 	// Resolve the image: build from Dockerfile or pull.
 	imageTag := cfg.Image
 	if cfg.Build != nil {
@@ -108,6 +130,14 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 			result.Error = err
 			return result, nil
 		}
+	}
+
+	// Task-controlled values are string-concatenated into the podman argv;
+	// reject values that could corrupt the invocation (issue #380).
+	if err := validateArgvSafety(cfg, imageTag); err != nil {
+		_ = e.reg.AppendLog(ctx, runID, "error", err.Error())
+		result.Error = err
+		return result, nil
 	}
 
 	args := e.buildArgs(cfg, imageTag, containerName, runID, spec.ID)
@@ -189,8 +219,7 @@ func (e *executor) buildImage(ctx context.Context, spec *task.Spec, runID string
 	if err != nil {
 		return "", fmt.Errorf("read Dockerfile: %w", err)
 	}
-	h := sha256.Sum256(content)
-	tag := fmt.Sprintf("dicode-%s:%x", spec.ID, h[:6])
+	tag := imagegc.Tag(spec.ID, content)
 
 	// Cache hit: image with this tag already exists.
 	if exec.CommandContext(ctx, e.podmanPath, "image", "exists", tag).Run() == nil { //nolint:gosec

--- a/pkg/runtime/podman/runtime_test.go
+++ b/pkg/runtime/podman/runtime_test.go
@@ -5,8 +5,28 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dicode/dicode/pkg/runtime/containersec"
 	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
 )
+
+// TestNewExecutor_PropagatesPolicy pins that the container security policy
+// set on the manager reaches the executor created later — including the
+// executors re-created by the webui install path (issue #380).
+func TestNewExecutor_PropagatesPolicy(t *testing.T) {
+	rt := New(nil, zap.NewNop())
+	rt.SetPolicy(containersec.Policy{AllowHostNetwork: true, AllowedCapAdd: []string{"SYS_PTRACE"}})
+	e, ok := rt.NewExecutor("/usr/bin/podman").(*executor)
+	if !ok {
+		t.Fatalf("NewExecutor did not return *executor")
+	}
+	if !e.policy.AllowHostNetwork {
+		t.Errorf("AllowHostNetwork not propagated to executor")
+	}
+	if len(e.policy.AllowedCapAdd) != 1 || e.policy.AllowedCapAdd[0] != "SYS_PTRACE" {
+		t.Errorf("AllowedCapAdd not propagated: %v", e.policy.AllowedCapAdd)
+	}
+}
 
 // argsContainPair asserts that args contains `flag` immediately followed by `value`.
 func argsContainPair(args []string, flag, value string) bool {
@@ -113,5 +133,128 @@ func TestBuildArgs_HardeningPrecedesImage(t *testing.T) {
 	// Command must come after image.
 	if args[len(args)-2] != "echo" || args[len(args)-1] != "hi" {
 		t.Errorf("command args malformed at tail: %v", args)
+	}
+}
+
+// TestValidateArgvSafety_Rejections pins the argv-injection floor (issue
+// #380): task-controlled values that could corrupt the podman invocation are
+// rejected before buildArgs assembles the argv.
+func TestValidateArgvSafety_Rejections(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *task.DockerConfig
+		imageRef string
+	}{
+		{
+			name:     "empty image ref",
+			cfg:      &task.DockerConfig{},
+			imageRef: "",
+		},
+		{
+			name:     "image ref starting with dash is parsed as a flag",
+			cfg:      &task.DockerConfig{},
+			imageRef: "--privileged",
+		},
+		{
+			name:     "image ref with embedded space",
+			cfg:      &task.DockerConfig{},
+			imageRef: "alpine --privileged",
+		},
+		{
+			name:     "image ref with newline",
+			cfg:      &task.DockerConfig{},
+			imageRef: "alpine\nlatest",
+		},
+		{
+			name:     "port with newline",
+			cfg:      &task.DockerConfig{Ports: []string{"8080:80\n"}},
+			imageRef: "alpine",
+		},
+		{
+			name:     "volume with NUL byte",
+			cfg:      &task.DockerConfig{Volumes: []string{"/srv/a\x00b:/data"}},
+			imageRef: "alpine",
+		},
+		{
+			name:     "extra host with carriage return",
+			cfg:      &task.DockerConfig{ExtraHosts: []string{"evil:1.2.3.4\r"}},
+			imageRef: "alpine",
+		},
+		{
+			name:     "network mode with newline",
+			cfg:      &task.DockerConfig{NetworkMode: "bridge\n"},
+			imageRef: "alpine",
+		},
+		{
+			name:     "user with control character",
+			cfg:      &task.DockerConfig{User: "0:0\n"},
+			imageRef: "alpine",
+		},
+		{
+			name:     "env key with equals smuggles a second pair",
+			cfg:      &task.DockerConfig{EnvVars: map[string]string{"FOO=BAR": "x"}},
+			imageRef: "alpine",
+		},
+		{
+			name:     "env key with leading dash",
+			cfg:      &task.DockerConfig{EnvVars: map[string]string{"-e": "x"}},
+			imageRef: "alpine",
+		},
+		{
+			name:     "env value with NUL",
+			cfg:      &task.DockerConfig{EnvVars: map[string]string{"FOO": "a\x00b"}},
+			imageRef: "alpine",
+		},
+		{
+			name:     "command token with NUL",
+			cfg:      &task.DockerConfig{Command: []string{"echo", "a\x00b"}},
+			imageRef: "alpine",
+		},
+		{
+			name:     "entrypoint token with NUL",
+			cfg:      &task.DockerConfig{Entrypoint: []string{"/bin/sh\x00"}},
+			imageRef: "alpine",
+		},
+		{
+			name:     "security opt with newline",
+			cfg:      &task.DockerConfig{SecurityOpt: []string{"no-new-privileges:true\n"}},
+			imageRef: "alpine",
+		},
+		{
+			name:     "cap_add with newline",
+			cfg:      &task.DockerConfig{CapAdd: []string{"NET_BIND_SERVICE\n"}},
+			imageRef: "alpine",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateArgvSafety(tt.cfg, tt.imageRef); err == nil {
+				t.Errorf("expected rejection for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestValidateArgvSafety_SafeConfigPasses(t *testing.T) {
+	cfg := &task.DockerConfig{
+		Ports:       []string{"8080:80", "9090:90/udp"},
+		Volumes:     []string{"/srv/data:/data:ro", "named-vol:/cache"},
+		ExtraHosts:  []string{"host.docker.internal:host-gateway"},
+		EnvVars:     map[string]string{"FOO": "bar baz", "MULTI": "line1\nline2", "_UNDERSCORE": "ok"},
+		WorkingDir:  "/app",
+		NetworkMode: "bridge",
+		CapDrop:     []string{"ALL"},
+		CapAdd:      []string{"NET_BIND_SERVICE"},
+		SecurityOpt: []string{"no-new-privileges:true"},
+		User:        "65532:65532",
+		Command:     []string{"echo", "--flag-for-the-container", "hi"},
+		Entrypoint:  []string{"/bin/sh", "-c"},
+	}
+	if err := validateArgvSafety(cfg, "alpine:3.20"); err != nil {
+		t.Errorf("safe config rejected: %v", err)
+	}
+	// Built image tags look like dicode-<task>:<hash> and must pass too.
+	if err := validateArgvSafety(&task.DockerConfig{}, "dicode-mytask:a1b2c3d4e5f6"); err != nil {
+		t.Errorf("built image tag rejected: %v", err)
 	}
 }

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -22,9 +22,10 @@ const (
 
 // DockerBuild configures a local Dockerfile build instead of pulling a pre-built image.
 // The built image is tagged dicode-<taskID>:<hash> and cached; rebuild only happens when
-// the Dockerfile content changes.
-//
-// TODO: clean up old dicode-<taskID>:* images when a task is removed or the Dockerfile changes.
+// the Dockerfile content changes. Old dicode-<taskID>:* images (task removed, or
+// Dockerfile changed) are reclaimed best-effort by the daemon's periodic image GC —
+// see pkg/runtime/imagegc and the ReclaimOrphanedImages functions in the docker and
+// podman runtimes.
 type DockerBuild struct {
 	Dockerfile string `yaml:"dockerfile,omitempty"` // path relative to task dir; default "Dockerfile"
 	Context    string `yaml:"context,omitempty"`    // path relative to task dir; default task dir
@@ -703,8 +704,11 @@ func (s *Spec) validate() error {
 }
 
 // dockerHardeningWarnings flags container settings that visibly weaken
-// isolation. These aren't errors — operators can explicitly opt in — but they
-// should surface in the UI so reviewers notice.
+// isolation so they surface in the UI at config-load time. Warnings are
+// advisory only; the hard security floor is enforced at dispatch by
+// pkg/runtime/containersec.Validate (issue #380), which rejects these
+// settings — plus sensitive bind mounts — unless the operator opted in via
+// the container_security block in dicode.yaml.
 func dockerHardeningWarnings(d *DockerConfig) []string {
 	var warns []string
 	if d.NetworkMode == "host" {


### PR DESCRIPTION
## Summary

Implements #380 (P0) — an **enforced** container security floor. Dangerous host config from an untrusted `task.yaml` is now **rejected** (the run is aborted before container creation) rather than merely warned, unless an operator explicitly opts in. Closes #380.

PR #296 added the configurable docker/podman fields; this PR adds the floor those fields can't cross.

## Design

- **Shared default-deny policy** — new `pkg/runtime/containersec` with a single `Validate(cfg, policy) error` entry point reused by **both** the docker SDK runtime and the podman CLI runtime, so the ruleset isn't duplicated.
- **Operator opt-out** — new `container_security` block in `dicode.yaml` (appended to `Config`, validated at load): `allow_host_network`, `allow_insecure_security_opt`, `allowed_cap_add: [...]`, `allowed_volume_roots: [...]`. Default = everything enforced.

### Now rejected (both runtimes)
- `network_mode: host` / `container:<id>` / `ns:<path>`
- `cap_add` of `ALL, SYS_ADMIN, SYS_PTRACE, SYS_MODULE, SYS_RAWIO, SYS_BOOT, SYS_TIME, NET_ADMIN, DAC_READ_SEARCH, DAC_OVERRIDE, BPF, SYSLOG` (case + `CAP_`-prefix normalized)
- `security_opt`: `seccomp=unconfined`, `apparmor=unconfined`, `label=disable`, `systempaths=unconfined`, `unmask=…`
- Bind mounts resolving (after `Clean` + best-effort `EvalSymlinks`) to `/` or under `/proc /sys /etc /dev /boot /root /run /var/run /var/lib/docker /var/lib/containers`, any `*.sock` named `docker.sock`/`podman.sock`, and all relative sources. Named/anonymous volumes still allowed.

### Also
- **Podman argv validation** (`argv.go`) — blocks flag-injection (image refs/values starting with `-`), whitespace/control chars, NUL/CR/LF in single-token flag values, and env keys that aren't `^[A-Za-z_][A-Za-z0-9_]*$` (`=`-smuggling).
- **Image GC** (`pkg/runtime/imagegc` + per-runtime reclaimers) — unit-tested selection of orphaned `dicode-*` build images (stale hash / removed task), shared `imagegc.Tag` so cache and GC agree; daemon reclaims 2 min after startup and every 24h; non-forced `rmi` so in-use images survive.

## Test plan
- [x] `make build`, `go vet ./...`, `gofmt -l` clean
- [x] Table-driven policy tests (each dangerous config rejected by default; allowed under opt-in; safe configs pass), volume traversal/socket/`/` rejection, podman argv-injection, image-GC selection — all green
- [x] `go test ./...` green except the 3 known offline deno/jsr tests (fixed separately in #396)

⚠️ Follow-up: the reclaim *wiring* (docker SDK / podman CLI calls) is best-effort and not exercised in CI (no daemon available); the pure selection logic is fully unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJMqv1hzZzUZep13oyKrCD)_