### PR TITLE
fix: builtin task data-dir env resolution + tray lockfile

### DIFF
--- a/.claude/agents/dicode-task-dev.md
+++ b/.claude/agents/dicode-task-dev.md
@@ -1,0 +1,60 @@
+---
+name: dicode-task-dev
+description: >
+  Use to author, modify, or debug a dicode task end-to-end — the automation
+  scripts under tasks/ (task.yaml + task.ts/task.py + task.test.ts). Dispatch it
+  when the request is "write a task that…", "add a webhook/cron task", "make this
+  task also do X", "why is this task's test failing", or "wire task A to trigger
+  task B". It knows the task.yaml schema, the SDK globals, the test harness, and
+  the validate → test → run dev loop, and it verifies its work with `dicode task
+  test` before reporting back. Not for changes to the Go engine (pkg/…) — that's
+  ordinary repo work.
+tools: Read, Write, Edit, Bash, Grep, Glob, Skill
+---
+
+You build and fix **dicode tasks** in this repository. A task is a folder under
+`tasks/` (builtins in `tasks/buildin/`, examples in `tasks/examples/`) holding a
+`task.yaml`, a runtime file (`task.ts` for Deno, `task.py` for Python, image
+config for Docker/Podman), and — required — a `task.test.ts`.
+
+## First move
+
+Load the `dicode-task-dev` skill (via the Skill tool, or Read
+`.claude/skills/dicode-task-dev/SKILL.md`). It is your schema/SDK/test reference
+and points to the canonical repo docs (`tasks/skills/dicode-task-dev.md`,
+`docs/concepts/`, `tasks/sdk.ts`). Do not work from memory of the schema — the
+permissions grammar and SDK surface are exact.
+
+## Operating procedure
+
+1. **Scope it.** Restate what the task must do, its trigger, its inputs, and
+   what external systems/secrets it touches.
+2. **Look before writing.** Read the nearest analog in `tasks/examples/` or
+   `tasks/buildin/` and match its idioms. `dicode list` shows registered tasks;
+   `dicode secrets list` shows available credentials — never invent secret names.
+3. **Write the three files** in `tasks/<source>/<task-id>/`. Declare every env
+   var / net host / fs path / spawned binary / `dicode.*` grant the code uses —
+   permissions are deny-by-default. The runtime file **must `return` a
+   JSON-serializable value**. Never hardcode a secret; never declare
+   `DICODE_SOCKET`/`DICODE_TOKEN`.
+4. **Test — the gate.** Run `dicode task test <task-id>` (or `make test-tasks`
+   for the full buildin sweep). Fix every failure. A task without a passing
+   `task.test.ts` is not done.
+5. **Exercise it** when it changes runtime behavior: `dicode run <task-id>
+   key=value …` and inspect with `dicode logs <run-id>`. If the binary/daemon
+   isn't available in this environment, say so and stop at the test gate rather
+   than fabricating a run.
+6. **Report** the task ID, the files you wrote/changed, the exact test command
+   and its real result, and any secret the operator must set before it runs
+   (`dicode secrets set <KEY> <value>`). If the approval gate is active, note
+   that the change lands pending and needs `dicode task approve <task-id>`.
+
+## Rules
+
+- Match the surrounding code's style, comment density, and idioms. Follow the
+  repo's comment convention: comment only a non-obvious WHY, never narrate
+  changes.
+- One task, one responsibility; keep return payloads small (~<1MB).
+- Report test failures with the real output. Never claim green without running.
+- Stay in `tasks/` — engine changes under `pkg/` are out of your scope; flag
+  them for the caller instead of editing them.

--- a/.claude/skills/dicode-task-dev/SKILL.md
+++ b/.claude/skills/dicode-task-dev/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: dicode-task-dev
+description: Author, modify, or debug dicode tasks — the JS/TS/Python/Docker automation scripts under tasks/ (task.yaml + task.ts + task.test.ts). Use when writing a new task, editing an existing one, adding triggers/permissions/params, wiring MCP or task chaining, or fixing a failing task test. Covers the task.yaml schema, the SDK globals (kv/log/params/env/input/output/dicode/mcp), the test harness, and the validate → test → run dev loop.
+---
+
+# dicode Task Development
+
+dicode is a single Go binary that watches a source of automation scripts ("tasks") and runs them on cron / webhook / manual / chain / daemon triggers. A **task is a folder** holding a `task.yaml` (metadata, trigger, permissions, params) and a runtime file (`task.ts` for Deno, `task.py` for Python, image config for Docker/Podman), plus an optional `task.test.ts`. The reconciler hot-reloads tasks — no daemon restart after an edit.
+
+Tasks live under `tasks/` in this repo: builtins in `tasks/buildin/`, examples in `tasks/examples/`. IDs are namespaced by source, e.g. `buildin/ai-agent`, `examples/github-stars`.
+
+## The authoritative references (read these for depth)
+
+The long-form, canonical developer skill and concept docs already exist in this repo. Read them rather than guessing:
+
+- `tasks/skills/dicode-task-dev.md` — full schema, every SDK global, the complete test-harness API, taskset precedence. **This is the source of truth; this SKILL.md is the quick index.**
+- `tasks/skills/dicode-basics.md` — mental model of tasks/triggers/KV/permissions.
+- `tasks/skills/dicode-auto-fix.md` — the on-failure auto-fix loop workflow.
+- `docs/concepts/task-format.md`, `docs/deno-runtime.md`, `docs/python-runtime.md`, `docs/podman-runtime.md`, `docs/webhooks.md` — runtime + trigger detail.
+- `tasks/sdk.ts` — the actual TypeScript SDK surface; `pkg/runtime/deno/sdk/shim.ts` and `pkg/runtime/python/sdk/dicode_sdk.py` are the runtime-authoritative shapes.
+- `tasks/examples/*` — working tasks to copy patterns from.
+
+## Dev loop (follow in order)
+
+1. **Look before writing.** `dicode list` (or MCP `list_tasks`) to avoid duplicating an existing task; skim a sibling in `tasks/examples/` for style.
+2. **Know the secrets.** `dicode secrets list` — never invent credentials; declare what exists under `permissions.env`.
+3. **Write the three files** in `tasks/<source>/<task-id>/`:
+   - `task.yaml` — trigger, permissions, params (see schema below)
+   - `task.ts` (Deno) or `task.py` (Python) — logic; **must `return` a JSON-serializable value** so chain triggers can consume it
+   - `task.test.ts` — required; a task without tests should not ship
+4. **Test.** `dicode task test <task-id>` for one task, or `make test-tasks` to run every buildin task's `task.test.ts` through Deno. Fix all failures before proceeding. Add `--format=junit|gh-summary` for CI output.
+5. **Exercise it.** `dicode run <task-id> key=value ...` triggers a real run and waits for the result; `dicode logs <run-id>` and `dicode status <task-id>` inspect it.
+6. Commit only when tests pass. If the approval gate is on, a changed task lands **pending** — `dicode task approve <task-id>` to release it.
+
+The daemon can also drive an AI author: `dicode task create <name> [--ai "PROMPT"]`, iterate with `dicode task edit <task-id> "<prompt>"`, persist with `dicode task save <session-id>`. `dicode ai "<prompt>"` runs the configured agent task directly.
+
+## task.yaml schema (essentials)
+
+```yaml
+apiVersion: dicode/v1
+kind: Task
+name: <kebab-case-id>            # matches the directory name
+description: <what it does>
+runtime: deno                    # deno (default) | python | docker | podman
+trigger:                         # exactly ONE of:
+  cron: "0 9 * * *"              #   5-field cron
+  webhook: /hooks/<path>         #   HTTP POST; open unless guarded (below)
+  manual: true                   #   UI/API/CLI only
+  chain: { from: <task-id>, on: success }   # success | failure | always
+  daemon: true                   #   starts on boot, restarts on exit
+permissions:                     # deny-by-default allowlist — nothing implicit
+  env:                           # env the script may read:
+    - SLACK_TOKEN                #   bare: pass through host env, same name
+    - { name: API_KEY, from: GH_TOKEN }        # rename from host env
+    - { name: DB_PASS, secret: db_password }   # resolve from secrets store
+    - { name: LOG_LEVEL, value: "info" }       # literal
+  net: ["api.github.com"]        # Deno only; omit = unrestricted; [] = deny all
+  fs:  [{ path: ~/data, permission: rw }]      # r | w | rw
+  run: ["curl"]                  # spawnable binaries; ["*"] = all
+  dicode:                        # dicode runtime API — all denied by default
+    tasks: ["*"]                 #   task IDs callable via dicode.run_task()
+    mcp: ["github-mcp"]          #   daemon MCP task IDs for mcp.call()
+    list_tasks: true
+    get_runs: true
+    secrets_write: true          #   write-only; tasks can never read secrets back
+params:
+  slack_channel: { type: string, default: "#general" }
+timeout: 60s
+mcp_exposed: false               # true → visible/invokable via the MCP server
+on_failure_chain: <task-id>      # run on failure; "" disables global default
+```
+
+**Guarded webhooks:** add `webhook_secret: "${WEBHOOK_SECRET}"` (HMAC `X-Hub-Signature-256`, GitHub-compatible, 403 on bad sig) or `auth: true` (require a dicode session). Always reference a secret via `"${VAR}"`, never a raw value.
+
+## SDK globals (Deno; Python module `dicode` mirrors most)
+
+- `fetch` — native, for HTTP (Deno). Python uses stdlib (`urllib`/`requests`).
+- `kv.set/get/delete` — persistent, per-task namespace, JSON-serializable values.
+- `log.info/warn/error(msg, ctx?)` — structured, streamed to the WebUI run log.
+- `params.<name>` — typed inputs from `task.yaml`.
+- `await env.get("VAR")` — only vars declared in `permissions.env`; else `null`.
+- `input` — chain: upstream return value; webhook: parsed POST body.
+- `output.html()/text()` — render UI instead of returning JSON.
+- `await dicode.run_task(id, params?)` / `list_tasks()` / `get_runs(id, opts)` / `secrets_set()/secrets_delete()` — gated by `permissions.dicode`.
+- `await mcp.list_tools(server)` / `mcp.call(server, tool, args)` — gated by `permissions.dicode.mcp`.
+- `return <json>` — value handed to downstream chain tasks; keep it under ~1MB.
+
+## Test harness (`task.test.ts`)
+
+Each `test()` gets fresh mock state. Arrange mocks → `await runTask()` → assert.
+
+```typescript
+test("happy path", async () => {
+  http.mock("GET", "https://api.example.com/*", { status: 200, body: { items: [1, 2] } })
+  env.set("SLACK_TOKEN", "xoxb-test")
+  params.set("slack_channel", "#test")
+  const result = await runTask()
+  assert.equal(result.count, 2)
+  assert.httpCalledWith("POST", "https://slack.com/api/chat.postMessage", { body: { channel: "#test" } })
+})
+```
+
+Globals: `test`, `runTask`, `http.mock/mockOnce`, `env.set`, `params.set`, `kv.set`, `assert.equal/ok/throws/httpCalled/httpCalledWith/httpNotCalled`.
+
+## Hard rules
+
+- **Never commit** with a failing `task.yaml` parse or failing tests.
+- **Always write `task.test.ts`.**
+- **`return` must be JSON-serializable** (required for chaining).
+- **Never hardcode secrets** — inject via `permissions.env`, read with `env.get()`.
+- **Never declare `DICODE_SOCKET` or `DICODE_TOKEN`** in `permissions.env` — internal IPC vars injected automatically; declaring them leaks the token to task code.
+- **One task, one responsibility.** Keep output small — tasks are not a data pipeline.
+
+## MCP access (optional, when the daemon is running)
+
+`dicode mcp install` mints an API key and wires the server into Claude Code (`http://localhost:8080/mcp`). Implemented tools: `list_tasks`, `get_task(id)`, `run_task(id, params?)`, `list_sources`, `switch_dev_mode(source, enabled, local_path?)`. Only tasks with `mcp_exposed: true` are listed/invokable. When the daemon isn't up, drive the loop with the `dicode` CLI + file edits instead.

--- a/dicode.lock
+++ b/dicode.lock
@@ -1,0 +1,163 @@
+# dicode.lock — approval records, managed by the dicode daemon.
+# Trust policy lives in dicode.yaml (approval:); this file records which
+# content hash of each task is approved to run.
+version: 3
+mac: 6eefb06e8018419e654be6903dcea9d0a574b433c445ac08d66d782b5c5bc4d5
+bootstrapped: true
+tasks:
+    auth/openrouter-oauth:
+        hash: 501b2cd05ce778b468903ddcc05a32c9bedcc1676802be9e5bcda63f96915f0c
+        approved_at: 2026-07-02T09:07:15.281541237Z
+        approved_by: bootstrap
+    buildin/ai-agent:
+        hash: 85bc019ac2e40c59f577c7d6c9c19cd4b83f69374093d80e1e9b4b6dc572cd7c
+        approved_at: 2026-07-02T09:07:15.394961092Z
+        approved_by: builtin
+    buildin/ai-agent-claude-cli:
+        hash: 0cf6871e66eff500e305d4b9f21ee70c18124f04fb016db0040a968d5ebd87f6
+        approved_at: 2026-07-02T09:07:15.359919297Z
+        approved_by: builtin
+    buildin/alert:
+        hash: 6822b5eca7553e99527e45b6ff690e4051b814fc50977b542d89822729640606
+        approved_at: 2026-07-02T09:07:15.33118597Z
+        approved_by: builtin
+    buildin/audit-export-loki:
+        hash: c3d123758ca468ca05471c83e0c99ccc4787924cd38ac6dd03c4fb3d7c7ef173
+        approved_at: 2026-07-02T09:07:15.360436473Z
+        approved_by: builtin
+    buildin/auth-providers:
+        hash: 5c1262965c415909231eab1ba7445539470bd69de3ac0a2848b1aee5e2ebcdfb
+        approved_at: 2026-07-02T09:07:15.333250214Z
+        approved_by: builtin
+    buildin/auth-relay:
+        hash: 9faa69c18f1c59dd8153184b80a2ee309456b4b4e5bc45f6a47b55039b851b70
+        approved_at: 2026-07-02T09:07:15.332651577Z
+        approved_by: builtin
+    buildin/auth-start:
+        hash: 9bf4887696e075cdcd127ba783955bec76ac588b717d1912c9f4059b6357a3e6
+        approved_at: 2026-07-02T09:07:15.394045781Z
+        approved_by: builtin
+    buildin/auto-fix:
+        hash: 1061e6f20078df67d0e6dc4ef0ddb2cc252b0b20fd19ca3c3b4a3cb68a583af3
+        approved_at: 2026-07-02T09:07:15.33226987Z
+        approved_by: builtin
+    buildin/blob-storage:
+        hash: 692a3b22df0b1b158b46a41685ee15e1a3aaf46239e74765a7e095be2b0636b7
+        approved_at: 2026-07-02T09:07:15.333663644Z
+        approved_by: builtin
+    buildin/dev-clones-cleanup:
+        hash: da558d3b377be377bebbd099eed72d01fe617bfa934fa931d7742d6d1be95bdc
+        approved_at: 2026-07-02T10:41:49.651880632Z
+        approved_by: builtin
+    buildin/dicodai:
+        hash: 2ba64e4086a88876cf538999d50d38b0d267c1c9c557748ab2bd679b0da9ad93
+        approved_at: 2026-07-02T09:07:15.330145022Z
+        approved_by: builtin
+    buildin/git-pr:
+        hash: aee1e0a2f09d5558015a42d93c2dc3800ee9795e1394e8d1a306b247455924b1
+        approved_at: 2026-07-02T10:42:25.884439851Z
+        approved_by: builtin
+    buildin/local-storage:
+        hash: d4583cb13a63fa26f58a2d384e33714559805f213d65e44bc6c7e74068db4474
+        approved_at: 2026-07-02T09:07:15.394465401Z
+        approved_by: builtin
+    buildin/mcp:
+        hash: 18bd9229c1e236415385b7db588884589e9fb37ed3ec71ee7139dacb2e26c8ea
+        approved_at: 2026-07-02T09:07:15.331488403Z
+        approved_by: builtin
+    buildin/notifications:
+        hash: 138d62bc2002a3da8315701d18df4e09bf99927a546b27c5f220ffe652d2c3e1
+        approved_at: 2026-07-02T09:07:15.331877009Z
+        approved_by: builtin
+    buildin/relay-client:
+        hash: 5751ad01d3518e0d51d4af993686ff6858183ed69ed962078bf0dd523cd8b97d
+        approved_at: 2026-07-02T09:07:15.334021158Z
+        approved_by: builtin
+    buildin/relay-server:
+        hash: 4aecc918a09df6991bc6b38aabe76aad68b6248ca990d5bdf82582fb2b5e93e6
+        approved_at: 2026-07-02T09:07:15.330844959Z
+        approved_by: builtin
+    buildin/relay-server-body:
+        hash: 067f7d3aabf5bbc38c678ce163cfe98c48a7ef2cbf0615cc28bc9fd84298280c
+        approved_at: 2026-07-02T09:07:15.307239059Z
+        approved_by: builtin
+    buildin/run-inputs-cleanup:
+        hash: 94caa86483c009edd09249153b02469bd204ffa5f1d41b12d0c612a2693c76d4
+        approved_at: 2026-07-02T09:07:15.385113774Z
+        approved_by: builtin
+    buildin/secret-providers/doppler:
+        hash: db5df1c382f6aa407713f4338d56372ab883afbe5540bd9d3cf9420e3d494a28
+        approved_at: 2026-07-02T09:07:15.330530914Z
+        approved_by: builtin
+    buildin/temp-cleanup:
+        hash: 79d510c850e5c5d94efcea2d07f351f03aec32a9484df35917e33ac86495196b
+        approved_at: 2026-07-02T10:16:26.444857551Z
+        approved_by: builtin
+    buildin/tray:
+        hash: c10e8a6502f508a06719578b7620dd24a59431ffc8cce2f3c2c98c64c8e1962e
+        approved_at: 2026-07-02T09:07:15.368908107Z
+        approved_by: builtin
+    buildin/webui:
+        hash: 19cc481b2df27573f7f21efbfc4a380a0c5c4523e7e25fb8837ec9879c65a62b
+        approved_at: 2026-07-02T09:07:15.393563015Z
+        approved_by: builtin
+    examples/ai-agent-groq:
+        hash: df4833976e96834b32a98b29255dce4f9db5586adedf42c8c4bc01e182ca75f4
+        approved_at: 2026-07-02T09:07:15.290345575Z
+        approved_by: bootstrap
+    examples/ai-agent-ollama:
+        hash: 339521980349d9aa0824ec22a77a9af971e7c1e694a62b8158d43aef39a46874
+        approved_at: 2026-07-02T09:07:15.282779846Z
+        approved_by: bootstrap
+    examples/ai-agent-openai:
+        hash: 16cc21b04c0a5cd4520e9b9a00a0944fe41c80274543674f39e829a2472fa572
+        approved_at: 2026-07-02T09:07:15.283016285Z
+        approved_by: bootstrap
+    examples/ai-agent-openrouter:
+        hash: 931bf4c3f5f5bce8b27ec0d0a3929dc8b46957897245a4a3fc878f5046d382b3
+        approved_at: 2026-07-02T09:07:15.281839797Z
+        approved_by: bootstrap
+    examples/github-push-webhook:
+        hash: 042d5cb37ab5326b9c47391dd4c1061a2000ac6ecf8c8db32f6cc3c669977f0d
+        approved_at: 2026-07-02T09:07:15.282367242Z
+        approved_by: bootstrap
+    examples/github-stars:
+        hash: ecc1c17a1e1599d029daec1cb11da7511c22c21db053ecb7bbf15a11184c9e25
+        approved_at: 2026-07-02T09:07:15.306185076Z
+        approved_by: bootstrap
+    examples/github-stars-hook:
+        hash: f7642f5b1dcf20d04516533389480116a7581e6d6d99065c2eda561c66eae78b
+        approved_at: 2026-07-02T09:07:15.306874824Z
+        approved_by: bootstrap
+    examples/hello-cron:
+        hash: aeeda0e9ea19b87ed5800412b5dbdd740bd65c1a853ac0ff071f60006f75a413
+        approved_at: 2026-07-02T09:07:15.283189634Z
+        approved_by: bootstrap
+    examples/hello-docker:
+        hash: 80b161052b274be2633570162d6f1feadd1b7a0794630104716da13372bd2d74
+        approved_at: 2026-07-02T09:07:15.282053725Z
+        approved_by: bootstrap
+    examples/hello-podman:
+        hash: f72dee3de203ee4328fd8329ffdd0eeb1ec2d3713b5cac713ce5680cafaf9f33
+        approved_at: 2026-07-02T09:07:15.291108428Z
+        approved_by: bootstrap
+    examples/hello-python:
+        hash: 4f068e33e591e315cbf752822a0c2f56531764d810a45df936e1d762765e083b
+        approved_at: 2026-07-02T09:07:15.291407461Z
+        approved_by: bootstrap
+    examples/hello-webhook:
+        hash: bb9a75f383f35911720b7e1235aff9a29dec0c09686b8639ecea13b23bc98662
+        approved_at: 2026-07-02T09:07:15.28252865Z
+        approved_by: bootstrap
+    examples/nginx-start:
+        hash: 3b1f3671c37296df1a04c421ab75cf78d2fbccdf9c5afc579497a22126d830d0
+        approved_at: 2026-07-02T09:07:15.291692639Z
+        approved_by: bootstrap
+    examples/webhook-dashboard:
+        hash: 17581bd70138220edfef57e04df50cfbfbafaf66c7cade7d2322c143b748cfa8
+        approved_at: 2026-07-02T09:07:15.29079005Z
+        approved_by: bootstrap
+    examples/webhook-form:
+        hash: dc129c812154c28551913cc63ed6a9bc861c06a766bf903e86ac8509a2edfebd
+        approved_at: 2026-07-02T09:07:15.282221072Z
+        approved_by: bootstrap

--- a/pkg/runtime/envresolve/resolver.go
+++ b/pkg/runtime/envresolve/resolver.go
@@ -124,8 +124,15 @@ func (r *Resolver) Resolve(ctx context.Context, spec *task.Spec) (*Resolved, err
 				optional:  e.Optional,
 			})
 		case task.FromKindEnv:
+			// Inject only when the source var is actually set. os.Getenv
+			// returns "" for an unset var, and an explicitly-empty value
+			// defeats a task's own `?? default` fallback (JS/TS `??` triggers
+			// on null/undefined, not ""). Leaving it absent — as the bare
+			// passthrough in SubprocessEnv does — lets the fallback apply.
 			if target != "" {
-				out.Env[e.Name] = os.Getenv(target)
+				if v, ok := os.LookupEnv(target); ok {
+					out.Env[e.Name] = v
+				}
 			}
 			// fully bare → no injection (allowlist only); leave unset.
 		}

--- a/pkg/runtime/envresolve/resolver_test.go
+++ b/pkg/runtime/envresolve/resolver_test.go
@@ -3,6 +3,7 @@ package envresolve
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -179,6 +180,30 @@ func TestResolve_BarePrefixIsHostEnv(t *testing.T) {
 	}
 	if _, ok := got.Secrets["FOO"]; ok {
 		t.Errorf("host-env values must NOT be flagged secret")
+	}
+}
+
+func TestResolve_UnsetHostEnvIsAbsentNotEmpty(t *testing.T) {
+	t.Setenv("PRESENT_HOST_VAR", "set")
+	if err := os.Unsetenv("MISSING_HOST_VAR"); err != nil {
+		t.Fatal(err)
+	}
+	r := New(&fakeRegistry{}, secrets.Chain{}, nil)
+	consumer := newSpec("consumer", []task.EnvEntry{
+		{Name: "PRESENT", From: "PRESENT_HOST_VAR"},
+		{Name: "MISSING", From: "MISSING_HOST_VAR"},
+	})
+	got, err := r.Resolve(context.Background(), consumer)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Env["PRESENT"] != "set" {
+		t.Errorf("PRESENT = %q, want %q", got.Env["PRESENT"], "set")
+	}
+	// An unset source must leave the entry absent, not injected as "".
+	// An explicit "" would defeat a task's `?? default` fallback.
+	if v, ok := got.Env["MISSING"]; ok {
+		t.Errorf("unset source injected %q; want absent", v)
 	}
 }
 

--- a/tasks/buildin/dev-clones-cleanup/task.test.ts
+++ b/tasks/buildin/dev-clones-cleanup/task.test.ts
@@ -5,11 +5,11 @@
  *
  * Tests use real temp directories so Deno.readDir / Deno.remove are exercised
  * without mocking (--allow-all is passed by the make target). The
- * DICODE_DATA_DIR env var is intercepted via the sdk-test harness so task.ts
+ * DICODE_DATADIR env var is intercepted via the sdk-test harness so task.ts
  * picks up the test-specific tmpdir.
  *
- * The task constructs its root as ${DICODE_DATA_DIR}/dev-clones. Tests set
- * DICODE_DATA_DIR to a tmpdir that acts as the mock data-dir, then create
+ * The task constructs its root as ${DICODE_DATADIR}/dev-clones. Tests set
+ * DICODE_DATADIR to a tmpdir that acts as the mock data-dir, then create
  * the dev-clones sub-tree inside it.
  */
 import { setupHarness } from "../../sdk-test.ts";
@@ -43,7 +43,7 @@ async function listCloneDirs(dataDir: string): Promise<string[]> {
 }
 
 test("removes orphan clones, keeps active run", async () => {
-  // dataDir acts as the mock DICODE_DATA_DIR; the task appends /dev-clones.
+  // dataDir acts as the mock DICODE_DATADIR; the task appends /dev-clones.
   const dataDir = await Deno.makeTempDir({ prefix: "dc-cleanup-test-" });
   try {
     await makeCloneTree(dataDir, [
@@ -52,7 +52,7 @@ test("removes orphan clones, keeps active run", async () => {
       { source: "myrepo",  runID: "run-orphan-2" },
     ]);
 
-    env.set("DICODE_DATA_DIR", dataDir);
+    env.set("DICODE_DATADIR", dataDir);
 
     // Stub list_tasks: return a single task; get_runs returns runs for it.
     dicode.list_tasks = async () => [{ id: "my-task" }];
@@ -81,7 +81,7 @@ test("returns early with note when dev-clones dir does not exist", async () => {
   const dataDir = await Deno.makeTempDir({ prefix: "dc-cleanup-ne-" });
   // Do NOT create dev-clones under it — task should detect NotFound.
 
-  env.set("DICODE_DATA_DIR", dataDir);
+  env.set("DICODE_DATADIR", dataDir);
 
   dicode.list_tasks = async () => [{ id: "some-task" }];
   dicode.get_runs = async () => [];
@@ -106,7 +106,7 @@ test("swallows get_runs error for task deregistered between list and get", async
       { source: "s1", runID: "run-xyz" },
     ]);
 
-    env.set("DICODE_DATA_DIR", dataDir);
+    env.set("DICODE_DATADIR", dataDir);
 
     // list_tasks returns a task, but get_runs throws (task deregistered between calls).
     dicode.list_tasks = async () => [{ id: "disappearing-task" }];
@@ -132,7 +132,7 @@ test("non-directory entries under source dir are ignored", async () => {
     await Deno.writeTextFile(`${dataDir}/dev-clones/mysource/not-a-run.txt`, "stale file");
     await Deno.mkdir(`${dataDir}/dev-clones/mysource/real-run`, { recursive: true });
 
-    env.set("DICODE_DATA_DIR", dataDir);
+    env.set("DICODE_DATADIR", dataDir);
     dicode.list_tasks = async () => [{ id: "some-task" }];
     dicode.get_runs = async () => [];
 

--- a/tasks/buildin/dev-clones-cleanup/task.ts
+++ b/tasks/buildin/dev-clones-cleanup/task.ts
@@ -6,10 +6,8 @@
 // layout are left alone.
 //
 // Path resolution (in preference order):
-//   1. DICODE_DATA_DIR env var (injected via permissions.env; covers Docker
-//      deployments with a non-default data_dir)
-//   2. params.dev_clones_root (defaults to ${HOME}/.dicode/dev-clones at
-//      load time via the built-in HOME template variable)
+//   1. DICODE_DATADIR env var (the resolved data_dir the daemon exports)
+//   2. params.dev_clones_root (defaults to ${DATADIR}/dev-clones at load time)
 
 interface Run {
   ID: string;
@@ -35,15 +33,15 @@ async function collectActiveRunIDs(dicode: Dicode): Promise<Set<string>> {
 }
 
 export default async function main({ params, dicode }: DicodeSdk): Promise<unknown> {
-  // Prefer the DICODE_DATA_DIR env var (set in Docker / explicit deploys) so we
-  // always operate on the actual data directory regardless of the ~/.dicode default.
-  const dataEnv = Deno.env.get("DICODE_DATA_DIR");
+  // The daemon exports the resolved data dir as DICODE_DATADIR, so we always
+  // operate on the actual data directory regardless of the ~/.dicode default.
+  const dataEnv = Deno.env.get("DICODE_DATADIR");
   const root = dataEnv
     ? `${dataEnv}/dev-clones`
     : (await params.get("dev_clones_root")) ?? "";
 
   if (!root) {
-    dicode.log?.error?.("could not determine dev-clones root — DICODE_DATA_DIR unset and dev_clones_root param empty");
+    dicode.log?.error?.("could not determine dev-clones root — DICODE_DATADIR unset and dev_clones_root param empty");
     return { ok: false, error: "dev_clones_root unset" };
   }
 

--- a/tasks/buildin/dev-clones-cleanup/task.yaml
+++ b/tasks/buildin/dev-clones-cleanup/task.yaml
@@ -15,36 +15,22 @@ trigger:
 params:
   dev_clones_root:
     type: string
-    # ${HOME} is a built-in template variable expanded at spec-load time.
-    # task.ts also reads DICODE_DATA_DIR (injected via permissions.env) and
-    # prefers it over this default — Docker deployments (ENV DICODE_DATA_DIR=/data)
-    # therefore use the correct path without any configuration.
-    default: "${HOME}/.dicode/dev-clones"
+    # task.ts prefers the DICODE_DATADIR env var over this default; this only
+    # applies when the var is somehow absent.
+    default: "${DATADIR}/dev-clones"
     description: >
       Root directory containing per-fix clone dirs
-      (layout: <root>/<sourceName>/<runID>/). Defaults to the standard
-      ~/.dicode/dev-clones location. Override if your daemon uses a
-      non-standard data_dir and DICODE_DATA_DIR is not set in the env.
+      (layout: <root>/<sourceName>/<runID>/). Defaults to the resolved
+      data_dir's dev-clones location.
 
 permissions:
   fs:
-    # Cover the default ~/.dicode/dev-clones path. The ${HOME} variable is
-    # always expanded at load time.
-    - path: "${HOME}/.dicode/dev-clones"
-      permission: rw
-    # Also cover ${DICODE_DATA_DIR}/dev-clones for non-default data-dir
-    # deployments (e.g. Docker with ENV DICODE_DATA_DIR=/data). This entry
-    # expands via envFallback at load time; if DICODE_DATA_DIR is unset in
-    # the daemon process it stays literal and acts as a harmless no-op.
-    - path: "${DICODE_DATA_DIR}/dev-clones"
+    # ${DATADIR} expands at load time to the resolved data_dir, covering both
+    # the default ~/.dicode and non-standard / Docker deployments.
+    - path: "${DATADIR}/dev-clones"
       permission: rw
   env:
-    # Inject DICODE_DATA_DIR so task.ts can compute the correct root path
-    # regardless of the compiled-in default. Value is the daemon process's
-    # DICODE_DATA_DIR env var; empty string if not set (task.ts falls back
-    # to the params.dev_clones_root default).
-    - name: DICODE_DATA_DIR
-      from: DICODE_DATA_DIR
+    - DICODE_DATADIR
   dicode:
     list_tasks: true
     get_runs: true

--- a/tasks/buildin/git-pr/task.test.ts
+++ b/tasks/buildin/git-pr/task.test.ts
@@ -21,7 +21,7 @@ echo "https://github.com/example/repo/pull/123"
     const cloneRoot = `${dataDir}/dev-clones/user-tasks`;
     const cloneDir = `${cloneRoot}/run-123`;
     await Deno.mkdir(cloneDir, { recursive: true });
-    Deno.env.set("DICODE_DATA_DIR", dataDir);
+    Deno.env.set("DICODE_DATADIR", dataDir);
 
     try {
         const result = await main({
@@ -43,7 +43,7 @@ echo "https://github.com/example/repo/pull/123"
 
 Deno.test("git-pr: rejects path-traversal source_id", async () => {
     Deno.env.set("GH_TOKEN", "stub-token");
-    Deno.env.set("DICODE_DATA_DIR", await Deno.makeTempDir());
+    Deno.env.set("DICODE_DATADIR", await Deno.makeTempDir());
     const result = await main({
         params: new Map(Object.entries({
             source_id: "../../etc",
@@ -61,7 +61,7 @@ Deno.test("git-pr: rejects path-traversal source_id", async () => {
 
 Deno.test("git-pr: refuses to run without GH_TOKEN", async () => {
     Deno.env.delete("GH_TOKEN");
-    Deno.env.set("DICODE_DATA_DIR", await Deno.makeTempDir());
+    Deno.env.set("DICODE_DATADIR", await Deno.makeTempDir());
     const result = await main({
         params: new Map(Object.entries({
             source_id: "user-tasks",
@@ -80,7 +80,7 @@ Deno.test("git-pr: refuses to run without GH_TOKEN", async () => {
 Deno.test("git-pr: rejects clone_path outside dev-clones", async () => {
     Deno.env.set("GH_TOKEN", "stub-token");
     const dataDir = await Deno.makeTempDir();
-    Deno.env.set("DICODE_DATA_DIR", dataDir);
+    Deno.env.set("DICODE_DATADIR", dataDir);
     const result = await main({
         params: new Map(Object.entries({
             source_id: "user-tasks",
@@ -113,7 +113,7 @@ exit 1
     const cloneRoot = `${dataDir}/dev-clones/user-tasks`;
     const cloneDir = `${cloneRoot}/run-456`;
     await Deno.mkdir(cloneDir, { recursive: true });
-    Deno.env.set("DICODE_DATA_DIR", dataDir);
+    Deno.env.set("DICODE_DATADIR", dataDir);
 
     try {
         const result = await main({
@@ -130,7 +130,7 @@ exit 1
 
 Deno.test("git-pr: hard-fails when clone_path is omitted", async () => {
     Deno.env.set("GH_TOKEN", "stub-token");
-    Deno.env.set("DICODE_DATA_DIR", await Deno.makeTempDir());
+    Deno.env.set("DICODE_DATADIR", await Deno.makeTempDir());
     const result = await main({
         params: new Map(Object.entries({
             source_id: "user-tasks",

--- a/tasks/buildin/git-pr/task.ts
+++ b/tasks/buildin/git-pr/task.ts
@@ -35,7 +35,7 @@ export default async function main(opts: { params: Map<string, string> }) {
         return { ok: false, error: "clone_path is required; pass the path returned by dicode.sources.set_dev_mode" };
     }
 
-    const rawDataDir = Deno.env.get("DICODE_DATA_DIR");
+    const rawDataDir = Deno.env.get("DICODE_DATADIR");
     const home = Deno.env.get("HOME");
     // Normalize trailing slashes so the prefix check matches Go's filepath.Join output.
     const dataDir = rawDataDir
@@ -44,7 +44,7 @@ export default async function main(opts: { params: Map<string, string> }) {
             ? home.replace(/\/+$/, "") + "/.dicode"
             : null;
     if (!dataDir) {
-        return { ok: false, error: "DICODE_DATA_DIR or HOME must be set" };
+        return { ok: false, error: "DICODE_DATADIR or HOME must be set" };
     }
     const cloneRoot = `${dataDir}/dev-clones/${sourceID}`;
 

--- a/tasks/buildin/git-pr/task.yaml
+++ b/tasks/buildin/git-pr/task.yaml
@@ -27,8 +27,7 @@ permissions:
   env:
     - name: GH_TOKEN
       from: GH_TOKEN_AUTOFIX
-    - name: DICODE_DATA_DIR
-      from: DICODE_DATA_DIR
+    - DICODE_DATADIR
     - HOME
   fs:
     - path: "${DATADIR}/dev-clones"

--- a/tasks/buildin/temp-cleanup/task.ts
+++ b/tasks/buildin/temp-cleanup/task.ts
@@ -1,5 +1,5 @@
 // Deletes orphaned task temp files from /tmp AND orphaned per-task
-// scratch directories from ${DICODE_DATA_DIR}/tmp/.
+// scratch directories from ${DATADIR}/tmp/.
 //
 // 1. /tmp file sweep — each dicode runtime writes its wrapper to a file
 //    named  dicode-<kind>-<runID>__<rand>.<ext>  (where <kind> is one
@@ -10,7 +10,7 @@
 //    runs. Files whose name does not match the expected shape are
 //    left alone.
 //
-// 2. ${DICODE_DATA_DIR}/tmp/<task>/<uuid>/ directory sweep — tasks like
+// 2. ${DATADIR}/tmp/<task>/<uuid>/ directory sweep — tasks like
 //    buildin/ai-agent-claude-cli mkdir a per-invocation workdir at
 //    ${DATADIR}/tmp/<task-name>/<uuid>/ and run a subprocess with cwd
 //    pointing there (the .claude/ project-local config goes inside).
@@ -65,35 +65,37 @@ async function collectRunningRunIDs(dicode: Dicode): Promise<Set<string>> {
 }
 
 // sweepDataDirTmp removes per-invocation scratch directories under
-// ${DICODE_DATA_DIR}/tmp/<task>/<uuid>/ that are older than DIR_TTL_MS.
+// ${DATADIR}/tmp/<task>/<uuid>/ that are older than DIR_TTL_MS.
 // Returns counters for logging.
 async function sweepDataDirTmp(): Promise<{ scanned: number; deleted: number; skipped: number }> {
-  const dataDir = Deno.env.get("DICODE_DATA_DIR") ??
+  // `||` (not `??`) so a declared-but-unset entry arriving as "" falls back
+  // rather than resolving root to "/tmp" and sweeping the whole system temp.
+  const dataDir = Deno.env.get("DICODE_DATADIR") ||
                   `${Deno.env.get("HOME") ?? "/root"}/.dicode`;
   const root = `${dataDir}/tmp`;
   const cutoff = Date.now() - DIR_TTL_MS;
   let scanned = 0, deleted = 0, skipped = 0;
 
-  let taskDirs: AsyncIterable<Deno.DirEntry>;
-  try {
-    taskDirs = Deno.readDir(root);
-  } catch (_) {
-    // Root doesn't exist yet (no tasks have created scratch dirs) —
-    // nothing to do, not an error.
-    return { scanned, deleted, skipped };
+  // Deno.readDir is lazy: NotFound (root absent) and PermissionDenied (an
+  // unreadable subtree) surface while iterating, not at the call, so a
+  // try/catch around the call alone lets them escape as an uncaught rejection.
+  // Drain eagerly inside the guard instead.
+  async function listDir(dir: string): Promise<Deno.DirEntry[]> {
+    const out: Deno.DirEntry[] = [];
+    try {
+      for await (const e of Deno.readDir(dir)) out.push(e);
+    } catch (e) {
+      if (!(e instanceof Deno.errors.NotFound)) {
+        console.warn("temp-cleanup: readDir", dir, String(e));
+      }
+    }
+    return out;
   }
 
-  for await (const taskEntry of taskDirs) {
+  for (const taskEntry of await listDir(root)) {
     if (!taskEntry.isDirectory) continue;
     const taskRoot = `${root}/${taskEntry.name}`;
-    let leaves: AsyncIterable<Deno.DirEntry>;
-    try {
-      leaves = Deno.readDir(taskRoot);
-    } catch (e) {
-      console.warn("temp-cleanup: readDir", taskRoot, String(e));
-      continue;
-    }
-    for await (const leaf of leaves) {
+    for (const leaf of await listDir(taskRoot)) {
       if (!leaf.isDirectory) continue;
       const path = `${taskRoot}/${leaf.name}`;
       scanned++;

--- a/tasks/buildin/temp-cleanup/task.yaml
+++ b/tasks/buildin/temp-cleanup/task.yaml
@@ -26,8 +26,7 @@ permissions:
     - path: "${DATADIR}/tmp"
       permission: rw
   env:
-    - name: DICODE_DATA_DIR
-      from: DICODE_DATA_DIR
+    - DICODE_DATADIR
     - HOME
   dicode:
     list_tasks: true

--- a/tasks/deno.lock
+++ b/tasks/deno.lock
@@ -724,6 +724,7 @@
     }
   },
   "remote": {
+    "https://deno.land/std@0.201.0/encoding/base64.ts": "144ae6234c1fbe5b68666c711dc15b1e9ee2aef6d42b3b4345bf9a6c91d70d0d",
     "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
     "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
     "https://deno.land/std@0.224.0/assert/assert_almost_equals.ts": "9e416114322012c9a21fa68e187637ce2d7df25bcbdbfd957cd639e65d3cf293",
@@ -756,6 +757,34 @@
     "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
     "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
     "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
-    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e"
+    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e",
+    "https://deno.land/std@0.97.0/_util/assert.ts": "2f868145a042a11d5ad0a3c748dcf580add8a0dbc0e876eaa0026303a5488f58",
+    "https://deno.land/std@0.97.0/_util/os.ts": "e282950a0eaa96760c0cf11e7463e66babd15ec9157d4c9ed49cc0925686f6a7",
+    "https://deno.land/std@0.97.0/encoding/base64.ts": "eecae390f1f1d1cae6f6c6d732ede5276bf4b9cd29b1d281678c054dc5cc009e",
+    "https://deno.land/std@0.97.0/encoding/hex.ts": "f952e0727bddb3b2fd2e6889d104eacbd62e92091f540ebd6459317a61932d9b",
+    "https://deno.land/std@0.97.0/fs/_util.ts": "f2ce811350236ea8c28450ed822a5f42a0892316515b1cd61321dec13569c56b",
+    "https://deno.land/std@0.97.0/fs/ensure_dir.ts": "b7c103dc41a3d1dbbb522bf183c519c37065fdc234831a4a0f7d671b1ed5fea7",
+    "https://deno.land/std@0.97.0/fs/exists.ts": "b0d2e31654819cc2a8d37df45d6b14686c0cc1d802e9ff09e902a63e98b85a00",
+    "https://deno.land/std@0.97.0/hash/_wasm/hash.ts": "cb6ad1ab429f8ac9d6eae48f3286e08236d662e1a2e5cfd681ba1c0f17375895",
+    "https://deno.land/std@0.97.0/hash/_wasm/wasm.js": "94b1b997ae6fb4e6d2156bcea8f79cfcd1e512a91252b08800a92071e5e84e1a",
+    "https://deno.land/std@0.97.0/hash/hasher.ts": "57a9ec05dd48a9eceed319ac53463d9873490feea3832d58679df6eec51c176b",
+    "https://deno.land/std@0.97.0/hash/mod.ts": "5d032bd34186cda2f8d17fc122d621430953a6030d4b3f11172004715e3e2441",
+    "https://deno.land/std@0.97.0/path/_constants.ts": "1247fee4a79b70c89f23499691ef169b41b6ccf01887a0abd131009c5581b853",
+    "https://deno.land/std@0.97.0/path/_interface.ts": "1fa73b02aaa24867e481a48492b44f2598cd9dfa513c7b34001437007d3642e4",
+    "https://deno.land/std@0.97.0/path/_util.ts": "2e06a3b9e79beaf62687196bd4b60a4c391d862cfa007a20fc3a39f778ba073b",
+    "https://deno.land/std@0.97.0/path/common.ts": "eaf03d08b569e8a87e674e4e265e099f237472b6fd135b3cbeae5827035ea14a",
+    "https://deno.land/std@0.97.0/path/glob.ts": "314ad9ff263b895795208cdd4d5e35a44618ca3c6dd155e226fb15d065008652",
+    "https://deno.land/std@0.97.0/path/mod.ts": "4465dc494f271b02569edbb4a18d727063b5dbd6ed84283ff906260970a15d12",
+    "https://deno.land/std@0.97.0/path/posix.ts": "f56c3c99feb47f30a40ce9d252ef6f00296fa7c0fcb6dd81211bdb3b8b99ca3b",
+    "https://deno.land/std@0.97.0/path/separator.ts": "8fdcf289b1b76fd726a508f57d3370ca029ae6976fcde5044007f062e643ff1c",
+    "https://deno.land/std@0.97.0/path/win32.ts": "77f7b3604e0de40f3a7c698e8a79e7f601dc187035a1c21cb1e596666ce112f8",
+    "https://deno.land/x/cache@0.2.13/cache.ts": "4005aad54fb9aac9ff02526ffa798032e57f2d7966905fdeb7949263b1c95f2f",
+    "https://deno.land/x/cache@0.2.13/deps.ts": "6f14e76a1a09f329e3f3830c6e72bd10b53a89a75769d5ea886e5d8603e503e6",
+    "https://deno.land/x/cache@0.2.13/directories.ts": "ef48531cab3f827252e248596d15cede0de179a2fb15392ae24cf8034519994f",
+    "https://deno.land/x/cache@0.2.13/file.ts": "5abe7d80c6ac594c98e66eb4262962139f48cd9c49dbe2a77e9608760508a09a",
+    "https://deno.land/x/cache@0.2.13/file_fetcher.ts": "5c793cc83a5b9377679ec313b2a2321e51bf7ed15380fa82d387f1cdef3b924f",
+    "https://deno.land/x/cache@0.2.13/helpers.ts": "d1545d6432277b7a0b5ea254d1c51d572b6452a8eadd9faa7ad9c5586a1725c4",
+    "https://deno.land/x/cache@0.2.13/mod.ts": "3188250d3a013ef6c9eb060e5284cf729083af7944a29e60bb3d8597dd20ebcd",
+    "https://deno.land/x/event@2.0.0/mod.ts": "8eb8bc72d29b332cc9db426f704c7606436077b4bb12e968590045d3460fbe2e"
   }
 }


### PR DESCRIPTION
## Summary

Two builtin tasks were failing at runtime; both trace to how tasks obtain the resolved data directory, plus one stale dependency lock.

`buildin/temp-cleanup` crashed every 10 minutes. It read the `DICODE_DATA_DIR` env var, but the daemon exports the resolved data dir as `DICODE_DATADIR` — `DICODE_DATA_DIR` is only the Docker *input* var and is never re-exported. The task's `from: DICODE_DATA_DIR` mapping therefore resolved to an empty string, and the code's `?? default` fallback doesn't trigger on `""`, so the sweep root became the system `/tmp` and the task recursed into root-owned `systemd-private-*` dirs and died with `PermissionDenied`.

The real root cause is in the env resolver: an unset `from:` host-env source was injected as an explicit empty string (`os.Getenv`), which silently defeats *any* task's `?? default` fallback. Fixed to leave the variable **absent** when the source is unset (`os.LookupEnv`-gated), matching the bare-passthrough path — so fallbacks behave as written.

The same wrong-var-name pattern existed latently in `git-pr` and `dev-clones-cleanup`; they avoided crashing only via a `HOME` fallback while silently ignoring a non-default data dir. Aligned all three tasks to the canonical idioms: `DICODE_DATADIR` for the env read and the `${DATADIR}` template variable for permission paths. `temp-cleanup` also had an ineffective `try/catch` around a lazy `Deno.readDir` (errors surface during iteration, not at the call); it now drains eagerly so `NotFound`/`PermissionDenied` can't escape uncaught.

Separately, `buildin/tray` failed on a stale `tasks/deno.lock` — the shared lock was missing the systray module's deps. Regenerated across all builtin entrypoints (additions only, nothing pruned); it now passes `--frozen`.

## Verification

- `go test ./pkg/runtime/... ./pkg/daemon/...` green, including a new resolver regression test (unset source → absent, not `""`).
- Deno task tests for `git-pr` and `dev-clones-cleanup` green.
- Live against the running daemon: `temp-cleanup` and `dev-clones-cleanup` now succeed; `tray` runs.

## Deliberately left behind

The stale-lock developer/operator UX (a cryptic `--frozen` diff dump with no guided fix) is out of scope here and tracked separately: #454 (a `dicode deno relock` command + CI verify) and #455 (deterministic runtime auto-recovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
