### PR TITLE
feat(dev): make dev-relay-config — render a local relay.yaml without Doppler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,10 @@ test-tasks:
 	@test -n "$(DENO)" || { echo "deno not found — install or run dicode daemon once to bootstrap"; exit 1; }
 	$(DENO) test --allow-all --config=tasks/deno.json 'tasks/buildin/**/task.test.ts'
 
+## dev-relay-config: render a minimal local relay.yaml (no Doppler) for dev — see issue #459
+dev-relay-config:
+	@bash scripts/dev-relay-config.sh $(RELAY_ARGS)
+
 ## proto-tools: install buf + protoc-gen-go (idempotent, needed by `make proto`)
 proto-tools:
 	$(GO) install github.com/bufbuild/buf/cmd/buf@latest

--- a/scripts/dev-relay-config.sh
+++ b/scripts/dev-relay-config.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Render a minimal local relay.yaml so buildin/relay-server-body can run without
+# Doppler. Stopgap for local/dev use only — the proper dev-mode render path is
+# tracked in issue #459. The broker signing key is bootstrapped by the relay
+# body itself, so this script does not touch it.
+#
+# Env overrides:
+#   DICODE_DATADIR        data dir (default: $HOME/.dicode)
+#   RELAY_PORT            listen port (default: 5553)
+#   RELAY_BASE_URL        advertised base URL (default: http://localhost:$RELAY_PORT)
+#   RELAY_STATUS_PASSWORD status endpoint password (default: random)
+# Pass --force to overwrite an existing relay.yaml.
+set -euo pipefail
+
+datadir="${DICODE_DATADIR:-$HOME/.dicode}"
+port="${RELAY_PORT:-5553}"
+base_url="${RELAY_BASE_URL:-http://localhost:$port}"
+dest="$datadir/relay/relay.yaml"
+
+force=0
+[ "${1:-}" = "--force" ] && force=1
+if [ -e "$dest" ] && [ "$force" -ne 1 ]; then
+  echo "dev-relay-config: refusing to overwrite existing $dest (pass --force)" >&2
+  exit 1
+fi
+
+status_password="${RELAY_STATUS_PASSWORD:-$(openssl rand -hex 16)}"
+mkdir -p "$datadir/relay"
+umask 077
+cat > "$dest" <<YAML
+server:
+  port: $port
+  base_url: $base_url
+  tls:
+    cert_file: ""
+    key_file: ""
+status:
+  password: $status_password
+relay:
+  timestamp_tolerance_s: 30
+  ping_interval_ms: 30000
+  pong_timeout_ms: 10000
+  request_timeout_ms: 30000
+  nonce_ttl_ms: 60000
+broker:
+  session_ttl_ms: 300000
+  signing_key_file: $datadir/relay/broker-signing.key
+  providers: {}
+YAML
+chmod 600 "$dest"
+echo "dev-relay-config: wrote $dest"
+echo "dev-relay-config: status password = $status_password"


### PR DESCRIPTION
## Summary

Captures the manual local-relay setup as a reproducible script + `make` target so it survives a data-dir reset. `buildin/relay-server-body` reads `${DATADIR}/relay/relay.yaml`, which today can only be produced by the Doppler-fed render pipeline — so a machine without Doppler has no way to stand up the relay locally. This renders a minimal, valid local config (empty providers, local `base_url`, generated status password) without Doppler.

Stopgap only. The proper fix — a supported in-pipeline dev-mode render that omits unconfigured optional providers instead of emitting `null` `client_id`s — is tracked in #459.

## Usage

```
make dev-relay-config                 # writes $HOME/.dicode/relay/relay.yaml
make dev-relay-config RELAY_ARGS=--force
```
Overrides via `DICODE_DATADIR`, `RELAY_PORT`, `RELAY_BASE_URL`, `RELAY_STATUS_PASSWORD`. The broker signing key is bootstrapped by the relay body itself, so the script leaves it alone.

## Verification

Ran against a throwaway data dir: writes a `0600` `relay.yaml`, refuses to overwrite without `--force`, and `make help` lists the target. This is the same config shape the running local relay accepted this session (`dicode-relay listening on port 5553`, `relay-client` connected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new development setup command to generate a minimal local relay configuration.
  * Included a helper script that creates the config with sensible defaults, supports custom data directory, port, and base URL, and can overwrite an existing config when needed.
  * The setup now prints the generated status password and output location for easier local use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->