### PR TITLE
fix(python): run async main() with no args and always log run failures (#405)

### DIFF
--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -244,6 +244,18 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	runID := opts.RunID
 	result := &pkgruntime.RunResult{RunID: runID}
 
+	// A failed run must always leave a diagnostic in the run log. Early
+	// returns (env resolution, missing script, socket/wrapper setup, uv
+	// start) set result.Error before any subprocess stderr exists; and a
+	// subprocess that exits non-zero without emitting stderr (signal kill,
+	// OOM) leaves the streamed-stderr log empty. Appending result.Error here
+	// guarantees the WebUI run detail and CLI log output show why it failed.
+	defer func() {
+		if result.Error != nil {
+			_ = e.reg.AppendLog(context.Background(), runID, "error", result.Error.Error())
+		}
+	}()
+
 	// Resolve declared env permissions. When the trigger engine ran
 	// preflight (issue #235), it forwards the *Resolved here so we don't
 	// re-spawn provider tasks. When opts.PreResolvedEnv is nil (legacy
@@ -430,7 +442,7 @@ func buildWrapper(scriptBytes []byte, pol guardPolicy) (string, error) {
 	w.WriteString("_asyncio_mod = _sys.modules['asyncio']\n")
 	w.WriteString("_main = globals().get('main')\n")
 	w.WriteString("if _main is not None and _asyncio_mod.iscoroutinefunction(_main):\n")
-	w.WriteString("    result = _asyncio_mod.run(_main(log=log, kv=kv, params=params, env=env, input=input, output=output, mcp=mcp, dicode=dicode))\n")
+	w.WriteString("    result = _asyncio_mod.run(_main())\n")
 	w.WriteString("_set_return(globals().get('result', None))\n")
 	// Schedule close on _loop so it runs *after* any pending _fire coroutines
 	// (the event loop is FIFO — tasks submitted before this will drain first).

--- a/pkg/runtime/python/runtime_405_test.go
+++ b/pkg/runtime/python/runtime_405_test.go
@@ -1,0 +1,156 @@
+//go:build !windows
+
+package python
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+	"github.com/dicode/dicode/pkg/task"
+	uvpkg "github.com/dicode/dicode/pkg/uv"
+	"go.uber.org/zap"
+)
+
+func newTestRuntime(t *testing.T) (*Runtime, *registry.Registry) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+	rt, err := New(reg, nil, d, zap.NewNop())
+	if err != nil {
+		t.Fatalf("python.New: %v", err)
+	}
+	return rt, reg
+}
+
+// TestExecute_FailedRunCapturesDiagnostics asserts the issue #405 invariant:
+// a Python run that fails before (or without) emitting subprocess stderr must
+// still leave its error in the run log. The "script not found" early return
+// exercises a failure path that never starts uv, so the only way the error
+// reaches the log is the runtime's diagnostic safety net.
+func TestExecute_FailedRunCapturesDiagnostics(t *testing.T) {
+	rt, reg := newTestRuntime(t)
+	ex := rt.NewExecutor("/nonexistent/uv")
+
+	spec := &task.Spec{
+		ID:      "examples/no-script",
+		Name:    "No Script",
+		Runtime: task.Runtime("python"),
+		TaskDir: t.TempDir(), // empty dir → ScriptPath() == "" → early failure
+		Trigger: task.TriggerConfig{Manual: true},
+	}
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	ctx := context.Background()
+	runID, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	res, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{RunID: runID})
+	if err != nil {
+		t.Fatalf("Execute returned a transport error: %v", err)
+	}
+	if res.Error == nil {
+		t.Fatal("expected a run error, got nil")
+	}
+
+	logs, err := reg.GetRunLogs(ctx, runID)
+	if err != nil {
+		t.Fatalf("GetRunLogs: %v", err)
+	}
+	if len(logs) == 0 {
+		t.Fatal("failed run captured zero log lines — #405 regression")
+	}
+	var found bool
+	for _, l := range logs {
+		if strings.Contains(l.Message, res.Error.Error()) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("run log does not contain the error %q; got %d lines", res.Error.Error(), len(logs))
+	}
+}
+
+// TestExecute_HelloPythonSucceeds is the end-to-end regression for #405: the
+// hello-python example (async def main(), PEP 723 httpx dep, an allowlisted
+// httpx GET to httpbin.org) must run to completion. It provisions uv the way
+// the runtime itself does — uv is not assumed to be on PATH — and reaches the
+// public internet, so it skips when uv cannot be provisioned. It guards the
+// async-main invocation (the kwargs bug that broke the run) and confirms the
+// PEP 578 net guard admits an allowlisted httpx call.
+func TestExecute_HelloPythonSucceeds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping network/uv integration test in -short mode")
+	}
+	uv, err := uvpkg.EnsureUv("")
+	if err != nil {
+		t.Skipf("uv provisioning failed (offline?): %v", err)
+	}
+
+	rt, reg := newTestRuntime(t)
+	ex := rt.NewExecutor(uv)
+
+	spec := &task.Spec{
+		ID:      "examples/hello-python",
+		Name:    "Hello Python",
+		Runtime: task.Runtime("python"),
+		TaskDir: "../../../tasks/examples/hello-python",
+		Trigger: task.TriggerConfig{Manual: true},
+		Timeout: 120 * time.Second,
+		Params: []task.Param{
+			{Name: "name", Default: "World"},
+			{Name: "count", Default: "1"},
+		},
+		Permissions: task.Permissions{Net: []string{"httpbin.org"}},
+	}
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	ctx := context.Background()
+	runID, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	res, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{RunID: runID})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	logs, _ := reg.GetRunLogs(ctx, runID)
+	if res.Error != nil {
+		t.Fatalf("hello-python failed: %v\nlogs:\n%s", res.Error, joinLogs(logs))
+	}
+	greeted := false
+	for _, l := range logs {
+		if strings.Contains(l.Message, "Hello, World!") {
+			greeted = true
+			break
+		}
+	}
+	if !greeted {
+		t.Fatalf("expected greeting log line; got:\n%s", joinLogs(logs))
+	}
+}
+
+func joinLogs(logs []*registry.LogEntry) string {
+	var b strings.Builder
+	for _, l := range logs {
+		b.WriteString("  [" + l.Level + "] " + l.Message + "\n")
+	}
+	return b.String()
+}


### PR DESCRIPTION
## Summary

`tasks/examples/hello-python` failed and, on some failure paths, produced no run log at all (#405). Investigation surfaced two independent defects in the Python runtime — neither a regression from the recently-merged security trio (#390 net guard, #391 SubprocessEnv allowlist, #394 net default-deny).

**1. The run failure.** The generated wrapper invoked the task's async entrypoint as `main(log=log, kv=kv, params=params, ...)`, passing the SDK surface as keyword arguments. But the documented Python contract is `async def main()` with no parameters — the SDK is exposed as module-level globals, not call arguments (see `docs/python-runtime.md`). So every async-`main` task raised `TypeError: main() got an unexpected keyword argument 'log'`. The kwargs form was introduced in #70 (replacing the original `_main()`), so this predates the security trio. There were no tests covering the async-`main` path, which is why it shipped. The fix is to call `_main()` with no arguments, matching the contract.

**2. The missing logs.** This was the higher-priority half of the issue: a failing Python run could leave an empty log. The Deno runtime has a `defer` that appends `result.Error` to the run log whenever a run fails, so the operator always sees *something*. The Python runtime had no such net. When a run failed before the subprocess emitted stderr (env resolution, missing script, socket/wrapper setup, uv start) — or when the subprocess exited non-zero without stderr (signal kill, OOM) — `result.Error` was set but nothing reached the run log, making the failure undiagnosable. Added the same diagnostic safety net to the Python runtime.

Once `main()` runs, the example's allowlisted `httpx` GET to `httpbin.org` (async → `socket.getaddrinfo` for the host, then `socket.connect` with the resolved IP literal) passes the PEP 578 net guard cleanly. This confirms #390/#391/#394 were not implicated: uv still provisions the interpreter and the PEP 723 `httpx` dep under the minimal `SubprocessEnv`, and the net guard admits the allowlisted call.

## Tests

- `TestExecute_HelloPythonSucceeds` — end-to-end: provisions uv the way the runtime does (not gated on `uv` being on PATH), runs the real hello-python example, asserts success and that the greeting is logged. Reaches the public internet, so it skips when uv can't be provisioned / `-short`.
- `TestExecute_FailedRunCapturesDiagnostics` — fast unit test driving the "script not found" early-return (no uv, no network) and asserting the run log contains `result.Error`, locking in the diagnostic safety net.

`make test` and `make lint` are green.

Fixes #405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)