### PR TITLE
feat(cli): dicode deno relock — pinned-Deno lockfile guard + CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,6 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
-      - name: Verify tasks/deno.lock is up to date
-        run: make deno-lock-check
       - name: Run Deno tests for tasks/buildin/*
         run: deno test --allow-all --config=tasks/deno.json 'tasks/buildin/**/task.test.ts'
 
@@ -78,6 +76,9 @@ jobs:
 
       - name: Build dicode binary
         run: go build -o dicode ./cmd/dicode
+
+      - name: Verify tasks/deno.lock is up to date
+        run: ./dicode deno relock --check
 
       - name: Start daemon and run task tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
+      - name: Verify tasks/deno.lock is up to date
+        run: make deno-lock-check
       - name: Run Deno tests for tasks/buildin/*
         run: deno test --allow-all --config=tasks/deno.json 'tasks/buildin/**/task.test.ts'
 

--- a/Makefile
+++ b/Makefile
@@ -98,14 +98,6 @@ test-tasks:
 	@test -n "$(DENO)" || { echo "deno not found — install or run dicode daemon once to bootstrap"; exit 1; }
 	$(DENO) test --allow-all --config=tasks/deno.json 'tasks/buildin/**/task.test.ts'
 
-## deno-lock: regenerate tasks/deno.lock via the pinned Deno (dicode deno relock)
-deno-lock: build
-	./$(BINARY) deno relock
-
-## deno-lock-check: verify tasks/deno.lock is current without mutating it (used in CI)
-deno-lock-check: build
-	./$(BINARY) deno relock --check
-
 ## dev-relay-config: render a minimal local relay.yaml (no Doppler) for dev — see issue #459
 dev-relay-config:
 	@bash scripts/dev-relay-config.sh $(RELAY_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,16 @@ test-tasks:
 	@test -n "$(DENO)" || { echo "deno not found — install or run dicode daemon once to bootstrap"; exit 1; }
 	$(DENO) test --allow-all --config=tasks/deno.json 'tasks/buildin/**/task.test.ts'
 
+## deno-lock: regenerate tasks/deno.lock across all buildin task.ts entrypoints
+deno-lock:
+	@test -n "$(DENO)" || { echo "deno not found — install or run dicode daemon once to bootstrap"; exit 1; }
+	$(DENO) cache --frozen=false --lock=tasks/deno.lock --config=tasks/deno.json $$(find tasks/buildin -name task.ts)
+
+## deno-lock-check: verify tasks/deno.lock is current without mutating it (used in CI)
+deno-lock-check:
+	@test -n "$(DENO)" || { echo "deno not found — install or run dicode daemon once to bootstrap"; exit 1; }
+	$(DENO) cache --frozen --lock=tasks/deno.lock --config=tasks/deno.json $$(find tasks/buildin -name task.ts)
+
 ## dev-relay-config: render a minimal local relay.yaml (no Doppler) for dev — see issue #459
 dev-relay-config:
 	@bash scripts/dev-relay-config.sh $(RELAY_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -98,15 +98,13 @@ test-tasks:
 	@test -n "$(DENO)" || { echo "deno not found — install or run dicode daemon once to bootstrap"; exit 1; }
 	$(DENO) test --allow-all --config=tasks/deno.json 'tasks/buildin/**/task.test.ts'
 
-## deno-lock: regenerate tasks/deno.lock across all buildin task.ts entrypoints
-deno-lock:
-	@test -n "$(DENO)" || { echo "deno not found — install or run dicode daemon once to bootstrap"; exit 1; }
-	$(DENO) cache --frozen=false --lock=tasks/deno.lock --config=tasks/deno.json $$(find tasks/buildin -name task.ts)
+## deno-lock: regenerate tasks/deno.lock via the pinned Deno (dicode deno relock)
+deno-lock: build
+	./$(BINARY) deno relock
 
 ## deno-lock-check: verify tasks/deno.lock is current without mutating it (used in CI)
-deno-lock-check:
-	@test -n "$(DENO)" || { echo "deno not found — install or run dicode daemon once to bootstrap"; exit 1; }
-	$(DENO) cache --frozen --lock=tasks/deno.lock --config=tasks/deno.json $$(find tasks/buildin -name task.ts)
+deno-lock-check: build
+	./$(BINARY) deno relock --check
 
 ## dev-relay-config: render a minimal local relay.yaml (no Doppler) for dev — see issue #459
 dev-relay-config:

--- a/cmd/dicode/deno.go
+++ b/cmd/dicode/deno.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+
+	denopkg "github.com/dicode/dicode/pkg/deno"
+)
+
+// cmdDeno implements `dicode deno <subcommand>` — local, daemon-free helpers
+// around the pinned Deno toolchain.
+func cmdDeno(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: dicode deno relock [--check] [dir]")
+	}
+	switch args[0] {
+	case "relock":
+		return cmdDenoRelock(args[1:])
+	default:
+		return fmt.Errorf("unknown deno subcommand %q — supported: relock", args[0])
+	}
+}
+
+// cmdDenoRelock regenerates or verifies a task source's deno.lock using the
+// exact Deno version dicode itself runs tasks with (provisioned on demand), so
+// the lock is deterministic across developer machines and CI regardless of any
+// system Deno. Runs without the daemon and works on any task tree, so task
+// developers can guard their own lockfiles the same way the buildin tasks do.
+//
+//	dicode deno relock [--check] [dir]
+//
+// dir defaults to "tasks". Without --check the lock is regenerated across all
+// task.ts entrypoints under dir (a single entrypoint would prune the shared
+// lock). With --check the lock is verified with --frozen and left untouched;
+// exit is non-zero if it is stale.
+func cmdDenoRelock(args []string) error {
+	check := false
+	dir := ""
+	for _, a := range args {
+		switch {
+		case a == "--check":
+			check = true
+		case a == "--help", a == "-h":
+			fmt.Fprintln(os.Stderr, `Usage: dicode deno relock [--check] [dir]   (dir defaults to "tasks")`)
+			return nil
+		case len(a) > 0 && a[0] == '-':
+			return fmt.Errorf("unknown flag %q — usage: dicode deno relock [--check] [dir]", a)
+		default:
+			if dir != "" {
+				return fmt.Errorf("unexpected argument %q — only one dir is allowed", a)
+			}
+			dir = a
+		}
+	}
+	if dir == "" {
+		dir = "tasks"
+	}
+
+	lockPath := filepath.Join(dir, "deno.lock")
+	if check {
+		if _, err := os.Stat(lockPath); err != nil {
+			return fmt.Errorf("no deno.lock at %s (run `dicode deno relock %s` to create it)", lockPath, dir)
+		}
+	}
+
+	entrypoints, err := findTaskEntrypoints(dir)
+	if err != nil {
+		return err
+	}
+	if len(entrypoints) == 0 {
+		return fmt.Errorf("no task.ts entrypoints found under %s", dir)
+	}
+
+	denoPath, err := denopkg.EnsureDeno(denopkg.DefaultVersion)
+	if err != nil {
+		return fmt.Errorf("provision deno %s: %w", denopkg.DefaultVersion, err)
+	}
+
+	cacheArgs := []string{"cache"}
+	if check {
+		cacheArgs = append(cacheArgs, "--frozen")
+	} else {
+		cacheArgs = append(cacheArgs, "--frozen=false")
+	}
+	cacheArgs = append(cacheArgs, "--lock="+lockPath)
+	if cfg := filepath.Join(dir, "deno.json"); fileExists(cfg) {
+		cacheArgs = append(cacheArgs, "--config="+cfg)
+	}
+	cacheArgs = append(cacheArgs, entrypoints...)
+
+	cmd := exec.Command(denoPath, cacheArgs...)
+	// Deno's Check/Download/lockfile-diff chatter goes to the operator terminal;
+	// stdout is kept clean for scripting.
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if runErr := cmd.Run(); runErr != nil {
+		if check {
+			return fmt.Errorf("%s is out of date — run `dicode deno relock %s` to update it", lockPath, dir)
+		}
+		return fmt.Errorf("deno cache: %w", runErr)
+	}
+
+	if check {
+		fmt.Fprintf(os.Stderr, "dicode: %s is up to date (%d entrypoints)\n", lockPath, len(entrypoints))
+	} else {
+		fmt.Fprintf(os.Stderr, "dicode: regenerated %s (%d entrypoints)\n", lockPath, len(entrypoints))
+	}
+	return nil
+}
+
+// findTaskEntrypoints returns every task.ts under dir, sorted for a stable
+// command line (deterministic lock ordering).
+func findTaskEntrypoints(dir string) ([]string, error) {
+	var out []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && d.Name() == "task.ts" {
+			out = append(out, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scan %s for task.ts: %w", dir, err)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}

--- a/cmd/dicode/deno.go
+++ b/cmd/dicode/deno.go
@@ -99,7 +99,11 @@ func cmdDenoRelock(args []string) error {
 	cmd.Stderr = os.Stderr
 	if runErr := cmd.Run(); runErr != nil {
 		if check {
-			return fmt.Errorf("%s is out of date — run `dicode deno relock %s` to update it", lockPath, dir)
+			// deno prints the cause above — a lockfile diff if the lock is
+			// stale, otherwise a dependency/config/type error. Don't assert
+			// staleness; surface both so a non-lock failure isn't mistaken for
+			// drift.
+			return fmt.Errorf("deno cache --frozen failed (see output above); if %s is stale, run `dicode deno relock %s`: %w", lockPath, dir, runErr)
 		}
 		return fmt.Errorf("deno cache: %w", runErr)
 	}

--- a/cmd/dicode/deno_test.go
+++ b/cmd/dicode/deno_test.go
@@ -13,7 +13,7 @@ func TestFindTaskEntrypoints(t *testing.T) {
 	mustWrite(t, filepath.Join(root, "a", "task.ts"), "")
 	mustWrite(t, filepath.Join(root, "b", "nested", "task.ts"), "")
 	mustWrite(t, filepath.Join(root, "b", "task.test.ts"), "") // not an entrypoint
-	mustWrite(t, filepath.Join(root, "c", "task.py"), "")       // other runtime
+	mustWrite(t, filepath.Join(root, "c", "task.py"), "")      // other runtime
 
 	got, err := findTaskEntrypoints(root)
 	if err != nil {

--- a/cmd/dicode/deno_test.go
+++ b/cmd/dicode/deno_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFindTaskEntrypoints(t *testing.T) {
+	root := t.TempDir()
+	// Two task.ts (one nested), plus decoys that must be ignored.
+	mustWrite(t, filepath.Join(root, "a", "task.ts"), "")
+	mustWrite(t, filepath.Join(root, "b", "nested", "task.ts"), "")
+	mustWrite(t, filepath.Join(root, "b", "task.test.ts"), "") // not an entrypoint
+	mustWrite(t, filepath.Join(root, "c", "task.py"), "")       // other runtime
+
+	got, err := findTaskEntrypoints(root)
+	if err != nil {
+		t.Fatalf("findTaskEntrypoints: %v", err)
+	}
+	want := []string{
+		filepath.Join(root, "a", "task.ts"),
+		filepath.Join(root, "b", "nested", "task.ts"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] { // also asserts sorted order
+			t.Errorf("entry %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// The early validation paths must fail before provisioning Deno, so they are
+// testable without the toolchain or network.
+func TestCmdDenoRelock_EarlyErrors(t *testing.T) {
+	empty := t.TempDir() // exists, but contains no task.ts and no deno.lock
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"unknown flag", []string{"--nope"}, "unknown flag"},
+		{"two dirs", []string{"a", "b"}, "only one dir"},
+		{"check without lock", []string{"--check", empty}, "no deno.lock"},
+		{"no entrypoints", []string{empty}, "no task.ts entrypoints"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := cmdDenoRelock(tc.args)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("got %v, want error containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -55,6 +55,17 @@ func main() {
 		return
 	}
 
+	// `deno` is a local dev/CI helper (relock/verify a task lockfile via the
+	// pinned Deno). It touches only files + the provisioned Deno toolchain, so
+	// it runs without the daemon — handle it before ensureDaemon.
+	if os.Args[1] == "deno" {
+		if err := cmdDeno(os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "dicode: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	// The daemon subcommand runs the full engine in-process.
 	// It must be handled before ensureDaemon — the daemon IS the daemon.
 	if os.Args[1] == "daemon" {
@@ -1105,6 +1116,7 @@ Commands:
   task delete <task-id> [flags]   remove a task from its source (local rm / git PR)
                                   flags: --source NAME, --force
   task approve <task-id>          approve a task held pending by the approval gate
+  deno relock [--check] [dir]     regenerate/verify a task tree's deno.lock via the pinned Deno
   secrets list                    list secret keys
   secrets set <key> <value>       store a secret
   secrets delete <key>            delete a secret

--- a/docs/deno-runtime.md
+++ b/docs/deno-runtime.md
@@ -398,6 +398,8 @@ Deno caches packages on first run.
 
 If a `deno.lock` file exists at or near the task directory (the runtime walks up to three parent directories), Deno is invoked with `--lock=<path> --frozen`. This prevents per-run resolution of newer versions within a caret range (`^`) — packages are pinned to the exact versions recorded in the lockfile. Buildin tasks ship a `tasks/deno.lock` that is automatically detected and enforced.
 
+When a task's dependencies change, regenerate the lock with `dicode deno relock [dir]` (dir defaults to `tasks`). It provisions the pinned Deno and re-caches every `task.ts` under the tree, so the lock is deterministic regardless of any system Deno. `dicode deno relock --check` verifies the lock without modifying it (exit non-zero if stale) — run it in CI to catch drift before it reaches the runtime.
+
 ---
 
 ## Deno permissions

--- a/tasks/deno.lock
+++ b/tasks/deno.lock
@@ -1,6 +1,7 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@panva/oauth4webapi@*": "3.8.6",
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.13",
     "jsr:@std/yaml@1": "1.1.0",
@@ -10,6 +11,9 @@
     "npm:openai@4": "4.104.0"
   },
   "jsr": {
+    "@panva/oauth4webapi@3.8.6": {
+      "integrity": "37569071868714cee36c5df8be7939efcf68811e849a80b87d4be22aff331c50"
+    },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [


### PR DESCRIPTION
## Summary

Implements #454 (both the CLI command and the CI guard) and fixes the root cause that made a `make`-based check fail in CI.

There was no target or CI check keeping the committed `tasks/deno.lock` in sync with the tasks' dependency graph — which is how `buildin/tray` shipped a stale lock and crash-looped at runtime on a cryptic `The lockfile is out of date` error. The first cut used `make` + `setup-deno`, but CI's `setup-deno@v2` (v2.x) computes a **different** lockfile than the pinned Deno `2.3.3` the daemon actually runs tasks with, so `--frozen` failed spuriously.

The fix routes everything through dicode's own pinned Deno:

- **`dicode deno relock [--check] [dir]`** — a local, daemon-free command that provisions the exact pinned Deno (`EnsureDeno`) and regenerates (or, with `--check`, verifies with `--frozen`) a task tree's `deno.lock`. `dir` defaults to `tasks`. Regenerates over **all** `task.ts` entrypoints (a single entrypoint would prune the shared lock). Because it's deterministic and works on any task tree, task developers can guard their own lockfiles the same way.
- **`make deno-lock` / `make deno-lock-check`** now wrap the command.
- **CI** runs `./dicode deno relock --check` in the `test-tasks-cli` job (which already builds the binary), so no system Deno is involved.

Also regenerates `tasks/deno.lock` over the full `tasks/` tree (buildin + examples + auth — 30 entrypoints). The prior lock covered `buildin` only and was incomplete for what the daemon runs.

## Verification

- `dicode deno relock --check` exits 0 on the regenerated lock; deleting a load-bearing entry makes it exit non-zero (drift caught); regenerating restores it.
- Unit tests for entrypoint discovery + the early-validation error paths (`go test ./cmd/dicode/...`).
- `gofmt`/`go vet` clean; a buildin task runs under `--frozen` against the new lock at runtime.

Closes #454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `deno relock [--check] [dir]` to regenerate or verify the `deno.lock` used for task caching.
  * `--check` validates lock freshness without modifying it and reports whether it’s up to date or stale.
  * Updated CLI help to document the new Deno subcommand.
* **Bug Fixes**
  * CI now verifies the lockfile is current before running buildin task tests.
* **Documentation**
  * Added guidance on regenerating and checking `deno.lock`.
* **Tests**
  * Added coverage for entrypoint discovery and `deno relock` early error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->