### PR TITLE
security(approval): embed bootstrap marker in dicode.lock to close DB-deletion vector (#434)

### DIFF
--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -615,7 +615,7 @@ cryptographically signed with an HMAC key derived from the daemon's master key.
 
 ```plaintext
 lockSigningKey = DeriveSubKey(masterKey, "dicode/approval-lock/v1")  // Argon2id
-canonicalContent = JSON(tasks_map)                                    // Go sort-ordered
+canonicalContent = JSON({bootstrapped, tasks_map})                    // Go sort-ordered (v3)
 mac = hex(HMAC-SHA256(lockSigningKey, canonicalContent))             // stored in mac: field
 ```
 
@@ -624,25 +624,48 @@ which is never forwarded to task subprocesses and survives independently of the
 SQLite database. Even if a task wipes the database it cannot forge a valid MAC
 without the master key.
 
+### Bootstrap marker — dual-store defence (#434)
+
+The first-run bootstrap marker is persisted in **two independent locations**:
+
+1. **`dicode.lock` `bootstrapped:` field** (v3 format) — covered by the HMAC,
+   so it cannot be silently flipped without invalidating the MAC. Survives SQLite
+   deletion.
+2. **`kv["approval.bootstrap_completed"]` row** in SQLite — survives `dicode.lock`
+   deletion (directory-level attacks that the file-level deny cannot block).
+
+At daemon startup the effective marker is:
+
+```
+markerExists = lock.IsBootstrapped() || dbMarkerExists
+```
+
+**Both** stores must be absent for bootstrap to re-run. Deleting either one alone
+is insufficient to reset the gate.
+
 ### Load-time behaviour
 
 | Condition | Outcome |
 |-----------|---------|
 | File absent | Empty lock (normal first-run) |
-| Legacy v1 (no `mac:` field), key available | Accepted + immediately re-signed (format upgrade) |
-| `mac:` present, verification passes | Normal load |
-| `mac:` present, verification fails | **Fail closed**: all records discarded; `Tampered()` returns `true`; daemon logs a warning; all tasks require explicit re-approval |
+| Legacy v1 (no `mac:` field), key available | Accepted + immediately upgraded to v3 (format upgrade) |
+| v2 `mac:` (tasks-only HMAC), verification passes | Accepted + immediately upgraded to v3 in-place |
+| v2 `mac:`, verification fails | **Fail closed**: all records discarded; `Tampered()` returns `true` |
+| v3 `mac:` (bootstrapped+tasks HMAC), verification passes | Normal load |
+| v3 `mac:`, verification fails | **Fail closed**: all records discarded; `Tampered()` returns `true`; daemon logs a warning; all tasks require explicit re-approval |
+| Unknown version with `mac:` present | **Fail closed**: cannot verify; treated as tampered |
 | No signing key available (env stripped of master key) | Unsigned/legacy mode — no verification |
 
 ### On-disk format
 
-Signed locks use `version: 2` and include a `mac:` field directly after the
-version line, before `tasks:`:
+Signed locks use `version: 3` and include a `mac:` field directly after the
+version line, before `bootstrapped:` and `tasks:`:
 
 ```yaml
 # dicode.lock — approval records, managed by the dicode daemon.
-version: 2
-mac: 8a3f1c...  # 64 hex chars = HMAC-SHA256
+version: 3
+mac: 8a3f1c...  # 64 hex chars = HMAC-SHA256 over {bootstrapped, tasks}
+bootstrapped: true
 tasks:
   my-task:
     hash: sha256:...
@@ -650,9 +673,11 @@ tasks:
     approved_by: manual
 ```
 
-Legacy unsigned files (`version: 1`, no `mac:`) are accepted on the first
-startup with a key and immediately upgraded to v2. After that, any subsequent
-load that sees a missing or wrong MAC treats the file as tampered.
+The `bootstrapped: true` field is omitted (YAML `omitempty`) until
+`MarkBootstrapped()` is called. Legacy unsigned files (`version: 1`, no `mac:`)
+and v2 signed files are accepted on the first startup with a key and immediately
+upgraded to v3. After that, any subsequent load that sees a missing or wrong MAC
+treats the file as tampered.
 
 ---
 
@@ -767,7 +792,7 @@ Top-level security blocks in `Config` (siblings of `server:`, not nested under i
 | CORS misconfiguration guard | Origins validated with `url.Parse()` at startup |
 | Passphrase rotation requires current | bcrypt verify on `current` field |
 | Per-task IPC socket in 0700 dir | On Linux/macOS each task run's Unix socket lives inside a per-run directory created `0700` (`/tmp/dicode-<runID>/ipc.sock`). The directory makes the socket unreachable to other local users independent of the socket file's own mode and the process umask. The socket file is also `chmod 0600` as belt-and-suspenders. |
-| `dicode.lock` HMAC integrity | Approval records are HMAC-SHA256 signed with a key derived from the master key via Argon2id (`"dicode/approval-lock/v1"` context). A MAC mismatch on load causes fail-closed: all records discarded, tasks require re-approval. Upgrade path: unsigned v1 files are accepted once and immediately re-signed. |
+| `dicode.lock` HMAC integrity | Approval records are HMAC-SHA256 signed with a key derived from the master key via Argon2id (`"dicode/approval-lock/v1"` context). v3 format: MAC covers `{bootstrapped, tasks}` so the bootstrap flag cannot be silently cleared. A MAC mismatch on load causes fail-closed: all records discarded, tasks require re-approval. Upgrade path: v1 unsigned and v2 tasks-only locks are accepted once and immediately upgraded to v3 in-place. |
 | Daemon crypto namespace isolated | `permissions.dicode.crypto: ["*"]` never grants access to daemon-private sub-keys (e.g. `dicode/run-inputs/v1`); these are listed in `daemonPrivateCryptoContexts` in `pkg/ipc/server.go` and denied before any grant check |
 | Replay retarget blocked | A task-scoped `dicode.runs.replay` call cannot redirect the replay at a different task ID — the target is pinned to the original run's task |
 | `dicode` permission overrides are exhaustive | `mergeDicodePerms` merges all `DicodePermissions` fields including `secrets_has` and `crypto`; added exhaustiveness test guards against future fields being silently dropped |

--- a/pkg/approval/lock.go
+++ b/pkg/approval/lock.go
@@ -50,21 +50,24 @@ type lockFile struct {
 	Version int `yaml:"version"`
 	// MAC is the HMAC-SHA256 (hex) of the canonical JSON of the tasks map,
 	// keyed by the daemon's lock-signing sub-key. Absent on unsigned v1 files.
-	MAC   string            `yaml:"mac,omitempty"`
-	Tasks map[string]Record `yaml:"tasks"`
+	MAC          string            `yaml:"mac,omitempty"`
+	Bootstrapped bool              `yaml:"bootstrapped,omitempty"`
+	Tasks        map[string]Record `yaml:"tasks"`
 }
 
 const (
-	lockVersionUnsigned = 1 // legacy; no MAC field
-	lockVersion         = 2 // HMAC-signed
+	lockVersionUnsigned     = 1 // legacy; no MAC field
+	lockVersion             = 2 // HMAC over tasks only
+	lockVersionBootstrapped = 3 // HMAC over {bootstrapped, tasks}
 )
 
 // Lock is the in-memory view of dicode.lock. All mutating methods persist
 // to disk before returning. Safe for concurrent use.
 type Lock struct {
-	path       string
-	signingKey []byte // nil = unsigned (legacy / test) mode
-	tampered   bool   // true when MAC verification failed; all records discarded
+	path         string
+	signingKey   []byte // nil = unsigned (legacy / test) mode
+	tampered     bool   // true when MAC verification failed; all records discarded
+	bootstrapped bool   // true after MarkBootstrapped is called
 
 	mu    sync.Mutex
 	tasks map[string]Record
@@ -104,6 +107,7 @@ func LoadSignedLock(path string, key []byte) (*Lock, error) {
 	if lf.Tasks != nil {
 		l.tasks = lf.Tasks
 	}
+	l.bootstrapped = lf.Bootstrapped
 
 	if key == nil {
 		// Unsigned mode: accept without verification.
@@ -111,16 +115,34 @@ func LoadSignedLock(path string, key []byte) (*Lock, error) {
 	}
 
 	if lf.MAC == "" {
-		// Legacy unsigned lock: seal immediately so future loads verify.
+		// Legacy unsigned lock (v1): seal immediately so future loads verify.
 		if err := l.save(); err != nil {
 			return nil, fmt.Errorf("seal legacy %s: %w", path, err)
 		}
 		return l, nil
 	}
 
-	if !l.verifyMAC(lf.MAC) {
-		// Tampered or forged lock: discard all records and fail closed.
-		// The caller learns of this via Tampered() and should warn the operator.
+	switch lf.Version {
+	case lockVersion: // v2: HMAC over tasks only
+		if !l.verifyMACv2(lf.MAC) {
+			// Tampered or forged lock: discard all records and fail closed.
+			l.tampered = true
+			l.tasks = map[string]Record{}
+			return l, nil
+		}
+		// Valid v2 — upgrade to v3 in-place so subsequent loads use the new MAC.
+		if err := l.save(); err != nil {
+			return nil, fmt.Errorf("upgrade %s to v3: %w", path, err)
+		}
+	case lockVersionBootstrapped: // v3: HMAC over {bootstrapped, tasks}
+		if !l.verifyMAC(lf.MAC) {
+			// Tampered or forged lock: discard all records and fail closed.
+			l.tampered = true
+			l.tasks = map[string]Record{}
+			return l, nil
+		}
+	default:
+		// Unknown version with a MAC present — we cannot verify it; fail closed.
 		l.tampered = true
 		l.tasks = map[string]Record{}
 		return l, nil
@@ -133,14 +155,24 @@ func LoadSignedLock(path string, key []byte) (*Lock, error) {
 // task requires explicit re-approval.
 func (l *Lock) Tampered() bool { return l.tampered }
 
-// macContent returns the canonical JSON that is HMAC'd. Go's encoding/json
-// sorts map keys, making this deterministic for the same set of records.
+// macPayloadV3 is the MAC input for v3 locks — covers both bootstrapped and tasks.
+type macPayloadV3 struct {
+	Bootstrapped bool              `json:"bootstrapped"`
+	Tasks        map[string]Record `json:"tasks"`
+}
+
+// macContent returns the canonical JSON HMAC'd for the current (v3) format.
 func (l *Lock) macContent() ([]byte, error) {
+	return json.Marshal(macPayloadV3{Bootstrapped: l.bootstrapped, Tasks: l.tasks})
+}
+
+// macContentV2 returns the canonical JSON HMAC'd for legacy v2 format (tasks only).
+func (l *Lock) macContentV2() ([]byte, error) {
 	return json.Marshal(l.tasks)
 }
 
 // computeMAC returns the HMAC-SHA256 hex digest over the canonical JSON of
-// the tasks map. Caller must hold mu (or call before mu is needed).
+// the v3 payload. Caller must hold mu (or call before mu is needed).
 func (l *Lock) computeMAC() (string, error) {
 	data, err := l.macContent()
 	if err != nil {
@@ -151,11 +183,32 @@ func (l *Lock) computeMAC() (string, error) {
 	return hex.EncodeToString(mac.Sum(nil)), nil
 }
 
-// verifyMAC reports whether macHex matches the HMAC of the current tasks map.
+// computeMACv2 returns the HMAC-SHA256 hex digest over the canonical JSON of
+// the v2 (tasks-only) payload. Used during v2→v3 upgrade verification.
+func (l *Lock) computeMACv2() (string, error) {
+	data, err := l.macContentV2()
+	if err != nil {
+		return "", fmt.Errorf("compute MAC v2: %w", err)
+	}
+	mac := hmac.New(sha256.New, l.signingKey)
+	mac.Write(data)
+	return hex.EncodeToString(mac.Sum(nil)), nil
+}
+
+// verifyMAC reports whether macHex matches the v3 HMAC of the current lock.
 // The stored hex is normalized to lowercase before comparison so that a file
 // manually edited with uppercase hex doesn't trigger a false tamper alarm.
 func (l *Lock) verifyMAC(macHex string) bool {
 	expected, err := l.computeMAC()
+	if err != nil {
+		return false
+	}
+	return hmac.Equal([]byte(expected), []byte(strings.ToLower(macHex)))
+}
+
+// verifyMACv2 reports whether macHex matches the v2 (tasks-only) HMAC.
+func (l *Lock) verifyMACv2(macHex string) bool {
+	expected, err := l.computeMACv2()
 	if err != nil {
 		return false
 	}
@@ -225,9 +278,33 @@ func (l *Lock) List() map[string]Record {
 	return out
 }
 
+// IsBootstrapped reports whether the first-run bootstrap has completed,
+// as recorded in the lock file (independent of the SQLite kv table).
+func (l *Lock) IsBootstrapped() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.bootstrapped
+}
+
+// MarkBootstrapped records that the first-run bootstrap has completed by
+// setting the bootstrapped flag in the lock file. Idempotent.
+func (l *Lock) MarkBootstrapped() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.bootstrapped {
+		return nil
+	}
+	l.bootstrapped = true
+	return l.save()
+}
+
 // save persists the lock atomically (temp file + rename). Caller must hold mu.
 func (l *Lock) save() error {
-	lf := lockFile{Version: lockVersion, Tasks: l.tasks}
+	lf := lockFile{
+		Version:      lockVersionBootstrapped,
+		Bootstrapped: l.bootstrapped,
+		Tasks:        l.tasks,
+	}
 	if l.signingKey != nil {
 		mac, err := l.computeMAC()
 		if err != nil {

--- a/pkg/approval/lock.go
+++ b/pkg/approval/lock.go
@@ -107,7 +107,9 @@ func LoadSignedLock(path string, key []byte) (*Lock, error) {
 	if lf.Tasks != nil {
 		l.tasks = lf.Tasks
 	}
-	l.bootstrapped = lf.Bootstrapped
+	// l.bootstrapped is intentionally NOT set here. Only the v3 authenticated
+	// path below may populate it; unsigned and v2 files do not cover this field
+	// in their MAC so an attacker who can write to the lock cannot forge the flag.
 
 	if key == nil {
 		// Unsigned mode: accept without verification.
@@ -115,6 +117,15 @@ func LoadSignedLock(path string, key []byte) (*Lock, error) {
 	}
 
 	if lf.MAC == "" {
+		// MAC absent: only treat as a legacy v1 lock (version ≤ 1). A v2/v3
+		// file with the mac field stripped is treated as tampered so an attacker
+		// who can write to the lock file cannot remove the MAC to bypass
+		// bootstrapped-flag protection or version gating.
+		if lf.Version > lockVersionUnsigned {
+			l.tampered = true
+			l.tasks = map[string]Record{}
+			return l, nil
+		}
 		// Legacy unsigned lock (v1): seal immediately so future loads verify.
 		if err := l.save(); err != nil {
 			return nil, fmt.Errorf("seal legacy %s: %w", path, err)
@@ -130,14 +141,21 @@ func LoadSignedLock(path string, key []byte) (*Lock, error) {
 			l.tasks = map[string]Record{}
 			return l, nil
 		}
-		// Valid v2 — upgrade to v3 in-place so subsequent loads use the new MAC.
+		// Valid v2 — bootstrapped is not covered by the v2 MAC so it is forced
+		// to false regardless of what the file field says.
+		l.bootstrapped = false
+		// Upgrade to v3 in-place so subsequent loads use the new MAC.
 		if err := l.save(); err != nil {
 			return nil, fmt.Errorf("upgrade %s to v3: %w", path, err)
 		}
 	case lockVersionBootstrapped: // v3: HMAC over {bootstrapped, tasks}
+		// Set bootstrapped before MAC verification so macContent() uses the
+		// correct value; cleared below if the MAC does not verify.
+		l.bootstrapped = lf.Bootstrapped
 		if !l.verifyMAC(lf.MAC) {
 			// Tampered or forged lock: discard all records and fail closed.
 			l.tampered = true
+			l.bootstrapped = false
 			l.tasks = map[string]Record{}
 			return l, nil
 		}
@@ -295,7 +313,12 @@ func (l *Lock) MarkBootstrapped() error {
 		return nil
 	}
 	l.bootstrapped = true
-	return l.save()
+	if err := l.save(); err != nil {
+		// Roll back in-memory flag so the next call can retry the disk write.
+		l.bootstrapped = false
+		return err
+	}
+	return nil
 }
 
 // save persists the lock atomically (temp file + rename). Caller must hold mu.

--- a/pkg/approval/lock_test.go
+++ b/pkg/approval/lock_test.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestLoadLockMissingFile(t *testing.T) {
@@ -440,7 +443,7 @@ func TestLoadSignedLock_BootstrappedCoveredByMAC(t *testing.T) {
 	}
 }
 
-func TestLoadSignedLock_V2UpgradeBootstrappedFalse(t *testing.T) {
+func TestLoadSignedLock_V1UpgradeBootstrappedFalse(t *testing.T) {
 	// A v1 unsigned lock (pre-v2/v3) should upgrade to v3 with bootstrapped=false.
 	path := filepath.Join(t.TempDir(), LockFileName)
 	key := testSigningKey()
@@ -466,6 +469,57 @@ func TestLoadSignedLock_V2UpgradeBootstrappedFalse(t *testing.T) {
 	verified, err := LoadSignedLock(path, key)
 	if err != nil || verified.Tampered() {
 		t.Fatalf("v3 verify after upgrade: tampered=%v err=%v", verified.Tampered(), err)
+	}
+}
+
+func TestLoadSignedLock_V2UpgradeBootstrappedFalse(t *testing.T) {
+	// A genuine v2 lock (version=2, HMAC over tasks only) should upgrade to v3
+	// with bootstrapped=false even if the file has bootstrapped: true in YAML,
+	// because bootstrapped is not covered by the v2 MAC and must be ignored.
+	path := filepath.Join(t.TempDir(), LockFileName)
+	key := testSigningKey()
+
+	// Build a v2 lock file manually: compute v2 MAC using the unexported helper.
+	tasks := map[string]Record{
+		"repo/deploy": {
+			Hash:       "abc123",
+			ApprovedBy: ApprovedByManual,
+			ApprovedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	ephemeral := &Lock{path: path, signingKey: key, tasks: tasks}
+	mac, err := ephemeral.computeMACv2()
+	if err != nil {
+		t.Fatalf("computeMACv2: %v", err)
+	}
+	// Write a v2 file with bootstrapped: true in the YAML — the loader must ignore it.
+	lf := lockFile{Version: lockVersion, MAC: mac, Bootstrapped: true, Tasks: tasks}
+	raw, err := yaml.Marshal(lf)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Load with signing key: should verify v2 MAC, ignore bootstrapped field, upgrade to v3.
+	upgraded, err := LoadSignedLock(path, key)
+	if err != nil {
+		t.Fatalf("LoadSignedLock on v2: %v", err)
+	}
+	if upgraded.Tampered() {
+		t.Fatal("v2 upgrade must not be tampered")
+	}
+	if _, ok := upgraded.Get("repo/deploy"); !ok {
+		t.Fatal("records must survive v2→v3 upgrade")
+	}
+	if upgraded.IsBootstrapped() {
+		t.Fatal("bootstrapped must be false after v2→v3 upgrade even if YAML field was true")
+	}
+	// Second load must be a valid v3 file.
+	verified, err := LoadSignedLock(path, key)
+	if err != nil || verified.Tampered() {
+		t.Fatalf("v3 verify after v2 upgrade: tampered=%v err=%v", verified.Tampered(), err)
 	}
 }
 

--- a/pkg/approval/lock_test.go
+++ b/pkg/approval/lock_test.go
@@ -374,6 +374,101 @@ func TestLoadSignedLock_UppercaseHexMAC(t *testing.T) {
 	}
 }
 
+func TestLockMarkBootstrapped_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), LockFileName)
+	key := testSigningKey()
+	l, err := LoadSignedLock(path, key)
+	if err != nil {
+		t.Fatalf("LoadSignedLock: %v", err)
+	}
+	if l.IsBootstrapped() {
+		t.Fatal("IsBootstrapped() should be false on fresh lock")
+	}
+	if err := l.MarkBootstrapped(); err != nil {
+		t.Fatalf("MarkBootstrapped: %v", err)
+	}
+	if !l.IsBootstrapped() {
+		t.Fatal("IsBootstrapped() should be true after mark")
+	}
+	reloaded, err := LoadSignedLock(path, key)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if reloaded.Tampered() {
+		t.Fatal("Tampered() should be false after round-trip")
+	}
+	if !reloaded.IsBootstrapped() {
+		t.Fatal("IsBootstrapped() should survive reload")
+	}
+}
+
+func TestLockMarkBootstrapped_Idempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), LockFileName)
+	l, _ := LoadSignedLock(path, testSigningKey())
+	if err := l.MarkBootstrapped(); err != nil {
+		t.Fatalf("first MarkBootstrapped: %v", err)
+	}
+	if err := l.MarkBootstrapped(); err != nil {
+		t.Fatalf("second MarkBootstrapped (idempotent): %v", err)
+	}
+}
+
+func TestLoadSignedLock_BootstrappedCoveredByMAC(t *testing.T) {
+	path := filepath.Join(t.TempDir(), LockFileName)
+	key := testSigningKey()
+	l, _ := LoadSignedLock(path, key)
+	_ = l.Record("repo/deploy", "abc", ApprovedByManual)
+	_ = l.MarkBootstrapped()
+
+	data, _ := os.ReadFile(path)
+	// Flip bootstrapped: true to bootstrapped: false to test MAC coverage.
+	flipped := strings.ReplaceAll(string(data), "bootstrapped: true", "bootstrapped: false")
+	if flipped == string(data) {
+		t.Skip("bootstrapped:true not found in expected form; adjust test")
+	}
+	_ = os.WriteFile(path, []byte(flipped), 0600)
+
+	reloaded, err := LoadSignedLock(path, key)
+	if err != nil {
+		t.Fatalf("LoadSignedLock after flag flip: %v", err)
+	}
+	if !reloaded.Tampered() {
+		t.Fatal("flipping bootstrapped must invalidate MAC (Tampered() = true)")
+	}
+	if len(reloaded.List()) != 0 {
+		t.Fatal("tampered lock must discard all records")
+	}
+}
+
+func TestLoadSignedLock_V2UpgradeBootstrappedFalse(t *testing.T) {
+	// A v1 unsigned lock (pre-v2/v3) should upgrade to v3 with bootstrapped=false.
+	path := filepath.Join(t.TempDir(), LockFileName)
+	key := testSigningKey()
+	// Write unsigned v1 lock.
+	unsigned, _ := LoadLock(path)
+	_ = unsigned.Record("repo/deploy", "abc123", ApprovedByManual)
+
+	// Load with signing key: upgrades to v3.
+	upgraded, err := LoadSignedLock(path, key)
+	if err != nil {
+		t.Fatalf("LoadSignedLock on v1: %v", err)
+	}
+	if upgraded.Tampered() {
+		t.Fatal("v1 upgrade must not be tampered")
+	}
+	if _, ok := upgraded.Get("repo/deploy"); !ok {
+		t.Fatal("records must survive v1→v3 upgrade")
+	}
+	if upgraded.IsBootstrapped() {
+		t.Fatal("bootstrapped must be false after upgrading from v1")
+	}
+	// Verify second load is clean v3.
+	verified, err := LoadSignedLock(path, key)
+	if err != nil || verified.Tampered() {
+		t.Fatalf("v3 verify after upgrade: tampered=%v err=%v", verified.Tampered(), err)
+	}
+}
+
 func TestLoadSignedLock_RecordAfterTamperDetection(t *testing.T) {
 	path := filepath.Join(t.TempDir(), LockFileName)
 	key := testSigningKey()

--- a/pkg/approval/lock_test.go
+++ b/pkg/approval/lock_test.go
@@ -424,7 +424,7 @@ func TestLoadSignedLock_BootstrappedCoveredByMAC(t *testing.T) {
 	// Flip bootstrapped: true to bootstrapped: false to test MAC coverage.
 	flipped := strings.ReplaceAll(string(data), "bootstrapped: true", "bootstrapped: false")
 	if flipped == string(data) {
-		t.Skip("bootstrapped:true not found in expected form; adjust test")
+		t.Fatal("bootstrapped: true not found in lock file after MarkBootstrapped; update the search string if YAML serialisation changed")
 	}
 	_ = os.WriteFile(path, []byte(flipped), 0600)
 

--- a/pkg/daemon/bootstrap.go
+++ b/pkg/daemon/bootstrap.go
@@ -19,11 +19,15 @@ func canonicalPath(p string) string {
 }
 
 // approvalBootstrapMarkerKey records that the approval gate has completed its
-// first-run seeding at least once. It lives in the kv table, which tasks can
-// only reach through the IPC control plane — and there every task key is
-// namespaced as "<taskID>:<key>". Because a task's row always contains a colon
-// from that namespace separator, this colon-free key can never be forged or
-// deleted by a task.
+// first-run seeding at least once. It lives in the kv table — and there every
+// task key is namespaced as "<taskID>:<key>", so this colon-free key is
+// unforgeable/undeleteable via the kv IPC API.
+//
+// DB-deletion attack: a task with broad fs.write can delete the SQLite DB
+// file, erasing this marker. To close that vector, the same flag is also
+// embedded in dicode.lock (covered by its HMAC). At daemon startup the
+// effective marker is the OR of this DB row and lock.IsBootstrapped(), so
+// deleting either alone is insufficient to re-enable bootstrap.
 const approvalBootstrapMarkerKey = "approval.bootstrap_completed"
 
 // bootstrapMarkerExists reports whether the first-run seeding marker is set.
@@ -51,6 +55,11 @@ func setBootstrapMarker(ctx context.Context, database db.DB) error {
 }
 
 // shouldBootstrap decides whether to seed the current inventory as approved.
+//
+// markerExists is the OR of the lock's bootstrapped flag (lock.IsBootstrapped)
+// and the DB kv marker (bootstrapMarkerExists). Both must be absent to permit
+// re-bootstrap, so deleting either alone (the SQLite DB or the lock file) cannot
+// reset the gate.
 //
 // Security invariant: an approval lock that disappears after the daemon has run
 // before must fail closed. A task with a broad fs-write grant can delete

--- a/pkg/daemon/bootstrap_test.go
+++ b/pkg/daemon/bootstrap_test.go
@@ -99,3 +99,29 @@ func TestBootstrapMarkerKeyIsTaskUnforgeable(t *testing.T) {
 		}
 	}
 }
+
+// TestBootstrapMarkerDBDeleteFallback verifies that the DB-deletion attack vector
+// is closed: if the DB (and thus its bootstrap marker) is wiped but the lock's
+// bootstrapped flag is still true, shouldBootstrap must remain false.
+func TestBootstrapMarkerDBDeleteFallback(t *testing.T) {
+	// Simulate: DB deleted (dbMarkerExists=false) but lock.IsBootstrapped()=true.
+	lockBootstrapped := true
+	dbMarkerExists := false
+	markerExists := lockBootstrapped || dbMarkerExists
+	if shouldBootstrap(false, markerExists, true) {
+		t.Fatal("DB deletion must not re-enable bootstrap when lock has bootstrapped=true")
+	}
+}
+
+// TestBootstrapMarkerLockDeleteFallback verifies that lock-loss alone
+// does not re-enable bootstrap when the DB marker is still present.
+func TestBootstrapMarkerLockDeleteFallback(t *testing.T) {
+	// Simulate: lock deleted (bootstrapped=false) but DB marker exists.
+	lockBootstrapped := false
+	dbMarkerExists := true
+	markerExists := lockBootstrapped || dbMarkerExists
+	// lock absent + marker present → shouldBootstrap=false (fail closed)
+	if shouldBootstrap(false, markerExists, true) {
+		t.Fatal("lock-deletion alone must not re-enable bootstrap when DB marker exists")
+	}
+}

--- a/pkg/daemon/bootstrap_test.go
+++ b/pkg/daemon/bootstrap_test.go
@@ -108,7 +108,8 @@ func TestBootstrapMarkerDBDeleteFallback(t *testing.T) {
 	lockBootstrapped := true
 	dbMarkerExists := false
 	markerExists := lockBootstrapped || dbMarkerExists
-	if shouldBootstrap(false, markerExists, true) {
+	// lockExisted=true: the v3 lock file still exists (only the DB was wiped).
+	if shouldBootstrap(true, markerExists, true) {
 		t.Fatal("DB deletion must not re-enable bootstrap when lock has bootstrapped=true")
 	}
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -373,7 +373,7 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	pythonRT.SetProtectedPaths(protectedPaths)
 	_, lockStatErr := os.Stat(lockPath)
 	lockExisted := lockStatErr == nil
-	markerExists, err := bootstrapMarkerExists(ctx, database)
+	dbMarkerExists, err := bootstrapMarkerExists(ctx, database)
 	if err != nil {
 		return fmt.Errorf("read approval bootstrap marker: %w", err)
 	}
@@ -406,6 +406,10 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 			"all approval records discarded, tasks require explicit re-approval",
 			zap.String("lock", lockPath))
 	}
+	// The effective bootstrap marker is the union of the DB kv row and the lock's
+	// own bootstrapped flag. Both must be absent to re-enter bootstrap, so deleting
+	// either alone (the SQLite DB or the lock file) cannot reset the gate (#434).
+	markerExists := lock.IsBootstrapped() || dbMarkerExists
 	gatePolicy := approval.Policy{
 		Enabled:        cfg.Approval.IsEnabled(),
 		TrustedSources: map[string]bool{},
@@ -462,6 +466,13 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 		approvalGate.SetBootstrap(true)
 		bootstrapTimer = time.AfterFunc(bootstrapSettle, func() {
 			if approvalGate.FinishBootstrap() {
+				// Persist the bootstrap marker in both the lock and the DB.
+				// Lock marker: survives DB deletion (the primary attack vector).
+				// DB marker: survives lock deletion (fallback / directory-level attacks).
+				if err := lock.MarkBootstrapped(); err != nil {
+					log.Warn("approval gate: failed to persist bootstrap marker in lock; lock-only DB deletion may re-bootstrap on next start",
+						zap.Error(err))
+				}
 				if err := setBootstrapMarker(ctx, database); err != nil {
 					log.Warn("approval gate: failed to persist bootstrap marker; next start may re-bootstrap",
 						zap.Error(err))
@@ -472,6 +483,11 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 		log.Info("approval gate: no dicode.lock — seeding current tasks as approved (first-run bootstrap); changes after startup require approval",
 			zap.String("lock", lockPath))
 	} else if gatePolicy.Enabled && lockExisted && !markerExists {
+		if err := lock.MarkBootstrapped(); err != nil {
+			log.Warn("approval gate: failed to persist bootstrap marker in lock for an adopted lock; "+
+				"a DB deletion could re-enable bootstrap",
+				zap.Error(err))
+		}
 		if err := setBootstrapMarker(ctx, database); err != nil {
 			log.Warn("approval gate: failed to persist bootstrap marker for an adopted lock; "+
 				"a later lock-loss may fail open rather than closed",


### PR DESCRIPTION
## Summary

Closes #434

The approval gate's bootstrap-once guarantee was enforced solely by a `kv` row in the SQLite database. Deleting the DB file erased that marker and allowed re-bootstrapping the gate as if the system had never run — effectively bypassing the trust-on-change policy for any previously approved tasks.

This PR closes the attack vector by embedding a `bootstrapped` flag directly inside `dicode.lock`, covered by the HMAC-SHA256 signature, creating a dual-marker defence: both the lock flag **and** the DB row must be absent before bootstrap is permitted.

## Changes

### `pkg/approval/lock.go`
- Adds `lockVersionBootstrapped = 3`; v2 signs `json(tasks)`, v3 signs `json({bootstrapped, tasks})`
- Adds `Bootstrapped bool` to `lockFile` / `Lock`; `IsBootstrapped()` and `MarkBootstrapped()` methods
- Version-aware MAC: `macContent()` (v3), `macContentV2()` (legacy); `LoadSignedLock` migrates v1→v3 and v2→v3 in-place without re-verifying with the wrong formula
- `save()` always writes version 3 for signed locks going forward

### `pkg/approval/lock_test.go`
- 4 new tests: `TestLockMarkBootstrapped_RoundTrip`, `TestLockMarkBootstrapped_Idempotent`, `TestLoadSignedLock_BootstrappedCoveredByMAC` (flipping the flag triggers tamper detection), `TestLoadSignedLock_V2UpgradeBootstrappedFalse`

### `pkg/daemon/bootstrap.go`
- Comments updated to document the dual-marker approach and the meaning of the `markerExists` parameter

### `pkg/daemon/bootstrap_test.go`
- 2 new tests: `TestBootstrapMarkerDBDeleteFallback` (DB deletion + lock has `bootstrapped=true` → no re-bootstrap), `TestBootstrapMarkerLockDeleteFallback` (lock deletion + DB row exists → no re-bootstrap)

### `pkg/daemon/daemon.go`
- Renames `markerExists` → `dbMarkerExists` at the DB query call
- Computes `markerExists := lock.IsBootstrapped() || dbMarkerExists` after the lock loads
- Bootstrap timer callback and adopted-lock backfill path both call `lock.MarkBootstrapped()` before/alongside `setBootstrapMarker()`

### `docs/concepts/security.md`
- Documents v3 lock format, dual-store defence, and the updated load-time behaviour table

## Security properties after this PR

| Attacker action | Result |
|---|---|
| Delete SQLite DB | `lock.IsBootstrapped()` still true → bootstrap blocked |
| Delete `dicode.lock` | `dbMarkerExists` still true → bootstrap blocked |
| Flip `bootstrapped: false` in lock file | HMAC mismatch → tampered, bootstrap blocked |
| Delete both DB and lock | Both markers gone → re-bootstrap proceeds (expected: clean-slate) |

## Test results

All packages pass. `TestEnforcement_Env_RelayImportNeedsReadExposed` fails identically on the base branch (pre-existing network/TLS dependency on npmjs.org in the test sandbox).


---
_Generated by [Claude Code](https://claude.ai/code/session_01BSLkXqJPDxv7NHZzKDszyE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Strengthened approval lock integrity with a new versioned MAC scheme and explicit tracking of whether bootstrapping was completed.
  * Added dual-store bootstrapping protection so bootstrap only completes when both indicators are present.
* **Bug Fixes**
  * Lock tampering or missing/invalid MACs now fail closed, discarding stored records to prevent silent bypass.
  * Startup bootstrap gating now requires agreement between the database marker and the lock’s bootstrapped state.
* **Tests**
  * Added unit tests for bootstrapped flag persistence, tamper detection, and upgrade behavior across legacy formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->