### PR TITLE
feat(python): env-read guardrail — restrict os.environ to declared vars (#418)

### DIFF
--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -75,7 +75,7 @@ permissions:
 | `trigger.restart` | string | | daemon only: `always` (default), `on-failure`, `never` |
 | `permissions` | object | | Explicit access grants — nothing is implicit |
 | `permissions.env` | list | | Env vars the script may read (see below); for unrestricted env read use `env_read_exposed` |
-| `permissions.env_read_exposed` | bool | | Deno only: grant bare `--allow-env` (read any env var) for node-compat / npm tasks (see below) |
+| `permissions.env_read_exposed` | bool | | Grant unrestricted env-var reads (Deno and Python): Deno gets bare `--allow-env`; Python lifts the os.environ filter added in #418. For node-compat / npm tasks (see below) |
 | `permissions.fs` | list | | Filesystem access declarations (Deno: read+write; Python: write only) |
 | `permissions.fs[].path` | string | | Absolute or `~`-prefixed path |
 | `permissions.fs[].permission` | string | | `r`, `w`, or `rw` |
@@ -1031,9 +1031,11 @@ export default async function main({ env }) {
 }
 ```
 
-#### `env_read_exposed` — grant unrestricted env read (Deno node-compat / npm escape hatch)
+#### `env_read_exposed` — grant unrestricted env read (Deno node-compat / npm escape hatch; Python env-filter bypass)
 
-`permissions.env_read_exposed: true` grants the Deno sandbox bare `--allow-env` (read **any** env var). It exists for node-compat / npm tasks: `import "npm:…"` pulls in transitive dependencies that read `process.env` keys (`NODE_ENV` and others) at module-init time, before your `main()` runs. The set is unpredictable per dependency, so pinning individual names is fragile — `import "npm:dicode-relay/start"`, for example, still throws `NotCapable` even with `NODE_ENV` explicitly declared.
+`permissions.env_read_exposed: true` grants unrestricted env-var reads. For Deno it passes bare `--allow-env` to the sandbox. For Python it disables the `os.environ` filter (#418): by default Python tasks can only read the names listed in `permissions.env` plus a runtime-essential set (`PATH`, `HOME`, cache/proxy/TLS vars, `DICODE_SOCKET`, `DICODE_TOKEN`, …); setting this flag lifts that restriction.
+
+The flag exists primarily for node-compat / npm tasks: `import "npm:…"` pulls in transitive dependencies that read `process.env` keys (`NODE_ENV` and others) at module-init time, before your `main()` runs. The set is unpredictable per dependency, so pinning individual names is fragile — `import "npm:dicode-relay/start"`, for example, still throws `NotCapable` even with `NODE_ENV` explicitly declared.
 
 `env_read_exposed` widens *read permission* only. It is independent of the `env:` list — set the flag to allow reads, and keep the named/`secret:`/`from:` entries that your task actually needs **forwarded** (the flag grants permission to read a var but does not inject any values):
 
@@ -1045,7 +1047,7 @@ permissions:
     - DICODE_VERSION
 ```
 
-**Blast radius — why this is safe.** A task subprocess does not inherit the daemon environment. `runtime.SubprocessEnv` assembles the subprocess env as an allowlist: process basics + cache/proxy/TLS vars (`PATH`, `HOME`, `XDG_CACHE_HOME`, `DENO_DIR`, `HTTP(S)_PROXY`, `SSL_CERT_*`, …), the per-run IPC coordinates (`DICODE_SOCKET`/`DICODE_TOKEN`, which the task already holds), the host values of the task's own named entries, and its resolved secrets/values. The daemon master key and admin/MCP API keys are explicitly denylisted and never forwarded. So bare `--allow-env` lets the script read only that minimal, already-task-scoped env — it exposes nothing the task didn't already have. (Deno only; Python tasks read env through the SDK, not `--allow-env`, so `env_read_exposed` is a Deno-runtime concept.)
+**Blast radius — why this is safe.** A task subprocess does not inherit the daemon environment. `runtime.SubprocessEnv` assembles the subprocess env as an allowlist: process basics + cache/proxy/TLS vars (`PATH`, `HOME`, `XDG_CACHE_HOME`, `DENO_DIR`, `HTTP(S)_PROXY`, `SSL_CERT_*`, …), the per-run IPC coordinates (`DICODE_SOCKET`/`DICODE_TOKEN`, which the task already holds), the host values of the task's own named entries, and its resolved secrets/values. The daemon master key and admin/MCP API keys are explicitly denylisted and never forwarded. So `env_read_exposed` lets the script read only that minimal, already-task-scoped env — it exposes nothing the task didn't already have.
 
 #### Example 5 — `if_missing`: run a prereq task when a secret is absent
 

--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -1033,7 +1033,7 @@ export default async function main({ env }) {
 
 #### `env_read_exposed` — grant unrestricted env read (Deno node-compat / npm escape hatch; Python env-filter bypass)
 
-`permissions.env_read_exposed: true` grants unrestricted env-var reads. For Deno it passes bare `--allow-env` to the sandbox. For Python it disables the `os.environ` filter (#418): by default Python tasks can only read the names listed in `permissions.env` plus a runtime-essential set (`PATH`, `HOME`, cache/proxy/TLS vars, `DICODE_SOCKET`, `DICODE_TOKEN`, …); setting this flag lifts that restriction.
+`permissions.env_read_exposed: true` grants unrestricted env-var reads. For Deno it passes bare `--allow-env` to the sandbox. For Python it disables the `os.environ` filter (#418): by default Python tasks can initially only read the names listed in `permissions.env` plus a runtime-essential set (`PATH`, `HOME`, cache/proxy/TLS vars, `DICODE_SOCKET`, `DICODE_TOKEN`, …); keys the task writes with `os.environ["K"] = v` become readable immediately without this flag. Setting `env_read_exposed: true` lifts all restrictions.
 
 The flag exists primarily for node-compat / npm tasks: `import "npm:…"` pulls in transitive dependencies that read `process.env` keys (`NODE_ENV` and others) at module-init time, before your `main()` runs. The set is unpredictable per dependency, so pinning individual names is fragile — `import "npm:dicode-relay/start"`, for example, still throws `NotCapable` even with `NODE_ENV` explicitly declared.
 

--- a/pkg/runtime/python/guard.go
+++ b/pkg/runtime/python/guard.go
@@ -34,6 +34,10 @@ type guardPolicy struct {
 	// directory. The audit hook checks this before the write allowlist so the
 	// deny always wins.
 	FSDeny []string `json:"fs_deny,omitempty"`
+	// EnvAllowed lists env var names the task may read; nil means no filtering
+	// (env_read_exposed=true). When set, guard.py replaces os.environ with a
+	// filtered view restricted to these names.
+	EnvAllowed []string `json:"env_allowed,omitempty"`
 }
 
 type guardNet struct {
@@ -104,6 +108,48 @@ func buildGuardPolicy(spec *task.Spec, socketPath string, protectedPaths []strin
 		}
 		pol.FSDeny = append(pol.FSDeny, filepath.Clean(p))
 	}
+
+	// Env-read guardrail: when env_read_exposed is false (the default), restrict
+	// os.environ reads to the declared env var names plus a runtime-essential set.
+	// When env_read_exposed is true, leave EnvAllowed nil (no filter).
+	if !spec.Permissions.EnvReadExposed {
+		essential := []string{
+			// Process basics.
+			"PATH", "HOME", "USER", "LOGNAME", "TMPDIR",
+			// Locale / timezone.
+			"LANG", "LC_ALL", "LC_CTYPE", "TZ",
+			// Cache, data, and config roots.
+			"XDG_CACHE_HOME", "XDG_DATA_HOME", "XDG_CONFIG_HOME",
+			// TLS trust store overrides.
+			"SSL_CERT_FILE", "SSL_CERT_DIR",
+			// Proxies, honored by uv/requests.
+			"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+			"http_proxy", "https_proxy", "no_proxy",
+			// Deno cache location (kept for consistency with subprocenv.go).
+			"DENO_DIR",
+			// uv interpreter and cache locations.
+			"UV_CACHE_DIR", "UV_PYTHON", "UV_PYTHON_INSTALL_DIR", "VIRTUAL_ENV",
+			// IPC handshake coordinates.
+			"DICODE_SOCKET", "DICODE_TOKEN",
+		}
+		seen := make(map[string]bool, len(essential)+len(spec.Permissions.Env))
+		allowed := make([]string, 0, len(essential)+len(spec.Permissions.Env))
+		for _, name := range essential {
+			if !seen[name] {
+				seen[name] = true
+				allowed = append(allowed, name)
+			}
+		}
+		for _, e := range spec.Permissions.Env {
+			if e.Name == "" || seen[e.Name] {
+				continue
+			}
+			seen[e.Name] = true
+			allowed = append(allowed, e.Name)
+		}
+		pol.EnvAllowed = allowed
+	}
+
 	return pol
 }
 

--- a/pkg/runtime/python/guard.go
+++ b/pkg/runtime/python/guard.go
@@ -125,8 +125,6 @@ func buildGuardPolicy(spec *task.Spec, socketPath string, protectedPaths []strin
 			// Proxies, honored by uv/requests.
 			"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
 			"http_proxy", "https_proxy", "no_proxy",
-			// Deno cache location (kept for consistency with subprocenv.go).
-			"DENO_DIR",
 			// uv interpreter and cache locations.
 			"UV_CACHE_DIR", "UV_PYTHON", "UV_PYTHON_INSTALL_DIR", "VIRTUAL_ENV",
 			// IPC handshake coordinates.

--- a/pkg/runtime/python/guard_integration_test.go
+++ b/pkg/runtime/python/guard_integration_test.go
@@ -32,7 +32,7 @@ func pythonForGuardTest(t *testing.T) []string {
 // runGuardScript renders the guard for pol, appends payload, and executes the
 // result with a real interpreter. Returns the combined output and the exec
 // error (nil on exit 0).
-func runGuardScript(t *testing.T, pol guardPolicy, payload string) (string, error) {
+func runGuardScript(t *testing.T, pol guardPolicy, payload string, extraEnv ...string) (string, error) {
 	t.Helper()
 	guard, err := buildGuard(pol)
 	if err != nil {
@@ -45,6 +45,9 @@ func runGuardScript(t *testing.T, pol guardPolicy, payload string) (string, erro
 	}
 	interp := pythonForGuardTest(t)
 	cmd := exec.Command(interp[0], append(interp[1:], script)...) //nolint:gosec
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
 	out, runErr := cmd.CombinedOutput()
 	return string(out), runErr
 }
@@ -232,7 +235,7 @@ func TestGuard_NetAllowlistPassesIPLiterals(t *testing.T) {
 }
 
 func TestGuard_EnvReadDenied(t *testing.T) {
-	// A var not in env_allowed must not be readable.
+	// A pre-seeded var not in env_allowed must not be readable.
 	pol := guardPolicy{
 		Net:        guardNet{Mode: "unrestricted"},
 		Run:        guardRun{Mode: "deny"},
@@ -244,18 +247,20 @@ try:
     v = os.environ["SECRET_NOT_DECLARED"]
     raise AssertionError(f"should have raised KeyError, got {v!r}")
 except KeyError:
-    pass  # expected
+    pass  # expected: pre-seeded but undeclared
 # .get() must also return None
 assert os.environ.get("SECRET_NOT_DECLARED") is None, "get must return None for filtered var"
 # Membership test must also be filtered
 assert "SECRET_NOT_DECLARED" not in os.environ, "in-test must return False for filtered var"
 `
-	out, err := runGuardScript(t, pol, payload)
+	// Seed SECRET_NOT_DECLARED into the subprocess env so the test proves the
+	// filter hides a var that actually exists in the process environment.
+	out, err := runGuardScript(t, pol, payload, "SECRET_NOT_DECLARED=shh")
 	requireAllowed(t, out, err)
 }
 
 func TestGuard_EnvReadAllowed_DeclaredVar(t *testing.T) {
-	// A declared var that is in os.environ must be readable.
+	// A declared var pre-seeded by the test harness must be readable.
 	pol := guardPolicy{
 		Net:        guardNet{Mode: "unrestricted"},
 		Run:        guardRun{Mode: "deny"},
@@ -263,11 +268,12 @@ func TestGuard_EnvReadAllowed_DeclaredVar(t *testing.T) {
 	}
 	payload := `
 import os
-os.environ["MY_DECLARED_VAR"] = "hello"  # set it first
 v = os.environ["MY_DECLARED_VAR"]
 assert v == "hello", f"expected 'hello', got {v!r}"
 `
-	out, err := runGuardScript(t, pol, payload)
+	// Seed MY_DECLARED_VAR into the subprocess environment so the test exercises
+	// filtering against a var that genuinely exists in the inherited env.
+	out, err := runGuardScript(t, pol, payload, "MY_DECLARED_VAR=hello")
 	requireAllowed(t, out, err)
 }
 
@@ -280,11 +286,12 @@ func TestGuard_EnvReadAll_NoFilter(t *testing.T) {
 	}
 	payload := `
 import os
-os.environ["ANYTHING"] = "value"
 v = os.environ.get("ANYTHING")
 assert v == "value", f"expected 'value', got {v!r}"
 `
-	out, err := runGuardScript(t, pol, payload)
+	// Seed ANYTHING so the test exercises reading a pre-existing env var in
+	// unfiltered mode (rather than writing inside the payload and reading back).
+	out, err := runGuardScript(t, pol, payload, "ANYTHING=value")
 	requireAllowed(t, out, err)
 }
 
@@ -299,20 +306,24 @@ func TestGuard_EnvIter_OnlyDeclaredAndWritten(t *testing.T) {
 	}
 	payload := `
 import os
-os.environ["DECLARED_VAR"] = "yes"
 os.environ["TASK_WRITTEN_VAR"] = "also_yes"  # not pre-declared but task wrote it
 keys = list(os.environ.keys())
 assert "DECLARED_VAR" in keys, f"DECLARED_VAR missing from {keys}"
 assert "TASK_WRITTEN_VAR" in keys, f"TASK_WRITTEN_VAR missing — task should read back what it wrote"
+assert "HIDDEN_PREEXISTING_VAR" not in keys, f"HIDDEN_PREEXISTING_VAR leaked in {keys}"
 # Read back what was written
 assert os.environ["TASK_WRITTEN_VAR"] == "also_yes", "write-then-read must work"
+# Declared var was seeded by the test harness and must be readable
+assert os.environ["DECLARED_VAR"] == "yes", "pre-seeded declared var must be readable"
 `
-	out, err := runGuardScript(t, pol, payload)
+	// Seed DECLARED_VAR and a hidden undeclared var to prove the filter works
+	// against vars that genuinely exist in the inherited process environment.
+	out, err := runGuardScript(t, pol, payload, "DECLARED_VAR=yes", "HIDDEN_PREEXISTING_VAR=secret")
 	requireAllowed(t, out, err)
 }
 
 func TestGuard_EnvDelete_UndeclaredDenied(t *testing.T) {
-	// Deleting a var not in env_allowed must raise KeyError.
+	// Deleting a pre-seeded var not in env_allowed must raise KeyError.
 	pol := guardPolicy{
 		Net:        guardNet{Mode: "unrestricted"},
 		Run:        guardRun{Mode: "deny"},
@@ -326,7 +337,9 @@ try:
 except KeyError:
     pass  # expected: cannot delete what you cannot see
 `
-	out, err := runGuardScript(t, pol, payload)
+	// Seed UNDECLARED_SECRET so the test proves the filter blocks deletion of a
+	// var that genuinely exists in the inherited process environment.
+	out, err := runGuardScript(t, pol, payload, "UNDECLARED_SECRET=secret")
 	requireAllowed(t, out, err)
 }
 

--- a/pkg/runtime/python/guard_integration_test.go
+++ b/pkg/runtime/python/guard_integration_test.go
@@ -288,20 +288,43 @@ assert v == "value", f"expected 'value', got {v!r}"
 	requireAllowed(t, out, err)
 }
 
-func TestGuard_EnvIter_OnlyDeclared(t *testing.T) {
-	// Iterating os.environ must only yield allowed keys.
+func TestGuard_EnvIter_OnlyDeclaredAndWritten(t *testing.T) {
+	// Iterating os.environ yields only declared keys plus keys the task wrote.
+	// A pre-existing var not in env_allowed is hidden; a task-written var is
+	// visible immediately after the write (write-then-read consistency).
 	pol := guardPolicy{
 		Net:        guardNet{Mode: "unrestricted"},
 		Run:        guardRun{Mode: "deny"},
-		EnvAllowed: []string{"ONLY_THIS_ONE", "DICODE_SOCKET", "DICODE_TOKEN"},
+		EnvAllowed: []string{"DECLARED_VAR", "DICODE_SOCKET", "DICODE_TOKEN"},
 	}
 	payload := `
 import os
-os.environ["ONLY_THIS_ONE"] = "yes"
-os.environ["NOT_THIS_ONE"] = "no"
+os.environ["DECLARED_VAR"] = "yes"
+os.environ["TASK_WRITTEN_VAR"] = "also_yes"  # not pre-declared but task wrote it
 keys = list(os.environ.keys())
-assert "ONLY_THIS_ONE" in keys, f"ONLY_THIS_ONE missing from {keys}"
-assert "NOT_THIS_ONE" not in keys, f"NOT_THIS_ONE leaked into {keys}"
+assert "DECLARED_VAR" in keys, f"DECLARED_VAR missing from {keys}"
+assert "TASK_WRITTEN_VAR" in keys, f"TASK_WRITTEN_VAR missing — task should read back what it wrote"
+# Read back what was written
+assert os.environ["TASK_WRITTEN_VAR"] == "also_yes", "write-then-read must work"
+`
+	out, err := runGuardScript(t, pol, payload)
+	requireAllowed(t, out, err)
+}
+
+func TestGuard_EnvDelete_UndeclaredDenied(t *testing.T) {
+	// Deleting a var not in env_allowed must raise KeyError.
+	pol := guardPolicy{
+		Net:        guardNet{Mode: "unrestricted"},
+		Run:        guardRun{Mode: "deny"},
+		EnvAllowed: []string{"DICODE_SOCKET", "DICODE_TOKEN"},
+	}
+	payload := `
+import os
+try:
+    del os.environ["UNDECLARED_SECRET"]
+    raise AssertionError("should have raised KeyError")
+except KeyError:
+    pass  # expected: cannot delete what you cannot see
 `
 	out, err := runGuardScript(t, pol, payload)
 	requireAllowed(t, out, err)

--- a/pkg/runtime/python/guard_integration_test.go
+++ b/pkg/runtime/python/guard_integration_test.go
@@ -231,6 +231,82 @@ func TestGuard_NetAllowlistPassesIPLiterals(t *testing.T) {
 	requireAllowed(t, out, err)
 }
 
+func TestGuard_EnvReadDenied(t *testing.T) {
+	// A var not in env_allowed must not be readable.
+	pol := guardPolicy{
+		Net:        guardNet{Mode: "unrestricted"},
+		Run:        guardRun{Mode: "deny"},
+		EnvAllowed: []string{"PATH", "HOME", "DICODE_SOCKET", "DICODE_TOKEN"},
+	}
+	payload := `
+import os
+try:
+    v = os.environ["SECRET_NOT_DECLARED"]
+    raise AssertionError(f"should have raised KeyError, got {v!r}")
+except KeyError:
+    pass  # expected
+# .get() must also return None
+assert os.environ.get("SECRET_NOT_DECLARED") is None, "get must return None for filtered var"
+# Membership test must also be filtered
+assert "SECRET_NOT_DECLARED" not in os.environ, "in-test must return False for filtered var"
+`
+	out, err := runGuardScript(t, pol, payload)
+	requireAllowed(t, out, err)
+}
+
+func TestGuard_EnvReadAllowed_DeclaredVar(t *testing.T) {
+	// A declared var that is in os.environ must be readable.
+	pol := guardPolicy{
+		Net:        guardNet{Mode: "unrestricted"},
+		Run:        guardRun{Mode: "deny"},
+		EnvAllowed: []string{"PATH", "HOME", "MY_DECLARED_VAR", "DICODE_SOCKET", "DICODE_TOKEN"},
+	}
+	payload := `
+import os
+os.environ["MY_DECLARED_VAR"] = "hello"  # set it first
+v = os.environ["MY_DECLARED_VAR"]
+assert v == "hello", f"expected 'hello', got {v!r}"
+`
+	out, err := runGuardScript(t, pol, payload)
+	requireAllowed(t, out, err)
+}
+
+func TestGuard_EnvReadAll_NoFilter(t *testing.T) {
+	// When env_allowed is nil (env_read_exposed=true), os.environ is unfiltered.
+	pol := guardPolicy{
+		Net:        guardNet{Mode: "unrestricted"},
+		Run:        guardRun{Mode: "deny"},
+		EnvAllowed: nil, // no filter
+	}
+	payload := `
+import os
+os.environ["ANYTHING"] = "value"
+v = os.environ.get("ANYTHING")
+assert v == "value", f"expected 'value', got {v!r}"
+`
+	out, err := runGuardScript(t, pol, payload)
+	requireAllowed(t, out, err)
+}
+
+func TestGuard_EnvIter_OnlyDeclared(t *testing.T) {
+	// Iterating os.environ must only yield allowed keys.
+	pol := guardPolicy{
+		Net:        guardNet{Mode: "unrestricted"},
+		Run:        guardRun{Mode: "deny"},
+		EnvAllowed: []string{"ONLY_THIS_ONE", "DICODE_SOCKET", "DICODE_TOKEN"},
+	}
+	payload := `
+import os
+os.environ["ONLY_THIS_ONE"] = "yes"
+os.environ["NOT_THIS_ONE"] = "no"
+keys = list(os.environ.keys())
+assert "ONLY_THIS_ONE" in keys, f"ONLY_THIS_ONE missing from {keys}"
+assert "NOT_THIS_ONE" not in keys, f"NOT_THIS_ONE leaked into {keys}"
+`
+	out, err := runGuardScript(t, pol, payload)
+	requireAllowed(t, out, err)
+}
+
 func TestGuard_NetAllowlistGetaddrinfo(t *testing.T) {
 	pol := guardPolicy{
 		Net: guardNet{Mode: "allowlist", Hosts: []string{"localhost"}},

--- a/pkg/runtime/python/guard_test.go
+++ b/pkg/runtime/python/guard_test.go
@@ -175,10 +175,19 @@ func TestBuildGuardPolicy_EnvAllowed_WithDeclaredVars(t *testing.T) {
 	for _, n := range pol.EnvAllowed {
 		names[n] = true
 	}
-	for _, want := range []string{"MY_API_KEY", "ANOTHER_VAR", "PATH", "HOME", "DICODE_SOCKET", "DICODE_TOKEN"} {
+	for _, want := range []string{
+		"MY_API_KEY", "ANOTHER_VAR",
+		// Essential set samples (locale, proxy, TLS, cache, IPC).
+		"PATH", "HOME", "LANG", "HTTP_PROXY", "SSL_CERT_FILE", "XDG_CACHE_HOME",
+		"DICODE_SOCKET", "DICODE_TOKEN",
+	} {
 		if !names[want] {
 			t.Errorf("EnvAllowed missing %q; got %v", want, pol.EnvAllowed)
 		}
+	}
+	// DENO_DIR is Deno-specific and must never appear in the Python essential set.
+	if names["DENO_DIR"] {
+		t.Errorf("EnvAllowed must not contain DENO_DIR (Deno-specific); got %v", pol.EnvAllowed)
 	}
 }
 
@@ -206,10 +215,16 @@ func TestBuildGuardPolicy_EnvAllowed_NoDeclarations(t *testing.T) {
 	for _, n := range pol.EnvAllowed {
 		names[n] = true
 	}
-	for _, want := range []string{"PATH", "HOME", "DICODE_SOCKET", "DICODE_TOKEN"} {
+	for _, want := range []string{
+		"PATH", "HOME", "LANG", "HTTP_PROXY", "SSL_CERT_FILE", "XDG_CACHE_HOME",
+		"DICODE_SOCKET", "DICODE_TOKEN",
+	} {
 		if !names[want] {
 			t.Errorf("EnvAllowed (essential-only) missing %q", want)
 		}
+	}
+	if names["DENO_DIR"] {
+		t.Errorf("EnvAllowed must not contain DENO_DIR; got %v", pol.EnvAllowed)
 	}
 }
 

--- a/pkg/runtime/python/guard_test.go
+++ b/pkg/runtime/python/guard_test.go
@@ -159,6 +159,60 @@ func TestBuildGuardPolicy_ProtectedPathsBecomeDenyList(t *testing.T) {
 	}
 }
 
+func TestBuildGuardPolicy_EnvAllowed_WithDeclaredVars(t *testing.T) {
+	// When env_read_exposed=false and env vars are declared, EnvAllowed
+	// must contain the declared names and the essential set.
+	spec := specWithPerms(task.Permissions{
+		Env: []task.EnvEntry{
+			{Name: "MY_API_KEY"},
+			{Name: "ANOTHER_VAR"},
+		},
+	})
+	pol := buildGuardPolicy(spec, "/tmp/dicode.sock", nil)
+
+	// Must contain declared names
+	names := make(map[string]bool, len(pol.EnvAllowed))
+	for _, n := range pol.EnvAllowed {
+		names[n] = true
+	}
+	for _, want := range []string{"MY_API_KEY", "ANOTHER_VAR", "PATH", "HOME", "DICODE_SOCKET", "DICODE_TOKEN"} {
+		if !names[want] {
+			t.Errorf("EnvAllowed missing %q; got %v", want, pol.EnvAllowed)
+		}
+	}
+}
+
+func TestBuildGuardPolicy_EnvAllowed_EnvReadExposed(t *testing.T) {
+	// env_read_exposed=true must set EnvAllowed=nil (no filter).
+	spec := specWithPerms(task.Permissions{
+		EnvReadExposed: true,
+		Env:            []task.EnvEntry{{Name: "FOO"}},
+	})
+	pol := buildGuardPolicy(spec, "/tmp/dicode.sock", nil)
+	if pol.EnvAllowed != nil {
+		t.Errorf("env_read_exposed=true must set EnvAllowed=nil; got %v", pol.EnvAllowed)
+	}
+}
+
+func TestBuildGuardPolicy_EnvAllowed_NoDeclarations(t *testing.T) {
+	// No declared vars: EnvAllowed must still be set (to essential set only),
+	// not nil, so filtering is active.
+	spec := specWithPerms(task.Permissions{})
+	pol := buildGuardPolicy(spec, "/tmp/dicode.sock", nil)
+	if pol.EnvAllowed == nil {
+		t.Error("EnvAllowed must be non-nil (essential set) even with no declared vars")
+	}
+	names := make(map[string]bool, len(pol.EnvAllowed))
+	for _, n := range pol.EnvAllowed {
+		names[n] = true
+	}
+	for _, want := range []string{"PATH", "HOME", "DICODE_SOCKET", "DICODE_TOKEN"} {
+		if !names[want] {
+			t.Errorf("EnvAllowed (essential-only) missing %q", want)
+		}
+	}
+}
+
 func TestBuildWrapper_GuardPlacement(t *testing.T) {
 	script := "# /// script\n# dependencies = [\"requests\"]\n# ///\nresult = 1\n"
 	pol := buildGuardPolicy(specWithPerms(task.Permissions{}), "/tmp/dicode.sock", nil)

--- a/pkg/runtime/python/sdk/guard.py
+++ b/pkg/runtime/python/sdk/guard.py
@@ -197,6 +197,32 @@ def _dicode_install_guard():
             parts = (_to_str(args[0]) or "").split()
             _check_run(parts[0] if parts else args[0])
 
+    # Env-read guardrail: restrict os.environ reads to declared names + essential vars.
+    env_allowed = policy.get("env_allowed")
+    if env_allowed is not None:
+        import collections.abc as _cabc
+        _env_allowed_set = frozenset(env_allowed)
+        _real_env = _os.environ  # keep the original MutableMapping
+
+        class _FilteredEnv(_cabc.MutableMapping):
+            """Filters os.environ reads to env_allowed_set; writes go through."""
+            def __getitem__(self, key):
+                if key in _env_allowed_set:
+                    return _real_env[key]
+                raise KeyError(key)
+            def __setitem__(self, key, value):
+                _real_env[key] = value
+            def __delitem__(self, key):
+                del _real_env[key]
+            def __iter__(self):
+                return (k for k in _real_env if k in _env_allowed_set)
+            def __len__(self):
+                return sum(1 for k in _real_env if k in _env_allowed_set)
+            def __contains__(self, key):
+                return key in _env_allowed_set and key in _real_env
+
+        _os.environ = _FilteredEnv()
+
     _sys.addaudithook(_hook)
 
 

--- a/pkg/runtime/python/sdk/guard.py
+++ b/pkg/runtime/python/sdk/guard.py
@@ -201,7 +201,9 @@ def _dicode_install_guard():
     env_allowed = policy.get("env_allowed")
     if env_allowed is not None:
         import collections.abc as _cabc
-        _env_allowed_set = frozenset(env_allowed)
+        # Mutable set: task writes (os.environ["K"] = v) extend the allowed set
+        # so the task can read back what it wrote without a KeyError.
+        _env_allowed_set = set(env_allowed)
         _real_env = _os.environ  # keep the original MutableMapping
 
         class _FilteredEnv(_cabc.MutableMapping):
@@ -212,12 +214,18 @@ def _dicode_install_guard():
                 raise KeyError(key)
             def __setitem__(self, key, value):
                 _real_env[key] = value
+                _env_allowed_set.add(key)  # task can read back what it wrote
             def __delitem__(self, key):
+                if key not in _env_allowed_set:
+                    raise KeyError(key)
                 del _real_env[key]
+                _env_allowed_set.discard(key)
             def __iter__(self):
                 return (k for k in _real_env if k in _env_allowed_set)
             def __len__(self):
-                return sum(1 for k in _real_env if k in _env_allowed_set)
+                # Iterate the smaller allowed set (O(|allowed|)) rather than
+                # all of _real_env (O(|real_env|)) which can be much larger.
+                return sum(1 for k in _env_allowed_set if k in _real_env)
             def __contains__(self, key):
                 return key in _env_allowed_set and key in _real_env
 

--- a/pkg/runtime/python/sdk/guard.py
+++ b/pkg/runtime/python/sdk/guard.py
@@ -228,8 +228,41 @@ def _dicode_install_guard():
                 return sum(1 for k in _env_allowed_set if k in _real_env)
             def __contains__(self, key):
                 return key in _env_allowed_set and key in _real_env
+            def copy(self):
+                return dict(self.items())
 
         _os.environ = _FilteredEnv()
+
+        # Also cover the bytes env API so os.environb / os.getenvb cannot be
+        # used to bypass the allowlist on platforms that expose them (Linux).
+        if hasattr(_os, "environb"):
+            _real_environb = _os.environb
+
+            class _FilteredEnvB:
+                def __getitem__(self, key):
+                    if key.decode(errors="replace") in _env_allowed_set:
+                        return _real_environb[key]
+                    raise KeyError(key)
+                def get(self, key, default=None):
+                    if key.decode(errors="replace") in _env_allowed_set:
+                        return _real_environb.get(key, default)
+                    return default
+                def __contains__(self, key):
+                    return key.decode(errors="replace") in _env_allowed_set and key in _real_environb
+                def __iter__(self):
+                    return (k for k in _real_environb if k.decode(errors="replace") in _env_allowed_set)
+                def keys(self):
+                    return list(self)
+
+            _os.environb = _FilteredEnvB()
+
+        if hasattr(_os, "getenvb"):
+            _real_getenvb = _os.getenvb
+            def _getenvb(key, default=None):
+                if key.decode(errors="replace") in _env_allowed_set:
+                    return _real_getenvb(key, default)
+                return default
+            _os.getenvb = _getenvb
 
     _sys.addaudithook(_hook)
 

--- a/pkg/runtime/python/sdk/guard.py
+++ b/pkg/runtime/python/sdk/guard.py
@@ -238,21 +238,26 @@ def _dicode_install_guard():
         if hasattr(_os, "environb"):
             _real_environb = _os.environb
 
-            class _FilteredEnvB:
+            class _FilteredEnvB(_cabc.MutableMapping):
+                """Bytes-key view of _FilteredEnv; mirrors the allowlist filtering."""
                 def __getitem__(self, key):
                     if key.decode(errors="replace") in _env_allowed_set:
                         return _real_environb[key]
                     raise KeyError(key)
-                def get(self, key, default=None):
-                    if key.decode(errors="replace") in _env_allowed_set:
-                        return _real_environb.get(key, default)
-                    return default
-                def __contains__(self, key):
-                    return key.decode(errors="replace") in _env_allowed_set and key in _real_environb
+                def __setitem__(self, key, value):
+                    _real_environb[key] = value
+                    _env_allowed_set.add(key.decode(errors="replace"))
+                def __delitem__(self, key):
+                    if key.decode(errors="replace") not in _env_allowed_set:
+                        raise KeyError(key)
+                    del _real_environb[key]
+                    _env_allowed_set.discard(key.decode(errors="replace"))
                 def __iter__(self):
                     return (k for k in _real_environb if k.decode(errors="replace") in _env_allowed_set)
-                def keys(self):
-                    return list(self)
+                def __len__(self):
+                    return sum(1 for k in _real_environb if k.decode(errors="replace") in _env_allowed_set)
+                def __contains__(self, key):
+                    return key.decode(errors="replace") in _env_allowed_set and key in _real_environb
 
             _os.environb = _FilteredEnvB()
 

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -263,15 +263,15 @@ func (e *EnvEntry) UnmarshalYAML(value *yaml.Node) error {
 type Permissions struct {
 	// Env lists env vars the task script may read or that are injected into it.
 	Env []EnvEntry `yaml:"env,omitempty" json:"env,omitempty"`
-	// EnvReadExposed grants the Deno sandbox bare --allow-env: the task may read
-	// ANY env var exposed to its subprocess, not only the names listed in Env.
-	// The exposed set is still bounded by runtime.SubprocessEnv (an allowlist —
-	// PATH/HOME/cache/proxy/TLS vars, DICODE_SOCKET/DICODE_TOKEN, and the task's
-	// own resolved vars; the daemon master/admin keys are denylisted), so this
-	// never reaches anything the task does not already hold. It exists for
-	// node-compat / npm tasks whose transitive deps enumerate process.env at
-	// import time. Deno only — Python has no per-var env-read gate (it reads its
-	// full exposed env regardless); parity tracked in #418.
+	// EnvReadExposed grants unrestricted env-var reads. For Deno it passes bare
+	// --allow-env to the sandbox. For Python it disables the os.environ filter
+	// added in #418 (by default Python tasks can only read the names listed in
+	// Env plus a runtime-essential set). The exposed set is still bounded by
+	// runtime.SubprocessEnv (an allowlist — PATH/HOME/cache/proxy/TLS vars,
+	// DICODE_SOCKET/DICODE_TOKEN, and the task's own resolved vars; the daemon
+	// master/admin keys are denylisted), so this never reaches anything the task
+	// does not already hold. It exists for node-compat / npm tasks whose
+	// transitive deps enumerate process.env at import time.
 	EnvReadExposed bool `yaml:"env_read_exposed,omitempty" json:"env_read_exposed,omitempty"`
 	// FS lists filesystem paths and their access modes ("r", "w", "rw").
 	// Deno enforces reads and writes. Python enforces writes only: an


### PR DESCRIPTION
Closes #418

## Summary

Adds declared-intent env-read filtering for Python tasks, matching Deno's `--allow-env` / `env_read_exposed` posture. The Python guard now replaces `os.environ` with a filtered `MutableMapping` that permits only:

- names listed in `permissions.env` (declared intent)
- a runtime-essential set (`PATH`, `HOME`, locale, cache/proxy/TLS vars, `DICODE_SOCKET`, `DICODE_TOKEN`) that stdlib and uv need to function

Setting `env_read_exposed: true` (already available for Deno) disables the filter — granting unrestricted reads of the curated subprocess env. Needed for node-compat/npm tasks that enumerate `process.env` at import time.

The filter is installed after the SDK shim's socket setup (which reads `DICODE_SOCKET`/`DICODE_TOKEN` at import time, before the filter) and before user task code, so the restriction applies exactly where it should.

**Blast radius is unchanged**: `runtime.SubprocessEnv` already builds an allowlist subprocess env (no daemon master key, no API keys); this adds declared-intent consistency, not a new secret boundary.

## Touched files

| File | Reason |
|------|--------|
| `pkg/runtime/python/sdk/guard.py` | Core: `_FilteredEnv` MutableMapping wrapping real `os.environ`; installed before task code runs |
| `pkg/runtime/python/guard.go` | `guardPolicy.EnvAllowed` field + `buildGuardPolicy` populates it from essential set + declared names |
| `pkg/runtime/python/guard_test.go` | 3 unit tests: `EnvAllowed` populated correctly, nil when `env_read_exposed=true`, non-nil when no declarations |
| `pkg/runtime/python/guard_integration_test.go` | 4 integration tests: undeclared var raises `KeyError`, declared var readable, `env_read_all=nil` skips filter, iter yields only allowed keys |
| `pkg/task/spec.go` | Updated `EnvReadExposed` comment: removes "Deno only", adds Python filter behavior |
| `docs/concepts/task-format.md` | Updated table row and `env_read_exposed` section to describe Python parity |

## Test coverage

**Unit tests** (`pkg/runtime/python/guard_test.go`): 3 new tests verify `buildGuardPolicy` builds the correct `EnvAllowed` allowlist under each condition.

**Integration tests** (`pkg/runtime/python/guard_integration_test.go`): 4 new tests run the guard with a real Python interpreter, covering: undeclared-var denial, declared-var access, no-filter path, and iteration boundary.

Unit-only (no e2e): the env filter is a pure Python `os.environ` wrapper applied inside the guard — there is no user-facing endpoint or cross-component flow to drive end-to-end for this behavior.

## Pre-existing test failure

`TestEnforcement_Env_RelayImportNeedsReadExposed` in `pkg/runtime/deno` fails in this sandbox (TLS `UnknownIssuer` when reaching `registry.npmjs.org` through the environment's proxy). Pre-existing and unrelated to these changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJA7Grq5Fb5xoVTyrweFfR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Python environment access now respects task permissions when `env_read_exposed` is off: reads, iteration, deletion, and membership checks are restricted to the allowed set, and undeclared keys are denied.
  * Iteration over `os.environ` now exposes only declared variables plus task-written values (pre-existing hidden values aren’t leaked).
  * When `env_read_exposed` is on, Python no longer applies the per-variable read filtering.

* **Documentation**
  * Updated `env_read_exposed` docs to describe consistent behavior across Deno and Python, including the safety boundary for subprocess environment exposure.

* **Tests**
  * Added/expanded Python tests for allowed vs denied access, iteration behavior, write-then-read consistency, and undeclared delete denial.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->