### PR TITLE
refactor(webui): static login page + Origin-header CSRF (Closes #133)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/go-chi/httprate v0.15.0
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/google/uuid v1.6.0
-	github.com/gorilla/csrf v1.7.3
 	github.com/robfig/cron/v3 v3.0.1
 	go.uber.org/zap v1.28.0
 	golang.org/x/crypto v0.53.0
@@ -45,7 +44,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -77,16 +77,10 @@ github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8J
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
-github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/csrf v1.7.3 h1:BHWt6FTLZAb2HtWT5KDBf6qgpZzvtbp9QWDRKZMXJC0=
-github.com/gorilla/csrf v1.7.3/go.mod h1:F1Fj3KG23WYHE6gozCmBAezKookxbIvUJT+121wTuLk=
-github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kXD8ePA=
-github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=

--- a/pkg/webui/browser_sim_test.go
+++ b/pkg/webui/browser_sim_test.go
@@ -19,15 +19,13 @@ import (
 
 // TestLogin_FormPost_BrowserOriginHeader pins two properties at once:
 //
-//  1. A same-origin form POST with a valid Origin header is accepted by the
-//     gorilla/csrf middleware (regression test for the playwright failure
-//     where Chrome sent Origin: null under Referrer-Policy: no-referrer, which
-//     gorilla rejected as "origin invalid").
+//  1. A same-origin form POST with a matching Origin header is accepted
+//     (the Origin-header check in validateOrigin passes when Origin == Host).
 //
 //  2. The login page's Referrer-Policy is not `no-referrer` — that header
-//     causes Chrome to strip the Origin header from form POSTs, breaking the
-//     real-browser login flow. `strict-origin-when-cross-origin` (or any
-//     same-origin-preserving policy) is required.
+//     causes Chrome to strip the Origin header from form POSTs, which would
+//     break the Origin-check CSRF defence. `strict-origin-when-cross-origin`
+//     (or any same-origin-preserving policy) is required.
 func TestLogin_FormPost_BrowserOriginHeader(t *testing.T) {
 	h := newBrowserTestHandler(t, "hunter2")
 
@@ -39,43 +37,21 @@ func TestLogin_FormPost_BrowserOriginHeader(t *testing.T) {
 		t.Fatalf("GET /login: expected 200, got %d", getW.Code)
 	}
 
-	// Regression guard: Referrer-Policy must NOT be `no-referrer` (Chrome sends
-	// Origin: null on form POSTs under that policy, which gorilla/csrf rejects).
+	// Regression guard: Referrer-Policy must NOT be `no-referrer` (Chrome omits
+	// the Origin header on form POSTs under that policy, breaking validateOrigin).
 	if rp := getW.Header().Get("Referrer-Policy"); rp == "no-referrer" {
-		t.Fatalf("Referrer-Policy must not be no-referrer (strips Origin header on POST, breaks CSRF sameOrigin check); got %q", rp)
+		t.Fatalf("Referrer-Policy must not be no-referrer (strips Origin header on POST, breaks Origin CSRF check); got %q", rp)
 	}
-
-	var csrfCookieVal string
-	for _, c := range getW.Result().Cookies() {
-		if c.Name == "dicode_csrf" {
-			csrfCookieVal = c.Value
-		}
-	}
-	if csrfCookieVal == "" {
-		t.Fatal("no dicode_csrf cookie on /login GET")
-	}
-
-	body := getW.Body.String()
-	const marker = `name="_csrf" value="`
-	i := strings.Index(body, marker)
-	if i < 0 {
-		t.Fatal("no _csrf field in rendered login form")
-	}
-	rest := body[i+len(marker):]
-	end := strings.Index(rest, `"`)
-	token := rest[:end]
 
 	form := url.Values{}
 	form.Set("password", "hunter2")
 	form.Set("next", "/hooks/webui")
-	form.Set("_csrf", token)
 
 	postReq := httptest.NewRequestWithContext(context.Background(), "POST", "http://localhost:8765/api/auth/login", strings.NewReader(form.Encode()))
 	postReq.Host = "localhost:8765"
 	postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	postReq.Header.Set("Origin", "http://localhost:8765")
 	postReq.Header.Set("Referer", "http://localhost:8765/login")
-	postReq.AddCookie(&http.Cookie{Name: "dicode_csrf", Value: csrfCookieVal})
 
 	postW := httptest.NewRecorder()
 	h.ServeHTTP(postW, postReq)
@@ -84,40 +60,19 @@ func TestLogin_FormPost_BrowserOriginHeader(t *testing.T) {
 	}
 }
 
-// TestLogin_FormPost_OriginNull verifies that Origin: null is rejected. This
-// is the correct security posture — if the browser is sending an anonymised
-// Origin, the same-origin property cannot be established and the request
-// should be refused rather than accepted.
+// TestLogin_FormPost_OriginNull verifies that Origin: null is rejected with 403.
+// Browsers send this anonymised origin in sandboxed contexts (data URIs, etc.);
+// since the same-origin property cannot be established, the request is refused.
 func TestLogin_FormPost_OriginNull(t *testing.T) {
 	h := newBrowserTestHandler(t, "hunter2")
 
-	getReq := httptest.NewRequestWithContext(context.Background(), "GET", "http://localhost:8765/login", nil)
-	getReq.Host = "localhost:8765"
-	getW := httptest.NewRecorder()
-	h.ServeHTTP(getW, getReq)
-
-	var csrfCookieVal string
-	for _, c := range getW.Result().Cookies() {
-		if c.Name == "dicode_csrf" {
-			csrfCookieVal = c.Value
-		}
-	}
-	body := getW.Body.String()
-	const marker = `name="_csrf" value="`
-	i := strings.Index(body, marker)
-	rest := body[i+len(marker):]
-	end := strings.Index(rest, `"`)
-	token := rest[:end]
-
 	form := url.Values{}
 	form.Set("password", "hunter2")
-	form.Set("_csrf", token)
 
 	postReq := httptest.NewRequestWithContext(context.Background(), "POST", "http://localhost:8765/api/auth/login", strings.NewReader(form.Encode()))
 	postReq.Host = "localhost:8765"
 	postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	postReq.Header.Set("Origin", "null")
-	postReq.AddCookie(&http.Cookie{Name: "dicode_csrf", Value: csrfCookieVal})
 
 	postW := httptest.NewRecorder()
 	h.ServeHTTP(postW, postReq)

--- a/pkg/webui/login/index.html
+++ b/pkg/webui/login/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Sign in to dicode</title>
+<link rel="stylesheet" href="/login/style.css">
+</head>
+<body>
+<main class="dc-login">
+<form method="post" action="/api/auth/login" enctype="application/x-www-form-urlencoded">
+<h1 id="login-title">Sign in to dicode</h1>
+<p class="dc-err" role="alert" id="dc-err" hidden></p>
+<label>Password<input type="password" name="password" autocomplete="current-password" autofocus required></label>
+<label class="dc-check"><input type="checkbox" name="trust" value="1">Trust this browser</label>
+<input type="hidden" name="next" id="next-input" value="">
+<button type="submit">Sign in</button>
+</form>
+</main>
+<script src="/login/login.js"></script>
+</body>
+</html>

--- a/pkg/webui/login/login.js
+++ b/pkg/webui/login/login.js
@@ -1,0 +1,31 @@
+(function () {
+  var p = new URLSearchParams(location.search);
+  var next = p.get('next') || '';
+  var err = p.get('err');
+
+  // Populate hidden next field. Guard against open-redirect attempts
+  // (server validates again at POST time; this is client-side defence-in-depth).
+  if (next && /^\/[^/\\]/.test(next)) {
+    document.getElementById('next-input').value = next;
+  }
+
+  // Show error banner when the server redirected back with ?err=1.
+  if (err) {
+    var el = document.getElementById('dc-err');
+    el.textContent = 'Incorrect password';
+    el.removeAttribute('hidden');
+  }
+
+  // Fetch contextual title (task name when signing in to reach a specific task).
+  var ctx = '/api/login/context';
+  if (next) { ctx += '?next=' + encodeURIComponent(next); }
+  fetch(ctx)
+    .then(function (r) { return r.ok ? r.json() : null; })
+    .then(function (d) {
+      if (d && d.title) {
+        document.title = d.title;
+        document.getElementById('login-title').textContent = d.title;
+      }
+    })
+    .catch(function () {});
+}());

--- a/pkg/webui/login/style.css
+++ b/pkg/webui/login/style.css
@@ -1,0 +1,11 @@
+body{margin:0;font:16px/1.4 system-ui,sans-serif;background:#0f1115;color:#e6e8eb;display:grid;place-items:center;min-height:100vh}
+.dc-login{width:100%;max-width:360px;padding:2rem}
+.dc-login h1{font-size:1.25rem;margin:0 0 1.25rem;font-weight:600}
+.dc-login form{display:flex;flex-direction:column;gap:0.75rem}
+.dc-login label{display:flex;flex-direction:column;gap:0.25rem;font-size:0.85rem;color:#9aa1ab}
+.dc-login input[type=password]{padding:0.6rem 0.7rem;border:1px solid #2a2f38;background:#181b21;color:#e6e8eb;border-radius:4px;font:inherit}
+.dc-login input[type=password]:focus{outline:2px solid #3b82f6;border-color:transparent}
+.dc-login .dc-check{flex-direction:row;align-items:center;gap:0.5rem;color:#cbd0d7}
+.dc-login button{margin-top:0.5rem;padding:0.65rem;background:#3b82f6;border:0;color:#fff;font:inherit;font-weight:600;border-radius:4px;cursor:pointer}
+.dc-login button:hover{background:#2563eb}
+.dc-err{margin:0 0 0.5rem;padding:0.5rem 0.7rem;background:#3a1a1a;border:1px solid #6b2424;color:#fca5a5;border-radius:4px;font-size:0.85rem}

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html/template"
 	"io"
 	"net/http"
 	"net/url"
@@ -38,7 +37,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/httprate"
-	"github.com/gorilla/csrf"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 )
@@ -114,6 +112,9 @@ const webhookPathPrefix = "/hooks/"
 //go:embed static
 var staticFS embed.FS
 
+//go:embed login
+var loginEmbedFS embed.FS
+
 // Version is the build-stamped version reported by GET /healthz. Set by
 // pkg/daemon before calling webui.New(). Defaults to "dev" when unset.
 var Version = "dev"
@@ -151,12 +152,6 @@ type Server struct {
 	log                *zap.Logger
 	port               int
 	srv                *http.Server
-
-	// csrfKey is a per-daemon random 32-byte HMAC key for gorilla/csrf. It is
-	// regenerated on every daemon restart — any open browser tab that was
-	// mid-login must reload /login to get a fresh token. Not persisted so a
-	// stolen key cannot outlast a restart.
-	csrfKey []byte
 
 	// replayer fires new runs from persisted inputs. Nil when input persistence
 	// is disabled (SetReplayer not called); the /api/runs/{runID}/replay
@@ -231,11 +226,6 @@ func New(port int, r *registry.Registry, eng *trigger.Engine, cfg *config.Config
 
 	wsHub := NewWSHub(log, wsOriginPatterns(cfg.Server.AllowedOrigins))
 
-	csrfKey := make([]byte, 32)
-	if _, err := rand.Read(csrfKey); err != nil {
-		return nil, fmt.Errorf("webui: generate csrf key: %w", err)
-	}
-
 	var dbs *dbSessionStore
 	var aks *apiKeyStore
 	var ps *passphraseStore
@@ -269,7 +259,6 @@ func New(port int, r *registry.Registry, eng *trigger.Engine, cfg *config.Config
 		log:               log,
 		port:              port,
 		gateway:           gateway,
-		csrfKey:           csrfKey,
 		db:                database,
 		audit:             audit.NewStore(database),
 	}
@@ -380,63 +369,27 @@ func (s *Server) Handler() http.Handler {
 
 	// Auth endpoints — always public (login flow must be reachable without session).
 	//
-	// CSRF protection via gorilla/csrf is scoped to the login-form flow only.
-	// GET /login sets/refreshes the masked token cookie; the form POST is
-	// validated by the middleware automatically. The JSON variant of
-	// /api/auth/login is exempted in csrfGuard below because it follows a
-	// different threat model (same-origin fetch with credentials; no cookie
-	// to forge in a cross-origin form).
-	s.cfgMu.RLock()
-	tlsConfigured := s.cfg.Server.TLSCertFile != ""
-	s.cfgMu.RUnlock()
-	csrfProtect := csrf.Protect(
-		s.csrfKey,
-		csrf.CookieName("dicode_csrf"),
-		csrf.FieldName("_csrf"),
-		csrf.Path("/"),
-		csrf.Secure(tlsConfigured),
-		csrf.SameSite(csrf.SameSiteStrictMode),
-		csrf.MaxAge(3600),
-	)
-	csrfGuard := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			// JSON POSTs to /api/auth/login bypass CSRF validation — see
-			// comment above. All other methods + content types go through.
-			if req.URL.Path == "/api/auth/login" && req.Method == http.MethodPost && !isFormRequest(req) {
-				next.ServeHTTP(w, req)
-				return
-			}
-			// gorilla/csrf defaults to treating the request as HTTPS and
-			// enforces Origin/Referer checks. dicode's daemon is typically
-			// HTTP over localhost (TLS only when TLSCertFile is configured),
-			// so mark the request plaintext when TLS is not configured —
-			// otherwise every local form submission is rejected with
-			// "referer not supplied". Under TLS, the strict-referer check
-			// stays on to defend against HTTP-downgrade MITM.
-			if !tlsConfigured {
-				req = csrf.PlaintextHTTPRequest(req)
-			}
-			csrfProtect(next).ServeHTTP(w, req)
-		})
-	}
-	r.Group(func(lr chi.Router) {
-		lr.Use(csrfGuard)
-		lr.Get("/login", s.handleLoginPage)
-		// Per-IP rate limit on the login POST (5 req/min). Skipped when
-		// DICODE_DISABLE_UNLOCK_LIMITER=1 so e2e tests can rapid-fire logins.
-		lr.Group(func(rl chi.Router) {
-			if os.Getenv("DICODE_DISABLE_UNLOCK_LIMITER") != "1" {
-				rl.Use(httprate.Limit(unlockMaxAttempts, unlockWindow,
-					httprate.WithKeyFuncs(func(r *http.Request) (string, error) {
-						s.cfgMu.RLock()
-						trustProxy := s.cfg.Server.TrustProxy
-						s.cfgMu.RUnlock()
-						return clientIP(r, trustProxy), nil
-					}),
-				))
-			}
-			rl.Post("/api/auth/login", s.apiSecretsUnlock)
-		})
+	// CSRF for form POSTs is enforced via Origin-header check in apiSecretsUnlock
+	// (validateOrigin). JSON POSTs follow a different threat model: same-origin
+	// fetch with SameSite=Strict session cookie — no form token needed.
+	r.Get("/login", s.serveLoginPage)
+	r.Get("/login/style.css", serveLoginFile("style.css", "text/css; charset=utf-8"))
+	r.Get("/login/login.js", serveLoginFile("login.js", "text/javascript; charset=utf-8"))
+	r.Get("/api/login/context", s.apiLoginContext)
+	// Per-IP rate limit on the login POST (5 req/min). Skipped when
+	// DICODE_DISABLE_UNLOCK_LIMITER=1 so e2e tests can rapid-fire logins.
+	r.Group(func(rl chi.Router) {
+		if os.Getenv("DICODE_DISABLE_UNLOCK_LIMITER") != "1" {
+			rl.Use(httprate.Limit(unlockMaxAttempts, unlockWindow,
+				httprate.WithKeyFuncs(func(r *http.Request) (string, error) {
+					s.cfgMu.RLock()
+					trustProxy := s.cfg.Server.TrustProxy
+					s.cfgMu.RUnlock()
+					return clientIP(r, trustProxy), nil
+				}),
+			))
+		}
+		rl.Post("/api/auth/login", s.apiSecretsUnlock)
 	})
 	r.Post("/api/auth/refresh", s.apiAuthRefresh)
 
@@ -1136,14 +1089,17 @@ func (s *Server) apiSecretsUnlock(w http.ResponseWriter, r *http.Request) {
 	var password, nextPath string
 	var trust bool
 	if isForm {
-		if err := r.ParseForm(); err != nil {
-			s.loginError(w, r, "invalid form", http.StatusBadRequest, "")
+		// Validate Origin header to defend against cross-origin form submissions
+		// (CSRF). A missing Origin is allowed for same-site tools and legacy
+		// clients; the SameSite=Strict session cookie provides belt-and-suspenders.
+		if !validateOrigin(r) {
+			http.Error(w, "Forbidden", http.StatusForbidden)
 			return
 		}
-		// CSRF: gorilla/csrf middleware has already validated the token on
-		// POST (see csrfGuard in Handler()) — the request would have been
-		// rejected with 403 before reaching here if the token was missing or
-		// mismatched.
+		if err := r.ParseForm(); err != nil {
+			http.Redirect(w, r, "/login?err=1", http.StatusSeeOther)
+			return
+		}
 		password = r.PostFormValue("password")
 		trust = r.PostFormValue("trust") != ""
 		nextPath = r.PostFormValue("next")
@@ -1181,13 +1137,21 @@ func (s *Server) apiSecretsUnlock(w http.ResponseWriter, r *http.Request) {
 	// than silently letting anyone in.
 	src := s.passphraseSource(r.Context())
 	if src == passphraseSourceUnknown {
-		s.loginError(w, r, "service temporarily unavailable", http.StatusServiceUnavailable, safeNext)
+		if isForm {
+			http.Redirect(w, r, loginErrURL(safeNext), http.StatusSeeOther)
+			return
+		}
+		jsonErr(w, "service temporarily unavailable", http.StatusServiceUnavailable)
 		return
 	}
 	if src != passphraseSourceNone {
 		if !s.verifyPassphrase(r.Context(), password) {
 			s.auditDenied(r, "incorrect password")
-			s.loginError(w, r, "incorrect password", http.StatusUnauthorized, safeNext)
+			if isForm {
+				http.Redirect(w, r, loginErrURL(safeNext), http.StatusSeeOther)
+				return
+			}
+			jsonErr(w, "incorrect password", http.StatusUnauthorized)
 			return
 		}
 	}
@@ -1217,39 +1181,67 @@ func (s *Server) apiSecretsUnlock(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, resp)
 }
 
-func (s *Server) loginError(w http.ResponseWriter, r *http.Request, msg string, code int, safeNext string) {
-	if !isFormRequest(r) {
-		jsonErr(w, msg, code)
-		return
-	}
-	// gorilla/csrf middleware has already placed a fresh masked token on the
-	// response cookie; csrf.TemplateField(r) returns the same value to embed in the
-	// retry form.
-	body, err := renderLoginPage(s.loginTitle(safeNext), safeNext, csrf.TemplateField(r), msg)
+// serveLoginPage serves the embedded static login page HTML.
+func (s *Server) serveLoginPage(w http.ResponseWriter, r *http.Request) {
+	data, err := loginEmbedFS.ReadFile("login/index.html")
 	if err != nil {
-		s.log.Error("login error render: template execute", zap.Error(err))
-		jsonErr(w, msg, code)
-		return
-	}
-	setLoginPageHeaders(w)
-	w.WriteHeader(code)
-	_, _ = w.Write(body)
-}
-
-func (s *Server) handleLoginPage(w http.ResponseWriter, r *http.Request) {
-	next := r.URL.Query().Get("next")
-	if next != "" && !isSafeNextPath(next) {
-		s.log.Warn("rejecting unsafe next on login page", zap.String("next", next))
-		next = ""
-	}
-	body, err := renderLoginPage(s.loginTitle(next), next, csrf.TemplateField(r), "")
-	if err != nil {
-		s.log.Error("login page: template execute", zap.Error(err))
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 	setLoginPageHeaders(w)
-	_, _ = w.Write(body)
+	_, _ = w.Write(data)
+}
+
+// serveLoginFile returns a handler that serves a named static login asset
+// (style.css, login.js) embedded in the binary.
+func serveLoginFile(name, contentType string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		data, err := loginEmbedFS.ReadFile("login/" + name)
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", contentType)
+		_, _ = w.Write(data)
+	}
+}
+
+// apiLoginContext returns JSON with the contextual page title. The static login
+// page fetches this via a short JS snippet to avoid server-side HTML rendering.
+func (s *Server) apiLoginContext(w http.ResponseWriter, r *http.Request) {
+	next := r.URL.Query().Get("next")
+	if next != "" && !isSafeNextPath(next) {
+		next = ""
+	}
+	jsonOK(w, map[string]string{"title": s.loginTitle(next)})
+}
+
+// validateOrigin checks the Origin header against the request Host to defend
+// against cross-origin form submissions (CSRF). A missing Origin is allowed —
+// same-site tools (curl, legacy browsers) omit it and pose no CSRF risk when
+// session cookies carry SameSite=Strict.
+func validateOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	host := r.Host
+	if host == "" {
+		host = r.URL.Host
+	}
+	return u.Host == host
+}
+
+// loginErrURL returns the URL to redirect to when a form login fails.
+func loginErrURL(safeNext string) string {
+	if safeNext == "" {
+		return "/login?err=1"
+	}
+	return "/login?err=1&next=" + url.QueryEscape(safeNext)
 }
 
 // isFormRequest returns true when the request body is a browser-style form
@@ -1260,18 +1252,18 @@ func isFormRequest(r *http.Request) bool {
 		strings.HasPrefix(ct, "multipart/form-data")
 }
 
-// setLoginPageHeaders applies defence-in-depth headers on any response that
-// renders the login form. Clickjacking prevention (XFO + frame-ancestors),
-// a referrer policy that keeps the `next` path from leaking cross-origin
-// but preserves the Origin header on same-origin POSTs (gorilla/csrf rejects
-// Origin: null, which Chrome sends when the policy is `no-referrer`), and a
-// CSP that allows only same-origin subresources plus inline styles.
+// setLoginPageHeaders applies defence-in-depth headers on the login page
+// response. Clickjacking prevention (XFO + frame-ancestors), a referrer policy
+// that keeps the `next` path from leaking cross-origin while preserving the
+// Origin header on same-origin POSTs (needed for validateOrigin), and a CSP
+// that allows same-origin scripts and styles (the page loads /login/login.js
+// and /login/style.css from the same origin).
 func setLoginPageHeaders(w http.ResponseWriter) {
 	h := w.Header()
 	h.Set("Content-Type", "text/html; charset=utf-8")
 	h.Set("X-Frame-Options", "DENY")
 	h.Set("Content-Security-Policy",
-		"default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'none'; "+
+		"default-src 'self'; style-src 'self'; script-src 'self'; "+
 			"img-src 'self' data:; frame-ancestors 'none'; base-uri 'none'; form-action 'self'")
 	h.Set("Referrer-Policy", "strict-origin-when-cross-origin")
 }
@@ -1312,70 +1304,6 @@ func (s *Server) loginTitle(next string) string {
 	}
 	return "Sign in to dicode"
 }
-
-// loginPageTpl is compiled once at init time. html/template applies context-
-// aware auto-escaping so every {{.X}} is safe in its surrounding markup:
-// .Title goes into <title> (body text), .Err into body text, .Next and .CSRF
-// into attribute values. Static analysers (CodeQL go/reflected-xss) recognise
-// html/template as a sanitising sink.
-var loginPageTpl = template.Must(template.New("login").Parse(`<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<title>{{.Title}}</title>
-<style>` + loginCSS + `</style>
-</head>
-<body>
-<main class="dc-login">
-<form method="post" action="/api/auth/login" enctype="application/x-www-form-urlencoded">
-<h1>{{.Title}}</h1>
-{{if .Err}}<p class="dc-err" role="alert">{{.Err}}</p>{{end}}
-<label>Password<input type="password" name="password" autocomplete="current-password" autofocus required></label>
-<label class="dc-check"><input type="checkbox" name="trust" value="1">Trust this browser</label>
-<input type="hidden" name="next" value="{{.Next}}">
-{{.CSRFField}}
-<button type="submit">Sign in</button>
-</form>
-</main>
-</body>
-</html>`))
-
-type loginPageData struct {
-	Title     string
-	Next      string
-	CSRFField template.HTML // rendered <input> tag from csrf.TemplateField
-	Err       string
-}
-
-// renderLoginPage produces the login form HTML with contextual auto-escaping
-// via html/template. The CSRF field is a template.HTML value produced by
-// csrf.TemplateField(r) — it carries its own escape-safe `<input>` tag so
-// html/template doesn't re-escape the base64 token's `+` characters as
-// numeric references, which would corrupt the form value in simple
-// string-based extractors (real browsers HTML-decode attribute values,
-// but not all clients do).
-func renderLoginPage(title, next string, csrfField template.HTML, errMsg string) ([]byte, error) {
-	var b strings.Builder
-	if err := loginPageTpl.Execute(&b, loginPageData{
-		Title: title, Next: next, CSRFField: csrfField, Err: errMsg,
-	}); err != nil {
-		return nil, err
-	}
-	return []byte(b.String()), nil
-}
-
-const loginCSS = `body{margin:0;font:16px/1.4 system-ui,sans-serif;background:#0f1115;color:#e6e8eb;display:grid;place-items:center;min-height:100vh}` +
-	`.dc-login{width:100%;max-width:360px;padding:2rem}` +
-	`.dc-login h1{font-size:1.25rem;margin:0 0 1.25rem;font-weight:600}` +
-	`.dc-login form{display:flex;flex-direction:column;gap:0.75rem}` +
-	`.dc-login label{display:flex;flex-direction:column;gap:0.25rem;font-size:0.85rem;color:#9aa1ab}` +
-	`.dc-login input[type=password]{padding:0.6rem 0.7rem;border:1px solid #2a2f38;background:#181b21;color:#e6e8eb;border-radius:4px;font:inherit}` +
-	`.dc-login input[type=password]:focus{outline:2px solid #3b82f6;border-color:transparent}` +
-	`.dc-login .dc-check{flex-direction:row;align-items:center;gap:0.5rem;color:#cbd0d7}` +
-	`.dc-login button{margin-top:0.5rem;padding:0.65rem;background:#3b82f6;border:0;color:#fff;font:inherit;font-weight:600;border-radius:4px;cursor:pointer}` +
-	`.dc-login button:hover{background:#2563eb}` +
-	`.dc-err{margin:0 0 0.5rem;padding:0.5rem 0.7rem;background:#3a1a1a;border:1px solid #6b2424;color:#fca5a5;border-radius:4px;font-size:0.85rem}`
 
 func (s *Server) apiListSecrets(w http.ResponseWriter, r *http.Request) {
 	if s.secretsMgr == nil {

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -1147,8 +1147,9 @@ func (s *Server) apiSecretsUnlock(w http.ResponseWriter, r *http.Request) {
 	// than silently letting anyone in.
 	src := s.passphraseSource(r.Context())
 	if src == passphraseSourceUnknown {
+		// DB/passphrase read failed — surface as 503, not as "Incorrect password".
 		if isForm {
-			http.Redirect(w, r, loginErrURL(safeNext), http.StatusSeeOther)
+			http.Error(w, "service temporarily unavailable", http.StatusServiceUnavailable)
 			return
 		}
 		jsonErr(w, "service temporarily unavailable", http.StatusServiceUnavailable)
@@ -1227,8 +1228,21 @@ func (s *Server) apiLoginContext(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]string{"title": s.loginTitle(next)})
 }
 
-// validateOrigin checks the Origin header against the request Host to defend
-// against cross-origin submissions (CSRF). A missing Origin is allowed —
+// requestScheme returns the externally visible scheme for r. TLS state takes
+// precedence; X-Forwarded-Proto covers the common case where TLS terminates at
+// a trusted reverse proxy and the backend receives plain HTTP.
+func requestScheme(r *http.Request) string {
+	if r.TLS != nil {
+		return "https"
+	}
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		return strings.ToLower(proto)
+	}
+	return "http"
+}
+
+// validateOrigin checks the Origin header against the request scheme+host to
+// defend against cross-origin submissions (CSRF). A missing Origin is allowed —
 // curl and other non-browser clients omit it and are not subject to CSRF.
 // "null" is explicitly rejected: browsers send it from sandboxed contexts where
 // the same-origin property cannot be established.
@@ -1246,6 +1260,12 @@ func validateOrigin(r *http.Request) bool {
 	}
 	u, err := url.Parse(origin)
 	if err != nil || u.Host == "" {
+		return false
+	}
+	// Scheme must match the externally visible scheme of the request. A page
+	// served over http:// is a different origin from https:// even on the same
+	// host, so Origin: http://myapp must be rejected for an HTTPS request.
+	if u.Scheme != requestScheme(r) {
 		return false
 	}
 	host := r.Host

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -1090,8 +1090,9 @@ func (s *Server) apiSecretsUnlock(w http.ResponseWriter, r *http.Request) {
 	var trust bool
 	if isForm {
 		// Validate Origin header to defend against cross-origin form submissions
-		// (CSRF). A missing Origin is allowed for same-site tools and legacy
-		// clients; the SameSite=Strict session cookie provides belt-and-suspenders.
+		// (CSRF). A missing Origin is allowed for curl and legacy clients that
+		// do not send it; modern browsers send Origin on cross-origin POSTs and
+		// will be rejected here if they don't match.
 		if !validateOrigin(r) {
 			http.Error(w, "Forbidden", http.StatusForbidden)
 			return
@@ -1104,6 +1105,15 @@ func (s *Server) apiSecretsUnlock(w http.ResponseWriter, r *http.Request) {
 		trust = r.PostFormValue("trust") != ""
 		nextPath = r.PostFormValue("next")
 	} else {
+		// Non-form path (JSON and other Content-Types). A cross-origin fetch
+		// with Content-Type: text/plain is a "simple" CORS request (no
+		// preflight) and Go's json.Decoder ignores Content-Type, so the JSON
+		// decode path is reachable cross-origin without a preflight. Validate
+		// the Origin header when it is present to close that vector.
+		if r.Header.Get("Origin") != "" && !validateOrigin(r) {
+			jsonErr(w, "forbidden", http.StatusForbidden)
+			return
+		}
 		var body struct {
 			Password string `json:"password"`
 			Trust    bool   `json:"trust"`
@@ -1202,6 +1212,7 @@ func serveLoginFile(name, contentType string) http.HandlerFunc {
 			return
 		}
 		w.Header().Set("Content-Type", contentType)
+		w.Header().Set("Cache-Control", "no-cache")
 		_, _ = w.Write(data)
 	}
 }
@@ -1217,21 +1228,39 @@ func (s *Server) apiLoginContext(w http.ResponseWriter, r *http.Request) {
 }
 
 // validateOrigin checks the Origin header against the request Host to defend
-// against cross-origin form submissions (CSRF). A missing Origin is allowed —
-// same-site tools (curl, legacy browsers) omit it and pose no CSRF risk when
-// session cookies carry SameSite=Strict.
+// against cross-origin submissions (CSRF). A missing Origin is allowed —
+// curl and other non-browser clients omit it and are not subject to CSRF.
+// "null" is explicitly rejected: browsers send it from sandboxed contexts where
+// the same-origin property cannot be established.
+// Browsers canonically omit default ports from the Origin serialisation
+// (https→443, http→80); we strip those same defaults from r.Host before
+// comparing so deployments behind a proxy that preserves an explicit-port
+// Host header (e.g. "myapp:443") still accept legitimate same-origin requests.
 func validateOrigin(r *http.Request) bool {
 	origin := r.Header.Get("Origin")
 	if origin == "" {
 		return true
 	}
+	if origin == "null" {
+		return false
+	}
 	u, err := url.Parse(origin)
-	if err != nil {
+	if err != nil || u.Host == "" {
 		return false
 	}
 	host := r.Host
 	if host == "" {
 		host = r.URL.Host
+	}
+	// Browsers omit the default port from Origin. Strip the same default from
+	// r.Host when the origin carries no port, so "myapp" matches "myapp:443".
+	if u.Port() == "" {
+		switch u.Scheme {
+		case "https":
+			host = strings.TrimSuffix(host, ":443")
+		case "http":
+			host = strings.TrimSuffix(host, ":80")
+		}
 	}
 	return u.Host == host
 }
@@ -1261,6 +1290,7 @@ func isFormRequest(r *http.Request) bool {
 func setLoginPageHeaders(w http.ResponseWriter) {
 	h := w.Header()
 	h.Set("Content-Type", "text/html; charset=utf-8")
+	h.Set("Cache-Control", "no-store")
 	h.Set("X-Frame-Options", "DENY")
 	h.Set("Content-Security-Policy",
 		"default-src 'self'; style-src 'self'; script-src 'self'; "+

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -990,104 +990,72 @@ func TestLoginPage_Served_WhenPathIsPublic(t *testing.T) {
 	if !contains(body, `name="next"`) {
 		t.Error("login form must contain a hidden next field")
 	}
-	if !contains(body, `name="_csrf"`) {
-		t.Error("login form must contain a hidden _csrf field")
-	}
-	var csrfSet bool
-	for _, c := range w.Result().Cookies() {
-		if c.Name == csrfCookie {
-			csrfSet = true
-			if !c.HttpOnly {
-				t.Error("csrf cookie must be HttpOnly")
-			}
-			if c.SameSite != http.SameSiteStrictMode {
-				t.Error("csrf cookie must be SameSite=Strict")
-			}
-		}
-	}
-	if !csrfSet {
-		t.Error("csrf cookie must be issued on /login GET")
-	}
 }
 
-// csrfCookie is the cookie name set by gorilla/csrf middleware. Kept here
-// (not in server.go) as a test helper so tests can assert on a stable name.
-const csrfCookie = "dicode_csrf"
-
-// prepareLoginPost performs a GET /login to obtain a CSRF cookie and token,
-// then builds a POST request carrying both. Returned request has the cookie
-// attached and the form body includes the matching _csrf field.
-func prepareLoginPost(t *testing.T, h http.Handler, form url.Values) *http.Request {
+// prepareLoginPost builds a POST /api/auth/login form request with a same-origin
+// Origin header so validateOrigin passes. The CSRF dance (gorilla token + cookie)
+// is no longer needed — Origin-header check is the sole CSRF defence for forms.
+func prepareLoginPost(t *testing.T, _ http.Handler, form url.Values) *http.Request {
 	t.Helper()
-	getReq := httptest.NewRequest(http.MethodGet, "/login", nil)
-	getW := httptest.NewRecorder()
-	h.ServeHTTP(getW, getReq)
-	if getW.Code != http.StatusOK {
-		t.Fatalf("prepareLoginPost: GET /login returned %d", getW.Code)
-	}
-	var csrfCookieVal string
-	for _, c := range getW.Result().Cookies() {
-		if c.Name == csrfCookie {
-			csrfCookieVal = c.Value
-		}
-	}
-	if csrfCookieVal == "" {
-		t.Fatal("prepareLoginPost: no csrf cookie on /login GET")
-	}
-	token := extractCSRFFromHTML(t, getW.Body.String())
-	if token == "" {
-		t.Fatal("prepareLoginPost: no _csrf field in rendered form")
-	}
 	if form == nil {
 		form = url.Values{}
 	}
-	form.Set("_csrf", token)
-
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.AddCookie(&http.Cookie{Name: csrfCookie, Value: csrfCookieVal})
+	// Simulate a same-origin browser form submission.
+	req.Host = "example.com"
+	req.Header.Set("Origin", "http://example.com")
 	return req
 }
 
-// extractCSRFFromHTML pulls the hidden _csrf value from the rendered login form.
-func extractCSRFFromHTML(t *testing.T, body string) string {
-	t.Helper()
-	const marker = `name="_csrf" value="`
-	i := strings.Index(body, marker)
-	if i < 0 {
-		return ""
-	}
-	rest := body[i+len(marker):]
-	end := strings.Index(rest, `"`)
-	if end < 0 {
-		return ""
-	}
-	return rest[:end]
-}
-
-func TestLoginPage_ShowsTaskNameForWebhookNext(t *testing.T) {
+// TestLoginContext_ShowsTaskNameForWebhookNext verifies that GET /api/login/context
+// returns the task name and description when next points at a known webhook task.
+// The static login page's JS fetches this endpoint to display a contextual title.
+func TestLoginContext_ShowsTaskNameForWebhookNext(t *testing.T) {
 	srv := newAuthServer(t, "hunter2")
 	spec := registerWebhookTask(t, srv.registry, srv, "ai-hook", "/hooks/ai", true)
 	spec.Name = "AI Assistant"
 	spec.Description = "Chat with your tasks"
 	h := srv.Handler()
 
-	req := httptest.NewRequest(http.MethodGet, "/login?next=%2Fhooks%2Fai", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/login/context?next=%2Fhooks%2Fai", nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
-	body := w.Body.String()
-	if !contains(body, "AI Assistant") {
-		t.Errorf("expected task name in login page, got:\n%s", body)
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
 	}
-	if !contains(body, "Chat with your tasks") {
-		t.Errorf("expected task description in login page, got:\n%s", body)
+	if !contains(resp["title"], "AI Assistant") {
+		t.Errorf("expected task name in title, got %q", resp["title"])
+	}
+	if !contains(resp["title"], "Chat with your tasks") {
+		t.Errorf("expected task description in title, got %q", resp["title"])
 	}
 }
 
+// TestLoginContext_GenericTitleForUnknownNext verifies that /api/login/context
+// returns the generic "Sign in to dicode" title when next is absent.
+func TestLoginContext_GenericTitleForUnknownNext(t *testing.T) {
+	srv := newAuthServer(t, "hunter2")
+	h := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/login/context", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	var resp map[string]string
+	_ = json.NewDecoder(w.Body).Decode(&resp)
+	if !contains(resp["title"], "Sign in to dicode") {
+		t.Errorf("expected generic fallback title, got %q", resp["title"])
+	}
+}
+
+// TestLoginPage_GenericTitleForUnknownNext confirms the static login HTML
+// contains the default "Sign in to dicode" text (shown before JS updates it).
 func TestLoginPage_GenericTitleForUnknownNext(t *testing.T) {
 	srv := newAuthServer(t, "hunter2")
 	h := srv.Handler()
@@ -1097,7 +1065,7 @@ func TestLoginPage_GenericTitleForUnknownNext(t *testing.T) {
 	h.ServeHTTP(w, req)
 
 	if !contains(w.Body.String(), "Sign in to dicode") {
-		t.Error("expected generic fallback title")
+		t.Error("expected generic fallback title in static HTML")
 	}
 }
 
@@ -1165,7 +1133,7 @@ func TestLogin_FormPost_Trust_IssuesDeviceCookie(t *testing.T) {
 	}
 }
 
-func TestLogin_FormPost_WrongPassword_RendersErrorHTML(t *testing.T) {
+func TestLogin_FormPost_WrongPassword_RedirectsToLoginWithErr(t *testing.T) {
 	srv := newAuthServer(t, "hunter2")
 	h := srv.Handler()
 
@@ -1177,27 +1145,29 @@ func TestLogin_FormPost_WrongPassword_RendersErrorHTML(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
-	if w.Code != http.StatusUnauthorized {
-		t.Fatalf("expected 401, got %d", w.Code)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303 redirect on wrong password, got %d", w.Code)
 	}
-	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
-		t.Errorf("expected HTML response, got Content-Type=%q", ct)
+	loc := w.Header().Get("Location")
+	if !contains(loc, "/login") || !contains(loc, "err=1") {
+		t.Errorf("expected redirect to /login?err=1, got %q", loc)
 	}
-	if !contains(w.Body.String(), "incorrect password") {
-		t.Error("expected error message in HTML body")
+	if !contains(loc, url.QueryEscape("/hooks/ai")) {
+		t.Errorf("next path not preserved in error redirect, got %q", loc)
 	}
 }
 
-func TestLogin_FormPost_MissingCSRFCookie_Rejected(t *testing.T) {
+// TestLogin_FormPost_OriginMismatch_Rejected verifies that a form POST with a
+// cross-origin Origin header is rejected with 403 (CSRF defence via Origin check).
+func TestLogin_FormPost_OriginMismatch_Rejected(t *testing.T) {
 	srv := newAuthServer(t, "hunter2")
 	h := srv.Handler()
 
-	form := url.Values{}
-	form.Set("password", "hunter2")
-	form.Set("_csrf", "decafbad") // form has a value, cookie missing
-
+	form := url.Values{"password": {"hunter2"}}
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Host = "example.com"
+	req.Header.Set("Origin", "https://evil.com") // cross-origin
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -1206,32 +1176,27 @@ func TestLogin_FormPost_MissingCSRFCookie_Rejected(t *testing.T) {
 	}
 	for _, c := range w.Result().Cookies() {
 		if c.Name == sessionCookie {
-			t.Error("session cookie must not be issued when CSRF check fails")
+			t.Error("session cookie must not be issued when Origin check fails")
 		}
 	}
 }
 
-func TestLogin_FormPost_CSRFMismatch_Rejected(t *testing.T) {
+// TestLogin_FormPost_MissingOrigin_Allowed verifies that a form POST without an
+// Origin header is allowed (same-site tools like curl omit it; SameSite=Strict
+// cookies provide belt-and-suspenders protection).
+func TestLogin_FormPost_MissingOrigin_Allowed(t *testing.T) {
 	srv := newAuthServer(t, "hunter2")
 	h := srv.Handler()
 
-	form := url.Values{}
-	form.Set("password", "hunter2")
-	form.Set("_csrf", "not-the-cookie-value")
-
+	form := url.Values{"password": {"hunter2"}}
 	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.AddCookie(&http.Cookie{Name: csrfCookie, Value: "cookie-value"})
+	// No Origin header — should be allowed.
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body)
-	}
-	for _, c := range w.Result().Cookies() {
-		if c.Name == sessionCookie {
-			t.Error("session cookie must not be issued when CSRF mismatches")
-		}
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303 (successful login redirect), got %d: %s", w.Code, w.Body)
 	}
 }
 
@@ -1309,13 +1274,12 @@ func TestLoginPage_SetsSecurityHeaders(t *testing.T) {
 	if !strings.Contains(csp, "frame-ancestors 'none'") {
 		t.Errorf("CSP must set frame-ancestors 'none', got %q", csp)
 	}
-	if !strings.Contains(csp, "script-src 'none'") {
-		t.Errorf("CSP must set script-src 'none' on login page, got %q", csp)
+	if !strings.Contains(csp, "script-src 'self'") {
+		t.Errorf("CSP must set script-src 'self' (login.js), got %q", csp)
 	}
-	// Referrer-Policy must preserve the Origin header on same-origin POSTs —
-	// `no-referrer` makes Chrome send Origin: null, which gorilla/csrf then
-	// rejects as "origin invalid". `strict-origin-when-cross-origin` keeps
-	// the anti-leak property cross-origin while letting the login form work.
+	// Referrer-Policy must preserve the Origin header on same-origin POSTs so
+	// validateOrigin can compare it to the Host. `strict-origin-when-cross-origin`
+	// keeps the anti-leak property cross-origin while letting the login form work.
 	if got := w.Header().Get("Referrer-Policy"); got != "strict-origin-when-cross-origin" {
 		t.Errorf("Referrer-Policy: want strict-origin-when-cross-origin, got %q", got)
 	}
@@ -1341,7 +1305,10 @@ func TestLogin_JSONPost_OpenRedirect_Dropped(t *testing.T) {
 	}
 }
 
-func TestLoginPage_RejectsUnsafeNextInQueryString(t *testing.T) {
+func TestLoginPage_UnsafeNextInQueryString_PageStillServed(t *testing.T) {
+	// The static login page is served even when ?next= is unsafe; the JS
+	// guards client-side, and the server rejects the open redirect at POST time
+	// (tested by TestLogin_FormPost_OpenRedirect_Attempts_FallbackToDefault).
 	srv := newAuthServer(t, "hunter2")
 	h := srv.Handler()
 
@@ -1352,11 +1319,29 @@ func TestLoginPage_RejectsUnsafeNextInQueryString(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
+	// Static HTML must not contain server-rendered evil.com.
 	if contains(w.Body.String(), "evil.com") {
-		t.Error("unsafe next leaked into rendered login page")
+		t.Error("unsafe next must not appear in static login HTML")
 	}
-	if !contains(w.Body.String(), `name="next" value=""`) {
-		t.Error("expected empty hidden next field when next is unsafe")
+}
+
+// TestLoginContext_UnsafeNextDropped confirms /api/login/context silently drops
+// an unsafe next param and returns the generic title instead.
+func TestLoginContext_UnsafeNextDropped(t *testing.T) {
+	srv := newAuthServer(t, "hunter2")
+	h := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/login/context?next=%2F%2Fevil.com", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	var resp map[string]string
+	_ = json.NewDecoder(w.Body).Decode(&resp)
+	if contains(resp["title"], "evil.com") {
+		t.Errorf("unsafe next must not leak into login context title, got %q", resp["title"])
+	}
+	if !contains(resp["title"], "Sign in to dicode") {
+		t.Errorf("expected generic title when next is unsafe, got %q", resp["title"])
 	}
 }
 

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -1200,6 +1200,52 @@ func TestLogin_FormPost_MissingOrigin_Allowed(t *testing.T) {
 	}
 }
 
+// TestLogin_FormPost_DefaultPortStripped verifies that a same-origin form POST
+// is accepted when the Origin header omits the default HTTPS port but the Host
+// header retains it (common when a reverse proxy preserves the explicit-port
+// form of the Host header while the browser canonicalises Origin without it).
+func TestLogin_FormPost_DefaultPortStripped(t *testing.T) {
+	srv := newAuthServer(t, "hunter2")
+	h := srv.Handler()
+
+	form := url.Values{"password": {"hunter2"}}
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Host = "myapp:443"
+	req.Header.Set("Origin", "https://myapp") // browser omits default :443
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("same-origin with implicit port: expected 303, got %d: %s", w.Code, w.Body)
+	}
+}
+
+// TestLogin_NonForm_CrossOrigin_Rejected verifies that a non-form (text/plain)
+// POST with a cross-origin Origin header is rejected. Without this check a
+// text/plain+JSON body bypasses the CORS preflight and isFormRequest at once.
+func TestLogin_NonForm_CrossOrigin_Rejected(t *testing.T) {
+	srv := newAuthServer(t, "hunter2")
+	h := srv.Handler()
+
+	body := strings.NewReader(`{"password":"hunter2"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", body)
+	req.Header.Set("Content-Type", "text/plain") // simple CORS request, no preflight
+	req.Host = "example.com"
+	req.Header.Set("Origin", "https://evil.com")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for cross-origin text/plain POST, got %d: %s", w.Code, w.Body)
+	}
+	for _, c := range w.Result().Cookies() {
+		if c.Name == sessionCookie {
+			t.Error("session cookie must not be issued when Origin check fails")
+		}
+	}
+}
+
 func TestLogin_JSONPost_EchoesSafeNext(t *testing.T) {
 	srv := newAuthServer(t, "hunter2")
 	h := srv.Handler()

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -3,6 +3,7 @@ package webui
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -1213,11 +1214,35 @@ func TestLogin_FormPost_DefaultPortStripped(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Host = "myapp:443"
 	req.Header.Set("Origin", "https://myapp") // browser omits default :443
+	req.TLS = &tls.ConnectionState{}          // simulate HTTPS connection
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
 	if w.Code != http.StatusSeeOther {
 		t.Fatalf("same-origin with implicit port: expected 303, got %d: %s", w.Code, w.Body)
+	}
+}
+
+// TestLogin_FormPost_SchemeMismatch_Rejected verifies that Origin: http://myapp
+// is rejected when the request is served over HTTPS (r.TLS set). http and https
+// are distinct origins even on the same host; accepting a mismatched scheme
+// would let a plain-HTTP page CSRF a login endpoint that is only served via TLS.
+func TestLogin_FormPost_SchemeMismatch_Rejected(t *testing.T) {
+	srv := newAuthServer(t, "hunter2")
+	h := srv.Handler()
+
+	form := url.Values{"password": {"hunter2"}}
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Host = "myapp"
+	req.Header.Set("Origin", "http://myapp") // wrong scheme — page is HTTP, endpoint is HTTPS
+	req.TLS = &tls.ConnectionState{}         // simulate HTTPS connection
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("scheme-mismatched Origin: expected 403, got %d: %s", w.Code, w.Body)
 	}
 }
 


### PR DESCRIPTION
## Summary

Replaces the server-side-rendered login page (gorilla/csrf token + html/template) with three embedded static files and an **Origin-header CSRF check** on form POSTs.

- **Removes** ~150 lines of Go HTML/CSS string concatenation and the gorilla/csrf dependency
- **Adds** `pkg/webui/login/{index.html,style.css,login.js}` embedded in the binary via `//go:embed login`
- **Adds** `validateOrigin()` — compares the `Origin` header to `Host`; missing Origin is allowed (curl/legacy clients; `SameSite=Strict` session cookie provides backup)
- **Adds** `GET /api/login/context?next=…` JSON endpoint for the contextual task title (JS fetches this instead of server rendering it into HTML)
- On login failure: redirects to `/login?err=1&next=…` instead of re-rendering HTML with an error message

## Touched files

| File | Reason |
|---|---|
| `pkg/webui/login/index.html` | New static login page HTML |
| `pkg/webui/login/style.css` | Extracted from `loginCSS` string constant |
| `pkg/webui/login/login.js` | Populates `?next`/`?err` from URL, fetches `/api/login/context` for title |
| `pkg/webui/server.go` | Remove gorilla/csrf + template; add validateOrigin, serveLoginPage, serveLoginFile, apiLoginContext, loginErrURL; update CSP (`script-src 'self'`) |
| `pkg/webui/server_test.go` | Remove CSRF token/cookie tests; add Origin-mismatch, missing-Origin, loginContext API tests; update wrong-password test to expect redirect |
| `pkg/webui/browser_sim_test.go` | Update both browser-sim tests to use Origin header instead of CSRF token dance |
| `go.mod` / `go.sum` | Remove `github.com/gorilla/csrf` |

## Test coverage

**Unit tests only** (e2e is not applicable here — the login page interaction is a browser form submit flow that our existing e2e Playwright suite covers via the `login()` helper; this refactor preserves the `/login` URL and form structure so existing e2e scenarios continue to exercise the live path).

New/updated unit tests in `pkg/webui/`:
- `TestLogin_FormPost_OriginMismatch_Rejected` — cross-origin POST → 403
- `TestLogin_FormPost_MissingOrigin_Allowed` — no Origin header → allowed (curl/legacy)
- `TestLogin_FormPost_WrongPassword_RedirectsToLoginWithErr` — wrong password → 303 to `/login?err=1`
- `TestLoginContext_ShowsTaskNameForWebhookNext` — `/api/login/context` returns task title
- `TestLoginContext_GenericTitleForUnknownNext` — falls back to "Sign in to dicode"
- `TestLoginContext_UnsafeNextDropped` — unsafe `next` silently dropped in context API
- `TestLoginPage_UnsafeNextInQueryString_PageStillServed` — static HTML doesn't leak evil.com
- `TestLogin_FormPost_BrowserOriginHeader` — same-origin browser POST accepted; Referrer-Policy check
- `TestLogin_FormPost_OriginNull` — `Origin: null` rejected with 403

Closes #133

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvtmbWpAmDsuHc7CNFCQjh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a redesigned sign-in page with updated styling, a “Trust this browser” option, contextual page titles, and an on-page error display.
  * Added a `/api/login/context` endpoint to return the sign-in page title based on the requested destination.
* **Bug Fixes**
  * Strengthened sign-in request validation by enforcing safer Origin handling for cross-origin submissions and improving scheme/port checks.
  * Improved incorrect-password behavior to redirect back to sign-in with an error indicator (while preserving safe `next` values).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->