### PR TITLE
perf(task): cap per-file bytes in task.Hash and skip heavy dirs (#401)

### DIFF
--- a/pkg/task/hash.go
+++ b/pkg/task/hash.go
@@ -38,6 +38,7 @@ var heavyDirs = map[string]bool{
 //     instead of their contents (see the const); a content edit that preserves
 //     both size and mtime is therefore not detected.
 //   - The node_modules and .git subtrees are skipped wholesale (see heavyDirs).
+//
 // Consequently, code reachable only through those exclusions can change without
 // re-triggering approval — acceptable under the trusted-author model, where the
 // operator approves the source, not every transitive vendored file.

--- a/pkg/task/hash.go
+++ b/pkg/task/hash.go
@@ -26,16 +26,21 @@ var heavyDirs = map[string]bool{
 	".git":         true,
 }
 
-// Hash computes a content hash over every regular file under dir,
-// recursively, in sorted dir-relative path order. The runtime allows the
-// task script to import any sibling file (the Deno sandbox allow-reads the
-// whole task dir; Python imports sibling modules), so every in-dir file is
-// reachable code and must be part of the fingerprint — the approval gate
-// (dicode.lock) keys re-approval off this hash.
+// Hash computes a content hash over the regular files under dir, recursively,
+// in sorted dir-relative path order. The runtime allows the task script to
+// import any sibling file (the Deno sandbox allow-reads the whole task dir;
+// Python imports sibling modules), so in-dir files are reachable code and form
+// the fingerprint the approval gate (dicode.lock) keys re-approval off.
 //
-// Files larger than maxHashedFileBytes are folded in by a size+mtime
-// descriptor rather than full contents (see the const). The node_modules and
-// .git subtrees are skipped entirely (see heavyDirs).
+// Two bounded exclusions keep the per-poll cost flat without losing
+// change-detection for task logic, which lives in small, top-level files:
+//   - Files larger than maxHashedFileBytes fold in a size+mtime descriptor
+//     instead of their contents (see the const); a content edit that preserves
+//     both size and mtime is therefore not detected.
+//   - The node_modules and .git subtrees are skipped wholesale (see heavyDirs).
+// Consequently, code reachable only through those exclusions can change without
+// re-triggering approval — acceptable under the trusted-author model, where the
+// operator approves the source, not every transitive vendored file.
 //
 // Symlinks are never read through: the link's target string is folded in
 // instead, so retargeting a link changes the hash without ever reading a

--- a/pkg/task/hash.go
+++ b/pkg/task/hash.go
@@ -10,12 +10,32 @@ import (
 	"sort"
 )
 
+// maxHashedFileBytes bounds the contents read into the digest per file. The
+// hash runs on every reconciler poll (~30s), so a committed large asset would
+// re-read its full bytes each cycle. Files at or below this size are hashed by
+// content; larger files fold in only a size+mtime descriptor — code files are
+// small, so change-detection for task logic stays exact while bulk assets cost
+// a stat instead of a full read.
+const maxHashedFileBytes = 1 << 20 // 1 MiB
+
+// heavyDirs are skipped wholesale during the walk: they hold no task code and
+// can dominate walk cost. node_modules in particular can be a committed tree of
+// thousands of files.
+var heavyDirs = map[string]bool{
+	"node_modules": true,
+	".git":         true,
+}
+
 // Hash computes a content hash over every regular file under dir,
 // recursively, in sorted dir-relative path order. The runtime allows the
 // task script to import any sibling file (the Deno sandbox allow-reads the
 // whole task dir; Python imports sibling modules), so every in-dir file is
 // reachable code and must be part of the fingerprint — the approval gate
 // (dicode.lock) keys re-approval off this hash.
+//
+// Files larger than maxHashedFileBytes are folded in by a size+mtime
+// descriptor rather than full contents (see the const). The node_modules and
+// .git subtrees are skipped entirely (see heavyDirs).
 //
 // Symlinks are never read through: the link's target string is folded in
 // instead, so retargeting a link changes the hash without ever reading a
@@ -36,6 +56,9 @@ func Hash(dir string) (string, error) {
 			return err
 		}
 		if d.IsDir() {
+			if path != dir && heavyDirs[d.Name()] {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		rel, err := filepath.Rel(dir, path)
@@ -73,11 +96,20 @@ func Hash(dir string) (string, error) {
 		if e.isLink {
 			h.Write([]byte(e.target))
 		} else {
-			data, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(e.rel)))
+			abs := filepath.Join(dir, filepath.FromSlash(e.rel))
+			info, err := os.Stat(abs)
 			if err != nil {
-				return "", fmt.Errorf("hash %s: %w", filepath.Join(dir, e.rel), err)
+				return "", fmt.Errorf("hash %s: %w", abs, err)
 			}
-			h.Write(data)
+			if info.Size() > maxHashedFileBytes {
+				fmt.Fprintf(h, "%d\x00%d", info.Size(), info.ModTime().UnixNano())
+			} else {
+				data, err := os.ReadFile(abs)
+				if err != nil {
+					return "", fmt.Errorf("hash %s: %w", abs, err)
+				}
+				h.Write(data)
+			}
 		}
 		h.Write([]byte{0})
 	}

--- a/pkg/task/hash_test.go
+++ b/pkg/task/hash_test.go
@@ -1,9 +1,11 @@
 package task
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // Tests for pkg/task.Hash and pkg/task.ScanDir.
@@ -443,6 +445,123 @@ func TestScanDir_StableAcrossInvocations(t *testing.T) {
 				t.Fatalf("trial %d: id=%q hash=%q, want %q", i, id, got[id], hash)
 			}
 		}
+	}
+}
+
+// TestHash_LargeFileHashedByDescriptor covers the per-file size cap: a file
+// over maxHashedFileBytes folds in only its size+mtime, so rewriting its
+// contents while preserving size and mtime must not change the hash, but
+// changing its size must. This keeps the ~30s poll off re-reading bulk assets
+// while still catching the kind of change a committed asset actually undergoes.
+func TestHash_LargeFileHashedByDescriptor(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "hello")
+	writeTaskFiles(t, dir, "name: hello\n", "export default () => 1\n")
+
+	asset := filepath.Join(dir, "asset.bin")
+	big := bytes.Repeat([]byte{'a'}, maxHashedFileBytes+1)
+	if err := os.WriteFile(asset, big, 0644); err != nil {
+		t.Fatalf("write asset: %v", err)
+	}
+	// Pin mtime so we control the descriptor independently of write time.
+	mtime := time.Unix(1_700_000_000, 0)
+	if err := os.Chtimes(asset, mtime, mtime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	before, err := Hash(dir)
+	if err != nil {
+		t.Fatalf("before: %v", err)
+	}
+
+	// Same size + same mtime, different bytes → descriptor unchanged → hash unchanged.
+	changed := bytes.Repeat([]byte{'b'}, maxHashedFileBytes+1)
+	if err := os.WriteFile(asset, changed, 0644); err != nil {
+		t.Fatalf("rewrite asset: %v", err)
+	}
+	if err := os.Chtimes(asset, mtime, mtime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	sameSize, err := Hash(dir)
+	if err != nil {
+		t.Fatalf("sameSize: %v", err)
+	}
+	if sameSize != before {
+		t.Fatalf("hash changed for large file content edit at fixed size+mtime: %q -> %q", before, sameSize)
+	}
+
+	// Grow the file → descriptor size changes → hash changes.
+	grown := bytes.Repeat([]byte{'b'}, maxHashedFileBytes+2)
+	if err := os.WriteFile(asset, grown, 0644); err != nil {
+		t.Fatalf("grow asset: %v", err)
+	}
+	if err := os.Chtimes(asset, mtime, mtime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	grownHash, err := Hash(dir)
+	if err != nil {
+		t.Fatalf("grownHash: %v", err)
+	}
+	if grownHash == before {
+		t.Fatalf("hash did not change after large file size change: both = %q", before)
+	}
+}
+
+// TestHash_SmallFileEditChanges guards that the size cap does not weaken
+// change-detection for code: editing a sub-threshold file (the common case)
+// still changes the hash so the reconciler reloads the task.
+func TestHash_SmallFileEditChanges(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "hello")
+	writeTaskFiles(t, dir, "name: hello\n", "export default () => 1\n")
+
+	helper := filepath.Join(dir, "helper.js")
+	if err := os.WriteFile(helper, []byte("export const x = 1\n"), 0644); err != nil {
+		t.Fatalf("write helper: %v", err)
+	}
+
+	before, err := Hash(dir)
+	if err != nil {
+		t.Fatalf("before: %v", err)
+	}
+	if err := os.WriteFile(helper, []byte("export const x = 2\n"), 0644); err != nil {
+		t.Fatalf("rewrite helper: %v", err)
+	}
+	after, err := Hash(dir)
+	if err != nil {
+		t.Fatalf("after: %v", err)
+	}
+	if before == after {
+		t.Fatalf("hash did not change after small file edit: both = %q", before)
+	}
+}
+
+// TestHash_SkipsHeavyDirs covers the heavy-dir skip: files under node_modules
+// and .git are not folded into the digest, so committing or churning them does
+// not force a task reload nor cost the walk a full subtree read.
+func TestHash_SkipsHeavyDirs(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "hello")
+	writeTaskFiles(t, dir, "name: hello\n", "export default () => 1\n")
+
+	before, err := Hash(dir)
+	if err != nil {
+		t.Fatalf("before: %v", err)
+	}
+
+	for _, sub := range []string{"node_modules", ".git"} {
+		nested := filepath.Join(dir, sub, "pkg")
+		if err := os.MkdirAll(nested, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+		if err := os.WriteFile(filepath.Join(nested, "index.js"), []byte("whatever\n"), 0644); err != nil {
+			t.Fatalf("write under %s: %v", sub, err)
+		}
+	}
+
+	after, err := Hash(dir)
+	if err != nil {
+		t.Fatalf("after: %v", err)
+	}
+	if before != after {
+		t.Fatalf("hash changed after adding files under heavy dirs: %q -> %q", before, after)
 	}
 }
 


### PR DESCRIPTION
Closes #401

## Summary

`task.Hash` runs on every reconciler poll (~30s) over every task directory. It read the full contents of every file each cycle, so a committed large asset (or a vendored `node_modules` tree) made the per-poll hash cost scale with bulk data that has nothing to do with task logic.

This bounds the work so per-poll cost stays flat without losing change-detection for the code that actually matters:

- Files larger than `maxHashedFileBytes` (1 MiB) fold in a `size+mtime` descriptor instead of their bytes. Task logic lives in small, top-level files, so content change-detection there stays exact; only bulk assets drop to a stat.
- `node_modules` and `.git` subtrees are skipped wholesale during the walk.

## Rationale / scope

The hash is the fingerprint the approval gate (`dicode.lock`) keys re-approval off, so weakening it is a deliberate trade-off. Under the trusted-author model the operator approves the source, not every transitive vendored file, so code reachable only through these exclusions changing without re-triggering approval is acceptable. Two known consequences, documented in the `Hash` docstring: a content edit to a >1 MiB file that preserves both size and mtime is not detected, and changes inside the skipped subtrees are not detected.

Symlink handling is unchanged (target string folded in, never read through).