### PR TITLE
feat(tasktest): --format=junit|gh-summary + test-tasks-cli CI job (#162)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
           # absolute workspace path (${CONFIGDIR} won't reach tasks/ from ci/).
           cat ci/dicode-tasktest.yaml > "$DICODE_DATA_DIR/dicode-ci.yaml"
           cat >> "$DICODE_DATA_DIR/dicode-ci.yaml" <<SPECEOF
+          data_dir: $DICODE_DATA_DIR
           spec:
             entries:
               buildin:
@@ -97,9 +98,11 @@ jobs:
           DAEMON_PID=$!
           trap "kill $DAEMON_PID 2>/dev/null || true" EXIT
 
-          # Wait for HTTP API readiness (max 30 s, 0.5 s poll)
+          # Wait for IPC socket readiness (max 30 s, 0.5 s poll).
+          # Poll the socket, not HTTP — the CLI communicates via IPC and we
+          # need that path ready before invoking `dicode task test`.
           for i in $(seq 1 60); do
-            curl -sf http://localhost:18765/api/tasks >/dev/null 2>&1 && break
+            test -S "$DICODE_DATA_DIR/daemon.sock" && break
             if [ "$i" -eq 60 ]; then
               echo "Daemon did not become ready in 30 s"
               echo "=== daemon log ==="

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,83 @@ jobs:
       - name: Run Deno tests for tasks/buildin/*
         run: deno test --allow-all --config=tasks/deno.json 'tasks/buildin/**/task.test.ts'
 
+  test-tasks-cli:
+    name: Test buildin tasks (dicode CLI)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      DICODE_DATA_DIR: /tmp/dicode-ci
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Build dicode binary
+        run: go build -o dicode ./cmd/dicode
+
+      - name: Start daemon and run task tests
+        run: |
+          set -euo pipefail
+          mkdir -p "$DICODE_DATA_DIR"
+
+          # Assemble the CI config: base file + spec entry that needs the
+          # absolute workspace path (${CONFIGDIR} won't reach tasks/ from ci/).
+          cat ci/dicode-tasktest.yaml > "$DICODE_DATA_DIR/dicode-ci.yaml"
+          cat >> "$DICODE_DATA_DIR/dicode-ci.yaml" <<SPECEOF
+          spec:
+            entries:
+              buildin:
+                ref:
+                  path: $GITHUB_WORKSPACE/tasks/buildin/taskset.yaml
+                  watch: false
+          SPECEOF
+
+          ./dicode daemon --config "$DICODE_DATA_DIR/dicode-ci.yaml" \
+            > "$DICODE_DATA_DIR/daemon.log" 2>&1 &
+          DAEMON_PID=$!
+          trap "kill $DAEMON_PID 2>/dev/null || true" EXIT
+
+          # Wait for HTTP API readiness (max 30 s, 0.5 s poll)
+          for i in $(seq 1 60); do
+            curl -sf http://localhost:18765/api/tasks >/dev/null 2>&1 && break
+            if [ "$i" -eq 60 ]; then
+              echo "Daemon did not become ready in 30 s"
+              echo "=== daemon log ==="
+              cat "$DICODE_DATA_DIR/daemon.log"
+              exit 1
+            fi
+            sleep 0.5
+          done
+
+          ./dicode task test buildin/webui --format=junit \
+            > "$RUNNER_TEMP/buildin-webui.xml"
+
+      - name: Upload JUnit results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: task-test-results
+          path: ${{ runner.temp }}/buildin-webui.xml
+          retention-days: 7
+          if-no-files-found: warn
+
+      - name: Upload daemon log on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: daemon-log
+          path: /tmp/dicode-ci/daemon.log
+          retention-days: 3
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
       DICODE_DATA_DIR: /tmp/dicode-ci
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v6
         with:
@@ -129,7 +131,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: daemon-log
-          path: /tmp/dicode-ci/daemon.log
+          path: ${{ env.DICODE_DATA_DIR }}/daemon.log
           retention-days: 3
 
   lint:

--- a/ci/dicode-tasktest.yaml
+++ b/ci/dicode-tasktest.yaml
@@ -1,0 +1,15 @@
+# Minimal dicode config for the test-tasks-cli CI job.
+# ${DATADIR} expands to DICODE_DATA_DIR (set in the workflow env).
+# ${CONFIGDIR} expands to the directory containing this file — the ci/
+# sub-directory. The spec path uses an absolute path written by the workflow.
+database:
+  path: ${DATADIR}/data.db
+  type: sqlite
+log_level: warn
+server:
+  port: 18765
+  auth: false
+  mcp: false
+  tray: false
+relay:
+  enabled: false

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -547,15 +547,15 @@ func cmdTaskTest(c *ipc.ControlClient, args []string) error {
 		return fmt.Errorf("usage: dicode task test <task-id> [--format=text|junit|gh-summary]")
 	}
 
-	resp, err := c.Send(ipc.Request{Method: "cli.task.test", TaskID: taskID})
-	if err != nil {
-		return err
-	}
-
 	switch format {
 	case "text", "junit", "gh-summary":
 	default:
 		return fmt.Errorf("unknown --format %q: must be text, junit, or gh-summary", format)
+	}
+
+	resp, err := c.Send(ipc.Request{Method: "cli.task.test", TaskID: taskID})
+	if err != nil {
+		return err
 	}
 
 	var r ipc.TaskTestResult

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/dicode/dicode/pkg/daemon"
 	"github.com/dicode/dicode/pkg/ipc"
+	"github.com/dicode/dicode/pkg/tasktest"
 )
 
 var version = "dev"
@@ -476,9 +477,9 @@ func cmdTask(c *ipc.ControlClient, args []string) error {
 	switch args[0] {
 	case "test":
 		if len(args) < 2 {
-			return fmt.Errorf("usage: dicode task test <task-id>")
+			return fmt.Errorf("usage: dicode task test <task-id> [--format=text|junit|gh-summary]")
 		}
-		return cmdTaskTest(c, args[1])
+		return cmdTaskTest(c, args[1:])
 	case "create":
 		return cmdTaskCreate(c, args[1:])
 	case "edit":
@@ -519,16 +520,48 @@ func cmdTaskApprove(c *ipc.ControlClient, args []string) error {
 	return nil
 }
 
-func cmdTaskTest(c *ipc.ControlClient, taskID string) error {
+// cmdTaskTest implements `dicode task test <task-id> [--format=text|junit|gh-summary]`.
+//
+// --format=text (default): human-readable output to stdout.
+// --format=junit:          JUnit XML to stdout; human-readable to stderr;
+//
+//	GH step-summary markdown appended to $GITHUB_STEP_SUMMARY.
+//
+// --format=gh-summary:     GH step-summary markdown to stdout; also written to
+//
+//	$GITHUB_STEP_SUMMARY when the env var is set.
+func cmdTaskTest(c *ipc.ControlClient, args []string) error {
+	format := "text"
+	var taskID string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--format":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--format requires a value")
+			}
+			format = args[i+1]
+			i++
+		case strings.HasPrefix(a, "--format="):
+			format = strings.TrimPrefix(a, "--format=")
+		case a == "--help" || a == "-h":
+			fmt.Fprintln(os.Stderr, "Usage: dicode task test <task-id> [--format=text|junit|gh-summary]")
+			return nil
+		default:
+			if taskID == "" {
+				taskID = a
+			}
+		}
+	}
+	if taskID == "" {
+		return fmt.Errorf("usage: dicode task test <task-id> [--format=text|junit|gh-summary]")
+	}
+
 	resp, err := c.Send(ipc.Request{Method: "cli.task.test", TaskID: taskID})
 	if err != nil {
 		return err
 	}
 
-	// The daemon returns a populated Result AND sometimes a non-empty
-	// resp.Error (e.g. failing tests produce real output but the handler
-	// flags them). Prefer the structured payload when we have one; fall
-	// back to the error string when we don't.
 	var r ipc.TaskTestResult
 	hasPayload := false
 	if resp.Result != nil {
@@ -543,19 +576,64 @@ func cmdTaskTest(c *ipc.ControlClient, taskID string) error {
 		return nil
 	}
 
-	fmt.Print(r.Output)
-	if !strings.HasSuffix(r.Output, "\n") {
-		fmt.Println()
+	result := tasktest.Result{
+		TaskID:   r.TaskID,
+		Runtime:  r.Runtime,
+		Passed:   r.Passed,
+		Failed:   r.Failed,
+		Skipped:  r.Skipped,
+		Duration: time.Duration(r.DurMs) * time.Millisecond,
+		ExitCode: r.ExitCode,
+		Output:   r.Output,
 	}
-	fmt.Printf("%s: %d passed, %d failed", r.TaskID, r.Passed, r.Failed)
-	if r.Skipped > 0 {
-		fmt.Printf(", %d skipped", r.Skipped)
+
+	switch format {
+	case "junit":
+		// JUnit XML → stdout; human-readable → stderr so CI logs stay readable.
+		fmt.Fprint(os.Stderr, r.Output)
+		if !strings.HasSuffix(r.Output, "\n") {
+			fmt.Fprintln(os.Stderr)
+		}
+		fmt.Fprintf(os.Stderr, "%s: %d passed, %d failed (runtime=%s, %dms)\n",
+			r.TaskID, r.Passed, r.Failed, r.Runtime, r.DurMs)
+		fmt.Print(tasktest.FormatJUnit(result))
+		writeGHStepSummary(tasktest.FormatGHSummary(result))
+	case "gh-summary":
+		summary := tasktest.FormatGHSummary(result)
+		fmt.Print(summary)
+		writeGHStepSummary(summary)
+	default: // "text"
+		fmt.Print(r.Output)
+		if !strings.HasSuffix(r.Output, "\n") {
+			fmt.Println()
+		}
+		fmt.Printf("%s: %d passed, %d failed", r.TaskID, r.Passed, r.Failed)
+		if r.Skipped > 0 {
+			fmt.Printf(", %d skipped", r.Skipped)
+		}
+		fmt.Printf(" (runtime=%s, %dms)\n", r.Runtime, r.DurMs)
 	}
-	fmt.Printf(" (runtime=%s, %dms)\n", r.Runtime, r.DurMs)
+
 	if r.Failed > 0 || r.ExitCode != 0 {
 		return fmt.Errorf("%d test(s) failed", r.Failed)
 	}
 	return nil
+}
+
+// writeGHStepSummary appends markdown to $GITHUB_STEP_SUMMARY when the env
+// var is set. Failures are silently ignored — the primary output path already
+// delivered the result; summary writing is best-effort.
+func writeGHStepSummary(markdown string) {
+	path := os.Getenv("GITHUB_STEP_SUMMARY")
+	if path == "" {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return
+	}
+	_, _ = f.WriteString(markdown)
+	_ = f.Close()
 }
 
 // cmdTaskDelete implements `dicode task delete <task-id> [--source NAME] [--force]`.
@@ -1023,7 +1101,8 @@ Commands:
   status [task-id]                daemon health or task's latest run
   ai <prompt> [flags]             run the configured AI task with a prompt
                                   flags: --session-id ID, --task TASK_ID
-  task test <task-id>             run the task's sibling task.test.* through its runtime
+  task test <task-id> [flags]     run the task's sibling task.test.* through its runtime
+                                  flags: --format=text|junit|gh-summary
   task delete <task-id> [flags]   remove a task from its source (local rm / git PR)
                                   flags: --source NAME, --force
   task approve <task-id>          approve a task held pending by the approval gate

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -520,16 +520,6 @@ func cmdTaskApprove(c *ipc.ControlClient, args []string) error {
 	return nil
 }
 
-// cmdTaskTest implements `dicode task test <task-id> [--format=text|junit|gh-summary]`.
-//
-// --format=text (default): human-readable output to stdout.
-// --format=junit:          JUnit XML to stdout; human-readable to stderr;
-//
-//	GH step-summary markdown appended to $GITHUB_STEP_SUMMARY.
-//
-// --format=gh-summary:     GH step-summary markdown to stdout; also written to
-//
-//	$GITHUB_STEP_SUMMARY when the env var is set.
 func cmdTaskTest(c *ipc.ControlClient, args []string) error {
 	format := "text"
 	var taskID string
@@ -562,11 +552,17 @@ func cmdTaskTest(c *ipc.ControlClient, args []string) error {
 		return err
 	}
 
+	switch format {
+	case "text", "junit", "gh-summary":
+	default:
+		return fmt.Errorf("unknown --format %q: must be text, junit, or gh-summary", format)
+	}
+
 	var r ipc.TaskTestResult
 	hasPayload := false
 	if resp.Result != nil {
 		if rerr := remarshal(resp.Result, &r); rerr == nil {
-			hasPayload = r.Output != "" || r.Failed > 0 || r.Passed > 0
+			hasPayload = r.Output != "" || r.Failed > 0 || r.Passed > 0 || r.Skipped > 0
 		}
 	}
 	if !hasPayload {
@@ -594,6 +590,9 @@ func cmdTaskTest(c *ipc.ControlClient, args []string) error {
 		if !strings.HasSuffix(r.Output, "\n") {
 			fmt.Fprintln(os.Stderr)
 		}
+		if r.Error != "" {
+			fmt.Fprintf(os.Stderr, "error: %s\n", r.Error)
+		}
 		fmt.Fprintf(os.Stderr, "%s: %d passed, %d failed (runtime=%s, %dms)\n",
 			r.TaskID, r.Passed, r.Failed, r.Runtime, r.DurMs)
 		fmt.Print(tasktest.FormatJUnit(result))
@@ -602,6 +601,9 @@ func cmdTaskTest(c *ipc.ControlClient, args []string) error {
 		summary := tasktest.FormatGHSummary(result)
 		fmt.Print(summary)
 		writeGHStepSummary(summary)
+		if r.Error != "" {
+			fmt.Fprintf(os.Stderr, "error: %s\n", r.Error)
+		}
 	default: // "text"
 		fmt.Print(r.Output)
 		if !strings.HasSuffix(r.Output, "\n") {
@@ -620,9 +622,6 @@ func cmdTaskTest(c *ipc.ControlClient, args []string) error {
 	return nil
 }
 
-// writeGHStepSummary appends markdown to $GITHUB_STEP_SUMMARY when the env
-// var is set. Failures are silently ignored — the primary output path already
-// delivered the result; summary writing is best-effort.
 func writeGHStepSummary(markdown string) {
 	path := os.Getenv("GITHUB_STEP_SUMMARY")
 	if path == "" {

--- a/docs/concepts/testing.md
+++ b/docs/concepts/testing.md
@@ -1,14 +1,19 @@
 # Testing & Validation
 
-> **Status**: This document describes the **planned** testing and validation system. The test harness (`pkg/testing/`), CLI commands (`dicode task validate`, `dicode task test`, `dicode task run --dry-run`, `dicode ci init`), and mock API are not yet implemented. This serves as the design spec for future development.
+> **Status**: This document describes the testing and validation system. Layer 2
+> (`dicode task test`) is implemented for the Deno runtime (`pkg/tasktest`).
+> Layer 1 (`dicode task validate`), Layer 3 (`dicode task run --dry-run`), and
+> `dicode ci init` remain planned. The mock API described under Layer 2 is the
+> long-term design; the current implementation runs Deno's built-in test runner
+> against `task.test.ts` files and parses its summary output.
 
 Dicode is designed with four validation layers, each catching different classes of problems.
 
 ```
 Layer 1: Static validation     — schema + syntax, zero execution, instant        [planned]
-Layer 2: Unit tests            — mocked globals, full task run, local             [planned]
+Layer 2: Unit tests            — mocked globals, full task run, local             [implemented: Deno]
 Layer 3: Dry run               — real secrets, intercepted HTTP, no side effects  [planned]
-Layer 4: CI guardrails         — layers 1+2 on every push, offline-safe           [planned]
+Layer 4: CI guardrails         — layers 1+2 on every push, offline-safe           [partial: see CI job below]
 ```
 
 ---
@@ -41,11 +46,42 @@ Checks performed without executing any code:
 
 ```bash
 dicode task test <id>
+dicode task test <id> --format=junit        # JUnit XML to stdout; human output to stderr
+dicode task test <id> --format=gh-summary   # GitHub Markdown to stdout + $GITHUB_STEP_SUMMARY
 dicode task test --all
-dicode task test <id> --watch   # re-run on file save
+dicode task test <id> --watch   # re-run on file save (planned)
 ```
 
-Runs `task.test.js` with mocked globals. No real HTTP calls, no real secrets, no database side effects.
+Runs `task.test.ts` (Deno runtime) through the Deno test runner. The current
+implementation captures aggregate passed/failed/skipped counts from Deno's
+summary line.
+
+### Output formats
+
+| Flag | stdout | $GITHUB_STEP_SUMMARY |
+|---|---|---|
+| `--format=text` (default) | Human-readable | not written |
+| `--format=junit` | JUnit XML | written if env var is set |
+| `--format=gh-summary` | GitHub Markdown | written if env var is set |
+
+When `--format=junit` is used, human-readable output goes to stderr so CI logs
+remain readable alongside the machine-readable XML.
+
+### CI job: `test-tasks-cli`
+
+The `.github/workflows/ci.yml` job `test-tasks-cli` boots the dicode daemon
+against the built-in task set (using `ci/dicode-tasktest.yaml`) and runs:
+
+```bash
+./dicode task test buildin/webui --format=junit
+```
+
+The resulting JUnit XML is uploaded as a workflow artifact. The daemon log is
+uploaded on failure for post-mortem inspection.
+
+The long-term design (mocked globals, `http.mock`, `runTask()`, etc.) remains
+the target for future layers. The current implementation uses Deno's native
+`Deno.test` runner and parses its output.
 
 ### Test file format
 

--- a/docs/concepts/testing.md
+++ b/docs/concepts/testing.md
@@ -9,7 +9,7 @@
 
 Dicode is designed with four validation layers, each catching different classes of problems.
 
-```
+```text
 Layer 1: Static validation     — schema + syntax, zero execution, instant        [planned]
 Layer 2: Unit tests            — mocked globals, full task run, local             [implemented: Deno]
 Layer 3: Dry run               — real secrets, intercepted HTTP, no side effects  [planned]

--- a/pkg/tasktest/format.go
+++ b/pkg/tasktest/format.go
@@ -6,8 +6,7 @@ import (
 	"strings"
 )
 
-// junitTestsuites / junitSuite / junitCase / junitFailure are the XML types
-// for JUnit output. Individual test names are synthetic ("test N") because
+// Individual test names in JUnit output are synthetic ("test N") because
 // Deno's summary line carries only aggregate counts, not per-test details.
 type junitTestsuites struct {
 	XMLName xml.Name     `xml:"testsuites"`
@@ -24,21 +23,23 @@ type junitSuite struct {
 }
 
 type junitCase struct {
-	Name      string        `xml:"name,attr"`
-	Classname string        `xml:"classname,attr"`
-	Time      string        `xml:"time,attr"`
-	Failure   *junitFailure `xml:"failure,omitempty"`
+	Name      string              `xml:"name,attr"`
+	Classname string              `xml:"classname,attr"`
+	Time      string              `xml:"time,attr"`
+	Failure   *junitFailure       `xml:"failure,omitempty"`
+	Skipped   *junitSkippedMarker `xml:"skipped,omitempty"`
 }
 
 type junitFailure struct {
 	Message string `xml:"message,attr"`
 }
 
-// FormatJUnit returns a JUnit XML string for r. Individual test names are
-// synthetic because Deno's summary line carries only aggregate counts.
+type junitSkippedMarker struct{}
+
+// FormatJUnit returns a JUnit XML string for r.
 func FormatJUnit(r Result) string {
 	secs := r.Duration.Seconds()
-	n := r.Passed + r.Failed
+	n := r.Passed + r.Failed + r.Skipped
 	perTest := 0.0
 	if n > 0 {
 		perTest = secs / float64(n)
@@ -60,6 +61,14 @@ func FormatJUnit(r Result) string {
 			Failure:   &junitFailure{Message: "test failed"},
 		})
 	}
+	for i := 0; i < r.Skipped; i++ {
+		cases = append(cases, junitCase{
+			Name:      fmt.Sprintf("test %d", r.Passed+r.Failed+i+1),
+			Classname: r.TaskID,
+			Time:      fmt.Sprintf("%.3f", perTest),
+			Skipped:   &junitSkippedMarker{},
+		})
+	}
 
 	suites := junitTestsuites{Suites: []junitSuite{{
 		Name:     r.TaskID,
@@ -78,7 +87,6 @@ func FormatJUnit(r Result) string {
 }
 
 // FormatGHSummary returns GitHub-flavoured Markdown for $GITHUB_STEP_SUMMARY.
-// It includes a pass/fail icon, a summary table, and a collapsible code block.
 func FormatGHSummary(r Result) string {
 	icon := ":white_check_mark:"
 	if r.Failed > 0 || r.ExitCode != 0 {
@@ -91,7 +99,8 @@ func FormatGHSummary(r Result) string {
 	fmt.Fprintf(&b, "|--------|--------|---------|---------|----------|\n")
 	fmt.Fprintf(&b, "| %d | %d | %d | %s | %dms |\n\n", r.Passed, r.Failed, r.Skipped, r.Runtime, ms)
 	if r.Output != "" {
-		fmt.Fprintf(&b, "<details><summary>Output</summary>\n\n```\n%s\n```\n\n</details>\n", r.Output)
+		// Use tilde fencing so triple-backticks in test output don't break the block.
+		fmt.Fprintf(&b, "<details><summary>Output</summary>\n\n~~~\n%s\n~~~\n\n</details>\n", r.Output)
 	}
 	return b.String()
 }

--- a/pkg/tasktest/format.go
+++ b/pkg/tasktest/format.go
@@ -1,0 +1,97 @@
+package tasktest
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+)
+
+// junitTestsuites / junitSuite / junitCase / junitFailure are the XML types
+// for JUnit output. Individual test names are synthetic ("test N") because
+// Deno's summary line carries only aggregate counts, not per-test details.
+type junitTestsuites struct {
+	XMLName xml.Name     `xml:"testsuites"`
+	Suites  []junitSuite `xml:"testsuite"`
+}
+
+type junitSuite struct {
+	Name     string      `xml:"name,attr"`
+	Tests    int         `xml:"tests,attr"`
+	Failures int         `xml:"failures,attr"`
+	Skipped  int         `xml:"skipped,attr"`
+	Time     string      `xml:"time,attr"`
+	Cases    []junitCase `xml:"testcase"`
+}
+
+type junitCase struct {
+	Name      string        `xml:"name,attr"`
+	Classname string        `xml:"classname,attr"`
+	Time      string        `xml:"time,attr"`
+	Failure   *junitFailure `xml:"failure,omitempty"`
+}
+
+type junitFailure struct {
+	Message string `xml:"message,attr"`
+}
+
+// FormatJUnit returns a JUnit XML string for r. Individual test names are
+// synthetic because Deno's summary line carries only aggregate counts.
+func FormatJUnit(r Result) string {
+	secs := r.Duration.Seconds()
+	n := r.Passed + r.Failed
+	perTest := 0.0
+	if n > 0 {
+		perTest = secs / float64(n)
+	}
+
+	var cases []junitCase
+	for i := 0; i < r.Passed; i++ {
+		cases = append(cases, junitCase{
+			Name:      fmt.Sprintf("test %d", i+1),
+			Classname: r.TaskID,
+			Time:      fmt.Sprintf("%.3f", perTest),
+		})
+	}
+	for i := 0; i < r.Failed; i++ {
+		cases = append(cases, junitCase{
+			Name:      fmt.Sprintf("test %d", r.Passed+i+1),
+			Classname: r.TaskID,
+			Time:      fmt.Sprintf("%.3f", perTest),
+			Failure:   &junitFailure{Message: "test failed"},
+		})
+	}
+
+	suites := junitTestsuites{Suites: []junitSuite{{
+		Name:     r.TaskID,
+		Tests:    r.Passed + r.Failed + r.Skipped,
+		Failures: r.Failed,
+		Skipped:  r.Skipped,
+		Time:     fmt.Sprintf("%.3f", secs),
+		Cases:    cases,
+	}}}
+
+	out, err := xml.MarshalIndent(suites, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("<!-- xml marshal error: %v -->", err)
+	}
+	return xml.Header + string(out) + "\n"
+}
+
+// FormatGHSummary returns GitHub-flavoured Markdown for $GITHUB_STEP_SUMMARY.
+// It includes a pass/fail icon, a summary table, and a collapsible code block.
+func FormatGHSummary(r Result) string {
+	icon := ":white_check_mark:"
+	if r.Failed > 0 || r.ExitCode != 0 {
+		icon = ":x:"
+	}
+	ms := r.Duration.Milliseconds()
+	var b strings.Builder
+	fmt.Fprintf(&b, "## %s `dicode task test %s`\n\n", icon, r.TaskID)
+	fmt.Fprintf(&b, "| Passed | Failed | Skipped | Runtime | Duration |\n")
+	fmt.Fprintf(&b, "|--------|--------|---------|---------|----------|\n")
+	fmt.Fprintf(&b, "| %d | %d | %d | %s | %dms |\n\n", r.Passed, r.Failed, r.Skipped, r.Runtime, ms)
+	if r.Output != "" {
+		fmt.Fprintf(&b, "<details><summary>Output</summary>\n\n```\n%s\n```\n\n</details>\n", r.Output)
+	}
+	return b.String()
+}

--- a/pkg/tasktest/format_test.go
+++ b/pkg/tasktest/format_test.go
@@ -106,3 +106,44 @@ func TestFormatGHSummary_WithOutput(t *testing.T) {
 		t.Error("expected raw output inside details block")
 	}
 }
+
+func TestFormatJUnit_WithSkipped(t *testing.T) {
+	r := Result{
+		TaskID:  "buildin/foo",
+		Runtime: "deno",
+		Passed:  2,
+		Failed:  1,
+		Skipped: 3,
+	}
+	out := FormatJUnit(r)
+	if !strings.Contains(out, `tests="6"`) {
+		t.Errorf("expected tests=6 (2+1+3), got:\n%s", out)
+	}
+	if !strings.Contains(out, `skipped="3"`) {
+		t.Errorf("expected skipped=3 on testsuite, got:\n%s", out)
+	}
+	// Every test (passed, failed, skipped) must have a <testcase> element.
+	if n := strings.Count(out, "<testcase"); n != 6 {
+		t.Errorf("expected 6 <testcase> elements (2+1+3), got %d:\n%s", n, out)
+	}
+	if n := strings.Count(out, "<skipped"); n != 3 {
+		t.Errorf("expected 3 <skipped> elements, got %d:\n%s", n, out)
+	}
+}
+
+func TestFormatGHSummary_BacktickOutputFence(t *testing.T) {
+	r := Result{
+		TaskID: "buildin/foo",
+		Passed: 1,
+		// Output contains triple-backticks; tilde fencing must survive them.
+		Output: "line1\n```\nsome code\n```\nline2\n",
+	}
+	out := FormatGHSummary(r)
+	// Fence delimiter must be tilde, not backtick, so output backticks don't close the block.
+	if !strings.Contains(out, "\n~~~\n") {
+		t.Error("expected tilde fence delimiter (~~~) in output details block")
+	}
+	if !strings.Contains(out, "some code") {
+		t.Error("expected raw output preserved inside the fenced block")
+	}
+}

--- a/pkg/tasktest/format_test.go
+++ b/pkg/tasktest/format_test.go
@@ -1,0 +1,108 @@
+package tasktest
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFormatJUnit_PassOnly(t *testing.T) {
+	r := Result{
+		TaskID:   "buildin/webui",
+		Runtime:  "deno",
+		Passed:   7,
+		Duration: 80 * time.Millisecond,
+	}
+	out := FormatJUnit(r)
+	if !strings.Contains(out, `<?xml`) {
+		t.Error("expected XML header")
+	}
+	if !strings.Contains(out, `name="buildin/webui"`) {
+		t.Errorf("expected task ID in testsuite name, got:\n%s", out)
+	}
+	if !strings.Contains(out, `tests="7"`) {
+		t.Errorf("expected tests=7, got:\n%s", out)
+	}
+	if !strings.Contains(out, `failures="0"`) {
+		t.Errorf("expected failures=0, got:\n%s", out)
+	}
+	if strings.Contains(out, "<failure") {
+		t.Error("expected no <failure> elements for pass-only result")
+	}
+	if n := strings.Count(out, "<testcase"); n != 7 {
+		t.Errorf("expected 7 <testcase> elements, got %d", n)
+	}
+}
+
+func TestFormatJUnit_WithFailures(t *testing.T) {
+	r := Result{
+		TaskID:  "buildin/alert",
+		Runtime: "deno",
+		Passed:  3,
+		Failed:  2,
+	}
+	out := FormatJUnit(r)
+	if !strings.Contains(out, `tests="5"`) {
+		t.Errorf("expected tests=5, got:\n%s", out)
+	}
+	if !strings.Contains(out, `failures="2"`) {
+		t.Errorf("expected failures=2, got:\n%s", out)
+	}
+	if n := strings.Count(out, "<failure"); n != 2 {
+		t.Errorf("expected 2 <failure> elements, got %d\n%s", n, out)
+	}
+}
+
+func TestFormatJUnit_Empty(t *testing.T) {
+	r := Result{TaskID: "buildin/noop"}
+	out := FormatJUnit(r)
+	if !strings.Contains(out, `tests="0"`) {
+		t.Errorf("expected tests=0 for empty result, got:\n%s", out)
+	}
+}
+
+func TestFormatGHSummary_Pass(t *testing.T) {
+	r := Result{
+		TaskID:   "buildin/webui",
+		Runtime:  "deno",
+		Passed:   7,
+		Duration: 80 * time.Millisecond,
+	}
+	out := FormatGHSummary(r)
+	if !strings.Contains(out, "buildin/webui") {
+		t.Error("expected task ID in summary")
+	}
+	if !strings.Contains(out, "7") {
+		t.Error("expected pass count in summary")
+	}
+	if !strings.Contains(out, ":white_check_mark:") {
+		t.Error("expected pass icon")
+	}
+}
+
+func TestFormatGHSummary_Fail(t *testing.T) {
+	r := Result{
+		TaskID:   "buildin/alert",
+		Failed:   1,
+		ExitCode: 1,
+	}
+	out := FormatGHSummary(r)
+	if !strings.Contains(out, ":x:") {
+		t.Error("expected fail icon when Failed > 0")
+	}
+}
+
+func TestFormatGHSummary_WithOutput(t *testing.T) {
+	r := Result{
+		TaskID: "buildin/foo",
+		Passed: 1,
+		Output: "test 1 ... ok\n",
+	}
+	out := FormatGHSummary(r)
+	if !strings.Contains(out, "<details>") {
+		t.Error("expected collapsible details block when output is non-empty")
+	}
+	if !strings.Contains(out, "test 1 ... ok") {
+		t.Error("expected raw output inside details block")
+	}
+}


### PR DESCRIPTION
Closes #162 (Thread 1, Item 1)

## Summary

- Adds `--format=text|junit|gh-summary` flag to `dicode task test`
- New `pkg/tasktest/format.go`: `FormatJUnit` and `FormatGHSummary` formatters
- New `test-tasks-cli` CI job that boots the daemon with a minimal config and runs `dicode task test buildin/webui --format=junit`
- Updates `docs/concepts/testing.md` status from "planned" to "implemented: Deno"

## Touched files

| File | Reason |
|------|--------|
| `pkg/tasktest/format.go` | New: `FormatJUnit` (JUnit XML) and `FormatGHSummary` (GH step-summary Markdown) |
| `pkg/tasktest/format_test.go` | New: 6 unit tests for both formatters |
| `cmd/dicode/main.go` | Add `--format` flag to `cmdTaskTest`; add `writeGHStepSummary` helper |
| `.github/workflows/ci.yml` | Add `test-tasks-cli` job (boots daemon + runs task test) |
| `ci/dicode-tasktest.yaml` | New: minimal dicode config for the CI job |
| `docs/concepts/testing.md` | Update Layer 2 status; document `--format` flag and CI job |

## Test coverage

**Unit tests** (`pkg/tasktest`): 6 new tests cover `FormatJUnit` (pass-only, with failures, empty) and `FormatGHSummary` (pass icon, fail icon, collapsible output). Unit-only because the formatters are pure functions on `Result` — there is no daemon/IPC/runtime path to exercise end-to-end for the formatting layer itself.

**CI e2e** (`test-tasks-cli` job): The new GitHub Actions job exercises the full daemon-bootstrap → IPC → `cli.task.test` → `pkg/tasktest.Run` → Deno chain that the existing `test-tasks` direct-`deno test` job misses entirely.

## Pre-existing test failure

`TestEnforcement_Env_RelayImportNeedsReadExposed` in `pkg/runtime/deno` fails in this sandbox (no outbound npm registry access). This test was failing before this PR on the same branch; it is network-dependent and unrelated to these changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyCxAwcLAWcMqQSNPEr9sS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `dicode task test` output formats: `text`, `junit`, and `gh-summary`, including GitHub step summary support.
  * Introduced a dedicated CI job to run task tests in CI and publish JUnit results (and daemon logs on failure).
* **Bug Fixes**
  * Improved task test result handling and pass/fail reporting, including correct treatment of skipped cases.
* **Documentation**
  * Updated testing documentation with the current CI approach and formatter output details.
* **Tests**
  * Added coverage for JUnit XML and GitHub summary rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->