### PR TITLE
security(approval): fold resolved permissions into gate content hash (#400)

### DIFF
--- a/pkg/approval/content_hash_guard_test.go
+++ b/pkg/approval/content_hash_guard_test.go
@@ -1,0 +1,84 @@
+package approval
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// TestOverrideFieldsClassified is a reflection tripwire: every field of
+// task.Overrides and task.TriggerPatch must be explicitly classified as
+// either FOLDED (it perturbs the approval content hash via
+// resolvedSecurityFields) or EXEMPT (with a recorded justification). A new
+// override field that lands in neither set fails this test, so the override
+// surface can never silently grow past the approval gate (issue #400).
+func TestOverrideFieldsClassified(t *testing.T) {
+	// folded: override fields whose effect on the resolved spec is folded
+	// into resolvedSecurityFields (see gate.go). The value notes where the
+	// effect lands.
+	overridesFolded := map[string]string{
+		"Net":     "permissions.net → resolvedSecurityFields.Permissions",
+		"Fs":      "permissions.fs → resolvedSecurityFields.Permissions",
+		"Dicode":  "permissions.dicode → resolvedSecurityFields.Permissions",
+		"Env":     "permissions.env → resolvedSecurityFields.Permissions (literal values redacted)",
+		"Runtime": "resolvedSecurityFields.Runtime",
+		"Timeout": "resolvedSecurityFields.Timeout",
+		"Params":  "resolvedSecurityFields.Params (name/default/required tuples)",
+		"Trigger": "resolvedSecurityFields trigger fields (see TriggerPatch below)",
+	}
+	// exempt: override fields deliberately NOT folded, each with a one-line
+	// justification.
+	overridesExempt := map[string]string{
+		"Name":        "cosmetic: display label only, no capability change",
+		"Description": "cosmetic: display text only, no capability change",
+		"Enabled":     "scheduling: enables/disables firing, capability when running unchanged",
+		"Retry":       "re-execution within the already-approved permission envelope",
+		"Defaults":    "structural cascade container: its effects land in concrete folded fields",
+		"Entries":     "structural cascade container: its effects land in concrete folded fields",
+	}
+	checkClassified(t, reflect.TypeOf(task.Overrides{}), overridesFolded, overridesExempt)
+
+	// Every TriggerPatch field rewires the task's exposure surface and is
+	// folded via the resolved trigger shape.
+	triggerPatchFolded := map[string]string{
+		"Cron":    "resolvedSecurityFields.Cron",
+		"Webhook": "resolvedSecurityFields.Webhook",
+		"Auth":    "resolvedSecurityFields.WebhookAuth",
+		"Manual":  "resolvedSecurityFields.Manual",
+		"Chain":   "resolvedSecurityFields.Chain",
+		"Daemon":  "resolvedSecurityFields.Daemon",
+		"Restart": "resolvedSecurityFields.Restart",
+	}
+	checkClassified(t, reflect.TypeOf(task.TriggerPatch{}), triggerPatchFolded, map[string]string{})
+}
+
+// checkClassified walks typ's fields and requires each to appear in exactly
+// one of folded/exempt; it also rejects stale classifications for fields that
+// no longer exist (renames must update the lists).
+func checkClassified(t *testing.T, typ reflect.Type, folded, exempt map[string]string) {
+	t.Helper()
+	fields := map[string]bool{}
+	for i := 0; i < typ.NumField(); i++ {
+		name := typ.Field(i).Name
+		fields[name] = true
+		_, isFolded := folded[name]
+		_, isExempt := exempt[name]
+		switch {
+		case isFolded && isExempt:
+			t.Errorf("%s.%s is classified as both folded and exempt; pick one", typ.Name(), name)
+		case !isFolded && !isExempt:
+			t.Errorf("new override field %s.%s must be classified: fold it into resolvedSecurityFields or add it to the exempt list with justification", typ.Name(), name)
+		}
+	}
+	for name := range folded {
+		if !fields[name] {
+			t.Errorf("folded classification references nonexistent field %s.%s (renamed or removed? update the list)", typ.Name(), name)
+		}
+	}
+	for name := range exempt {
+		if !fields[name] {
+			t.Errorf("exempt classification references nonexistent field %s.%s (renamed or removed? update the list)", typ.Name(), name)
+		}
+	}
+}

--- a/pkg/approval/content_hash_test.go
+++ b/pkg/approval/content_hash_test.go
@@ -2,12 +2,13 @@ package approval
 
 import (
 	"testing"
+	"time"
 
 	"github.com/dicode/dicode/pkg/task"
 )
 
-// specInDir returns a dir-backed spec for the given task dir (created once by
-// the caller via writeTaskDir) with the supplied mutation applied, so tests
+// specVariant returns a dir-backed spec for the given task dir (created once
+// by the caller via writeTaskDir) with the supplied mutation applied, so tests
 // can vary single resolved fields against an identical on-disk dir.
 func specVariant(base *task.Spec, mutate func(*task.Spec)) *task.Spec {
 	s := &task.Spec{ID: base.ID, TaskDir: base.TaskDir}
@@ -57,6 +58,8 @@ func TestContentHashFoldsResolvedSecurityFields(t *testing.T) {
 		"dicode tasks":     func(s *task.Spec) { s.Permissions.Dicode = &task.DicodePermissions{Tasks: []string{"*"}} },
 		"runtime swap":     func(s *task.Spec) { s.Runtime = task.Runtime("python") },
 		"webhook auth off": func(s *task.Spec) { s.Trigger.WebhookAuth = true },
+		"param default":    func(s *task.Spec) { s.Params = task.Params{{Name: "url", Default: "https://evil.example"}} },
+		"timeout widened":  func(s *task.Spec) { s.Timeout = 4 * time.Hour },
 	}
 
 	baseHash := mustHash(t, specVariant(base, nil))
@@ -65,6 +68,105 @@ func TestContentHashFoldsResolvedSecurityFields(t *testing.T) {
 		if got == baseHash {
 			t.Errorf("%s: hash unchanged despite elevated resolved field", name)
 		}
+	}
+}
+
+// TestContentHashFoldsParamDefault: param defaults are override-mutable
+// program inputs (mergeParams); repointing one against an identical dir must
+// perturb the hash, while a cosmetic param description edit must not.
+func TestContentHashFoldsParamDefault(t *testing.T) {
+	base := writeTaskDir(t, t.TempDir(), "repo/deploy", "x")
+
+	a := mustHash(t, specVariant(base, func(s *task.Spec) {
+		s.Params = task.Params{{Name: "url", Default: "https://api.example.com"}}
+	}))
+	b := mustHash(t, specVariant(base, func(s *task.Spec) {
+		s.Params = task.Params{{Name: "url", Default: "https://exfil.example.com"}}
+	}))
+	if a == b {
+		t.Fatal("param default change must perturb the hash (override-mutable program input)")
+	}
+
+	withDesc := mustHash(t, specVariant(base, func(s *task.Spec) {
+		s.Params = task.Params{{Name: "url", Default: "https://api.example.com", Description: "the endpoint"}}
+	}))
+	if a != withDesc {
+		t.Fatal("param description edit must not churn the hash")
+	}
+}
+
+// TestContentHashFoldsTimeout: an override-widened timeout extends the
+// wall-clock budget and must re-pend.
+func TestContentHashFoldsTimeout(t *testing.T) {
+	base := writeTaskDir(t, t.TempDir(), "repo/deploy", "x")
+	a := mustHash(t, specVariant(base, func(s *task.Spec) { s.Timeout = time.Minute }))
+	b := mustHash(t, specVariant(base, func(s *task.Spec) { s.Timeout = 24 * time.Hour }))
+	if a == b {
+		t.Fatal("timeout change must perturb the hash")
+	}
+}
+
+// TestContentHashRedactsEnvLiteralValues: dicode.lock is committable, so a
+// literal env value must never feed the hash (offline dictionary attack on a
+// low-entropy credential). A Value-only change therefore keeps the hash; a
+// NAME change (a different variable becomes injectable) must perturb it.
+func TestContentHashRedactsEnvLiteralValues(t *testing.T) {
+	base := writeTaskDir(t, t.TempDir(), "repo/deploy", "x")
+
+	valA := mustHash(t, specVariant(base, func(s *task.Spec) {
+		s.Permissions.Env = []task.EnvEntry{{Name: "API_TOKEN", Value: "hunter2"}}
+	}))
+	valB := mustHash(t, specVariant(base, func(s *task.Spec) {
+		s.Permissions.Env = []task.EnvEntry{{Name: "API_TOKEN", Value: "correct-horse-battery-staple"}}
+	}))
+	if valA != valB {
+		t.Fatal("env literal Value must be redacted from the hash input; value-only change churned the hash")
+	}
+
+	renamed := mustHash(t, specVariant(base, func(s *task.Spec) {
+		s.Permissions.Env = []task.EnvEntry{{Name: "OTHER_TOKEN", Value: "hunter2"}}
+	}))
+	if renamed == valA {
+		t.Fatal("env entry NAME change must perturb the hash")
+	}
+}
+
+// TestContentHashDirlessFallbackSanitized: the dir-less *task.Spec fallback
+// marshals the spec, and TriggerConfig has yaml tags only — every exported
+// field would marshal by Go name. The fallback must clear WebhookSecret (and
+// redact env literals) so the committable lock never embeds a digest over
+// secret material.
+func TestContentHashDirlessFallbackSanitized(t *testing.T) {
+	mk := func(secret string) *task.Spec {
+		return &task.Spec{
+			ID: "set/inline",
+			Trigger: task.TriggerConfig{
+				Webhook:       "/hooks/inline",
+				WebhookSecret: secret,
+			},
+		}
+	}
+	a := mustHash(t, mk("s3cret-one"))
+	b := mustHash(t, mk("s3cret-two"))
+	if a != b {
+		t.Fatal("dir-less fallback must exclude Trigger.WebhookSecret from the hash input")
+	}
+
+	// Env literal redaction applies to the fallback too.
+	mkEnv := func(val string) *task.Spec {
+		s := mk("")
+		s.Permissions.Env = []task.EnvEntry{{Name: "API_TOKEN", Value: val}}
+		return s
+	}
+	if mustHash(t, mkEnv("one")) != mustHash(t, mkEnv("two")) {
+		t.Fatal("dir-less fallback must redact env literal values")
+	}
+
+	// Sanity: the webhook path itself still folds.
+	c := mk("")
+	c.Trigger.Webhook = "/hooks/other"
+	if mustHash(t, c) == a {
+		t.Fatal("dir-less fallback lost non-secret trigger fields")
 	}
 }
 
@@ -120,101 +222,97 @@ func TestContentHashIgnoresCosmeticResolvedFields(t *testing.T) {
 	}
 }
 
-// TestContentHashPipelineTaskKeepsDirHash: pipelines are not subject to
-// permission-replacing taskset overrides, so their gate hash remains the
-// plain directory hash.
-func TestContentHashPipelineTaskKeepsDirHash(t *testing.T) {
+// TestContentHashPipelineFoldsResolvedTrigger: dir-backed pipelines get the
+// same dirHash+resolved-fields scheme as Specs, so a future resolver that
+// applies override layers to pipelines fails closed (re-pends) instead of
+// silently keeping a dir-only approval. A manual→webhook rewire against an
+// identical dir must perturb the hash, and the hash must not degrade to the
+// plain dir hash.
+func TestContentHashPipelineFoldsResolvedTrigger(t *testing.T) {
 	// Reuse writeTaskDir for the directory contents; only the dir matters.
 	dir := writeTaskDir(t, t.TempDir(), "repo/pipe", "stages").TaskDir
-	p := &task.PipelineTask{ID: "repo/pipe", TaskDir: dir}
-	got := mustHash(t, p)
-	want, err := task.Hash(dir)
+
+	manual := &task.PipelineTask{ID: "repo/pipe", TaskDir: dir,
+		Trigger: task.PipelineTrigger{Manual: true}}
+	webhook := &task.PipelineTask{ID: "repo/pipe", TaskDir: dir,
+		Trigger: task.PipelineTrigger{Webhook: "/hooks/pipe"}}
+
+	hm := mustHash(t, manual)
+	hw := mustHash(t, webhook)
+	if hm == hw {
+		t.Fatal("pipeline trigger rewire (manual→webhook) must perturb the hash")
+	}
+
+	dirHash, err := task.Hash(dir)
 	if err != nil {
 		t.Fatalf("task.Hash: %v", err)
 	}
-	if got != want {
-		t.Fatalf("pipeline ContentHash = %q, want plain dir hash %q", got, want)
+	if hm == dirHash || hw == dirHash {
+		t.Fatal("pipeline ContentHash must not be the plain dir hash")
 	}
 }
 
-// TestOverrideElevatedPermissionsRePend is the gate-level regression test for
-// issue #400: an approved task whose resolved permissions are later elevated
-// by a taskset override (same dir on disk) must be held pending again, not
-// auto-approved off the stale lock entry.
-func TestOverrideElevatedPermissionsRePend(t *testing.T) {
-	g, arm, lock := newTestGate(t, enabledPolicy())
-	base := writeTaskDir(t, t.TempDir(), "repo/deploy", "v1")
+// TestOverrideElevationRePend is the gate-level regression test for issue
+// #400: an approved task whose resolved spec is later elevated by a taskset
+// override (same dir on disk) must be held pending again, not auto-armed off
+// the stale lock entry — whether the elevation is a permission grant or a
+// trigger rewire.
+func TestOverrideElevationRePend(t *testing.T) {
+	cases := []struct {
+		name     string
+		initial  func(*task.Spec)
+		elevated func(*task.Spec)
+	}{
+		{
+			// Override-elevated permissions (simulating a taskset.yaml edit
+			// outside the task dir).
+			name:    "elevated permissions",
+			initial: nil,
+			elevated: func(s *task.Spec) {
+				s.Permissions.Net = []string{"*"}
+				s.Permissions.Dicode = &task.DicodePermissions{SecretsWrite: true}
+			},
+		},
+		{
+			// A TriggerPatch override rewires the approved manual task to an
+			// unauthenticated webhook (Webhook set, Manual cleared, auth false).
+			name:     "trigger rewire to unauthenticated webhook",
+			initial:  func(s *task.Spec) { s.Trigger.Manual = true },
+			elevated: func(s *task.Spec) { s.Trigger.Webhook = "/hooks/x" },
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g, arm, lock := newTestGate(t, enabledPolicy())
+			base := writeTaskDir(t, t.TempDir(), "repo/deploy", "v1")
 
-	// Admit at base permissions and approve.
-	if armed, err := g.Admit(specVariant(base, nil)); err != nil || armed {
-		t.Fatalf("Admit base = (%v, %v), want pending", armed, err)
-	}
-	if err := g.Approve("repo/deploy"); err != nil {
-		t.Fatalf("Approve: %v", err)
-	}
-	approvedRec, _ := lock.Get("repo/deploy")
+			// Admit at the initial shape and approve.
+			if armed, err := g.Admit(specVariant(base, tc.initial)); err != nil || armed {
+				t.Fatalf("Admit initial = (%v, %v), want pending", armed, err)
+			}
+			if err := g.Approve("repo/deploy"); err != nil {
+				t.Fatalf("Approve: %v", err)
+			}
+			approvedRec, _ := lock.Get("repo/deploy")
 
-	// Same dir, but the resolved spec now carries override-elevated
-	// permissions (simulating a taskset.yaml edit outside the task dir).
-	elevated := specVariant(base, func(s *task.Spec) {
-		s.Permissions.Net = []string{"*"}
-		s.Permissions.Dicode = &task.DicodePermissions{SecretsWrite: true}
-	})
-	armed, err := g.Admit(elevated)
-	if err != nil {
-		t.Fatalf("Admit elevated: %v", err)
-	}
-	if armed {
-		t.Fatal("override-elevated task must re-pend, got armed (issue #400 bypass)")
-	}
-	if !g.IsPending("repo/deploy") {
-		t.Fatal("elevated task not in pending set")
-	}
-	if got := arm.armedIDs(); len(got) != 1 {
-		t.Fatalf("armed = %v, want only the original approval", got)
-	}
-	// The lock keeps the previously approved hash for drift inspection.
-	if rec, ok := lock.Get("repo/deploy"); !ok || rec != approvedRec {
-		t.Fatalf("lock record changed on re-pend: %+v → %+v (ok=%v)", approvedRec, rec, ok)
-	}
-}
-
-// TestOverrideTriggerRewireRePend is the gate-level regression for the
-// trigger-shape gap: an approved manual task whose resolved trigger is later
-// switched to an unauthenticated webhook by a taskset override (same dir on
-// disk, webhook_auth still false) must be held pending again, not auto-armed
-// off the stale lock entry.
-func TestOverrideTriggerRewireRePend(t *testing.T) {
-	g, arm, lock := newTestGate(t, enabledPolicy())
-	base := writeTaskDir(t, t.TempDir(), "repo/deploy", "v1")
-
-	// Admit as a manual-trigger task and approve.
-	manual := specVariant(base, func(s *task.Spec) { s.Trigger.Manual = true })
-	if armed, err := g.Admit(manual); err != nil || armed {
-		t.Fatalf("Admit manual = (%v, %v), want pending", armed, err)
-	}
-	if err := g.Approve("repo/deploy"); err != nil {
-		t.Fatalf("Approve: %v", err)
-	}
-	approvedRec, _ := lock.Get("repo/deploy")
-
-	// Same dir, but a TriggerPatch override has rewired the task to an
-	// unauthenticated webhook (Webhook set, Manual cleared, auth false).
-	webhook := specVariant(base, func(s *task.Spec) { s.Trigger.Webhook = "/hooks/x" })
-	armed, err := g.Admit(webhook)
-	if err != nil {
-		t.Fatalf("Admit webhook: %v", err)
-	}
-	if armed {
-		t.Fatal("trigger-rewired task must re-pend, got armed (issue #400 trigger-shape bypass)")
-	}
-	if !g.IsPending("repo/deploy") {
-		t.Fatal("trigger-rewired task not in pending set")
-	}
-	if got := arm.armedIDs(); len(got) != 1 {
-		t.Fatalf("armed = %v, want only the original approval", got)
-	}
-	if rec, ok := lock.Get("repo/deploy"); !ok || rec != approvedRec {
-		t.Fatalf("lock record changed on re-pend: %+v → %+v (ok=%v)", approvedRec, rec, ok)
+			// Same dir, but the resolved spec is now override-elevated.
+			armed, err := g.Admit(specVariant(base, tc.elevated))
+			if err != nil {
+				t.Fatalf("Admit elevated: %v", err)
+			}
+			if armed {
+				t.Fatal("override-elevated task must re-pend, got armed (issue #400 bypass)")
+			}
+			if !g.IsPending("repo/deploy") {
+				t.Fatal("elevated task not in pending set")
+			}
+			if got := arm.armedIDs(); len(got) != 1 {
+				t.Fatalf("armed = %v, want only the original approval", got)
+			}
+			// The lock keeps the previously approved hash for drift inspection.
+			if rec, ok := lock.Get("repo/deploy"); !ok || rec != approvedRec {
+				t.Fatalf("lock record changed on re-pend: %+v → %+v (ok=%v)", approvedRec, rec, ok)
+			}
+		})
 	}
 }

--- a/pkg/approval/content_hash_test.go
+++ b/pkg/approval/content_hash_test.go
@@ -68,6 +68,42 @@ func TestContentHashFoldsResolvedSecurityFields(t *testing.T) {
 	}
 }
 
+// TestContentHashFoldsResolvedTriggerShape: a TriggerPatch override can
+// switch a manual/cron task to an (unauthenticated) webhook, change its path,
+// or rewire chain/daemon — all without touching the task dir or webhook_auth.
+// Every such trigger-shape change must perturb the hash.
+func TestContentHashFoldsResolvedTriggerShape(t *testing.T) {
+	base := writeTaskDir(t, t.TempDir(), "repo/deploy", "x")
+
+	pairs := []struct {
+		name string
+		a, b func(*task.Spec)
+	}{
+		{
+			name: "manual to unauthenticated webhook",
+			a:    func(s *task.Spec) { s.Trigger.Manual = true },
+			b:    func(s *task.Spec) { s.Trigger.Webhook = "/hooks/x" },
+		},
+		{
+			name: "webhook path change",
+			a:    func(s *task.Spec) { s.Trigger.Webhook = "/hooks/a" },
+			b:    func(s *task.Spec) { s.Trigger.Webhook = "/hooks/b" },
+		},
+		{
+			name: "chain rewire",
+			a:    nil,
+			b:    func(s *task.Spec) { s.Trigger.Chain = &task.ChainTrigger{From: "repo/other"} },
+		},
+	}
+	for _, p := range pairs {
+		ha := mustHash(t, specVariant(base, p.a))
+		hb := mustHash(t, specVariant(base, p.b))
+		if ha == hb {
+			t.Errorf("%s: hash unchanged despite trigger shape change", p.name)
+		}
+	}
+}
+
 // TestContentHashIgnoresCosmeticResolvedFields documents the intended scope:
 // only security-bearing resolved fields are folded in; cosmetic resolved
 // drift (e.g. an override-free description tweak applied post-load) must not
@@ -138,6 +174,46 @@ func TestOverrideElevatedPermissionsRePend(t *testing.T) {
 		t.Fatalf("armed = %v, want only the original approval", got)
 	}
 	// The lock keeps the previously approved hash for drift inspection.
+	if rec, ok := lock.Get("repo/deploy"); !ok || rec != approvedRec {
+		t.Fatalf("lock record changed on re-pend: %+v → %+v (ok=%v)", approvedRec, rec, ok)
+	}
+}
+
+// TestOverrideTriggerRewireRePend is the gate-level regression for the
+// trigger-shape gap: an approved manual task whose resolved trigger is later
+// switched to an unauthenticated webhook by a taskset override (same dir on
+// disk, webhook_auth still false) must be held pending again, not auto-armed
+// off the stale lock entry.
+func TestOverrideTriggerRewireRePend(t *testing.T) {
+	g, arm, lock := newTestGate(t, enabledPolicy())
+	base := writeTaskDir(t, t.TempDir(), "repo/deploy", "v1")
+
+	// Admit as a manual-trigger task and approve.
+	manual := specVariant(base, func(s *task.Spec) { s.Trigger.Manual = true })
+	if armed, err := g.Admit(manual); err != nil || armed {
+		t.Fatalf("Admit manual = (%v, %v), want pending", armed, err)
+	}
+	if err := g.Approve("repo/deploy"); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	approvedRec, _ := lock.Get("repo/deploy")
+
+	// Same dir, but a TriggerPatch override has rewired the task to an
+	// unauthenticated webhook (Webhook set, Manual cleared, auth false).
+	webhook := specVariant(base, func(s *task.Spec) { s.Trigger.Webhook = "/hooks/x" })
+	armed, err := g.Admit(webhook)
+	if err != nil {
+		t.Fatalf("Admit webhook: %v", err)
+	}
+	if armed {
+		t.Fatal("trigger-rewired task must re-pend, got armed (issue #400 trigger-shape bypass)")
+	}
+	if !g.IsPending("repo/deploy") {
+		t.Fatal("trigger-rewired task not in pending set")
+	}
+	if got := arm.armedIDs(); len(got) != 1 {
+		t.Fatalf("armed = %v, want only the original approval", got)
+	}
 	if rec, ok := lock.Get("repo/deploy"); !ok || rec != approvedRec {
 		t.Fatalf("lock record changed on re-pend: %+v → %+v (ok=%v)", approvedRec, rec, ok)
 	}

--- a/pkg/approval/content_hash_test.go
+++ b/pkg/approval/content_hash_test.go
@@ -1,0 +1,144 @@
+package approval
+
+import (
+	"testing"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// specInDir returns a dir-backed spec for the given task dir (created once by
+// the caller via writeTaskDir) with the supplied mutation applied, so tests
+// can vary single resolved fields against an identical on-disk dir.
+func specVariant(base *task.Spec, mutate func(*task.Spec)) *task.Spec {
+	s := &task.Spec{ID: base.ID, TaskDir: base.TaskDir}
+	if mutate != nil {
+		mutate(s)
+	}
+	return s
+}
+
+func mustHash(t *testing.T, k task.Kinded) string {
+	t.Helper()
+	h, err := ContentHash(k)
+	if err != nil {
+		t.Fatalf("ContentHash: %v", err)
+	}
+	if h == "" {
+		t.Fatal("ContentHash returned empty hash")
+	}
+	return h
+}
+
+func TestContentHashStableAcrossCalls(t *testing.T) {
+	base := writeTaskDir(t, t.TempDir(), "repo/deploy", "x")
+	spec := specVariant(base, func(s *task.Spec) {
+		s.Runtime = task.RuntimeDeno
+		s.Permissions.Net = []string{"api.github.com"}
+		s.Permissions.Dicode = &task.DicodePermissions{Tasks: []string{"repo/other"}}
+		s.Trigger.WebhookAuth = true
+	})
+	h1 := mustHash(t, spec)
+	h2 := mustHash(t, spec)
+	if h1 != h2 {
+		t.Fatalf("ContentHash not stable: %q vs %q", h1, h2)
+	}
+}
+
+// TestContentHashFoldsResolvedSecurityFields is the core of issue #400:
+// taskset overrides mutate the resolved spec outside the task dir, so any
+// security-bearing resolved field must perturb the hash even when the dir is
+// byte-identical.
+func TestContentHashFoldsResolvedSecurityFields(t *testing.T) {
+	base := writeTaskDir(t, t.TempDir(), "repo/deploy", "x")
+
+	variants := map[string]func(*task.Spec){
+		"net wildcard":     func(s *task.Spec) { s.Permissions.Net = []string{"*"} },
+		"fs write grant":   func(s *task.Spec) { s.Permissions.FS = []task.FSEntry{{Path: "/etc", Permission: "w"}} },
+		"dicode tasks":     func(s *task.Spec) { s.Permissions.Dicode = &task.DicodePermissions{Tasks: []string{"*"}} },
+		"runtime swap":     func(s *task.Spec) { s.Runtime = task.Runtime("python") },
+		"webhook auth off": func(s *task.Spec) { s.Trigger.WebhookAuth = true },
+	}
+
+	baseHash := mustHash(t, specVariant(base, nil))
+	for name, mutate := range variants {
+		got := mustHash(t, specVariant(base, mutate))
+		if got == baseHash {
+			t.Errorf("%s: hash unchanged despite elevated resolved field", name)
+		}
+	}
+}
+
+// TestContentHashIgnoresCosmeticResolvedFields documents the intended scope:
+// only security-bearing resolved fields are folded in; cosmetic resolved
+// drift (e.g. an override-free description tweak applied post-load) must not
+// churn approvals for dir-backed tasks.
+func TestContentHashIgnoresCosmeticResolvedFields(t *testing.T) {
+	base := writeTaskDir(t, t.TempDir(), "repo/deploy", "x")
+	plain := mustHash(t, specVariant(base, nil))
+	cosmetic := mustHash(t, specVariant(base, func(s *task.Spec) {
+		s.Description = "totally different description"
+		s.Name = "renamed"
+	}))
+	if plain != cosmetic {
+		t.Fatalf("cosmetic field change altered hash: %q vs %q", plain, cosmetic)
+	}
+}
+
+// TestContentHashPipelineTaskKeepsDirHash: pipelines are not subject to
+// permission-replacing taskset overrides, so their gate hash remains the
+// plain directory hash.
+func TestContentHashPipelineTaskKeepsDirHash(t *testing.T) {
+	// Reuse writeTaskDir for the directory contents; only the dir matters.
+	dir := writeTaskDir(t, t.TempDir(), "repo/pipe", "stages").TaskDir
+	p := &task.PipelineTask{ID: "repo/pipe", TaskDir: dir}
+	got := mustHash(t, p)
+	want, err := task.Hash(dir)
+	if err != nil {
+		t.Fatalf("task.Hash: %v", err)
+	}
+	if got != want {
+		t.Fatalf("pipeline ContentHash = %q, want plain dir hash %q", got, want)
+	}
+}
+
+// TestOverrideElevatedPermissionsRePend is the gate-level regression test for
+// issue #400: an approved task whose resolved permissions are later elevated
+// by a taskset override (same dir on disk) must be held pending again, not
+// auto-approved off the stale lock entry.
+func TestOverrideElevatedPermissionsRePend(t *testing.T) {
+	g, arm, lock := newTestGate(t, enabledPolicy())
+	base := writeTaskDir(t, t.TempDir(), "repo/deploy", "v1")
+
+	// Admit at base permissions and approve.
+	if armed, err := g.Admit(specVariant(base, nil)); err != nil || armed {
+		t.Fatalf("Admit base = (%v, %v), want pending", armed, err)
+	}
+	if err := g.Approve("repo/deploy"); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	approvedRec, _ := lock.Get("repo/deploy")
+
+	// Same dir, but the resolved spec now carries override-elevated
+	// permissions (simulating a taskset.yaml edit outside the task dir).
+	elevated := specVariant(base, func(s *task.Spec) {
+		s.Permissions.Net = []string{"*"}
+		s.Permissions.Dicode = &task.DicodePermissions{SecretsWrite: true}
+	})
+	armed, err := g.Admit(elevated)
+	if err != nil {
+		t.Fatalf("Admit elevated: %v", err)
+	}
+	if armed {
+		t.Fatal("override-elevated task must re-pend, got armed (issue #400 bypass)")
+	}
+	if !g.IsPending("repo/deploy") {
+		t.Fatal("elevated task not in pending set")
+	}
+	if got := arm.armedIDs(); len(got) != 1 {
+		t.Fatalf("armed = %v, want only the original approval", got)
+	}
+	// The lock keeps the previously approved hash for drift inspection.
+	if rec, ok := lock.Get("repo/deploy"); !ok || rec != approvedRec {
+		t.Fatalf("lock record changed on re-pend: %+v → %+v (ok=%v)", approvedRec, rec, ok)
+	}
+}

--- a/pkg/approval/gate.go
+++ b/pkg/approval/gate.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/dicode/dicode/pkg/task"
 	"go.uber.org/zap"
@@ -279,25 +280,78 @@ func SourceOf(id string) string {
 	return ""
 }
 
-// contentHashDomainV3 is the versioned domain-separation prefix for the
-// dir-backed *task.Spec hash. Bump the version whenever the folded field set
-// or encoding changes so old lock entries can never collide with new ones.
-// v3 folds the full resolved trigger shape (v2 only covered webhook auth).
-const contentHashDomainV3 = "dicode-approval-content-v3"
+// contentHashDomain is the versioned domain-separation prefix for the
+// dir-backed content hash. Bump the version whenever the folded field set or
+// encoding changes so old lock entries can never collide with new ones.
+const contentHashDomain = "dicode-approval-content-v1"
+
+// redactedEnvValue replaces literal EnvEntry.Value contents in every hash
+// input. dicode.lock is documented as committable and every other hash input
+// is reconstructable from the repo, so folding a literal env value would put
+// a low-entropy credential digest in the lock — an offline dictionary
+// attack. Trade-off: value-content edits no longer re-pend; a value change
+// does not widen capability (the entry's name/secret/from refs still fold),
+// which matches the WebhookSecret exclusion rationale.
+const redactedEnvValue = "<redacted>"
+
+// sanitizePermissions returns p with every non-empty Env literal Value
+// replaced by redactedEnvValue. The Env slice is copied before mutation so
+// the caller's spec is never touched; name/secret/from refs are kept.
+func sanitizePermissions(p task.Permissions) task.Permissions {
+	needsRedact := false
+	for _, e := range p.Env {
+		if e.Value != "" {
+			needsRedact = true
+			break
+		}
+	}
+	if !needsRedact {
+		return p
+	}
+	env := make([]task.EnvEntry, len(p.Env))
+	copy(env, p.Env)
+	for i := range env {
+		if env[i].Value != "" {
+			env[i].Value = redactedEnvValue
+		}
+	}
+	p.Env = env
+	return p
+}
+
+// resolvedParam is the minimal override-mutable tuple of a task.Param folded
+// into the hash. Description (and Type, which mergeParams cannot touch) are
+// deliberately excluded so cosmetic param edits do not churn approvals.
+type resolvedParam struct {
+	Name     string `json:"name"`
+	Default  string `json:"default"`
+	Required bool   `json:"required"`
+}
 
 // resolvedSecurityFields pins the exact set of resolved (post-override)
-// security-bearing spec fields folded into the v3 content hash. Keeping the
-// set in a dedicated struct (rather than hashing the whole spec) makes it
+// security-bearing spec fields folded into the content hash. Keeping the set
+// in a dedicated struct (rather than hashing the whole spec) makes it
 // explicit and deterministic: cosmetic resolved fields (name, description,
-// params, …) do not churn approvals, while anything that widens what the
-// task may touch does.
+// param descriptions, …) do not churn approvals, while anything that widens
+// what the task may touch — or what it is fed — does.
+//
+// The reflection guard in content_hash_guard_test.go enforces that every
+// field of task.Overrides / task.TriggerPatch is either represented here or
+// explicitly exempted.
 type resolvedSecurityFields struct {
 	// Permissions is the full resolved permission set (env, fs, run, net,
 	// sys, dicode) — taskset overrides can replace or merge any of these.
+	// Env literal values are redacted (see redactedEnvValue).
 	Permissions task.Permissions `json:"permissions"`
 	// Runtime is folded in because overrides can swap deno→python, which
 	// changes how (and whether) the declared permissions are enforced.
 	Runtime task.Runtime `json:"runtime"`
+	// Params are override-mutable (mergeParams) program inputs: an override
+	// can repoint a param-default URL at an attacker endpoint without
+	// touching the dir, so defaults must perturb the hash.
+	Params []resolvedParam `json:"params,omitempty"`
+	// Timeout is override-mutable and widens the task's wall-clock budget.
+	Timeout time.Duration `json:"timeout"`
 	// Trigger captures the full resolved trigger shape: an override's
 	// TriggerPatch (pkg/task/overrides.go: Cron, Webhook, Auth, Manual,
 	// Chain, Daemon, Restart) can switch a manual/cron task to an
@@ -315,39 +369,82 @@ type resolvedSecurityFields struct {
 	Chain       *task.ChainTrigger `json:"chain,omitempty"`
 }
 
+// resolvedPipelineSecurityFields mirrors resolvedSecurityFields for
+// kind: PipelineTask. Pipelines skip taskset override layers in v1
+// (pkg/taskset/resolver.go, case KindPipelineTask), but folding the resolved
+// shape now means a future resolver that does apply overrides to pipelines
+// fails closed (re-pends) instead of silently keeping a stale dir-only
+// approval. PipelineTrigger has no Daemon/Restart; WebhookSecret and
+// ReplayProtection are excluded for the same reasons as on Spec.
+type resolvedPipelineSecurityFields struct {
+	Timeout     time.Duration      `json:"timeout"`
+	Webhook     string             `json:"webhook"`
+	WebhookAuth bool               `json:"webhook_auth"`
+	Cron        string             `json:"cron"`
+	Manual      bool               `json:"manual"`
+	Chain       *task.ChainTrigger `json:"chain,omitempty"`
+}
+
+// hashDirResolved combines the task-dir hash with the canonical JSON of the
+// resolved security fields under the versioned domain prefix, NUL-delimited.
+func hashDirResolved(taskID, dir string, resolved any) (string, error) {
+	dirHash, err := task.Hash(dir)
+	if err != nil {
+		return "", err
+	}
+	b, err := json.Marshal(resolved)
+	if err != nil {
+		return "", fmt.Errorf("hash %s: marshal resolved fields: %w", taskID, err)
+	}
+	h := sha256.New()
+	h.Write([]byte(contentHashDomain))
+	h.Write([]byte{0})
+	h.Write([]byte(dirHash))
+	h.Write([]byte{0})
+	h.Write(b)
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
 // ContentHash computes the gate's content hash for a task.
 //
 // For a *task.Spec with a task directory, the hash covers task.Hash over the
 // directory (task.yaml + script files) AND a canonical JSON encoding of the
-// resolved security-bearing fields (permissions, runtime, and the full
-// resolved trigger shape). Folding the resolved fields in is essential:
-// taskset overrides (pkg/taskset/override.go) mutate the resolved spec after
-// load — they can replace permissions.net/fs/dicode, merge env entries, swap
-// the runtime, and patch the trigger (switch a manual/cron task to an
-// unauthenticated webhook, change its path, rewire chain/daemon) — and
-// taskset.yaml lives outside the task dir, so a dir-only hash would let an
-// override elevate a task's effective permissions or exposure without ever
-// re-pending it for approval (issue #400). The two inputs are combined under
-// the versioned domain-separation prefix contentHashDomainV3, NUL-delimited.
+// resolved security-bearing fields (permissions, runtime, params, timeout,
+// and the full resolved trigger shape). Folding the resolved fields in is
+// essential: taskset overrides (pkg/taskset/override.go) mutate the resolved
+// spec after load — they can replace permissions.net/fs/dicode, merge env
+// entries, swap the runtime, repoint param defaults, widen the timeout, and
+// patch the trigger (switch a manual/cron task to an unauthenticated
+// webhook, change its path, rewire chain/daemon) — and taskset.yaml lives
+// outside the task dir, so a dir-only hash would let an override elevate a
+// task's effective permissions or exposure without ever re-pending it for
+// approval (issue #400). The two inputs are combined under the versioned
+// domain-separation prefix contentHashDomain, NUL-delimited.
 //
-// A *task.PipelineTask with a directory keeps the plain dir hash: pipelines
-// are not subject to permission-replacing taskset overrides (see
-// pkg/taskset/resolver.go, case KindPipelineTask), and their per-stage
-// overrides live in the pipeline's own task.yaml, which the dir hash already
-// covers.
+// A *task.PipelineTask with a directory uses the same scheme over its
+// resolved trigger shape and timeout — see resolvedPipelineSecurityFields.
 //
-// Dir-less tasks (inline taskset entries) hash the resolved spec JSON.
+// Dir-less tasks (inline taskset entries) hash the resolved spec JSON; for
+// *task.Spec the marshalled copy has Trigger.WebhookSecret cleared and env
+// literal values redacted (TriggerConfig carries yaml tags only, so every
+// exported field — secret included — would otherwise marshal by Go name).
 func ContentHash(k task.Kinded) (string, error) {
 	switch s := k.(type) {
 	case *task.Spec:
 		if s.TaskDir != "" {
-			dirHash, err := task.Hash(s.TaskDir)
-			if err != nil {
-				return "", err
+			var params []resolvedParam
+			for _, p := range s.Params {
+				params = append(params, resolvedParam{
+					Name:     p.Name,
+					Default:  p.Default,
+					Required: p.Required,
+				})
 			}
-			resolved, err := json.Marshal(resolvedSecurityFields{
-				Permissions: s.Permissions,
+			return hashDirResolved(k.TaskID(), s.TaskDir, resolvedSecurityFields{
+				Permissions: sanitizePermissions(s.Permissions),
 				Runtime:     s.Runtime,
+				Params:      params,
+				Timeout:     s.Timeout,
 				Webhook:     s.Trigger.Webhook,
 				WebhookAuth: s.Trigger.WebhookAuth,
 				Cron:        s.Trigger.Cron,
@@ -356,25 +453,33 @@ func ContentHash(k task.Kinded) (string, error) {
 				Restart:     s.Trigger.Restart,
 				Chain:       s.Trigger.Chain,
 			})
-			if err != nil {
-				return "", fmt.Errorf("hash %s: marshal resolved fields: %w", k.TaskID(), err)
-			}
-			h := sha256.New()
-			h.Write([]byte(contentHashDomainV3))
-			h.Write([]byte{0})
-			h.Write([]byte(dirHash))
-			h.Write([]byte{0})
-			h.Write(resolved)
-			return hex.EncodeToString(h.Sum(nil)), nil
 		}
+		// Dir-less fallback: hash a shallow copy with secrets stripped so the
+		// committable lock never embeds a digest over secret material.
+		c := *s
+		c.Trigger.WebhookSecret = ""
+		c.Permissions = sanitizePermissions(c.Permissions)
+		return hashJSON(k.TaskID(), &c)
 	case *task.PipelineTask:
 		if s.TaskDir != "" {
-			return task.Hash(s.TaskDir)
+			return hashDirResolved(k.TaskID(), s.TaskDir, resolvedPipelineSecurityFields{
+				Timeout:     s.Timeout,
+				Webhook:     s.Trigger.Webhook,
+				WebhookAuth: s.Trigger.WebhookAuth,
+				Cron:        s.Trigger.Cron,
+				Manual:      s.Trigger.Manual,
+				Chain:       s.Trigger.Chain,
+			})
 		}
 	}
-	b, err := json.Marshal(k)
+	return hashJSON(k.TaskID(), k)
+}
+
+// hashJSON is the dir-less fallback: SHA-256 over the JSON encoding of v.
+func hashJSON(taskID string, v any) (string, error) {
+	b, err := json.Marshal(v)
 	if err != nil {
-		return "", fmt.Errorf("hash %s: %w", k.TaskID(), err)
+		return "", fmt.Errorf("hash %s: %w", taskID, err)
 	}
 	sum := sha256.Sum256(b)
 	return hex.EncodeToString(sum[:]), nil

--- a/pkg/approval/gate.go
+++ b/pkg/approval/gate.go
@@ -279,13 +279,14 @@ func SourceOf(id string) string {
 	return ""
 }
 
-// contentHashDomainV2 is the versioned domain-separation prefix for the
+// contentHashDomainV3 is the versioned domain-separation prefix for the
 // dir-backed *task.Spec hash. Bump the version whenever the folded field set
 // or encoding changes so old lock entries can never collide with new ones.
-const contentHashDomainV2 = "dicode-approval-content-v2"
+// v3 folds the full resolved trigger shape (v2 only covered webhook auth).
+const contentHashDomainV3 = "dicode-approval-content-v3"
 
 // resolvedSecurityFields pins the exact set of resolved (post-override)
-// security-bearing spec fields folded into the v2 content hash. Keeping the
+// security-bearing spec fields folded into the v3 content hash. Keeping the
 // set in a dedicated struct (rather than hashing the whole spec) makes it
 // explicit and deterministic: cosmetic resolved fields (name, description,
 // params, …) do not churn approvals, while anything that widens what the
@@ -297,24 +298,37 @@ type resolvedSecurityFields struct {
 	// Runtime is folded in because overrides can swap deno→python, which
 	// changes how (and whether) the declared permissions are enforced.
 	Runtime task.Runtime `json:"runtime"`
-	// WebhookAuth is folded in because a trigger patch can silently drop
-	// session auth from a webhook-triggered task.
-	WebhookAuth bool `json:"webhook_auth"`
+	// Trigger captures the full resolved trigger shape: an override's
+	// TriggerPatch (pkg/task/overrides.go: Cron, Webhook, Auth, Manual,
+	// Chain, Daemon, Restart) can switch a manual/cron task to an
+	// (unauthenticated) webhook, change its path, or rewire chain/daemon —
+	// none of which touch the dir hash. WebhookSecret and ReplayProtection
+	// are deliberately excluded: TriggerPatch cannot set them, the secret
+	// is already covered by the dir hash, and a secret must never feed a
+	// non-secret hash input.
+	Webhook     string             `json:"webhook"`
+	WebhookAuth bool               `json:"webhook_auth"`
+	Cron        string             `json:"cron"`
+	Manual      bool               `json:"manual"`
+	Daemon      bool               `json:"daemon"`
+	Restart     string             `json:"restart"`
+	Chain       *task.ChainTrigger `json:"chain,omitempty"`
 }
 
 // ContentHash computes the gate's content hash for a task.
 //
 // For a *task.Spec with a task directory, the hash covers task.Hash over the
 // directory (task.yaml + script files) AND a canonical JSON encoding of the
-// resolved security-bearing fields (permissions, runtime, webhook auth).
-// Folding the resolved fields in is essential: taskset overrides
-// (pkg/taskset/override.go) mutate the resolved spec after load — they can
-// replace permissions.net/fs/dicode, merge env entries, patch trigger.auth
-// and swap the runtime — and taskset.yaml lives outside the task dir, so a
-// dir-only hash would let an override elevate a task's effective permissions
-// without ever re-pending it for approval (issue #400). The two inputs are
-// combined under the versioned domain-separation prefix
-// contentHashDomainV2, NUL-delimited.
+// resolved security-bearing fields (permissions, runtime, and the full
+// resolved trigger shape). Folding the resolved fields in is essential:
+// taskset overrides (pkg/taskset/override.go) mutate the resolved spec after
+// load — they can replace permissions.net/fs/dicode, merge env entries, swap
+// the runtime, and patch the trigger (switch a manual/cron task to an
+// unauthenticated webhook, change its path, rewire chain/daemon) — and
+// taskset.yaml lives outside the task dir, so a dir-only hash would let an
+// override elevate a task's effective permissions or exposure without ever
+// re-pending it for approval (issue #400). The two inputs are combined under
+// the versioned domain-separation prefix contentHashDomainV3, NUL-delimited.
 //
 // A *task.PipelineTask with a directory keeps the plain dir hash: pipelines
 // are not subject to permission-replacing taskset overrides (see
@@ -334,13 +348,19 @@ func ContentHash(k task.Kinded) (string, error) {
 			resolved, err := json.Marshal(resolvedSecurityFields{
 				Permissions: s.Permissions,
 				Runtime:     s.Runtime,
+				Webhook:     s.Trigger.Webhook,
 				WebhookAuth: s.Trigger.WebhookAuth,
+				Cron:        s.Trigger.Cron,
+				Manual:      s.Trigger.Manual,
+				Daemon:      s.Trigger.Daemon,
+				Restart:     s.Trigger.Restart,
+				Chain:       s.Trigger.Chain,
 			})
 			if err != nil {
 				return "", fmt.Errorf("hash %s: marshal resolved fields: %w", k.TaskID(), err)
 			}
 			h := sha256.New()
-			h.Write([]byte(contentHashDomainV2))
+			h.Write([]byte(contentHashDomainV3))
 			h.Write([]byte{0})
 			h.Write([]byte(dirHash))
 			h.Write([]byte{0})

--- a/pkg/approval/gate.go
+++ b/pkg/approval/gate.go
@@ -279,19 +279,78 @@ func SourceOf(id string) string {
 	return ""
 }
 
-// ContentHash computes the gate's content hash for a task: task.Hash over
-// the task directory (task.yaml + script files) when the task has one, else
-// a hash of the resolved spec JSON (inline / dir-less tasks).
+// contentHashDomainV2 is the versioned domain-separation prefix for the
+// dir-backed *task.Spec hash. Bump the version whenever the folded field set
+// or encoding changes so old lock entries can never collide with new ones.
+const contentHashDomainV2 = "dicode-approval-content-v2"
+
+// resolvedSecurityFields pins the exact set of resolved (post-override)
+// security-bearing spec fields folded into the v2 content hash. Keeping the
+// set in a dedicated struct (rather than hashing the whole spec) makes it
+// explicit and deterministic: cosmetic resolved fields (name, description,
+// params, …) do not churn approvals, while anything that widens what the
+// task may touch does.
+type resolvedSecurityFields struct {
+	// Permissions is the full resolved permission set (env, fs, run, net,
+	// sys, dicode) — taskset overrides can replace or merge any of these.
+	Permissions task.Permissions `json:"permissions"`
+	// Runtime is folded in because overrides can swap deno→python, which
+	// changes how (and whether) the declared permissions are enforced.
+	Runtime task.Runtime `json:"runtime"`
+	// WebhookAuth is folded in because a trigger patch can silently drop
+	// session auth from a webhook-triggered task.
+	WebhookAuth bool `json:"webhook_auth"`
+}
+
+// ContentHash computes the gate's content hash for a task.
+//
+// For a *task.Spec with a task directory, the hash covers task.Hash over the
+// directory (task.yaml + script files) AND a canonical JSON encoding of the
+// resolved security-bearing fields (permissions, runtime, webhook auth).
+// Folding the resolved fields in is essential: taskset overrides
+// (pkg/taskset/override.go) mutate the resolved spec after load — they can
+// replace permissions.net/fs/dicode, merge env entries, patch trigger.auth
+// and swap the runtime — and taskset.yaml lives outside the task dir, so a
+// dir-only hash would let an override elevate a task's effective permissions
+// without ever re-pending it for approval (issue #400). The two inputs are
+// combined under the versioned domain-separation prefix
+// contentHashDomainV2, NUL-delimited.
+//
+// A *task.PipelineTask with a directory keeps the plain dir hash: pipelines
+// are not subject to permission-replacing taskset overrides (see
+// pkg/taskset/resolver.go, case KindPipelineTask), and their per-stage
+// overrides live in the pipeline's own task.yaml, which the dir hash already
+// covers.
+//
+// Dir-less tasks (inline taskset entries) hash the resolved spec JSON.
 func ContentHash(k task.Kinded) (string, error) {
-	var dir string
 	switch s := k.(type) {
 	case *task.Spec:
-		dir = s.TaskDir
+		if s.TaskDir != "" {
+			dirHash, err := task.Hash(s.TaskDir)
+			if err != nil {
+				return "", err
+			}
+			resolved, err := json.Marshal(resolvedSecurityFields{
+				Permissions: s.Permissions,
+				Runtime:     s.Runtime,
+				WebhookAuth: s.Trigger.WebhookAuth,
+			})
+			if err != nil {
+				return "", fmt.Errorf("hash %s: marshal resolved fields: %w", k.TaskID(), err)
+			}
+			h := sha256.New()
+			h.Write([]byte(contentHashDomainV2))
+			h.Write([]byte{0})
+			h.Write([]byte(dirHash))
+			h.Write([]byte{0})
+			h.Write(resolved)
+			return hex.EncodeToString(h.Sum(nil)), nil
+		}
 	case *task.PipelineTask:
-		dir = s.TaskDir
-	}
-	if dir != "" {
-		return task.Hash(dir)
+		if s.TaskDir != "" {
+			return task.Hash(s.TaskDir)
+		}
 	}
 	b, err := json.Marshal(k)
 	if err != nil {

--- a/pkg/approval/gate_test.go
+++ b/pkg/approval/gate_test.go
@@ -145,7 +145,7 @@ func TestTrustedSourceArmsAndRecords(t *testing.T) {
 	if !ok || rec.ApprovedBy != ApprovedByTrustedSource {
 		t.Fatalf("lock record = %+v, ok=%v", rec, ok)
 	}
-	wantHash, err := task.Hash(spec.TaskDir)
+	wantHash, err := ContentHash(spec)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/task/overrides.go
+++ b/pkg/task/overrides.go
@@ -103,6 +103,11 @@ func (p *ParamOverrides) UnmarshalYAML(value *yaml.Node) error {
 // implementation continues to live in pkg/taskset (exported as
 // taskset.ApplyOverrides) so per-edge dispatch sites can reuse the exact
 // same semantics as the global `dicode tasks override <id>` path.
+//
+// SECURITY: every field added here (and to TriggerPatch) must be classified
+// in pkg/approval/content_hash_guard_test.go — either folded into the
+// approval gate's resolvedSecurityFields or explicitly exempted with a
+// justification. The guard test fails the build of pkg/approval otherwise.
 type Overrides struct {
 	Enabled     *bool          `yaml:"enabled,omitempty"`
 	Name        string         `yaml:"name,omitempty"`        // replaces spec.Name


### PR DESCRIPTION
## Summary

Fixes the approval-bypass found in the #393 review: taskset overrides can replace `permissions.{net,fs,dicode}`, merge env, patch `trigger.auth`, and swap `runtime` on the resolved spec **after** load, but the gate's content hash covered only the on-disk task dir — so an override that elevates a task's effective permissions never re-pended it. Closes #400.

## Design

- **`approval.ContentHash`** for a dir-backed `*task.Spec` now returns `hex(sha256("dicode-approval-content-v2" \0 dirHash \0 resolvedJSON))`, where `resolvedJSON` is a canonical encoding of an explicit `resolvedSecurityFields` struct pinning exactly:
  - `Permissions` (full `task.Permissions`: env, fs, run, net, sys, dicode)
  - `Runtime` (an override swapping deno→python changes enforcement semantics — Python doesn't enforce fs reads)
  - `Trigger.WebhookAuth` (a `TriggerPatch.Auth` override can silently drop webhook auth)
- **`*task.PipelineTask` is unchanged** (plain `task.Hash(dir)`): pipelines are not subject to permission-replacing taskset overrides (`pkg/taskset/resolver.go`, `case KindPipelineTask` applies none), and per-stage overrides live in the pipeline's own `task.yaml`, which the dir hash already covers. Commented in code.
- Dir-less (inline) tasks already hashed the whole resolved spec JSON — unchanged.

**End-to-end behavior**: the taskset source diffs snapshots on the *resolved* spec JSON (`hashKinded`, `pkg/taskset/source.go`), so editing an override already re-registers the task and re-runs `Gate.Admit` — the content hash was the only broken link. With this change, a permission-elevating override produces a new hash, the lock no longer matches, and the task re-pends.

**No lock migration**: the gate is unreleased (post-0.3.0 main only, v0.4.0 still pending in #370); existing `dicode.lock` entries re-pend once at the new hash.

## Tests

New `pkg/approval/content_hash_test.go`:
- hash stability across calls for an identical resolved spec
- hash perturbation for Net / FS-write / `Dicode.Tasks` / `Runtime` / `WebhookAuth` changes with an **identical dir**
- cosmetic fields (Name/Description) do *not* change the hash (documents intended scope)
- PipelineTask hash == plain dir hash
- gate-level regression: approve at base perms → re-Admit same dir with elevated resolved perms ⇒ **held pending**, original lock record preserved

One stale assertion in `gate_test.go` updated (it asserted the exact pre-change hash format).

## Test plan
- [x] `make build`, `go vet ./...`, `gofmt -l` clean
- [x] `make test` (full `go test ./...`) green — including the formerly-flaky deno fixtures (hermetic since #396)
- [x] Explicit `go test ./pkg/approval/... ./pkg/webui/... ./pkg/registry/... ./pkg/taskset/...` green

Opened as a draft; will be driven through the security/code review loop before being marked ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2VRemgpvrJuTinMGtQMYX)_