### PR TITLE
fix(relay): gate relay-server-body daemon on relay config (#406)

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -121,6 +121,27 @@ func resolveDataDir(cfg *config.Config) (string, error) {
 	return home + "/.dicode", nil
 }
 
+// relayConfigured reports whether the operator has configured the dicode-relay
+// server. It mirrors the gate used when exporting DICODE_RELAY_* env vars at boot.
+func relayConfigured(cfg *config.Config) bool {
+	return cfg.Relay.Enabled && cfg.Relay.ServerURL != ""
+}
+
+// gateRelayServerBody disables the buildin/relay-server-body daemon when the
+// relay is not configured. With trigger.daemon + restart:always the engine would
+// otherwise auto-start it on every daemon, and its `import "npm:dicode-relay/start"`
+// reads process.env beyond the task's declared --allow-env names — throwing
+// NotCapable at import time and crash-looping even where the relay is unused.
+// Disabling before eng.Register keeps the engine from spawning the daemon unless
+// the operator has actually configured the relay. No-op for every other task.
+func gateRelayServerBody(spec *task.Spec, cfg *config.Config) bool {
+	if spec.ID == "buildin/relay-server-body" && !relayConfigured(cfg) {
+		spec.Enabled = false
+		return true
+	}
+	return false
+}
+
 func hasDisplay() bool {
 	switch runtime.GOOS {
 	case "darwin", "windows":
@@ -265,6 +286,10 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 					break
 				}
 			}
+		}
+		if isSpec && gateRelayServerBody(spec, cfg) {
+			log.Info("relay-server-body disabled — relay not configured (set relay.enabled + relay.server_url in dicode.yaml to run it)",
+				zap.String("task", spec.ID))
 		}
 		if err := eng.Register(k); err != nil {
 			// Cross-spec validation (pipeline stage refs pointing at an unknown
@@ -429,7 +454,7 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 			return fmt.Errorf("setenv DICODE_STORAGE_TASK: %w", err)
 		}
 	}
-	if cfg.Relay.Enabled && cfg.Relay.ServerURL != "" {
+	if relayConfigured(cfg) {
 		if err := os.Setenv("DICODE_RELAY_SERVER_URL", cfg.Relay.ServerURL); err != nil {
 			return fmt.Errorf("setenv DICODE_RELAY_SERVER_URL: %w", err)
 		}

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -131,3 +131,49 @@ func TestRetentionOverrideSkippedWhenZero(t *testing.T) {
 		t.Errorf("expected default unchanged (2592000) when retention is zero, got %q", got)
 	}
 }
+
+// TestRelayServerBodyGate exercises the gate the arm closure applies before
+// eng.Register. The configured-relay branch is the load-bearing half — it must
+// NOT disable the task when the operator has set up the relay, or the relay
+// never starts.
+func TestRelayServerBodyGate(t *testing.T) {
+	cases := []struct {
+		name        string
+		enabled     bool
+		serverURL   string
+		wantEnabled bool
+	}{
+		{name: "relay unconfigured (default)", wantEnabled: false},
+		{name: "enabled flag but no server url", enabled: true, wantEnabled: false},
+		{name: "server url but flag off", serverURL: "wss://relay.example.com", wantEnabled: false},
+		{name: "relay fully configured", enabled: true, serverURL: "wss://relay.example.com", wantEnabled: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Relay.Enabled = tc.enabled
+			cfg.Relay.ServerURL = tc.serverURL
+
+			// SetEnabled defaults to true at resolve time; the gate only flips
+			// it off, never on.
+			spec := &task.Spec{ID: "buildin/relay-server-body", Enabled: true}
+			gateRelayServerBody(spec, cfg)
+
+			if spec.Enabled != tc.wantEnabled {
+				t.Errorf("relay-server-body Enabled = %v, want %v", spec.Enabled, tc.wantEnabled)
+			}
+		})
+	}
+}
+
+// TestRelayServerBodyGateLeavesOtherTasksAlone guards against the gate
+// accidentally disabling unrelated daemon tasks when the relay is off.
+func TestRelayServerBodyGateLeavesOtherTasksAlone(t *testing.T) {
+	cfg := &config.Config{} // relay unconfigured
+	spec := &task.Spec{ID: "buildin/relay-client", Enabled: true}
+	gateRelayServerBody(spec, cfg)
+	if !spec.Enabled {
+		t.Error("gate disabled an unrelated task (buildin/relay-client)")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #406. The buildin `relay-server-body` task crash-looped on any daemon where the relay was not configured.

`relay-server-body` declares `trigger.daemon: true` + `restart: always`, so the engine auto-starts it the moment it registers. Its body does `import "npm:dicode-relay@^0.1.6/start"` (Deno node-compat), and that import transitively reads `process.env` beyond the task's declared `permissions.env` (`DICODE_DATADIR`, `DICODE_VERSION`). Deno's `--allow-env` is built only from the declared names (`buildDenoArgs`), so the access throws `NotCapable: Requires env access` — at **import time**, before `main()` runs — and `restart: always` turns that into a tight crash-loop that spams the log even when the operator never uses the relay.

This is not a regression from the env-isolation work (#391): `NotCapable` is an `--allow-env` permission decision, which #391 did not touch. It is pre-existing and surfaced by running the daemon.

## Approach

Because the throw is at import, a body-level "is the relay configured?" check can't prevent it — the gating has to happen before the task is started as a daemon. So the fix disables `buildin/relay-server-body` at registration (in the `arm` closure, before `eng.Register`) whenever the relay is not configured. The engine already skips scheduling/daemon-spawning for `Enabled: false` tasks, so the daemon is simply never spawned and nothing imports the relay.

"Relay configured" reuses the exact predicate that already guards the `DICODE_RELAY_*` env exports at boot: `relay.enabled == true && relay.server_url != ""`. That predicate is extracted into a small `relayConfigured` helper and used at both sites, so the gate and the env export can't drift apart.

## Configured relay still works

The gate only flips `Enabled` to `false`, and only when the relay is unconfigured. When the operator sets `relay.enabled: true` + `relay.server_url`, `relayConfigured` returns true, the task is left enabled, and the `relay-server` PipelineTask (whose terminal stage is `relay-server-body`) runs exactly as before. The terminal stage is the only thing carrying `trigger.daemon`, so gating it is both necessary and sufficient — the pipeline itself has no top-level trigger.

Verified the gate's truth table (unconfigured / enabled-but-no-URL / URL-but-flag-off / fully-configured) and that it leaves unrelated tasks alone in `pkg/daemon`. `make test` + `make lint` green.

## What was deliberately left behind

The `--allow-env` gap itself (issue's secondary point: which exact env var the relay import reads) is a follow-up. The import-time read comes from a transitive dependency of `npm:dicode-relay/start` (Express and friends read `NODE_ENV` and similar at module init); pinning the exact variable needs reproduction under the daemon's sandbox, and dicode has no `env: ["*"]` escape hatch today. Since the task is now gated to only run when the relay is configured, the crash-loop is resolved regardless; closing the env gap for the configured path can be done separately once the precise variable is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)