### PR TITLE
feat(approval): approve surfaces — WebUI, CLI, tokenized link (#392 phase 2)

### DIFF
--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -489,9 +489,34 @@ func cmdTask(c *ipc.ControlClient, args []string) error {
 		return cmdTaskCancel(c, args[1:])
 	case "delete":
 		return cmdTaskDelete(c, args[1:])
+	case "approve":
+		return cmdTaskApprove(c, args[1:])
 	default:
-		return fmt.Errorf("unknown task subcommand %q — supported: test, create, edit, save, cancel, delete", args[0])
+		return fmt.Errorf("unknown task subcommand %q — supported: test, create, edit, save, cancel, delete, approve", args[0])
 	}
+}
+
+// cmdTaskApprove implements `dicode task approve <task-id>`: approves a task
+// held pending by the trust-on-change gate, recording its content hash in
+// dicode.lock and arming its triggers.
+func cmdTaskApprove(c *ipc.ControlClient, args []string) error {
+	if len(args) != 1 || strings.HasPrefix(args[0], "-") {
+		return fmt.Errorf("usage: dicode task approve <task-id>")
+	}
+	taskID := args[0]
+	resp, err := c.Send(ipc.Request{Method: "cli.task.approve", TaskID: taskID})
+	if err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	var r ipc.TaskApproveResult
+	if err := remarshal(resp.Result, &r); err != nil {
+		return err
+	}
+	fmt.Printf("Task %q approved — triggers armed, hash recorded in dicode.lock.\n", r.TaskID)
+	return nil
 }
 
 func cmdTaskTest(c *ipc.ControlClient, taskID string) error {
@@ -1001,6 +1026,7 @@ Commands:
   task test <task-id>             run the task's sibling task.test.* through its runtime
   task delete <task-id> [flags]   remove a task from its source (local rm / git PR)
                                   flags: --source NAME, --force
+  task approve <task-id>          approve a task held pending by the approval gate
   secrets list                    list secret keys
   secrets set <key> <value>       store a secret
   secrets delete <key>            delete a secret

--- a/pkg/approval/gate.go
+++ b/pkg/approval/gate.go
@@ -165,6 +165,24 @@ func (g *Gate) Admit(k task.Kinded) (armed bool, err error) {
 // Approve approves a pending task: records its observed hash in the lock and
 // arms its triggers. Returns an error when the task is not pending.
 func (g *Gate) Approve(id string) error {
+	return g.approve(id, "", ApprovedByManual)
+}
+
+// ApproveIfHash approves a pending task only when the hash observed at
+// gate-decision time equals hash. Token-link redemptions go through this so a
+// token minted for one version of a task can never approve a later version:
+// if the task content changed after the token was issued, the redemption is
+// rejected and the task stays pending.
+func (g *Gate) ApproveIfHash(id, hash string) error {
+	if hash == "" {
+		return fmt.Errorf("approve %q: empty hash", id)
+	}
+	return g.approve(id, hash, ApprovedByToken)
+}
+
+// approve is the shared approval path. A non-empty wantHash must match the
+// pending entry's observed hash exactly.
+func (g *Gate) approve(id, wantHash, by string) error {
 	g.mu.Lock()
 	ent, ok := g.pending[id]
 	g.mu.Unlock()
@@ -174,13 +192,22 @@ func (g *Gate) Approve(id string) error {
 	if ent.hash == "" {
 		return fmt.Errorf("task %q has no computable content hash; cannot approve", id)
 	}
-	if err := g.lock.Record(id, ent.hash, ApprovedByManual); err != nil {
+	if wantHash != "" && ent.hash != wantHash {
+		return fmt.Errorf("task %q changed since the approval was issued; re-review and approve the current version", id)
+	}
+	if err := g.lock.Record(id, ent.hash, by); err != nil {
 		return fmt.Errorf("record approval for %q: %w", id, err)
 	}
 	if err := g.arm(ent.kinded); err != nil {
 		return fmt.Errorf("arm %q: %w", id, err)
 	}
-	g.clearPending(id)
+	// Clear only the entry we approved: a concurrent Admit may have re-pended
+	// the task at a newer hash, and that newer version must stay held.
+	g.mu.Lock()
+	if cur, ok := g.pending[id]; ok && cur.hash == ent.hash {
+		delete(g.pending, id)
+	}
+	g.mu.Unlock()
 	return nil
 }
 
@@ -212,6 +239,18 @@ func (g *Gate) IsPending(id string) bool {
 	defer g.mu.Unlock()
 	_, ok := g.pending[id]
 	return ok
+}
+
+// PendingHash returns the content hash observed when id was held pending,
+// and whether id is pending at all. Approval tokens are bound to this hash.
+func (g *Gate) PendingHash(id string) (string, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	ent, ok := g.pending[id]
+	if !ok {
+		return "", false
+	}
+	return ent.hash, true
 }
 
 // FireGuard vetoes any fire of a pending task. Wired into the trigger

--- a/pkg/approval/gate_test.go
+++ b/pkg/approval/gate_test.go
@@ -380,3 +380,85 @@ func TestContentHashFallsBackToSpecJSON(t *testing.T) {
 		t.Fatalf("fallback hashes not distinct: %q vs %q", ha, hb)
 	}
 }
+
+func TestPendingHash(t *testing.T) {
+	g, _, _ := newTestGate(t, enabledPolicy())
+	spec := writeTaskDir(t, t.TempDir(), "repo/deploy", "v1")
+
+	if _, ok := g.PendingHash("repo/deploy"); ok {
+		t.Fatal("PendingHash before Admit must report not-pending")
+	}
+	if armed, _ := g.Admit(spec); armed {
+		t.Fatal("expected pending")
+	}
+	hash, ok := g.PendingHash("repo/deploy")
+	if !ok || hash == "" {
+		t.Fatalf("PendingHash = (%q, %v), want observed hash", hash, ok)
+	}
+	want, err := ContentHash(spec)
+	if err != nil {
+		t.Fatalf("ContentHash: %v", err)
+	}
+	if hash != want {
+		t.Fatalf("PendingHash = %q, want %q", hash, want)
+	}
+}
+
+func TestApproveIfHashMatch(t *testing.T) {
+	g, arm, lock := newTestGate(t, enabledPolicy())
+	spec := writeTaskDir(t, t.TempDir(), "repo/deploy", "v1")
+	if armed, _ := g.Admit(spec); armed {
+		t.Fatal("expected pending")
+	}
+	hash, _ := g.PendingHash("repo/deploy")
+
+	if err := g.ApproveIfHash("repo/deploy", hash); err != nil {
+		t.Fatalf("ApproveIfHash: %v", err)
+	}
+	if got := arm.armedIDs(); len(got) != 1 || got[0] != "repo/deploy" {
+		t.Fatalf("armed = %v", got)
+	}
+	rec, ok := lock.Get("repo/deploy")
+	if !ok || rec.ApprovedBy != ApprovedByToken || rec.Hash != hash {
+		t.Fatalf("lock record = %+v, ok=%v", rec, ok)
+	}
+	if g.IsPending("repo/deploy") {
+		t.Fatal("approved task still pending")
+	}
+}
+
+func TestApproveIfHashMismatchRejected(t *testing.T) {
+	g, arm, lock := newTestGate(t, enabledPolicy())
+	spec := writeTaskDir(t, t.TempDir(), "repo/deploy", "v1")
+	if armed, _ := g.Admit(spec); armed {
+		t.Fatal("expected pending")
+	}
+	staleHash, _ := g.PendingHash("repo/deploy")
+
+	// Task content changes; the gate re-observes a new hash.
+	if err := os.WriteFile(filepath.Join(spec.TaskDir, "task.js"), []byte("v2 — changed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if armed, _ := g.Admit(spec); armed {
+		t.Fatal("changed task must still be pending")
+	}
+
+	// The stale hash must not approve the new version.
+	if err := g.ApproveIfHash("repo/deploy", staleHash); err == nil {
+		t.Fatal("stale-hash approval must be rejected")
+	}
+	if !g.IsPending("repo/deploy") {
+		t.Fatal("task must stay pending after rejected approval")
+	}
+	if got := arm.armedIDs(); len(got) != 0 {
+		t.Fatalf("arm called despite rejection: %v", got)
+	}
+	if _, ok := lock.Get("repo/deploy"); ok {
+		t.Fatal("lock must not be written on rejected approval")
+	}
+
+	// Empty hash never approves.
+	if err := g.ApproveIfHash("repo/deploy", ""); err == nil {
+		t.Fatal("empty-hash approval must be rejected")
+	}
+}

--- a/pkg/approval/lock.go
+++ b/pkg/approval/lock.go
@@ -27,6 +27,7 @@ const (
 	ApprovedByTrustedSource = "trusted-source"
 	ApprovedByTrustedTask   = "trusted-task"
 	ApprovedByManual        = "manual"
+	ApprovedByToken         = "token-link"
 	ApprovedByGateDisabled  = "gate-disabled"
 	ApprovedByBootstrap     = "bootstrap"
 )

--- a/pkg/approval/token.go
+++ b/pkg/approval/token.go
@@ -1,0 +1,154 @@
+package approval
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+)
+
+// TokenTTL is how long a minted approve-link token stays redeemable.
+const TokenTTL = 24 * time.Hour
+
+// tokenPrefix marks dicode approval tokens so they are recognisable in
+// notification URLs and secret scanners.
+const tokenPrefix = "dcap_"
+
+var (
+	// ErrTokenInvalid covers unknown, malformed, and already-redeemed tokens.
+	// Deliberately one error: a redemption attempt learns nothing about
+	// whether the token ever existed.
+	ErrTokenInvalid = errors.New("approval token invalid or already used")
+	// ErrTokenExpired is returned for a token past its TTL. The row is
+	// consumed on the failed redemption.
+	ErrTokenExpired = errors.New("approval token expired")
+)
+
+// TokenInfo is the (task, hash) binding carried by an approval token.
+type TokenInfo struct {
+	TaskID string
+	Hash   string
+}
+
+// TokenStore persists single-use, TTL'd approve-link tokens. Only the
+// SHA-256 of a token is stored, so a database read cannot recover a
+// redeemable token. Each token is bound to the exact (task_id, content_hash)
+// pair it was minted for; redemption hands that binding to the gate, which
+// refuses to approve any other version of the task.
+type TokenStore struct {
+	db  db.DB
+	now func() time.Time // test hook
+}
+
+// NewTokenStore builds a TokenStore over the daemon database.
+func NewTokenStore(d db.DB) *TokenStore {
+	return &TokenStore{db: d, now: time.Now}
+}
+
+// Mint creates a single-use token bound to (taskID, hash), valid for
+// TokenTTL, and returns the raw token. The raw value exists only in this
+// return — the store keeps its SHA-256.
+func (ts *TokenStore) Mint(ctx context.Context, taskID, hash string) (string, error) {
+	if taskID == "" || hash == "" {
+		return "", fmt.Errorf("approval token: task id and hash are required")
+	}
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("approval token: %w", err)
+	}
+	token := tokenPrefix + base64.RawURLEncoding.EncodeToString(raw)
+	now := ts.now().UTC()
+
+	// Opportunistic GC: expired rows are dead weight, drop them on mint.
+	_ = ts.db.Exec(ctx, `DELETE FROM approval_tokens WHERE expires_at < ?`, now.Unix())
+
+	if err := ts.db.Exec(ctx,
+		`INSERT INTO approval_tokens (token_hash, task_id, content_hash, created_at, expires_at)
+		 VALUES (?, ?, ?, ?, ?)`,
+		hashToken(token), taskID, hash, now.Unix(), now.Add(TokenTTL).Unix(),
+	); err != nil {
+		return "", fmt.Errorf("approval token: store: %w", err)
+	}
+	return token, nil
+}
+
+// Peek validates a token without consuming it. Used by the confirm page so a
+// link prefetcher (mail client, chat unfurler) issuing GETs cannot burn the
+// token or approve anything.
+func (ts *TokenStore) Peek(ctx context.Context, token string) (TokenInfo, error) {
+	info, expiresAt, err := ts.lookup(ctx, ts.db, token)
+	if err != nil {
+		return TokenInfo{}, err
+	}
+	if ts.now().UTC().Unix() > expiresAt {
+		return TokenInfo{}, ErrTokenExpired
+	}
+	return info, nil
+}
+
+// Redeem consumes a token and returns its (task, hash) binding. The row is
+// deleted before the result is returned — inside one transaction, so two
+// concurrent redemptions cannot both succeed — and an expired token is
+// consumed by the failed attempt.
+func (ts *TokenStore) Redeem(ctx context.Context, token string) (TokenInfo, error) {
+	var info TokenInfo
+	var expiresAt int64
+	err := ts.db.Tx(ctx, func(tx db.DB) error {
+		var err error
+		info, expiresAt, err = ts.lookup(ctx, tx, token)
+		if err != nil {
+			return err
+		}
+		return tx.Exec(ctx, `DELETE FROM approval_tokens WHERE token_hash = ?`, hashToken(token))
+	})
+	if err != nil {
+		return TokenInfo{}, err
+	}
+	if ts.now().UTC().Unix() > expiresAt {
+		return TokenInfo{}, ErrTokenExpired
+	}
+	return info, nil
+}
+
+// lookup resolves a raw token to its row via q (the base handle or a tx).
+func (ts *TokenStore) lookup(ctx context.Context, q db.DB, token string) (TokenInfo, int64, error) {
+	if !strings.HasPrefix(token, tokenPrefix) {
+		return TokenInfo{}, 0, ErrTokenInvalid
+	}
+	var info TokenInfo
+	var expiresAt int64
+	found := false
+	err := q.Query(ctx,
+		`SELECT task_id, content_hash, expires_at FROM approval_tokens WHERE token_hash = ?`,
+		[]any{hashToken(token)},
+		func(rows db.Scanner) error {
+			for rows.Next() {
+				if err := rows.Scan(&info.TaskID, &info.Hash, &expiresAt); err != nil {
+					return err
+				}
+				found = true
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return TokenInfo{}, 0, fmt.Errorf("approval token: lookup: %w", err)
+	}
+	if !found {
+		return TokenInfo{}, 0, ErrTokenInvalid
+	}
+	return info, expiresAt, nil
+}
+
+// hashToken returns the hex SHA-256 of a raw token — the storage key.
+func hashToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}

--- a/pkg/approval/token_test.go
+++ b/pkg/approval/token_test.go
@@ -1,0 +1,134 @@
+package approval
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+)
+
+func newTestTokenStore(t *testing.T) *TokenStore {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return NewTokenStore(d)
+}
+
+func TestTokenMintAndRedeem(t *testing.T) {
+	ts := newTestTokenStore(t)
+	ctx := context.Background()
+
+	token, err := ts.Mint(ctx, "repo/deploy", "hash-1")
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	if !strings.HasPrefix(token, "dcap_") {
+		t.Fatalf("token missing prefix: %q", token)
+	}
+
+	info, err := ts.Peek(ctx, token)
+	if err != nil {
+		t.Fatalf("Peek: %v", err)
+	}
+	if info.TaskID != "repo/deploy" || info.Hash != "hash-1" {
+		t.Fatalf("Peek binding = %+v", info)
+	}
+
+	info, err = ts.Redeem(ctx, token)
+	if err != nil {
+		t.Fatalf("Redeem: %v", err)
+	}
+	if info.TaskID != "repo/deploy" || info.Hash != "hash-1" {
+		t.Fatalf("Redeem binding = %+v", info)
+	}
+}
+
+func TestTokenSingleUse(t *testing.T) {
+	ts := newTestTokenStore(t)
+	ctx := context.Background()
+
+	token, err := ts.Mint(ctx, "repo/deploy", "hash-1")
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	if _, err := ts.Redeem(ctx, token); err != nil {
+		t.Fatalf("first Redeem: %v", err)
+	}
+	if _, err := ts.Redeem(ctx, token); !errors.Is(err, ErrTokenInvalid) {
+		t.Fatalf("second Redeem err = %v, want ErrTokenInvalid", err)
+	}
+	if _, err := ts.Peek(ctx, token); !errors.Is(err, ErrTokenInvalid) {
+		t.Fatalf("Peek after redeem err = %v, want ErrTokenInvalid", err)
+	}
+}
+
+func TestTokenUnknownAndMalformed(t *testing.T) {
+	ts := newTestTokenStore(t)
+	ctx := context.Background()
+
+	for _, tok := range []string{"", "garbage", "dcap_doesnotexist"} {
+		if _, err := ts.Redeem(ctx, tok); !errors.Is(err, ErrTokenInvalid) {
+			t.Errorf("Redeem(%q) err = %v, want ErrTokenInvalid", tok, err)
+		}
+	}
+}
+
+func TestTokenExpiry(t *testing.T) {
+	ts := newTestTokenStore(t)
+	ctx := context.Background()
+
+	token, err := ts.Mint(ctx, "repo/deploy", "hash-1")
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+
+	// Move the clock past the TTL.
+	ts.now = func() time.Time { return time.Now().Add(TokenTTL + time.Minute) }
+
+	if _, err := ts.Peek(ctx, token); !errors.Is(err, ErrTokenExpired) {
+		t.Fatalf("Peek expired err = %v, want ErrTokenExpired", err)
+	}
+	if _, err := ts.Redeem(ctx, token); !errors.Is(err, ErrTokenExpired) {
+		t.Fatalf("Redeem expired err = %v, want ErrTokenExpired", err)
+	}
+	// The failed redemption consumed the row.
+	if _, err := ts.Redeem(ctx, token); !errors.Is(err, ErrTokenInvalid) {
+		t.Fatalf("re-Redeem err = %v, want ErrTokenInvalid", err)
+	}
+}
+
+func TestTokenMintRequiresBinding(t *testing.T) {
+	ts := newTestTokenStore(t)
+	if _, err := ts.Mint(context.Background(), "", "h"); err == nil {
+		t.Error("Mint with empty task id must fail")
+	}
+	if _, err := ts.Mint(context.Background(), "repo/deploy", ""); err == nil {
+		t.Error("Mint with empty hash must fail")
+	}
+}
+
+func TestTokensAreUniqueAndUnguessableShape(t *testing.T) {
+	ts := newTestTokenStore(t)
+	ctx := context.Background()
+	seen := map[string]bool{}
+	for i := 0; i < 16; i++ {
+		tok, err := ts.Mint(ctx, "repo/deploy", "hash-1")
+		if err != nil {
+			t.Fatalf("Mint: %v", err)
+		}
+		if seen[tok] {
+			t.Fatal("duplicate token minted")
+		}
+		seen[tok] = true
+		// 32 random bytes → 43 base64url chars after the prefix.
+		if len(tok) != len("dcap_")+43 {
+			t.Fatalf("unexpected token length %d for %q", len(tok), tok)
+		}
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -474,6 +474,10 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	}
 	srv.SetManagedRuntimes(managedRuntimes)
 	srv.SetTestGuard(approvalGate.FireGuard)
+	// Approve surfaces (#398): pending visibility + POST /api/tasks/{id}/approve
+	// + the single-use tokenized approve link for notifications.
+	srv.SetApprovalGate(approvalGate)
+	srv.SetApprovalTokenStore(approval.NewTokenStore(database))
 	if replayer != nil {
 		srv.SetReplayer(replayer)
 	}
@@ -504,6 +508,9 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	// Approval-gate veto for `dicode task test` — same guard as the engine's
 	// fire paths and the REST test endpoint.
 	ctrlSrv.SetTestGuard(approvalGate.FireGuard)
+
+	// `dicode task approve` — the control socket is a trusted local channel.
+	ctrlSrv.SetTaskApprover(approvalGate.Approve)
 
 	// Wire AI-first task authoring so `dicode task create|edit|save|cancel`
 	// reuses the same source manager and author_sessions store the REST

--- a/pkg/db/sqlite.go
+++ b/pkg/db/sqlite.go
@@ -242,6 +242,22 @@ func (s *SQLiteDB) migrate() error {
 		return fmt.Errorf("migrate author_sessions index: %w", err)
 	}
 
+	// approval_tokens — single-use approve-link tokens (#398). token_hash is
+	// the SHA-256 of the raw token; the raw value is never stored.
+	_, err = s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS approval_tokens (
+			token_hash   TEXT PRIMARY KEY,
+			task_id      TEXT NOT NULL,
+			content_hash TEXT NOT NULL,
+			created_at   INTEGER NOT NULL,
+			expires_at   INTEGER NOT NULL
+		);
+		CREATE INDEX IF NOT EXISTS idx_approval_tokens_expires ON approval_tokens(expires_at);
+	`)
+	if err != nil {
+		return fmt.Errorf("migrate approval_tokens: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -43,6 +43,10 @@ type ControlServer struct {
 	taskDeleter     TaskDeleter      // nil if webui not wired (tests)
 	log             *zap.Logger
 
+	// taskApprover is the approval gate's Approve, wired via SetTaskApprover.
+	// Nil when the gate is not configured (tests).
+	taskApprover func(taskID string) error
+
 	// defaultAITask is cfg.AI.Task — the task id that `dicode ai` fires when
 	// the client doesn't supply --task. Empty when the daemon was started
 	// without config (tests).
@@ -253,6 +257,9 @@ func (cs *ControlServer) dispatch(ctx context.Context, req Request) (any, error)
 
 	case "cli.task.delete":
 		return cs.handleTaskDelete(ctx, req)
+
+	case "cli.task.approve":
+		return cs.handleTaskApprove(req)
 
 	case "cli.auth.reset_passphrase":
 		return cs.handleAuthResetPassphrase(ctx)

--- a/pkg/ipc/control_task_approve.go
+++ b/pkg/ipc/control_task_approve.go
@@ -1,0 +1,36 @@
+package ipc
+
+import (
+	"errors"
+
+	"go.uber.org/zap"
+)
+
+// TaskApproveResult is the cli.task.approve response.
+type TaskApproveResult struct {
+	TaskID   string `json:"taskID"`
+	Approved bool   `json:"approved"`
+}
+
+// SetTaskApprover wires the approval gate's Approve for cli.task.approve
+// dispatch. The control socket is a trusted local channel (0600 socket +
+// peer-UID / pre-shared-token handshake), so no further auth is layered on.
+// Nil leaves the method returning a clear error (tests without the gate).
+func (cs *ControlServer) SetTaskApprover(a func(taskID string) error) { cs.taskApprover = a }
+
+// handleTaskApprove approves a task held pending by the approval gate. The
+// gate records the observed content hash in dicode.lock and arms the task's
+// triggers; a non-pending task id is an error.
+func (cs *ControlServer) handleTaskApprove(req Request) (TaskApproveResult, error) {
+	if req.TaskID == "" {
+		return TaskApproveResult{}, errors.New("taskID required")
+	}
+	if cs.taskApprover == nil {
+		return TaskApproveResult{}, errors.New("approval gate not configured")
+	}
+	if err := cs.taskApprover(req.TaskID); err != nil {
+		return TaskApproveResult{TaskID: req.TaskID}, err
+	}
+	cs.log.Info("task approved via control socket", zap.String("task", req.TaskID))
+	return TaskApproveResult{TaskID: req.TaskID, Approved: true}, nil
+}

--- a/pkg/ipc/control_task_approve_test.go
+++ b/pkg/ipc/control_task_approve_test.go
@@ -1,0 +1,68 @@
+package ipc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func newApproveTestServer(approver func(string) error) *ControlServer {
+	return &ControlServer{
+		taskApprover: approver,
+		log:          zap.NewNop(),
+	}
+}
+
+func TestTaskApprove_Success(t *testing.T) {
+	var approved string
+	cs := newApproveTestServer(func(id string) error {
+		approved = id
+		return nil
+	})
+
+	res, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.task.approve", TaskID: "repo/deploy"})
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	out, ok := res.(TaskApproveResult)
+	if !ok {
+		t.Fatalf("result type %T", res)
+	}
+	if !out.Approved || out.TaskID != "repo/deploy" {
+		t.Fatalf("result = %+v", out)
+	}
+	if approved != "repo/deploy" {
+		t.Fatalf("gate approver called with %q", approved)
+	}
+}
+
+func TestTaskApprove_NotPendingErrorPropagates(t *testing.T) {
+	gateErr := errors.New(`task "repo/deploy" is not pending approval`)
+	cs := newApproveTestServer(func(string) error { return gateErr })
+
+	_, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.task.approve", TaskID: "repo/deploy"})
+	if !errors.Is(err, gateErr) {
+		t.Fatalf("err = %v, want gate error", err)
+	}
+}
+
+func TestTaskApprove_RequiresTaskID(t *testing.T) {
+	called := false
+	cs := newApproveTestServer(func(string) error { called = true; return nil })
+
+	if _, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.task.approve"}); err == nil {
+		t.Fatal("expected error without taskID")
+	}
+	if called {
+		t.Fatal("approver must not be called without a task id")
+	}
+}
+
+func TestTaskApprove_NotConfigured(t *testing.T) {
+	cs := newApproveTestServer(nil)
+	if _, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.task.approve", TaskID: "x"}); err == nil {
+		t.Fatal("expected error when approval gate is not wired")
+	}
+}

--- a/pkg/webui/approval.go
+++ b/pkg/webui/approval.go
@@ -1,0 +1,193 @@
+package webui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"html/template"
+	"net/http"
+
+	"github.com/dicode/dicode/pkg/approval"
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
+)
+
+// ApprovalGate is the narrow surface of the trust-on-change approval gate
+// (pkg/approval.Gate) the WebUI uses: pending visibility, plain approval
+// (session / API-key callers), and hash-bound approval (token-link
+// redemptions). Defined here so tests can wire a fake — same decoupling as
+// SecretsManager.
+type ApprovalGate interface {
+	IsPending(id string) bool
+	PendingHash(id string) (string, bool)
+	Approve(id string) error
+	ApproveIfHash(id, hash string) error
+}
+
+// SetApprovalGate wires the approval gate. Call after New and before Start.
+// Nil (the default) hides the pending flag and disables the approve
+// endpoints.
+func (s *Server) SetApprovalGate(g ApprovalGate) { s.approvalGate = g }
+
+// SetApprovalTokenStore wires the store backing the single-use approve-link
+// tokens. Call after New and before Start. Nil (the default) disables the
+// /approve/{token} flow and MintApproveLink.
+func (s *Server) SetApprovalTokenStore(ts *approval.TokenStore) { s.approvalTokens = ts }
+
+// taskPendingApproval reports whether id is held by the approval gate.
+func (s *Server) taskPendingApproval(id string) bool {
+	return s.approvalGate != nil && s.approvalGate.IsPending(id)
+}
+
+// MintApproveLink mints a single-use, TTL'd approve token for a pending task
+// and returns the absolute URL that redeems it. The notification flow embeds
+// this URL so an operator can approve without a full session; the token is
+// bound to the task's currently observed content hash, so it cannot approve
+// a version the operator never saw.
+func (s *Server) MintApproveLink(ctx context.Context, taskID string) (string, error) {
+	if s.approvalGate == nil || s.approvalTokens == nil {
+		return "", errors.New("approval gate not configured")
+	}
+	hash, ok := s.approvalGate.PendingHash(taskID)
+	if !ok {
+		return "", fmt.Errorf("task %q is not pending approval", taskID)
+	}
+	if hash == "" {
+		return "", fmt.Errorf("task %q has no computable content hash", taskID)
+	}
+	token, err := s.approvalTokens.Mint(ctx, taskID, hash)
+	if err != nil {
+		return "", err
+	}
+	return s.WebUIBaseURL() + "/approve/" + token, nil
+}
+
+// apiApproveTask handles POST /api/tasks/{id}/approve. Auth mirrors the
+// replay endpoint: session cookie or Bearer API key (requireSessionOrAPIKey).
+//
+// Status codes:
+//   - 200 — approved; triggers armed, hash recorded in dicode.lock.
+//   - 404 — no such task.
+//   - 409 — task is not pending approval (or the approval failed).
+//   - 503 — approval gate not wired.
+func (s *Server) apiApproveTask(w http.ResponseWriter, r *http.Request) {
+	id := taskIDParam(r)
+	if s.approvalGate == nil {
+		jsonErr(w, "approval gate not available", http.StatusServiceUnavailable)
+		return
+	}
+	if _, ok := s.registry.GetKinded(id); !ok {
+		jsonErr(w, "task not found: "+id, http.StatusNotFound)
+		return
+	}
+	if err := s.approvalGate.Approve(id); err != nil {
+		jsonErr(w, err.Error(), http.StatusConflict)
+		return
+	}
+	s.log.Info("task approved via API", zap.String("task", id))
+	s.ws.Broadcast(WSMsg{Type: "tasks:changed"})
+	jsonOK(w, map[string]any{"task_id": id, "approved": true})
+}
+
+// approvePageTmpl renders the token-link confirm / result pages. Bare HTML on
+// purpose: the page must work from a notification click with no session, no
+// app shell, and no JS.
+var approvePageTmpl = template.Must(template.New("approve").Parse(`<!doctype html>
+<html><head><meta charset="utf-8"><title>dicode — task approval</title>
+<meta name="robots" content="noindex">
+<style>
+body{font-family:system-ui,sans-serif;background:#14151a;color:#e6e6e6;display:flex;justify-content:center;padding-top:10vh}
+main{max-width:34rem;padding:2rem;background:#1d1f26;border:1px solid #33363f;border-radius:10px}
+code{background:#2a2d36;padding:0.15rem 0.4rem;border-radius:4px;word-break:break-all}
+button{background:#3fb950;color:#fff;border:none;border-radius:6px;padding:0.6rem 1.4rem;font-size:1rem;cursor:pointer}
+.err{color:#f85149}.ok{color:#3fb950}.meta{color:#8c96a3;font-size:0.85rem}
+</style></head><body><main>
+{{if .Error}}
+  <h1 class="err">Approval failed</h1>
+  <p>{{.Error}}</p>
+  <p class="meta">Approve links are single-use and expire after 24 hours. Approve the task from the dicode dashboard or with <code>dicode task approve &lt;id&gt;</code>.</p>
+{{else if .Approved}}
+  <h1 class="ok">Task approved</h1>
+  <p>Task <code>{{.TaskID}}</code> is approved — its triggers are armed and the content hash is recorded in <code>dicode.lock</code>.</p>
+{{else}}
+  <h1>Approve task?</h1>
+  <p>This will approve task <code>{{.TaskID}}</code> at content hash <code>{{.Hash}}</code> and arm its triggers.</p>
+  <p class="meta">Only approve if you reviewed this task change. The link is single-use.</p>
+  <form method="post"><button type="submit">Approve task</button></form>
+{{end}}
+</main></body></html>`))
+
+type approvePageData struct {
+	TaskID   string
+	Hash     string
+	Approved bool
+	Error    string
+}
+
+func (s *Server) renderApprovePage(w http.ResponseWriter, status int, data approvePageData) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	// The token lives in the URL: never let a follow-up navigation leak it.
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = approvePageTmpl.Execute(w, data)
+}
+
+// handleApproveLinkPage serves GET /approve/{token}: a confirm page with the
+// approve button. The token is validated (Peek) but NOT consumed — mail
+// clients and chat unfurlers prefetch GET links, and a prefetch must neither
+// approve the task nor burn the token. Invalid and expired tokens render the
+// same generic failure, with status hiding nothing an attacker couldn't
+// learn by POSTing anyway.
+func (s *Server) handleApproveLinkPage(w http.ResponseWriter, r *http.Request) {
+	token := chi.URLParam(r, "token")
+	if s.approvalGate == nil || s.approvalTokens == nil {
+		s.renderApprovePage(w, http.StatusNotFound, approvePageData{Error: "approval links are not enabled on this daemon"})
+		return
+	}
+	info, err := s.approvalTokens.Peek(r.Context(), token)
+	if err != nil {
+		s.renderApprovePage(w, http.StatusNotFound, approvePageData{Error: "this approval link is invalid, expired, or already used"})
+		return
+	}
+	// The link must only ever approve what it was minted for: if the task is
+	// no longer pending at that exact hash, say so up front.
+	if hash, ok := s.approvalGate.PendingHash(info.TaskID); !ok || hash != info.Hash {
+		s.renderApprovePage(w, http.StatusConflict, approvePageData{Error: "the task is no longer pending at the version this link was issued for"})
+		return
+	}
+	s.renderApprovePage(w, http.StatusOK, approvePageData{TaskID: info.TaskID, Hash: shortHash(info.Hash)})
+}
+
+// handleApproveLinkRedeem serves POST /approve/{token}: consumes the token
+// (single-use, even on failure) and approves the bound task iff it is still
+// pending at the exact hash the token was minted for.
+func (s *Server) handleApproveLinkRedeem(w http.ResponseWriter, r *http.Request) {
+	token := chi.URLParam(r, "token")
+	if s.approvalGate == nil || s.approvalTokens == nil {
+		s.renderApprovePage(w, http.StatusNotFound, approvePageData{Error: "approval links are not enabled on this daemon"})
+		return
+	}
+	info, err := s.approvalTokens.Redeem(r.Context(), token)
+	if err != nil {
+		s.renderApprovePage(w, http.StatusNotFound, approvePageData{Error: "this approval link is invalid, expired, or already used"})
+		return
+	}
+	if err := s.approvalGate.ApproveIfHash(info.TaskID, info.Hash); err != nil {
+		s.log.Warn("approve link redemption rejected",
+			zap.String("task", info.TaskID), zap.Error(err))
+		s.renderApprovePage(w, http.StatusConflict, approvePageData{Error: err.Error()})
+		return
+	}
+	s.log.Info("task approved via approve link", zap.String("task", info.TaskID))
+	s.ws.Broadcast(WSMsg{Type: "tasks:changed"})
+	s.renderApprovePage(w, http.StatusOK, approvePageData{TaskID: info.TaskID, Approved: true})
+}
+
+// shortHash trims a content hash for display.
+func shortHash(h string) string {
+	if len(h) > 12 {
+		return h[:12] + "…"
+	}
+	return h
+}

--- a/pkg/webui/approval_test.go
+++ b/pkg/webui/approval_test.go
@@ -1,0 +1,459 @@
+package webui
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/approval"
+	"github.com/dicode/dicode/pkg/config"
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/ipc"
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+	"github.com/dicode/dicode/pkg/trigger"
+	"go.uber.org/zap"
+)
+
+// fakeApprovalGate implements ApprovalGate over an in-memory pending map.
+type fakeApprovalGate struct {
+	mu       sync.Mutex
+	pending  map[string]string // task id → observed hash
+	approved []string
+}
+
+func newFakeGate() *fakeApprovalGate {
+	return &fakeApprovalGate{pending: map[string]string{}}
+}
+
+func (g *fakeApprovalGate) IsPending(id string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	_, ok := g.pending[id]
+	return ok
+}
+
+func (g *fakeApprovalGate) PendingHash(id string) (string, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	h, ok := g.pending[id]
+	return h, ok
+}
+
+func (g *fakeApprovalGate) Approve(id string) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if _, ok := g.pending[id]; !ok {
+		return fmt.Errorf("task %q is not pending approval", id)
+	}
+	delete(g.pending, id)
+	g.approved = append(g.approved, id)
+	return nil
+}
+
+func (g *fakeApprovalGate) ApproveIfHash(id, hash string) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	cur, ok := g.pending[id]
+	if !ok {
+		return fmt.Errorf("task %q is not pending approval", id)
+	}
+	if hash == "" || cur != hash {
+		return fmt.Errorf("task %q changed since the approval was issued", id)
+	}
+	delete(g.pending, id)
+	g.approved = append(g.approved, id)
+	return nil
+}
+
+// newApprovalTestServer builds a deno-free Server (no runtime needed for the
+// approval surfaces) with an optional auth wall, plus the backing db handle
+// so token rows can be manipulated directly.
+func newApprovalTestServer(t *testing.T, auth bool) (*Server, *registry.Registry, db.DB) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+
+	reg := registry.New(d)
+	eng := trigger.New(reg, nil, zap.NewNop())
+	cfg := &config.Config{Server: config.ServerConfig{Port: 8080, Auth: auth, Secret: "hunter2"}}
+	srv, err := New(8080, reg, eng, cfg, "", nil, nil, nil, "", NewLogBroadcaster(), zap.NewNop(), d, ipc.NewGateway())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return srv, reg, d
+}
+
+func registerMinimalTask(t *testing.T, reg *registry.Registry, id string) {
+	t.Helper()
+	if err := reg.Register(&task.Spec{ID: id, Name: id, Trigger: task.TriggerConfig{Manual: true}, Enabled: true}); err != nil {
+		t.Fatalf("register %s: %v", id, err)
+	}
+}
+
+// ── Pending visibility ───────────────────────────────────────────────────────
+
+func TestAPI_ListTasks_PendingApprovalFlag(t *testing.T) {
+	srv, reg, _ := newApprovalTestServer(t, false)
+	registerMinimalTask(t, reg, "repo/pending-task")
+	registerMinimalTask(t, reg, "repo/approved-task")
+
+	gate := newFakeGate()
+	gate.pending["repo/pending-task"] = "hash-1"
+	srv.SetApprovalGate(gate)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var items []map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&items); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	flags := map[string]bool{}
+	for _, it := range items {
+		id, _ := it["id"].(string)
+		flags[id], _ = it["pending_approval"].(bool)
+	}
+	if !flags["repo/pending-task"] {
+		t.Error("pending task must carry pending_approval: true")
+	}
+	if flags["repo/approved-task"] {
+		t.Error("non-pending task must not carry pending_approval")
+	}
+}
+
+func TestAPI_GetTask_PendingApprovalFlag(t *testing.T) {
+	srv, reg, _ := newApprovalTestServer(t, false)
+	registerMinimalTask(t, reg, "repo/pending-task")
+	gate := newFakeGate()
+	gate.pending["repo/pending-task"] = "hash-1"
+	srv.SetApprovalGate(gate)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks/repo%2Fpending-task", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", w.Code, w.Body.String())
+	}
+	var detail map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got, _ := detail["pending_approval"].(bool); !got {
+		t.Errorf("detail pending_approval = %v, want true", detail["pending_approval"])
+	}
+}
+
+// ── POST /api/tasks/{id}/approve ─────────────────────────────────────────────
+
+func TestAPI_ApproveTask_ApprovesPending(t *testing.T) {
+	srv, reg, _ := newApprovalTestServer(t, false)
+	registerMinimalTask(t, reg, "repo/pending-task")
+	gate := newFakeGate()
+	gate.pending["repo/pending-task"] = "hash-1"
+	srv.SetApprovalGate(gate)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/repo%2Fpending-task/approve", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", w.Code, w.Body.String())
+	}
+	if gate.IsPending("repo/pending-task") {
+		t.Error("task still pending after approve")
+	}
+	if len(gate.approved) != 1 || gate.approved[0] != "repo/pending-task" {
+		t.Errorf("approved = %v", gate.approved)
+	}
+}
+
+func TestAPI_ApproveTask_NotPending409(t *testing.T) {
+	srv, reg, _ := newApprovalTestServer(t, false)
+	registerMinimalTask(t, reg, "repo/normal-task")
+	srv.SetApprovalGate(newFakeGate())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/repo%2Fnormal-task/approve", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPI_ApproveTask_UnknownTask404(t *testing.T) {
+	srv, _, _ := newApprovalTestServer(t, false)
+	srv.SetApprovalGate(newFakeGate())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/ghost/approve", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPI_ApproveTask_NoGate503(t *testing.T) {
+	srv, reg, _ := newApprovalTestServer(t, false)
+	registerMinimalTask(t, reg, "repo/x")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/repo%2Fx/approve", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPI_ApproveTask_RequiresAuth(t *testing.T) {
+	srv, reg, _ := newApprovalTestServer(t, true)
+	registerMinimalTask(t, reg, "repo/pending-task")
+	gate := newFakeGate()
+	gate.pending["repo/pending-task"] = "hash-1"
+	srv.SetApprovalGate(gate)
+
+	// No session, no API key → 401, and the gate must not have been touched.
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/repo%2Fpending-task/approve", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401: %s", w.Code, w.Body.String())
+	}
+	if !gate.IsPending("repo/pending-task") {
+		t.Fatal("unauthenticated request must not approve")
+	}
+
+	// Garbage Bearer token → still 401.
+	req = httptest.NewRequest(http.MethodPost, "/api/tasks/repo%2Fpending-task/approve", nil)
+	req.Header.Set("Authorization", "Bearer dck_bogus")
+	w = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("bad key: status = %d, want 401", w.Code)
+	}
+
+	// Valid API key → approves.
+	raw, _, err := srv.apiKeys.generate(context.Background(), "approve-test")
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	req = httptest.NewRequest(http.MethodPost, "/api/tasks/repo%2Fpending-task/approve", nil)
+	req.Header.Set("Authorization", "Bearer "+raw)
+	w = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("api key: status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if gate.IsPending("repo/pending-task") {
+		t.Fatal("task still pending after API-key approve")
+	}
+}
+
+func TestAPI_ApproveTask_SessionCookieWorks(t *testing.T) {
+	srv, reg, _ := newApprovalTestServer(t, true)
+	registerMinimalTask(t, reg, "repo/pending-task")
+	gate := newFakeGate()
+	gate.pending["repo/pending-task"] = "hash-1"
+	srv.SetApprovalGate(gate)
+	h := srv.Handler()
+
+	cookie := login(t, h, "hunter2", false)
+	if cookie == nil {
+		t.Fatal("login failed")
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/repo%2Fpending-task/approve", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("session: status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if gate.IsPending("repo/pending-task") {
+		t.Fatal("task still pending after session approve")
+	}
+}
+
+// ── Tokenized approve link ───────────────────────────────────────────────────
+
+// tokenFromLink extracts the raw token from a MintApproveLink URL.
+func tokenFromLink(t *testing.T, link string) string {
+	t.Helper()
+	i := strings.LastIndex(link, "/approve/")
+	if i < 0 {
+		t.Fatalf("link %q has no /approve/ segment", link)
+	}
+	return link[i+len("/approve/"):]
+}
+
+func newTokenLinkServer(t *testing.T) (*Server, *fakeApprovalGate, db.DB) {
+	t.Helper()
+	srv, reg, d := newApprovalTestServer(t, true) // auth ON: the token must be the only credential needed
+	registerMinimalTask(t, reg, "repo/pending-task")
+	gate := newFakeGate()
+	gate.pending["repo/pending-task"] = "hash-1"
+	srv.SetApprovalGate(gate)
+	srv.SetApprovalTokenStore(approval.NewTokenStore(d))
+	return srv, gate, d
+}
+
+func TestApproveLink_MintRequiresPendingTask(t *testing.T) {
+	srv, _, _ := newTokenLinkServer(t)
+	if _, err := srv.MintApproveLink(context.Background(), "repo/not-pending"); err == nil {
+		t.Fatal("minting a link for a non-pending task must fail")
+	}
+	link, err := srv.MintApproveLink(context.Background(), "repo/pending-task")
+	if err != nil {
+		t.Fatalf("MintApproveLink: %v", err)
+	}
+	if !strings.Contains(link, "/approve/dcap_") {
+		t.Fatalf("link = %q", link)
+	}
+}
+
+func TestApproveLink_GetConfirmPageDoesNotConsume(t *testing.T) {
+	srv, gate, _ := newTokenLinkServer(t)
+	link, err := srv.MintApproveLink(context.Background(), "repo/pending-task")
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	token := tokenFromLink(t, link)
+	h := srv.Handler()
+
+	// Simulate a prefetcher hammering the GET: nothing may change.
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/approve/"+token, nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET #%d status = %d: %s", i, w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), "repo/pending-task") {
+			t.Fatalf("confirm page must name the task: %s", w.Body.String())
+		}
+	}
+	if !gate.IsPending("repo/pending-task") {
+		t.Fatal("GET must not approve")
+	}
+
+	// The token is still redeemable afterwards.
+	req := httptest.NewRequest(http.MethodPost, "/approve/"+token, nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST after GETs: status = %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestApproveLink_RedeemApprovesAndIsSingleUse(t *testing.T) {
+	srv, gate, _ := newTokenLinkServer(t)
+	link, err := srv.MintApproveLink(context.Background(), "repo/pending-task")
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	token := tokenFromLink(t, link)
+	h := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/approve/"+token, nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", w.Code, w.Body.String())
+	}
+	if gate.IsPending("repo/pending-task") {
+		t.Fatal("task still pending after redemption")
+	}
+
+	// Second redemption: token consumed.
+	req = httptest.NewRequest(http.MethodPost, "/approve/"+token, nil)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("replayed token: status = %d, want 404", w.Code)
+	}
+}
+
+func TestApproveLink_WrongHashRejected(t *testing.T) {
+	srv, gate, _ := newTokenLinkServer(t)
+	link, err := srv.MintApproveLink(context.Background(), "repo/pending-task")
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	token := tokenFromLink(t, link)
+
+	// The task changes after the token was issued — new observed hash.
+	gate.mu.Lock()
+	gate.pending["repo/pending-task"] = "hash-2-changed"
+	gate.mu.Unlock()
+
+	h := srv.Handler()
+	req := httptest.NewRequest(http.MethodPost, "/approve/"+token, nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", w.Code, w.Body.String())
+	}
+	if !gate.IsPending("repo/pending-task") {
+		t.Fatal("changed task must stay pending — token bound to the old hash")
+	}
+	// The stale-page GET also refuses.
+	req = httptest.NewRequest(http.MethodGet, "/approve/"+token, nil)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict && w.Code != http.StatusNotFound {
+		t.Fatalf("GET with stale binding: status = %d, want 409/404", w.Code)
+	}
+}
+
+func TestApproveLink_ExpiredRejected(t *testing.T) {
+	srv, gate, d := newTokenLinkServer(t)
+	link, err := srv.MintApproveLink(context.Background(), "repo/pending-task")
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	token := tokenFromLink(t, link)
+
+	// Force-expire the row.
+	if err := d.Exec(context.Background(), `UPDATE approval_tokens SET expires_at = 1`); err != nil {
+		t.Fatalf("expire: %v", err)
+	}
+
+	h := srv.Handler()
+	req := httptest.NewRequest(http.MethodPost, "/approve/"+token, nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404: %s", w.Code, w.Body.String())
+	}
+	if !gate.IsPending("repo/pending-task") {
+		t.Fatal("expired token must not approve")
+	}
+}
+
+func TestApproveLink_BogusTokenRejected(t *testing.T) {
+	srv, gate, _ := newTokenLinkServer(t)
+	h := srv.Handler()
+
+	for _, tok := range []string{"dcap_bogus", "x", "dcap_" + strings.Repeat("A", 43)} {
+		for _, method := range []string{http.MethodGet, http.MethodPost} {
+			req := httptest.NewRequest(method, "/approve/"+tok, nil)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+			if w.Code != http.StatusNotFound {
+				t.Errorf("%s /approve/%s: status = %d, want 404", method, tok, w.Code)
+			}
+		}
+	}
+	if !gate.IsPending("repo/pending-task") {
+		t.Fatal("bogus tokens must not approve")
+	}
+}

--- a/pkg/webui/log_middleware.go
+++ b/pkg/webui/log_middleware.go
@@ -2,6 +2,7 @@ package webui
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5/middleware"
@@ -17,10 +18,20 @@ func (f *zapLogFormatter) NewLogEntry(r *http.Request) middleware.LogEntry {
 	return &zapLogEntry{
 		log:    f.log,
 		method: r.Method,
-		path:   r.URL.Path,
+		path:   redactPath(r.URL.Path),
 		remote: r.RemoteAddr,
 		reqID:  middleware.GetReqID(r.Context()),
 	}
+}
+
+// redactPath strips capability-bearing path segments from request logs.
+// /approve/{token} carries a single-use approval token — the URL is the
+// credential, so it must not land in (potentially shipped) daemon logs.
+func redactPath(p string) string {
+	if strings.HasPrefix(p, "/approve/") {
+		return "/approve/[redacted]"
+	}
+	return p
 }
 
 type zapLogEntry struct {

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/alexedwards/scs/v2"
+	"github.com/dicode/dicode/pkg/approval"
 	"github.com/dicode/dicode/pkg/config"
 	"github.com/dicode/dicode/pkg/db"
 	"github.com/dicode/dicode/pkg/ipc"
@@ -155,6 +156,13 @@ type Server struct {
 	// test file runs with full host permissions, so it must be refused
 	// exactly like a fire. Nil means allow.
 	testGuard func(taskID string) error
+
+	// approvalGate is the trust-on-change gate's approve/pending surface
+	// (SetApprovalGate). Nil disables the pending flag and the approve
+	// endpoints. approvalTokens persists single-use approve-link tokens
+	// (SetApprovalTokenStore); nil disables the /approve/{token} link flow.
+	approvalGate   ApprovalGate
+	approvalTokens *approval.TokenStore
 }
 
 // SetReplayer wires a Replayer for the POST /api/runs/{runID}/replay
@@ -598,6 +606,17 @@ func (s *Server) Handler() http.Handler {
 	// or a Bearer API key (CLI / auto-fix scripts). Mounted outside the
 	// session-only group so machine callers without cookies still work.
 	r.With(s.requireSessionOrAPIKey).Post("/api/runs/{runID}/replay", s.apiReplayRun)
+
+	// Approval-gate approve endpoint (#398) — same auth posture as replay:
+	// session cookie (WebUI approve button) or Bearer API key.
+	r.With(s.requireSessionOrAPIKey).Post("/api/tasks/{id}/approve", s.apiApproveTask)
+
+	// Tokenized approve link (#398) — the single-use token in the URL is the
+	// auth, so these stay outside the session groups. GET renders a confirm
+	// page without consuming the token (link prefetchers must not approve);
+	// POST redeems it.
+	r.Get("/approve/{token}", s.handleApproveLinkPage)
+	r.Post("/approve/{token}", s.handleApproveLinkRedeem)
 
 	return r
 }
@@ -1308,6 +1327,9 @@ type TaskListItem struct {
 	TriggerLabel  string `json:"trigger_label"`
 	LastRunID     string `json:"last_run_id,omitempty"`
 	LastRunStatus string `json:"last_run_status,omitempty"`
+	// PendingApproval flags a task held by the trust-on-change approval gate:
+	// its triggers are not armed until an operator approves it.
+	PendingApproval bool `json:"pending_approval,omitempty"`
 }
 
 // PipelineListItem is the shape returned by GET /api/tasks for a kind:
@@ -1315,13 +1337,14 @@ type TaskListItem struct {
 // view reads (id/name/enabled/kind/trigger_label/last_run_*) without embedding
 // *task.Spec, since a PipelineTask is a peer of Spec, not a Spec.
 type PipelineListItem struct {
-	ID            string `json:"id"`
-	Name          string `json:"name"`
-	Enabled       bool   `json:"enabled"`
-	Kind          string `json:"kind"`
-	TriggerLabel  string `json:"trigger_label"`
-	LastRunID     string `json:"last_run_id,omitempty"`
-	LastRunStatus string `json:"last_run_status,omitempty"`
+	ID              string `json:"id"`
+	Name            string `json:"name"`
+	Enabled         bool   `json:"enabled"`
+	Kind            string `json:"kind"`
+	TriggerLabel    string `json:"trigger_label"`
+	LastRunID       string `json:"last_run_id,omitempty"`
+	LastRunStatus   string `json:"last_run_status,omitempty"`
+	PendingApproval bool   `json:"pending_approval,omitempty"`
 }
 
 func (s *Server) apiListTasks(w http.ResponseWriter, r *http.Request) {
@@ -1334,24 +1357,27 @@ func (s *Server) apiListTasks(w http.ResponseWriter, r *http.Request) {
 			lastRunID = runs[0].ID
 			lastRunStatus = runs[0].Status
 		}
+		pendingApproval := s.taskPendingApproval(k.TaskID())
 		switch v := k.(type) {
 		case *task.Spec:
 			items = append(items, TaskListItem{
-				Spec:          v,
-				Kind:          task.KindTask,
-				TriggerLabel:  triggerLabel(v.Trigger),
-				LastRunID:     lastRunID,
-				LastRunStatus: lastRunStatus,
+				Spec:            v,
+				Kind:            task.KindTask,
+				TriggerLabel:    triggerLabel(v.Trigger),
+				LastRunID:       lastRunID,
+				LastRunStatus:   lastRunStatus,
+				PendingApproval: pendingApproval,
 			})
 		case *task.PipelineTask:
 			items = append(items, PipelineListItem{
-				ID:            v.ID,
-				Name:          v.Name,
-				Enabled:       v.Enabled,
-				Kind:          task.KindPipelineTask,
-				TriggerLabel:  pipelineTriggerLabel(v),
-				LastRunID:     lastRunID,
-				LastRunStatus: lastRunStatus,
+				ID:              v.ID,
+				Name:            v.Name,
+				Enabled:         v.Enabled,
+				Kind:            task.KindPipelineTask,
+				TriggerLabel:    pipelineTriggerLabel(v),
+				LastRunID:       lastRunID,
+				LastRunStatus:   lastRunStatus,
+				PendingApproval: pendingApproval,
 			})
 		default:
 			// Forward-compat safety net: the registry only ever holds
@@ -1363,13 +1389,14 @@ func (s *Server) apiListTasks(w http.ResponseWriter, r *http.Request) {
 			// Give it a parity TriggerLabel ("—") so the list renders sanely
 			// instead of falling back to a misleading "manual".
 			items = append(items, PipelineListItem{
-				ID:            k.TaskID(),
-				Name:          k.TaskID(),
-				Enabled:       k.IsEnabled(),
-				Kind:          k.KindOf(),
-				TriggerLabel:  "—",
-				LastRunID:     lastRunID,
-				LastRunStatus: lastRunStatus,
+				ID:              k.TaskID(),
+				Name:            k.TaskID(),
+				Enabled:         k.IsEnabled(),
+				Kind:            k.KindOf(),
+				TriggerLabel:    "—",
+				LastRunID:       lastRunID,
+				LastRunStatus:   lastRunStatus,
+				PendingApproval: pendingApproval,
 			})
 		}
 	}
@@ -1391,6 +1418,9 @@ type TaskDetail struct {
 	// "stopped" so operators can tell "fireAsync broke" (#318) and "body
 	// crashed without auto-restart" (#325) apart from "deliberately stopped".
 	DaemonState string `json:"daemon_state,omitempty"`
+
+	// PendingApproval flags a task held by the trust-on-change approval gate.
+	PendingApproval bool `json:"pending_approval,omitempty"`
 }
 
 // PipelineDetail is the shape returned by GET /api/tasks/{id} for a kind:
@@ -1400,8 +1430,9 @@ type TaskDetail struct {
 // daemon_state contract.
 type PipelineDetail struct {
 	*task.PipelineTask
-	TriggerLabel string `json:"trigger_label"`
-	DaemonState  string `json:"daemon_state,omitempty"`
+	TriggerLabel    string `json:"trigger_label"`
+	DaemonState     string `json:"daemon_state,omitempty"`
+	PendingApproval bool   `json:"pending_approval,omitempty"`
 }
 
 func (s *Server) apiGetTask(w http.ResponseWriter, r *http.Request) {
@@ -1421,8 +1452,9 @@ func (s *Server) apiGetTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	detail := TaskDetail{
-		Spec:         spec,
-		TriggerLabel: triggerLabel(spec.Trigger),
+		Spec:            spec,
+		TriggerLabel:    triggerLabel(spec.Trigger),
+		PendingApproval: s.taskPendingApproval(spec.ID),
 	}
 	// Daemon lifecycle state — empty for non-daemon tasks so the UI
 	// doesn't render "stopped" labels on every cron job.
@@ -1470,8 +1502,9 @@ func (s *Server) apiGetTask(w http.ResponseWriter, r *http.Request) {
 // see the same lifecycle badge they'd see on the bare daemon task.
 func (s *Server) writePipelineDetail(w http.ResponseWriter, p *task.PipelineTask) {
 	detail := PipelineDetail{
-		PipelineTask: p,
-		TriggerLabel: pipelineTriggerLabel(p),
+		PipelineTask:    p,
+		TriggerLabel:    pipelineTriggerLabel(p),
+		PendingApproval: s.taskPendingApproval(p.ID),
 	}
 	if len(p.Stages) > 0 {
 		terminalID := p.Stages[len(p.Stages)-1].Task

--- a/tasks/buildin/webui/app/components/dc-task-detail.js
+++ b/tasks/buildin/webui/app/components/dc-task-detail.js
@@ -123,6 +123,14 @@ class DcTaskDetail extends LitElement {
     } catch(e) { alert('Failed: ' + e.message); }
   }
 
+  async _approve() {
+    if (!confirm(`Approve task "${this.taskid}"? Its triggers will arm and the current version will be trusted.`)) return;
+    try {
+      await post(`/api/tasks/${encodeURIComponent(this.taskid)}/approve`);
+      await this._load();
+    } catch(e) { alert('Approve failed: ' + e.message); }
+  }
+
   _openEditor() {
     this._editorOpen = true;
     this._currentFile = this._task?.script_file || 'task.ts';
@@ -479,9 +487,14 @@ class DcTaskDetail extends LitElement {
     const isPipeline = task.kind === 'PipelineTask';
     const hasEditor  = !isPipeline && !!task.script_file;
 
+    const needsApproval = task.pending_approval === true;
+
     return html`
       <div style="display:flex;align-items:center;gap:0.75rem;margin-bottom:var(--space-sm)">
         <h1 style="margin:0">${task.name}</h1>
+        ${needsApproval ? html`<span title="This task is new or changed and its triggers are not armed until approved"
+          style="padding:0 0.45rem;font-size:0.75rem;border-radius:3px;background:rgba(210,153,34,0.18);color:#d29922;border:1px solid rgba(210,153,34,0.45)">pending approval</span>` : ''}
+        ${needsApproval ? html`<button class="btn" style="background:#d29922" @click=${() => this._approve()}>&#10003; Approve</button>` : ''}
         <button class="btn" @click=${() => this._run()}>&#9654; Run now</button>
         ${hasEditor ? html`<button class="btn" style="background:var(--muted)" @click=${() => this._openEditor()}>&#9998; Edit code</button>` : ''}
       </div>

--- a/tasks/buildin/webui/app/components/dc-task-list.js
+++ b/tasks/buildin/webui/app/components/dc-task-list.js
@@ -100,6 +100,14 @@ class DcTaskList extends LitElement {
     } catch(e) { alert('Failed to run task: ' + e.message); }
   }
 
+  async _approve(taskID) {
+    if (!confirm(`Approve task "${taskID}"? Its triggers will arm and the current version will be trusted.`)) return;
+    try {
+      await post(`/api/tasks/${encodeURIComponent(taskID)}/approve`);
+      await this._load();
+    } catch(e) { this._toast('Approve failed: ' + e.message); }
+  }
+
   // Group tasks by top-level namespace segment, applying the active
   // filter as a case-insensitive substring match against ID, name, and
   // trigger label. Tasks without '/' in their ID go in the '' bucket.
@@ -178,9 +186,10 @@ class DcTaskList extends LitElement {
     const id = t.id;
     const disabled = t.enabled === false;
     const pending = this._togglePending.has(id);
+    const needsApproval = t.pending_approval === true;
     return html`
       <tr class=${disabled ? 'disabled' : ''} data-task-id=${id}>
-        <td><a href="/tasks/${t.id}" @click=${e => { e.preventDefault(); navigate('/tasks/' + t.id); }}>${shown}</a>${disabled ? html`<span class="badge-paused">paused</span>` : ''}</td>
+        <td><a href="/tasks/${t.id}" @click=${e => { e.preventDefault(); navigate('/tasks/' + t.id); }}>${shown}</a>${disabled ? html`<span class="badge-paused">paused</span>` : ''}${needsApproval ? html`<span class="badge-pending-approval" title="This task is new or changed and its triggers are not armed until approved">pending approval</span>` : ''}</td>
         <td>${t.name}</td>
         <td>${t.trigger?.Webhook
           ? html`<a href="${webhookURL(this._relayBase, t.trigger.Webhook)}" target="_blank" class="meta">${t.trigger_label}</a>`
@@ -203,6 +212,9 @@ class DcTaskList extends LitElement {
                 </svg>`
               : html`<svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="9"/></svg>`}
           </button>
+          ${needsApproval
+            ? html`<button class="btn btn-sm btn-approve" title="Approve this task version" @click=${() => this._approve(t.id)}>&#10003; Approve</button>`
+            : ''}
           <button class="btn btn-sm" @click=${() => this._run(t.id)}>&#9654; Run</button>
         </td>
       </tr>`;
@@ -319,6 +331,18 @@ class DcTaskList extends LitElement {
           vertical-align: middle;
         }
         dc-task-list .toggle-btn:disabled { cursor: wait; }
+        dc-task-list .badge-pending-approval {
+          display: inline-block;
+          margin-left: 0.5rem;
+          padding: 0 0.4rem;
+          font-size: 0.7rem;
+          border-radius: 3px;
+          background: rgba(210, 153, 34, 0.18);
+          color: #d29922;
+          border: 1px solid rgba(210, 153, 34, 0.45);
+          vertical-align: middle;
+        }
+        dc-task-list .btn-approve { background: #d29922; }
         dc-task-list .toggle-btn.on  { color: var(--accent, #4caf50); }
         dc-task-list .toggle-btn.off { color: var(--muted, #888); }
         dc-task-list .toggle-btn svg { display: inline-block; width: 18px; height: 18px; vertical-align: middle; }


### PR DESCRIPTION
Closes #398. Part of #392 (phase 2).

## Summary

Phase 1 landed the trust-on-change gate, but the only ways to approve a pending task were hand-editing `dicode.lock` or declaring a `trust:` policy. This makes the gate usable by adding the three operator approve surfaces, all funnelling into `approval.Gate`:

- **WebUI** — the task list/detail API now carries `pending_approval`, the dashboard badges pending tasks and shows an Approve button, and `POST /api/tasks/{id}/approve` performs the approval. Auth mirrors the replay endpoint exactly (`requireSessionOrAPIKey`: session cookie or Bearer API key); non-pending → 409, unknown task → 404.
- **CLI** — `dicode task approve <id>` over the control socket (`cli.task.approve`), following the `task delete` dispatch wiring. The control socket is already a trusted local channel (0600 socket, peer-UID/token handshake), so no extra auth layer.
- **Tokenized approve link** (for the phase-3 notification) — `Server.MintApproveLink(ctx, taskID)` mints a single-use token and returns the `/approve/{token}` URL; #399 only has to embed it. Firing the notification itself is out of scope here.

## Token scheme

- 32 bytes `crypto/rand`, `dcap_`-prefixed; only the SHA-256 lands in the new `approval_tokens` table, so a DB read can't recover a redeemable token.
- Bound to the exact `(task_id, content_hash)` observed when the task went pending. Redemption goes through the new `Gate.ApproveIfHash`, which rejects the approval if the task has changed since the token was issued — a token can never approve a version the operator didn't see.
- Single-use (row consumed inside one transaction, even on a failed/expired attempt) with a 24h TTL.
- `GET /approve/{token}` renders a confirm page via a non-consuming peek — mail-client/chat link prefetchers can neither approve nor burn the token; the actual redemption is the form `POST`. The token is the credential, so `/approve/` paths are redacted from HTTP request logs and the pages send `Referrer-Policy: no-referrer` + `Cache-Control: no-store`.

## Notes for review

- The gate's shared approve path now clears only the pending entry it actually approved, so a concurrent re-pend at a newer hash stays held instead of being wiped by a racing approval.
- `MintApproveLink` builds the URL from `WebUIBaseURL()` (localhost-based); if phase 3 needs an externally reachable base (relay), that substitution belongs in #399 where the notification target is known.
- A pending task remains non-executable on every path (fire guard untouched); approval arms triggers and records the hash in `dicode.lock` via the existing gate machinery — nothing here duplicates that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)