### PR TITLE
feat(deno): permissions.env "*" wildcard for unrestricted env reads (#412)

### DIFF
--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -933,6 +933,9 @@ Four forms, with clear source distinction:
 | `from:` | host OS var name | Host OS env | Read `$GH_TOKEN` from OS, inject subprocess env as `API_KEY` |
 | `secret:` | secrets store key | Secrets store | Resolve encrypted secret, inject as the given name; **fails if not found** |
 | `value:` | — | Literal | Inject a fixed string (used by taskset override layers) |
+| `"*"` | — | — | Unrestricted env reads (`--allow-env`); see the wildcard note below |
+
+A bare `"*"` entry grants the script unrestricted env reads. It is the escape hatch for `npm:`/node-compat imports whose dependencies read `process.env` (e.g. `NODE_ENV`) at module init beyond a declarable allowlist. This is safe to grant because the subprocess env is itself an allowlist: only the IPC/cache vars and the task's resolved env reach the subprocess, and daemon-only credentials (the master key, the daemon API keys) are withheld regardless of what the task declares — so `"*"` exposes nothing a named list wouldn't. The wildcard coexists with named entries; keep the bare names of any host vars whose *values* the script needs forwarded (`"*"` controls read permission, not forwarding).
 
 Two modifiers apply on top:
 

--- a/docs/deno-runtime.md
+++ b/docs/deno-runtime.md
@@ -403,7 +403,7 @@ Permissions are derived from `task.yaml`:
 | Permission | Source |
 | --- | --- |
 | `--allow-net` / `--allow-net=host1,...` | `net:` entries — omit or `[]` = denied (no flag), `["*"]` = unrestricted, host list = allowlist |
-| `--allow-env=DICODE_SOCKET,DICODE_TOKEN,VAR1,...` | `DICODE_SOCKET`, `DICODE_TOKEN` (IPC handshake) + all `env:` vars |
+| `--allow-env=DICODE_SOCKET,DICODE_TOKEN,VAR1,...` / `--allow-env` | `DICODE_SOCKET`, `DICODE_TOKEN` (IPC handshake) + all `env:` vars; an `"*"` entry emits a bare `--allow-env` (unrestricted, bounded by the subprocess env allowlist) |
 | `--allow-read=path1,path2` | `fs:` entries with `r` or `rw` |
 | `--allow-write=path1` | `fs:` entries with `w` or `rw` |
 

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -547,11 +547,27 @@ func buildDenoArgs(spec *task.Spec, socketPath, shimPath, runnerPath string) []s
 
 	// Env: always allow the internal IPC vars plus HOME/DENO_DIR/XDG_CACHE_HOME
 	// (required by deno.land/x/cache for vendored binary downloads).
-	envVars := []string{"DICODE_SOCKET", "DICODE_TOKEN", "HOME", "DENO_DIR", "XDG_CACHE_HOME"}
+	// A "*" entry emits a bare --allow-env (unrestricted): the subprocess env is
+	// itself an allowlist (runtime.SubprocessEnv — IPC/cache vars + resolved task
+	// vars, master key Unsetenv'd), so "all" only exposes that minimal forwarded
+	// set. The wildcard coexists with named entries, which still drive value
+	// forwarding in SubprocessEnv.
+	envWildcard := false
 	for _, e := range spec.Permissions.Env {
-		envVars = append(envVars, e.Name)
+		if e.Name == "*" {
+			envWildcard = true
+			break
+		}
 	}
-	args = append(args, "--allow-env="+strings.Join(envVars, ","))
+	if envWildcard {
+		args = append(args, "--allow-env")
+	} else {
+		envVars := []string{"DICODE_SOCKET", "DICODE_TOKEN", "HOME", "DENO_DIR", "XDG_CACHE_HOME"}
+		for _, e := range spec.Permissions.Env {
+			envVars = append(envVars, e.Name)
+		}
+		args = append(args, "--allow-env="+strings.Join(envVars, ","))
+	}
 
 	// Sys: omit field = deny all (default); ["*"] = all; named = allowlist.
 	sys := spec.Permissions.Sys

--- a/pkg/runtime/deno/runtime_test.go
+++ b/pkg/runtime/deno/runtime_test.go
@@ -702,3 +702,65 @@ func TestRuntime_Silent_DropsStdoutStderr(t *testing.T) {
 		}
 	}
 }
+
+// envFlag extracts the --allow-env argument from a buildDenoArgs result.
+// Returns ("", false) when no --allow-env flag is present.
+func envFlag(args []string) (string, bool) {
+	for _, a := range args {
+		if a == "--allow-env" {
+			return "", true
+		}
+		if v, ok := strings.CutPrefix(a, "--allow-env="); ok {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// TestBuildDenoArgs_Env covers the env-permission cases: named entries produce
+// a scoped --allow-env=...; a "*" entry produces a bare (unrestricted)
+// --allow-env; and an empty/omitted list still scopes to the internal vars.
+func TestBuildDenoArgs_Env(t *testing.T) {
+	base := func(env []task.EnvEntry) *task.Spec {
+		return &task.Spec{
+			ID: "env-args", Name: "env-args", Runtime: task.RuntimeDeno,
+			TaskDir:     "/tmp/task",
+			Permissions: task.Permissions{Env: env},
+		}
+	}
+
+	t.Run("named entries are appended to the internal allowlist", func(t *testing.T) {
+		args := buildDenoArgs(base([]task.EnvEntry{{Name: "API_KEY"}, {Name: "DB_URL"}}), "/sock", "/shim.ts", "/runner.ts")
+		val, ok := envFlag(args)
+		if !ok {
+			t.Fatal("expected an --allow-env flag")
+		}
+		want := "DICODE_SOCKET,DICODE_TOKEN,HOME,DENO_DIR,XDG_CACHE_HOME,API_KEY,DB_URL"
+		if val != want {
+			t.Errorf("--allow-env = %q, want %q", val, want)
+		}
+	})
+
+	t.Run("wildcard entry emits a bare --allow-env", func(t *testing.T) {
+		// Named entries alongside "*" must not turn it back into a scoped list.
+		args := buildDenoArgs(base([]task.EnvEntry{{Name: "*"}, {Name: "DICODE_DATADIR"}}), "/sock", "/shim.ts", "/runner.ts")
+		val, ok := envFlag(args)
+		if !ok {
+			t.Fatal("expected an --allow-env flag")
+		}
+		if val != "" {
+			t.Errorf("expected bare --allow-env, got --allow-env=%q", val)
+		}
+	})
+
+	t.Run("empty list scopes to the internal vars only", func(t *testing.T) {
+		args := buildDenoArgs(base(nil), "/sock", "/shim.ts", "/runner.ts")
+		val, ok := envFlag(args)
+		if !ok {
+			t.Fatal("expected an --allow-env flag")
+		}
+		if val != "DICODE_SOCKET,DICODE_TOKEN,HOME,DENO_DIR,XDG_CACHE_HOME" {
+			t.Errorf("--allow-env = %q, want the internal-vars-only allowlist", val)
+		}
+	})
+}

--- a/pkg/runtime/deno/runtime_test.go
+++ b/pkg/runtime/deno/runtime_test.go
@@ -753,6 +753,17 @@ func TestBuildDenoArgs_Env(t *testing.T) {
 		}
 	})
 
+	t.Run("wildcard after a named entry still emits a bare --allow-env", func(t *testing.T) {
+		args := buildDenoArgs(base([]task.EnvEntry{{Name: "API_KEY"}, {Name: "*"}}), "/sock", "/shim.ts", "/runner.ts")
+		val, ok := envFlag(args)
+		if !ok {
+			t.Fatal("expected an --allow-env flag")
+		}
+		if val != "" {
+			t.Errorf("expected bare --allow-env regardless of entry order, got --allow-env=%q", val)
+		}
+	})
+
 	t.Run("empty list scopes to the internal vars only", func(t *testing.T) {
 		args := buildDenoArgs(base(nil), "/sock", "/shim.ts", "/runner.ts")
 		val, ok := envFlag(args)

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -262,6 +262,11 @@ func (e *EnvEntry) UnmarshalYAML(value *yaml.Node) error {
 // subprocess executable, network host, and dicode API must be listed here.
 type Permissions struct {
 	// Env lists env vars the task script may read or that are injected into it.
+	// Use [{name: "*"}] (YAML: env: ["*"]) for unrestricted env access — needed by
+	// node-compat/npm imports that read process.env beyond a declarable allowlist.
+	// Safe to grant: the subprocess env is itself an allowlist (only IPC/cache vars
+	// and resolved task vars are forwarded; the master key is removed), so "all"
+	// exposes nothing the named-list form wouldn't.
 	Env []EnvEntry `yaml:"env,omitempty" json:"env,omitempty"`
 	// FS lists filesystem paths and their access modes ("r", "w", "rw").
 	// Deno enforces reads and writes. Python enforces writes only: an

--- a/tasks/buildin/relay-server-body/task.yaml
+++ b/tasks/buildin/relay-server-body/task.yaml
@@ -30,6 +30,12 @@ permissions:
   fs:
     - path: "${DATADIR}/relay"
       permission: rw
+  # "*" grants unrestricted env reads for the npm:dicode-relay import, whose
+  # Express-family deps read process.env (NODE_ENV, etc.) at module init beyond
+  # a declarable allowlist. Bounded: the subprocess env is itself an allowlist
+  # (IPC/cache vars + the named entries below; daemon secrets withheld). The
+  # named entries stay so their host values are forwarded into the subprocess.
   env:
+    - "*"
     - DICODE_DATADIR
     - DICODE_VERSION


### PR DESCRIPTION
Closes #412.

## Summary

Deno tasks run sandboxed: `buildDenoArgs` derives `--allow-env` solely from the names declared in `permissions.env`. That works for tasks that read a fixed set of env vars, but breaks node-compat/npm imports. `buildin/relay-server-body` does `import "npm:dicode-relay@^0.1.6/start"`, whose Express-family dependencies read `process.env` (NODE_ENV and similar) at module init — names the task cannot enumerate ahead of time. The scoped `--allow-env` then throws `NotCapable: Requires env access` even when the relay is correctly configured, and there was no escape hatch for broad env.

This adds a `"*"` entry to `permissions.env` that emits a bare, unrestricted `--allow-env`, mirroring the existing omit/`["*"]` conventions already used for `net`/`run`/`sys` in the same builder. The wildcard is allowed to coexist with named entries: it controls only the read-permission flag, while named bare entries continue to drive value forwarding in `SubprocessEnv` — so a task can both read arbitrary env and still have specific host values (e.g. `DICODE_DATADIR`) forwarded into its subprocess.

Granting unrestricted env reads is bounded and safe because the subprocess env is itself an allowlist (`runtime.SubprocessEnv`, #391): only IPC/cache vars and the task's resolved env reach the subprocess, and daemon-only credentials (master key, daemon API keys) are withheld regardless of what the task declares. So `"*"` exposes nothing the named-list form could not. That invariant is documented at the `Permissions.Env` field and in the task-format docs.

`buildin/relay-server-body` now declares the wildcard alongside the two named vars it actually reads, so its npm import resolves while those host values are still forwarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
