### PR TITLE
feat(approval): operator notification on pending task (#399)

### DIFF
--- a/pkg/approval/gate.go
+++ b/pkg/approval/gate.go
@@ -48,9 +48,10 @@ type Gate struct {
 	hashFn func(task.Kinded) (string, error)
 	log    *zap.Logger
 
-	mu        sync.Mutex
-	pending   map[string]pendingEntry
-	bootstrap bool
+	mu          sync.Mutex
+	pending     map[string]pendingEntry
+	pendingHook func(k task.Kinded, hash string)
+	bootstrap   bool
 }
 
 // pendingEntry captures the task (and the hash observed at decision time) so
@@ -79,6 +80,18 @@ func NewGate(policy Policy, lock *Lock, arm func(task.Kinded) error, log *zap.Lo
 
 // SetHashFunc overrides the content-hash function (tests).
 func (g *Gate) SetHashFunc(fn func(task.Kinded) (string, error)) { g.hashFn = fn }
+
+// SetPendingHook installs the operator-notification hook. It is invoked only
+// on the transition into pending — a task newly held, or a held task observed
+// at a different content hash — never on a re-admit of an unchanged pending
+// task, so a 30s reconcile loop cannot spam notifications. The hook is called
+// without the gate lock held; it must not block (spawn a goroutine for any
+// slow work).
+func (g *Gate) SetPendingHook(fn func(k task.Kinded, hash string)) {
+	g.mu.Lock()
+	g.pendingHook = fn
+	g.mu.Unlock()
+}
 
 // SetBootstrap toggles bootstrap mode. While on, Admit seeds (auto-approves +
 // records) every task instead of holding it pending, so adopting the gate on
@@ -143,8 +156,13 @@ func (g *Gate) Admit(k task.Kinded) (armed bool, err error) {
 		by = ApprovedByBootstrap
 	default:
 		g.mu.Lock()
+		prev, was := g.pending[id]
 		g.pending[id] = pendingEntry{kinded: k, hash: hash}
+		hook := g.pendingHook
 		g.mu.Unlock()
+		if hook != nil && (!was || prev.hash != hash) {
+			hook(k, hash)
+		}
 		return false, nil
 	}
 

--- a/pkg/approval/gate_hook_test.go
+++ b/pkg/approval/gate_hook_test.go
@@ -1,0 +1,102 @@
+package approval
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// hookCall records one pending-hook invocation.
+type hookCall struct {
+	id   string
+	hash string
+}
+
+func TestPendingHookFiresOnNewHold(t *testing.T) {
+	g, _, _ := newTestGate(t, enabledPolicy())
+	g.SetHashFunc(func(task.Kinded) (string, error) { return "h1", nil })
+	var mu sync.Mutex
+	var calls []hookCall
+	g.SetPendingHook(func(k task.Kinded, hash string) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, hookCall{k.TaskID(), hash})
+	})
+
+	spec := &task.Spec{ID: "repo/deploy"}
+	if armed, _ := g.Admit(spec); armed {
+		t.Fatal("untrusted task must be pending")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(calls) != 1 || calls[0] != (hookCall{"repo/deploy", "h1"}) {
+		t.Fatalf("hook calls = %+v, want one {repo/deploy h1}", calls)
+	}
+}
+
+func TestPendingHookSkipsUnchangedReAdmit(t *testing.T) {
+	g, _, _ := newTestGate(t, enabledPolicy())
+	g.SetHashFunc(func(task.Kinded) (string, error) { return "h1", nil })
+	var mu sync.Mutex
+	var n int
+	g.SetPendingHook(func(task.Kinded, string) { mu.Lock(); n++; mu.Unlock() })
+
+	spec := &task.Spec{ID: "repo/deploy"}
+	g.Admit(spec) // new hold → fires
+	g.Admit(spec) // unchanged re-admit (reconcile poll) → must NOT re-fire
+	g.Admit(spec)
+	mu.Lock()
+	defer mu.Unlock()
+	if n != 1 {
+		t.Fatalf("hook fired %d times, want 1 (only on transition)", n)
+	}
+}
+
+func TestPendingHookFiresOnHashChange(t *testing.T) {
+	g, _, _ := newTestGate(t, enabledPolicy())
+	hash := "h1"
+	g.SetHashFunc(func(task.Kinded) (string, error) { return hash, nil })
+	var mu sync.Mutex
+	var calls []hookCall
+	g.SetPendingHook(func(k task.Kinded, h string) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, hookCall{k.TaskID(), h})
+	})
+
+	spec := &task.Spec{ID: "repo/deploy"}
+	g.Admit(spec) // h1 hold
+	hash = "h2"   // content changed while still pending
+	g.Admit(spec) // h2 → must re-fire
+	mu.Lock()
+	defer mu.Unlock()
+	if len(calls) != 2 || calls[1].hash != "h2" {
+		t.Fatalf("hook calls = %+v, want a second fire at h2", calls)
+	}
+}
+
+func TestPendingHookNotFiredForTrustedTask(t *testing.T) {
+	policy := enabledPolicy()
+	policy.TrustedTasks["repo/deploy"] = true
+	g, _, _ := newTestGate(t, policy)
+	g.SetHashFunc(func(task.Kinded) (string, error) { return "h1", nil })
+	var fired bool
+	g.SetPendingHook(func(task.Kinded, string) { fired = true })
+
+	if armed, _ := g.Admit(&task.Spec{ID: "repo/deploy"}); !armed {
+		t.Fatal("trusted task must arm")
+	}
+	if fired {
+		t.Fatal("hook must not fire for an auto-approved task")
+	}
+}
+
+func TestPendingHookNilSafe(t *testing.T) {
+	g, _, _ := newTestGate(t, enabledPolicy())
+	g.SetHashFunc(func(task.Kinded) (string, error) { return "h1", nil })
+	// No hook installed; Admit must not panic on the pending path.
+	if armed, _ := g.Admit(&task.Spec{ID: "repo/deploy"}); armed {
+		t.Fatal("untrusted task must be pending")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -192,8 +192,11 @@ type ApprovalConfig struct {
 	// maintained as a running inventory.
 	Enabled *bool `yaml:"enabled,omitempty"`
 
-	// NotifyTask is the task fired when a task goes pending. Reserved: parsed
-	// and validated for shape, but not consumed by the daemon yet.
+	// NotifyTask is fired (manual trigger) on the transition into pending with
+	// string params {task_id, hash, approve_url}; delivery (slack/email/ntfy)
+	// is that task's concern. It should be a builtin or trusted task — the
+	// notify task is itself subject to the gate, so an untrusted one would sit
+	// pending and never fire. Empty → WebUI broadcast + WARN log only.
 	NotifyTask string `yaml:"notify_task,omitempty"`
 
 	// Sources maps a source name (the first segment of a namespaced task ID,

--- a/pkg/daemon/approval_notify.go
+++ b/pkg/daemon/approval_notify.go
@@ -1,0 +1,58 @@
+package daemon
+
+import "go.uber.org/zap"
+
+// approvalNotifier turns an approval-gate "task went pending" transition into
+// operator notification: it always broadcasts the WebUI approval:pending
+// event, and, when a notify_task is configured, fires it with the approve
+// details so the operator's delivery task (slack/email/ntfy) can reach them.
+//
+// The notify_task is itself subject to the approval gate. The operator must
+// point notify_task at a builtin or trusted task; an untrusted notify_task
+// would sit pending and never fire (the fire guard vetoes it). That is a
+// no-op, not a deadlock — fire just returns a veto error, which is logged.
+type approvalNotifier struct {
+	notifyTask string
+	broadcast  func(taskID, hash string)
+	mintLink   func(taskID string) (string, error)
+	fire       func(taskID string, params map[string]string) error
+	log        *zap.Logger
+}
+
+// notify runs the broadcast + (optional) notify-task fire for one pending
+// transition. It never returns an error: notification is best-effort and must
+// not affect gate or reconciler behavior. Safe to call from a goroutine.
+func (n approvalNotifier) notify(taskID, hash string) {
+	if n.broadcast != nil {
+		n.broadcast(taskID, hash)
+	}
+	if n.notifyTask == "" {
+		// Gate already logged the remediation hint (WARN) on hold.
+		return
+	}
+	// Mint the single-use approve link. On failure, still notify with an empty
+	// URL so the operator at least learns a task went pending.
+	var approveURL string
+	if n.mintLink != nil {
+		url, err := n.mintLink(taskID)
+		if err != nil && n.log != nil {
+			n.log.Debug("approval notify: mint approve link failed; notifying without URL",
+				zap.String("task", taskID), zap.Error(err))
+		}
+		approveURL = url
+	}
+	if n.fire == nil {
+		return
+	}
+	if err := n.fire(n.notifyTask, map[string]string{
+		"task_id":     taskID,
+		"hash":        hash,
+		"approve_url": approveURL,
+	}); err != nil && n.log != nil {
+		// The single-use token lives in approveURL — keep it out of the log.
+		n.log.Warn("approval notify task failed to fire",
+			zap.String("task", taskID),
+			zap.String("notify_task", n.notifyTask),
+			zap.Error(err))
+	}
+}

--- a/pkg/daemon/approval_notify_test.go
+++ b/pkg/daemon/approval_notify_test.go
@@ -1,0 +1,108 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+)
+
+type fireCall struct {
+	taskID string
+	params map[string]string
+}
+
+func TestApprovalNotifyFiresWithParams(t *testing.T) {
+	var broadcasts [][2]string
+	var fires []fireCall
+	n := approvalNotifier{
+		notifyTask: "buildin/notify",
+		broadcast:  func(id, hash string) { broadcasts = append(broadcasts, [2]string{id, hash}) },
+		mintLink:   func(id string) (string, error) { return "https://host/approve/tok123", nil },
+		fire: func(id string, params map[string]string) error {
+			fires = append(fires, fireCall{id, params})
+			return nil
+		},
+	}
+
+	n.notify("repo/deploy", "abc123")
+
+	if len(broadcasts) != 1 || broadcasts[0] != [2]string{"repo/deploy", "abc123"} {
+		t.Fatalf("broadcasts = %v", broadcasts)
+	}
+	if len(fires) != 1 {
+		t.Fatalf("fires = %v, want 1", fires)
+	}
+	f := fires[0]
+	if f.taskID != "buildin/notify" {
+		t.Fatalf("fired task = %q, want buildin/notify", f.taskID)
+	}
+	want := map[string]string{
+		"task_id":     "repo/deploy",
+		"hash":        "abc123",
+		"approve_url": "https://host/approve/tok123",
+	}
+	for k, v := range want {
+		if f.params[k] != v {
+			t.Fatalf("param %q = %q, want %q", k, f.params[k], v)
+		}
+	}
+}
+
+func TestApprovalNotifyEmptyNotifyTaskBroadcastsOnly(t *testing.T) {
+	var broadcasts int
+	var minted, fired bool
+	n := approvalNotifier{
+		notifyTask: "",
+		broadcast:  func(string, string) { broadcasts++ },
+		mintLink:   func(string) (string, error) { minted = true; return "", nil },
+		fire:       func(string, map[string]string) error { fired = true; return nil },
+	}
+
+	n.notify("repo/deploy", "abc123")
+
+	if broadcasts != 1 {
+		t.Fatalf("broadcasts = %d, want 1", broadcasts)
+	}
+	if minted || fired {
+		t.Fatalf("empty notify_task must not mint (%v) or fire (%v)", minted, fired)
+	}
+}
+
+func TestApprovalNotifyMintFailureStillFiresEmptyURL(t *testing.T) {
+	var fires []fireCall
+	n := approvalNotifier{
+		notifyTask: "buildin/notify",
+		broadcast:  func(string, string) {},
+		mintLink:   func(string) (string, error) { return "", errors.New("not pending") },
+		fire: func(id string, params map[string]string) error {
+			fires = append(fires, fireCall{id, params})
+			return nil
+		},
+	}
+
+	n.notify("repo/deploy", "abc123")
+
+	if len(fires) != 1 {
+		t.Fatalf("fires = %v, want 1 even when mint fails", fires)
+	}
+	if got := fires[0].params["approve_url"]; got != "" {
+		t.Fatalf("approve_url = %q, want empty on mint failure", got)
+	}
+}
+
+func TestApprovalNotifyFireFailureDoesNotPanic(t *testing.T) {
+	n := approvalNotifier{
+		notifyTask: "repo/untrusted-notify", // would itself be pending → veto
+		broadcast:  func(string, string) {},
+		mintLink:   func(string) (string, error) { return "url", nil },
+		fire:       func(string, map[string]string) error { return errors.New("task pending approval") },
+	}
+	// Must not panic; failure is swallowed (logged).
+	n.notify("repo/deploy", "abc123")
+}
+
+func TestApprovalNotifyNilDepsNoPanic(t *testing.T) {
+	// Degrade gracefully if any dependency is nil (defensive against wiring
+	// order / partial construction).
+	(approvalNotifier{notifyTask: "buildin/notify"}).notify("repo/deploy", "h")
+	(approvalNotifier{}).notify("repo/deploy", "h")
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -478,6 +478,36 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	// + the single-use tokenized approve link for notifications.
 	srv.SetApprovalGate(approvalGate)
 	srv.SetApprovalTokenStore(approval.NewTokenStore(database))
+	// Phase 3 (#399): notify on the transition into pending. Installed here —
+	// after srv exists — because the gate is built earlier (step 7a) than the
+	// webui Server (step 8), and the hook needs srv for the broadcast + the
+	// tokenized approve link. The gate invokes this without its lock held and
+	// only on a true pending transition (new hold / hash change), never on an
+	// unchanged re-admit, so the 30s reconcile loop cannot spam notifications.
+	notifier := approvalNotifier{
+		notifyTask: cfg.Approval.NotifyTask,
+		broadcast:  srv.BroadcastApprovalPending,
+		mintLink:   func(id string) (string, error) { return srv.MintApproveLink(ctx, id) },
+		fire: func(id string, params map[string]string) error {
+			_, err := eng.FireManual(ctx, id, params)
+			return err
+		},
+		log: log,
+	}
+	approvalGate.SetPendingHook(func(k task.Kinded, hash string) {
+		id := k.TaskID()
+		// The reconciler goroutine drives the hook; never let notification work
+		// block it, and never let a notify failure crash the daemon.
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Error("approval notify hook panicked",
+						zap.String("task", id), zap.Any("panic", r))
+				}
+			}()
+			notifier.notify(id, hash)
+		}()
+	})
 	if replayer != nil {
 		srv.SetReplayer(replayer)
 	}

--- a/pkg/webui/approval.go
+++ b/pkg/webui/approval.go
@@ -34,6 +34,16 @@ func (s *Server) SetApprovalGate(g ApprovalGate) { s.approvalGate = g }
 // /approve/{token} flow and MintApproveLink.
 func (s *Server) SetApprovalTokenStore(ts *approval.TokenStore) { s.approvalTokens = ts }
 
+// BroadcastApprovalPending emits the "approval:pending" WebSocket event so
+// dashboards can surface a newly held task without polling. The hash is
+// shortened to its display form — the browser never needs the full hash.
+func (s *Server) BroadcastApprovalPending(taskID, hash string) {
+	s.ws.Broadcast(WSMsg{
+		Type: "approval:pending",
+		Data: ApprovalPendingData{TaskID: taskID, Hash: shortHash(hash)},
+	})
+}
+
 // taskPendingApproval reports whether id is held by the approval gate.
 func (s *Server) taskPendingApproval(id string) bool {
 	return s.approvalGate != nil && s.approvalGate.IsPending(id)

--- a/pkg/webui/ws.go
+++ b/pkg/webui/ws.go
@@ -44,6 +44,12 @@ type RunFinishedData struct {
 	ReturnValue       string `json:"returnValue,omitempty"`
 }
 
+// ApprovalPendingData is the payload for "approval:pending".
+type ApprovalPendingData struct {
+	TaskID string `json:"taskID"`
+	Hash   string `json:"hash,omitempty"`
+}
+
 // WSHub manages all WebSocket clients.
 type WSHub struct {
 	mu             sync.Mutex


### PR DESCRIPTION
## Summary

Phase 3 of the approval gate (epic #392, closes #399). When the gate holds a task pending, the operator is now notified instead of having to discover the hold by polling the dashboard or reading the daemon log.

A "pending transition" is a new untrusted task being held, or an already-held task observed at a *changed* content hash. The gate fires its notification hook only on that transition — never on an unchanged re-admit — so the 30s reconcile loop, which re-admits every task each poll, cannot turn into a notification storm.

## Approach

The gate (`pkg/approval`) exposes `SetPendingHook`, invoked from `Admit` after the gate lock is released and only when the pending entry is new or its hash changed. The daemon installs the hook after the webui `Server` is constructed — the gate is built earlier in startup (step 7a) than the Server (step 8), and the hook needs the Server for both the WebSocket broadcast and the tokenized approve link. The hook body runs in a recovering goroutine, so notification work can never block the reconciler goroutine that drives the hook, and a notify failure or panic can never crash the daemon.

Notification behavior:
- Always emits an `approval:pending` WebSocket event (mirrors `run:started`/`run:finished`) so dashboards update live.
- If `approval.notify_task` is set, mints the single-use approve link (phase 2, #398) and fires the notify task via `FireManual` with string params `{task_id, hash, approve_url}`; delivery (slack/email/ntfy) is that task's concern. If minting fails, the task still fires with an empty `approve_url` so the operator at least learns a hold occurred.
- If `notify_task` is empty, broadcast + the gate's existing remediation WARN only.

The notify-task fire logic is factored into a small `approvalNotifier` helper (`pkg/daemon/approval_notify.go`) with function-typed dependencies, so the broadcast/mint/fire/param-assembly behavior is unit-testable with fakes; the daemon closure only adds the goroutine + recover wrapper.

## Security / caveats

- The single-use approve token (embedded in `approve_url`) is never written to the log — mint failures log at debug without the URL, and fire failures log the task id and notify-task name only.
- `notify_task` is itself subject to the gate. The operator must point it at a builtin or trusted task; an untrusted `notify_task` would sit pending and never fire (the fire guard vetoes it). This is a no-op, not a deadlock — the fire returns a veto error that is logged. Documented in the config field doc and the helper.
- The external base URL for the approve link is whatever `WebUIBaseURL()` currently returns; making that a configured public/external base for off-host notification delivery is deferred.

## Tests

- Gate hook contract (`pkg/approval/gate_hook_test.go`): fires on new hold; does NOT re-fire on unchanged re-admit; DOES re-fire on hash change; not fired for auto-approved/trusted tasks; nil-hook safe.
- Notifier (`pkg/daemon/approval_notify_test.go`): fires with correct params; empty `notify_task` broadcasts only (no mint/fire); mint failure still fires with empty URL; fire failure does not panic; nil dependencies degrade gracefully.

`make test` and `make lint` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)