### PR TITLE
fix(hot-reload): LocalSource Sync delivery, new-dir watching, provider retry, Docker template expansion

### DIFF
--- a/pkg/registry/reconciler.go
+++ b/pkg/registry/reconciler.go
@@ -29,6 +29,13 @@ type Reconciler struct {
 	merged  chan source.Event
 	cancels map[string]context.CancelFunc // sourceID → cancel fn
 	runCtx  context.Context
+
+	// pending holds events that failed validateTaskProviders because a
+	// provider task was not yet registered. After any successful registration
+	// these are re-emitted to merged for a retry. Keyed by task ID so a
+	// repeated failure for the same task replaces the previous attempt
+	// (always retrying the most recent event).
+	pending map[string]source.Event
 }
 
 // NewReconciler creates a Reconciler for the given registry and sources.
@@ -42,6 +49,7 @@ func NewReconciler(r *Registry, sources []source.Source, dataDir string, log *za
 		dataDir:  dataDir,
 		log:      log,
 		cancels:  make(map[string]context.CancelFunc),
+		pending:  make(map[string]source.Event),
 	}
 }
 
@@ -177,11 +185,14 @@ func (rc *Reconciler) handle(ev source.Event) {
 		// pipelines declare no env providers.
 		if spec, ok := k.(*task.Spec); ok {
 			if err := rc.validateTaskProviders(spec); err != nil {
-				rc.log.Warn("task references unknown provider",
+				rc.log.Warn("task references unknown provider; queued for retry after next registration",
 					zap.String("task", ev.TaskID),
 					zap.String("source", ev.Source),
 					zap.Error(err),
 				)
+				rc.mu.Lock()
+				rc.pending[ev.TaskID] = ev
+				rc.mu.Unlock()
 				return
 			}
 		}
@@ -189,6 +200,10 @@ func (rc *Reconciler) handle(ev source.Event) {
 			rc.log.Error("failed to register task", zap.String("task", ev.TaskID), zap.Error(err))
 			return
 		}
+		// Clear from pending if this was a successful retry.
+		rc.mu.Lock()
+		delete(rc.pending, ev.TaskID)
+		rc.mu.Unlock()
 		rc.log.Info("task registered",
 			zap.String("task", ev.TaskID),
 			zap.String("kind", string(ev.Kind)),
@@ -196,6 +211,8 @@ func (rc *Reconciler) handle(ev source.Event) {
 		if rc.OnRegister != nil {
 			rc.OnRegister(k)
 		}
+		// Re-queue pending tasks — any of them may now have their provider satisfied.
+		rc.retryPending()
 
 	case source.EventRemoved:
 		rc.registry.Unregister(ev.TaskID)
@@ -206,6 +223,34 @@ func (rc *Reconciler) handle(ev source.Event) {
 	}
 }
 
+// retryPending re-emits every pending event to the merged channel so they
+// get a second chance now that a new provider may have registered. It runs
+// in a goroutine to avoid deadlocking the handle() call-site (handle is
+// called from the Run loop, which is the only reader of merged).
+func (rc *Reconciler) retryPending() {
+	rc.mu.Lock()
+	if len(rc.pending) == 0 {
+		rc.mu.Unlock()
+		return
+	}
+	events := make([]source.Event, 0, len(rc.pending))
+	for _, ev := range rc.pending {
+		events = append(events, ev)
+	}
+	ctx := rc.runCtx
+	rc.mu.Unlock()
+
+	go func() {
+		for _, ev := range events {
+			select {
+			case rc.merged <- ev:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
 // validateTaskProviders inspects every EnvEntry whose From has the
 // "task:" prefix and confirms the referenced provider task is already
 // registered. Issue #119: a misspelled provider must not silently fall
@@ -214,9 +259,9 @@ func (rc *Reconciler) handle(ev source.Event) {
 // Order dependency: provider tasks must reconcile before their consumers.
 // The buildin source registers providers first because they live under
 // tasks/buildin/secret-providers/* and the taskset.yaml entry order is
-// preserved. For multi-source setups, a transient miss on first
-// reconciler pass causes the consumer to be skipped; the next sync (30s
-// later, or on the source's next event) retries.
+// preserved. For multi-source setups, a miss on the first reconciler pass
+// causes the consumer to be queued in rc.pending and retried after the
+// next successful registration (see handle and retryPending).
 func (rc *Reconciler) validateTaskProviders(spec *task.Spec) error {
 	for _, e := range spec.Permissions.Env {
 		kind, target := task.ParseFrom(e.From)

--- a/pkg/registry/reconciler.go
+++ b/pkg/registry/reconciler.go
@@ -247,6 +247,16 @@ func (rc *Reconciler) retryPending() {
 
 	go func() {
 		for _, ev := range events {
+			// Re-check pending membership: an EventRemoved may have arrived
+			// after the snapshot was taken, deleting this task from rc.pending
+			// and unregistering it. Skipping here prevents a re-registration
+			// of a task that was intentionally removed.
+			rc.mu.Lock()
+			_, stillPending := rc.pending[ev.TaskID]
+			rc.mu.Unlock()
+			if !stillPending {
+				continue
+			}
 			select {
 			case rc.merged <- ev:
 			case <-ctx.Done():

--- a/pkg/registry/reconciler.go
+++ b/pkg/registry/reconciler.go
@@ -215,6 +215,11 @@ func (rc *Reconciler) handle(ev source.Event) {
 		rc.retryPending()
 
 	case source.EventRemoved:
+		// Cancel any pending retry so a removed-then-retried task is not
+		// re-registered after its provider eventually shows up.
+		rc.mu.Lock()
+		delete(rc.pending, ev.TaskID)
+		rc.mu.Unlock()
 		rc.registry.Unregister(ev.TaskID)
 		rc.log.Info("task unregistered", zap.String("task", ev.TaskID))
 		if rc.OnUnregister != nil {

--- a/pkg/registry/reconciler_test.go
+++ b/pkg/registry/reconciler_test.go
@@ -279,6 +279,60 @@ func TestReconciler_MultipleSources(t *testing.T) {
 	}
 }
 
+// TestReconciler_RetryPendingAfterProviderRegisters verifies that a consumer
+// task referencing a provider via `from: task:my-provider` is queued (not
+// registered) when it arrives before its provider, and is automatically
+// registered once the provider registers via the pending-retry mechanism.
+func TestReconciler_RetryPendingAfterProviderRegisters(t *testing.T) {
+	fs := newFakeSource("test")
+	reg, rec := newTestReconciler(t, fs)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go rec.Run(ctx)
+
+	time.Sleep(20 * time.Millisecond) // let Run() set up merged channel
+
+	provider := &task.Spec{
+		ID:      "my-provider",
+		Name:    "my-provider",
+		Trigger: task.TriggerConfig{Manual: true},
+	}
+	consumer := &task.Spec{
+		ID:   "my-consumer",
+		Name: "my-consumer",
+		Permissions: task.Permissions{
+			Env: []task.EnvEntry{{Name: "PG_URL", From: "task:my-provider"}},
+		},
+		Trigger: task.TriggerConfig{Manual: true},
+	}
+
+	// Consumer arrives first — provider not yet registered.
+	fs.ch <- source.Event{Kind: source.EventAdded, TaskID: "my-consumer", Kinded: consumer, Source: "test"}
+	time.Sleep(100 * time.Millisecond)
+
+	if _, ok := reg.Get("my-consumer"); ok {
+		t.Fatal("consumer should be pending (provider not yet registered), not in registry")
+	}
+
+	// Register the provider — this should trigger a retry of the pending consumer.
+	fs.ch <- source.Event{Kind: source.EventAdded, TaskID: "my-provider", Kinded: provider, Source: "test"}
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			_, provOk := reg.Get("my-provider")
+			_, conOk := reg.Get("my-consumer")
+			t.Fatalf("timeout: provider=%v consumer=%v; consumer should have been retried automatically", provOk, conOk)
+		case <-time.After(20 * time.Millisecond):
+			if _, ok := reg.Get("my-consumer"); ok {
+				return
+			}
+		}
+	}
+}
+
 func TestReconciler_InjectsDATADIR(t *testing.T) {
 	dataDir := "/var/lib/dicode-test"
 	// The reconciler derives spec.ID from filepath.Base(ev.TaskDir), so the

--- a/pkg/registry/reconciler_test.go
+++ b/pkg/registry/reconciler_test.go
@@ -333,6 +333,53 @@ func TestReconciler_RetryPendingAfterProviderRegisters(t *testing.T) {
 	}
 }
 
+// TestReconciler_RemovedWhilePendingNotRetried verifies that a task removed
+// (EventRemoved) while it sits in the pending-retry queue is NOT re-registered
+// when its provider eventually registers.
+func TestReconciler_RemovedWhilePendingNotRetried(t *testing.T) {
+	fs := newFakeSource("test")
+	reg, rec := newTestReconciler(t, fs)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go rec.Run(ctx)
+
+	time.Sleep(20 * time.Millisecond)
+
+	provider := &task.Spec{
+		ID:      "ghost-provider",
+		Name:    "ghost-provider",
+		Trigger: task.TriggerConfig{Manual: true},
+	}
+	consumer := &task.Spec{
+		ID:   "ghost-consumer",
+		Name: "ghost-consumer",
+		Permissions: task.Permissions{
+			Env: []task.EnvEntry{{Name: "X", From: "task:ghost-provider"}},
+		},
+		Trigger: task.TriggerConfig{Manual: true},
+	}
+
+	// Consumer queued — provider not yet registered.
+	fs.ch <- source.Event{Kind: source.EventAdded, TaskID: "ghost-consumer", Kinded: consumer, Source: "test"}
+	time.Sleep(80 * time.Millisecond)
+
+	// Consumer is removed before the provider arrives.
+	fs.ch <- source.Event{Kind: source.EventRemoved, TaskID: "ghost-consumer", Source: "test"}
+	time.Sleep(80 * time.Millisecond)
+
+	// Provider registers — must NOT cause removed consumer to reappear.
+	fs.ch <- source.Event{Kind: source.EventAdded, TaskID: "ghost-provider", Kinded: provider, Source: "test"}
+	time.Sleep(300 * time.Millisecond)
+
+	if _, ok := reg.Get("ghost-consumer"); ok {
+		t.Fatal("removed-while-pending consumer was re-registered after provider arrived")
+	}
+	if _, ok := reg.Get("ghost-provider"); !ok {
+		t.Fatal("ghost-provider should be registered")
+	}
+}
+
 func TestReconciler_InjectsDATADIR(t *testing.T) {
 	dataDir := "/var/lib/dicode-test"
 	// The reconciler derives spec.ID from filepath.Base(ev.TaskDir), so the

--- a/pkg/source/local/local.go
+++ b/pkg/source/local/local.go
@@ -25,7 +25,8 @@ type LocalSource struct {
 	watchEnabled bool   // whether to run fsnotify; false = poll-only via explicit Sync()
 
 	mu       sync.Mutex
-	snapshot map[string]string // taskID → hash at last sync
+	snapshot map[string]string   // taskID → hash at last sync
+	ch       chan<- source.Event // send end of events channel; nil until Start is called
 
 	log *zap.Logger
 }
@@ -53,6 +54,10 @@ func (s *LocalSource) ID() string { return s.id }
 // Events are debounced (150ms) to handle editors that write via tmp-rename.
 func (s *LocalSource) Start(ctx context.Context) (<-chan source.Event, error) {
 	ch := make(chan source.Event, 32)
+
+	s.mu.Lock()
+	s.ch = ch
+	s.mu.Unlock()
 
 	// Initial scan — emit Added for every task already on disk.
 	if err := s.syncAndEmit(ctx, ch); err != nil {
@@ -107,13 +112,19 @@ func (s *LocalSource) addWatchDirs(watcher *fsnotify.Watcher) error {
 	return nil
 }
 
-// Sync triggers an immediate rescan and emits any changes.
+// Sync triggers an immediate rescan and emits any changes to the channel
+// established by Start. If Start has not been called yet, only the snapshot
+// is updated (events are silently discarded — callers that need events must
+// call Start first).
 func (s *LocalSource) Sync(ctx context.Context) error {
-	// We emit to a local sink because callers of Sync don't consume events.
-	// Callers that need events go through Start.
-	_ = ctx
-	_, err := s.diff()
-	return err
+	s.mu.Lock()
+	ch := s.ch
+	s.mu.Unlock()
+	if ch == nil {
+		_, err := s.diff()
+		return err
+	}
+	return s.syncAndEmit(ctx, ch)
 }
 
 func (s *LocalSource) watch(ctx context.Context, watcher *fsnotify.Watcher, ch chan<- source.Event) {
@@ -146,9 +157,18 @@ func (s *LocalSource) watch(ctx context.Context, watcher *fsnotify.Watcher, ch c
 				return
 			}
 			s.log.Warn("watcher error", zap.Error(err))
-		case _, ok := <-watcher.Events:
+		case ev, ok := <-watcher.Events:
 			if !ok {
 				return
+			}
+			// When a new directory appears under the tasks root, start watching
+			// it immediately so edits inside it trigger reloads. This covers
+			// tasks created after Start() — without this, changes inside a
+			// newly created task dir are never seen until a daemon restart.
+			if ev.Has(fsnotify.Create) {
+				if fi, err := os.Lstat(ev.Name); err == nil && fi.IsDir() {
+					_ = watcher.Add(ev.Name)
+				}
 			}
 			debounced(trigger)
 		case <-fireSig:

--- a/pkg/source/local/local.go
+++ b/pkg/source/local/local.go
@@ -80,6 +80,9 @@ func (s *LocalSource) Start(ctx context.Context) (<-chan source.Event, error) {
 	if !s.watchEnabled {
 		go func() {
 			<-ctx.Done()
+			s.mu.Lock()
+			s.ch = nil
+			s.mu.Unlock()
 			close(ch)
 		}()
 		return ch, nil
@@ -139,6 +142,11 @@ func (s *LocalSource) Sync(ctx context.Context) error {
 func (s *LocalSource) watch(ctx context.Context, watcher *fsnotify.Watcher, ch chan<- source.Event) {
 	defer watcher.Close()
 	defer close(ch)
+	defer func() {
+		s.mu.Lock()
+		s.ch = nil
+		s.mu.Unlock()
+	}()
 
 	// bep/debounce schedules its callback via time.AfterFunc in a detached
 	// goroutine and has no Stop() in v1.2.1 — so a callback scheduled just

--- a/pkg/source/local/local.go
+++ b/pkg/source/local/local.go
@@ -59,9 +59,18 @@ func (s *LocalSource) Start(ctx context.Context) (<-chan source.Event, error) {
 	s.ch = ch
 	s.mu.Unlock()
 
+	// abort clears s.ch and closes ch on any Start error path so that a later
+	// Sync() call does not send on a closed channel and panic.
+	abort := func() {
+		s.mu.Lock()
+		s.ch = nil
+		s.mu.Unlock()
+		close(ch)
+	}
+
 	// Initial scan — emit Added for every task already on disk.
 	if err := s.syncAndEmit(ctx, ch); err != nil {
-		close(ch)
+		abort()
 		return nil, err
 	}
 
@@ -78,13 +87,13 @@ func (s *LocalSource) Start(ctx context.Context) (<-chan source.Event, error) {
 
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		close(ch)
+		abort()
 		return nil, err
 	}
 	// Watch root tasks dir and all current task subdirectories.
 	if err := s.addWatchDirs(watcher); err != nil {
 		watcher.Close()
-		close(ch)
+		abort()
 		return nil, err
 	}
 

--- a/pkg/source/local/local_test.go
+++ b/pkg/source/local/local_test.go
@@ -390,3 +390,40 @@ func TestLocalSource_WatchNewTaskDir(t *testing.T) {
 		t.Error("edit inside new task dir should trigger EventUpdated")
 	}
 }
+
+// TestLocalSource_StartError_SyncDoesNotPanic verifies that if Start() fails
+// after setting s.ch, the channel is cleared so a subsequent Sync() call does
+// not panic with "send on closed channel".
+func TestLocalSource_StartError_SyncDoesNotPanic(t *testing.T) {
+	// Create a source pointing at a non-existent directory so that the initial
+	// ScanDir in syncAndEmit won't fail (ScanDir returns empty for missing dir).
+	// Instead we trigger failure by corrupting the snapshot-advance path:
+	// use an inaccessible directory after construction.
+	dir := t.TempDir()
+	s, err := New("test-abort", dir, false, zap.NewNop())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Remove the directory so syncAndEmit's ScanDir returns an error.
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	_, startErr := s.Start(ctx)
+	if startErr == nil {
+		// ScanDir on a missing dir may return empty rather than error on some
+		// platforms; skip the panic check in that case — the test still guards
+		// that no panic occurs.
+		t.Skip("ScanDir did not error on removed dir on this platform; skipping closed-channel check")
+	}
+
+	// s.ch must have been cleared to nil; Sync() must not panic.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Sync() panicked after failed Start(): %v", r)
+		}
+	}()
+	_ = s.Sync(ctx)
+}

--- a/pkg/source/local/local_test.go
+++ b/pkg/source/local/local_test.go
@@ -309,3 +309,84 @@ func TestLocalSource_WatchDisabled_NoFsNotifyEvents(t *testing.T) {
 		t.Fatalf("Sync: %v", err)
 	}
 }
+
+// TestLocalSource_Sync_EmitsEvents verifies that Sync() delivers events to
+// the channel opened by Start() instead of silently discarding them (#386).
+func TestLocalSource_Sync_EmitsEvents(t *testing.T) {
+	dir := t.TempDir()
+	s, err := New("test-sync", dir, false, zap.NewNop()) // watchEnabled=false, driven by Sync
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, err := s.Start(ctx)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	collectEvents(ch, 50*time.Millisecond) // drain initial empty scan
+
+	// Write a new task after Start.
+	writeTask(t, dir, "new-task")
+
+	if err := s.Sync(ctx); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	evs := collectEvents(ch, 500*time.Millisecond)
+	found := false
+	for _, ev := range evs {
+		if ev.TaskID == "new-task" && ev.Kind == source.EventAdded {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Sync() should emit EventAdded for new-task; got %+v", evs)
+	}
+}
+
+// TestLocalSource_WatchNewTaskDir verifies that task directories created
+// after Start() are watched and edits inside them trigger reload events (#386).
+func TestLocalSource_WatchNewTaskDir(t *testing.T) {
+	dir := t.TempDir()
+	s := newTestSource(t, dir)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, err := s.Start(ctx)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	collectEvents(ch, 300*time.Millisecond) // drain initial empty scan
+
+	// Create a new task dir after Start — should trigger Added.
+	writeTask(t, dir, "late-task")
+
+	evs := collectEvents(ch, 2*time.Second)
+	var gotAdded bool
+	for _, ev := range evs {
+		if ev.TaskID == "late-task" && ev.Kind == source.EventAdded {
+			gotAdded = true
+		}
+	}
+	if !gotAdded {
+		t.Fatal("new task dir created after Start should trigger EventAdded")
+	}
+
+	// Edit a file inside the new task dir — should trigger Updated.
+	td := filepath.Join(dir, "late-task")
+	if err := os.WriteFile(filepath.Join(td, "task.js"), []byte("// v2"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	evs = collectEvents(ch, 2*time.Second)
+	var gotUpdated bool
+	for _, ev := range evs {
+		if ev.TaskID == "late-task" && ev.Kind == source.EventUpdated {
+			gotUpdated = true
+		}
+	}
+	if !gotUpdated {
+		t.Error("edit inside new task dir should trigger EventUpdated")
+	}
+}

--- a/pkg/source/local/local_test.go
+++ b/pkg/source/local/local_test.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -426,4 +427,37 @@ func TestLocalSource_StartError_SyncDoesNotPanic(t *testing.T) {
 		}
 	}()
 	_ = s.Sync(ctx)
+}
+
+// TestLocalSource_CtxCancel_SyncDoesNotPanic verifies that Sync() does not panic
+// after ctx cancellation closes the channel on the normal (non-error) close path.
+// Covers both watchEnabled=false (ctx-done goroutine) and watchEnabled=true
+// (watch() defer close).
+func TestLocalSource_CtxCancel_SyncDoesNotPanic(t *testing.T) {
+	for _, watchEnabled := range []bool{false, true} {
+		watchEnabled := watchEnabled
+		t.Run(fmt.Sprintf("watchEnabled=%v", watchEnabled), func(t *testing.T) {
+			dir := t.TempDir()
+			s, err := New("test-cancel", dir, watchEnabled, zap.NewNop())
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+
+			_, err = s.Start(ctx)
+			if err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+
+			cancel()
+			time.Sleep(50 * time.Millisecond) // let close goroutine/watch run
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("Sync() panicked after ctx cancel (watchEnabled=%v): %v", watchEnabled, r)
+				}
+			}()
+			_ = s.Sync(context.Background())
+		})
+	}
 }

--- a/pkg/task/template.go
+++ b/pkg/task/template.go
@@ -126,6 +126,7 @@ func expandSpec(spec *Spec, vars map[string]string) {
 	// or daemon env vars through these fields. TASK_DIR and other builtins
 	// always resolve because they are in the vars map, not the process env.
 	if spec.Docker != nil {
+		spec.Docker.Image = expandString(spec.Docker.Image, vars, false)
 		for i := range spec.Docker.Volumes {
 			spec.Docker.Volumes[i] = expandString(spec.Docker.Volumes[i], vars, false)
 		}

--- a/pkg/task/template.go
+++ b/pkg/task/template.go
@@ -121,13 +121,24 @@ func expandSpec(spec *Spec, vars map[string]string) {
 		spec.Params[i].Default = expandString(spec.Params[i].Default, vars, false)
 	}
 
-	// docker.volumes: lets tasks reference shared paths (${DATADIR}/foo) as
-	// mount sources. envFallback=false — a task.yaml from an untrusted
-	// source must not be able to mount arbitrary host paths by naming a
-	// daemon env var.
+	// docker.*: all fields expanded with envFallback=false — a task.yaml from
+	// an untrusted source must not be able to reference arbitrary host paths
+	// or daemon env vars through these fields. TASK_DIR and other builtins
+	// always resolve because they are in the vars map, not the process env.
 	if spec.Docker != nil {
 		for i := range spec.Docker.Volumes {
 			spec.Docker.Volumes[i] = expandString(spec.Docker.Volumes[i], vars, false)
+		}
+		for i := range spec.Docker.Command {
+			spec.Docker.Command[i] = expandString(spec.Docker.Command[i], vars, false)
+		}
+		for i := range spec.Docker.Entrypoint {
+			spec.Docker.Entrypoint[i] = expandString(spec.Docker.Entrypoint[i], vars, false)
+		}
+		spec.Docker.WorkingDir = expandString(spec.Docker.WorkingDir, vars, false)
+		if spec.Docker.Build != nil {
+			spec.Docker.Build.Context = expandString(spec.Docker.Build.Context, vars, false)
+			spec.Docker.Build.Dockerfile = expandString(spec.Docker.Build.Dockerfile, vars, false)
 		}
 	}
 

--- a/pkg/task/template_test.go
+++ b/pkg/task/template_test.go
@@ -465,12 +465,13 @@ permissions:
 	}
 }
 
-// TestExpandSpec_DockerFields verifies that ${VAR} in docker.command,
-// docker.entrypoint, docker.working_dir, docker.build.context, and
-// docker.build.dockerfile are all expanded at spec-load time (#386).
+// TestExpandSpec_DockerFields verifies that ${VAR} in docker.image,
+// docker.command, docker.entrypoint, docker.working_dir, docker.build.context,
+// and docker.build.dockerfile are all expanded at spec-load time (#386).
 func TestExpandSpec_DockerFields(t *testing.T) {
 	spec := &Spec{
 		Docker: &DockerConfig{
+			Image:      "${REGISTRY}/myapp:latest",
 			Command:    []string{"${TASK_DIR}/start.sh", "--verbose"},
 			Entrypoint: []string{"/bin/sh", "${TASK_DIR}/entrypoint.sh"},
 			WorkingDir: "${TASK_DIR}/app",
@@ -480,9 +481,12 @@ func TestExpandSpec_DockerFields(t *testing.T) {
 			},
 		},
 	}
-	vars := map[string]string{VarTaskDir: "/abs/task"}
+	vars := map[string]string{VarTaskDir: "/abs/task", "REGISTRY": "registry.example.com"}
 	expandSpec(spec, vars)
 
+	if got := spec.Docker.Image; got != "registry.example.com/myapp:latest" {
+		t.Errorf("Image = %q, want registry.example.com/myapp:latest", got)
+	}
 	if got := spec.Docker.Command[0]; got != "/abs/task/start.sh" {
 		t.Errorf("Command[0] = %q, want /abs/task/start.sh", got)
 	}

--- a/pkg/task/template_test.go
+++ b/pkg/task/template_test.go
@@ -464,3 +464,70 @@ permissions:
 		t.Errorf("FS[1] = %q, want %s/local", spec.Permissions.FS[1].Path, dir)
 	}
 }
+
+// TestExpandSpec_DockerFields verifies that ${VAR} in docker.command,
+// docker.entrypoint, docker.working_dir, docker.build.context, and
+// docker.build.dockerfile are all expanded at spec-load time (#386).
+func TestExpandSpec_DockerFields(t *testing.T) {
+	spec := &Spec{
+		Docker: &DockerConfig{
+			Command:    []string{"${TASK_DIR}/start.sh", "--verbose"},
+			Entrypoint: []string{"/bin/sh", "${TASK_DIR}/entrypoint.sh"},
+			WorkingDir: "${TASK_DIR}/app",
+			Build: &DockerBuild{
+				Context:    "${TASK_DIR}/context",
+				Dockerfile: "${TASK_DIR}/Dockerfile.prod",
+			},
+		},
+	}
+	vars := map[string]string{VarTaskDir: "/abs/task"}
+	expandSpec(spec, vars)
+
+	if got := spec.Docker.Command[0]; got != "/abs/task/start.sh" {
+		t.Errorf("Command[0] = %q, want /abs/task/start.sh", got)
+	}
+	if got := spec.Docker.Command[1]; got != "--verbose" {
+		t.Errorf("Command[1] = %q, want --verbose (literal)", got)
+	}
+	if got := spec.Docker.Entrypoint[1]; got != "/abs/task/entrypoint.sh" {
+		t.Errorf("Entrypoint[1] = %q, want /abs/task/entrypoint.sh", got)
+	}
+	if got := spec.Docker.WorkingDir; got != "/abs/task/app" {
+		t.Errorf("WorkingDir = %q, want /abs/task/app", got)
+	}
+	if got := spec.Docker.Build.Context; got != "/abs/task/context" {
+		t.Errorf("Build.Context = %q, want /abs/task/context", got)
+	}
+	if got := spec.Docker.Build.Dockerfile; got != "/abs/task/Dockerfile.prod" {
+		t.Errorf("Build.Dockerfile = %q, want /abs/task/Dockerfile.prod", got)
+	}
+}
+
+// TestExpandSpec_DockerFields_NoEnvFallback guards against an untrusted
+// task.yaml using a daemon env var in docker fields to reach host paths.
+func TestExpandSpec_DockerFields_NoEnvFallback(t *testing.T) {
+	t.Setenv("DICODE_DAEMON_SECRET_PATH", "/daemon/secret")
+	spec := &Spec{
+		Docker: &DockerConfig{
+			Command:    []string{"${DICODE_DAEMON_SECRET_PATH}/cmd"},
+			WorkingDir: "${DICODE_DAEMON_SECRET_PATH}",
+			Build: &DockerBuild{
+				Context:    "${DICODE_DAEMON_SECRET_PATH}/ctx",
+				Dockerfile: "${DICODE_DAEMON_SECRET_PATH}/Dockerfile",
+			},
+		},
+	}
+	expandSpec(spec, map[string]string{})
+
+	for _, got := range []string{
+		spec.Docker.Command[0],
+		spec.Docker.WorkingDir,
+		spec.Docker.Build.Context,
+		spec.Docker.Build.Dockerfile,
+	} {
+		if got == "/daemon/secret/cmd" || got == "/daemon/secret" ||
+			got == "/daemon/secret/ctx" || got == "/daemon/secret/Dockerfile" {
+			t.Errorf("daemon env leaked into docker field: %q", got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes three silent correctness gaps that broke hot-reload and task-provider ordering (issue #386):

- **`pkg/source/local` — Sync() event delivery**: `Sync()` was calling `diff()` directly and discarding events instead of delivering them through the channel opened by `Start()`. The `LocalSource` now stores the channel under its mutex in `Start()` so `Sync()` can re-use it. Added `TestLocalSource_Sync_EmitsEvents`.

- **`pkg/source/local` — new-dir watching**: Task directories created after `Start()` were never added to the fsnotify watcher, so edits inside them were invisible until a daemon restart. The `watch()` loop now calls `watcher.Add()` on every newly created directory child of the tasks root. Added `TestLocalSource_WatchNewTaskDir`.

- **`pkg/registry/reconciler` — provider-ordering retry**: Tasks with `permissions.env[].from: task:<provider>` were permanently dropped when the consumer reconciled before the provider (a `validateTaskProviders` failure with no retry). The reconciler now queues them in `rc.pending` (keyed by task ID so a repeated failure replaces the stale entry) and re-emits them in a goroutine after each successful registration, avoiding a deadlock with the `Run` loop that is the sole reader of `rc.merged`. Added `TestReconciler_RetryPendingAfterProviderRegisters`.

- **`pkg/task/template` — Docker field expansion**: `docker.command`, `docker.entrypoint`, `docker.working_dir`, `docker.build.context`, and `docker.build.dockerfile` were missing from `expandSpec`. Tokens like `${TASK_DIR}` and `${DATADIR}` in those fields survived unexpanded into the runtime, causing container launches to fail. All new expansions use `envFallback=false` (same policy as `docker.volumes`) — daemon env vars cannot be exfiltrated via an untrusted `task.yaml`. Added `TestExpandSpec_DockerFields` and `TestExpandSpec_DockerFields_NoEnvFallback`.

> **Note:** The same `Sync()` bug exists in `pkg/source/git/git.go` but that file is currently in-flight on PR #414 and is intentionally excluded from this change.

Closes #386

## Test plan

- [x] `make build` — passes
- [x] `go vet ./...` — clean
- [x] `make lint` (`go fmt` + `go vet`) — clean
- [x] `go test ./pkg/registry/... ./pkg/source/local/... ./pkg/task/...` — all pass
- [x] `make test` — all pass except pre-existing `TestExecute_HelloPythonSucceeds` (httpbin.org 403 in this environment, unrelated to this change)
- [x] `TestReconciler_RetryPendingAfterProviderRegisters` — verifies consumer queued → auto-registered after provider
- [x] `TestLocalSource_Sync_EmitsEvents` — verifies Sync() delivers events via channel
- [x] `TestLocalSource_WatchNewTaskDir` — verifies fsnotify picks up dirs created after Start()
- [x] `TestExpandSpec_DockerFields` — verifies TASK_DIR expands in all docker fields
- [x] `TestExpandSpec_DockerFields_NoEnvFallback` — verifies daemon env vars don't leak through docker fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1pi2sxNZFoPUPeEsEfukC

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1pi2sxNZFoPUPeEsEfukC)_