### PR TITLE
feat(python): lock inline PEP 723 deps for reproducibility (#465)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Verify tasks/deno.lock is up to date
         run: ./dicode deno relock --check
 
+      - name: Verify Python task lock sidecars are up to date
+        run: ./dicode python relock --check
+
       - name: Start daemon and run task tests
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,11 +77,8 @@ jobs:
       - name: Build dicode binary
         run: go build -o dicode ./cmd/dicode
 
-      - name: Verify tasks/deno.lock is up to date
-        run: ./dicode deno relock --check
-
-      - name: Verify Python task lock sidecars are up to date
-        run: ./dicode python relock --check
+      - name: Verify task locks are up to date (deno.lock + task.py.lock sidecars)
+        run: ./dicode relock --check
 
       - name: Start daemon and run task tests
         run: |

--- a/cmd/dicode/deno.go
+++ b/cmd/dicode/deno.go
@@ -2,11 +2,9 @@ package main
 
 import (
 	"fmt"
-	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 
 	denopkg "github.com/dicode/dicode/pkg/deno"
 )
@@ -38,26 +36,9 @@ func cmdDeno(args []string) error {
 // lock). With --check the lock is verified with --frozen and left untouched;
 // exit is non-zero if it is stale.
 func cmdDenoRelock(args []string) error {
-	check := false
-	dir := ""
-	for _, a := range args {
-		switch {
-		case a == "--check":
-			check = true
-		case a == "--help", a == "-h":
-			fmt.Fprintln(os.Stderr, `Usage: dicode deno relock [--check] [dir]   (dir defaults to "tasks")`)
-			return nil
-		case len(a) > 0 && a[0] == '-':
-			return fmt.Errorf("unknown flag %q — usage: dicode deno relock [--check] [dir]", a)
-		default:
-			if dir != "" {
-				return fmt.Errorf("unexpected argument %q — only one dir is allowed", a)
-			}
-			dir = a
-		}
-	}
-	if dir == "" {
-		dir = "tasks"
+	check, dir, showedHelp, err := parseRelockArgs("deno", args)
+	if err != nil || showedHelp {
+		return err
 	}
 
 	lockPath := filepath.Join(dir, "deno.lock")
@@ -119,21 +100,7 @@ func cmdDenoRelock(args []string) error {
 // findTaskEntrypoints returns every task.ts under dir, sorted for a stable
 // command line (deterministic lock ordering).
 func findTaskEntrypoints(dir string) ([]string, error) {
-	var out []string
-	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if !d.IsDir() && d.Name() == "task.ts" {
-			out = append(out, path)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("scan %s for task.ts: %w", dir, err)
-	}
-	sort.Strings(out)
-	return out, nil
+	return findTaskFiles(dir, "task.ts")
 }
 
 func fileExists(p string) bool {

--- a/cmd/dicode/deno.go
+++ b/cmd/dicode/deno.go
@@ -40,7 +40,12 @@ func cmdDenoRelock(args []string) error {
 	if err != nil || showedHelp {
 		return err
 	}
+	return runDenoRelock(check, dir)
+}
 
+// runDenoRelock is the parse-free core of `dicode deno relock`, shared with
+// the runtime-spanning `dicode relock` frontend.
+func runDenoRelock(check bool, dir string) error {
 	lockPath := filepath.Join(dir, "deno.lock")
 	if check {
 		if _, err := os.Stat(lockPath); err != nil {

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -66,6 +66,17 @@ func main() {
 		return
 	}
 
+	// `python` is the uv-side twin of `deno` (relock/verify per-script lock
+	// sidecars via the pinned uv). Same contract: files + the provisioned
+	// toolchain only, so it runs without the daemon.
+	if os.Args[1] == "python" {
+		if err := cmdPython(os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "dicode: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	// The daemon subcommand runs the full engine in-process.
 	// It must be handled before ensureDaemon — the daemon IS the daemon.
 	if os.Args[1] == "daemon" {
@@ -1117,6 +1128,7 @@ Commands:
                                   flags: --source NAME, --force
   task approve <task-id>          approve a task held pending by the approval gate
   deno relock [--check] [dir]     regenerate/verify a task tree's deno.lock via the pinned Deno
+  python relock [--check] [dir]   regenerate/verify Python tasks' task.py.lock sidecars via the pinned uv
   secrets list                    list secret keys
   secrets set <key> <value>       store a secret
   secrets delete <key>            delete a secret

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -77,6 +77,17 @@ func main() {
 		return
 	}
 
+	// `relock` spans both runtimes: it runs the deno and python lock passes
+	// for whichever task kinds exist under the tree. Same daemon-free
+	// contract as `deno`/`python` above.
+	if os.Args[1] == "relock" {
+		if err := cmdRelock(os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "dicode: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	// The daemon subcommand runs the full engine in-process.
 	// It must be handled before ensureDaemon — the daemon IS the daemon.
 	if os.Args[1] == "daemon" {
@@ -1127,6 +1138,7 @@ Commands:
   task delete <task-id> [flags]   remove a task from its source (local rm / git PR)
                                   flags: --source NAME, --force
   task approve <task-id>          approve a task held pending by the approval gate
+  relock [--check] [dir]          regenerate/verify all task locks (deno.lock + task.py.lock sidecars)
   deno relock [--check] [dir]     regenerate/verify a task tree's deno.lock via the pinned Deno
   python relock [--check] [dir]   regenerate/verify Python tasks' task.py.lock sidecars via the pinned uv
   secrets list                    list secret keys

--- a/cmd/dicode/python.go
+++ b/cmd/dicode/python.go
@@ -84,6 +84,9 @@ func cmdPythonRelock(args []string) error {
 		sidecar := pythonpkg.LockSidecarPath(p)
 		if pythonpkg.HasInlineMetadata(src) {
 			lockable = append(lockable, p)
+			if !pythonpkg.HasRequiresPython(src) {
+				fmt.Fprintf(os.Stderr, "dicode: warning: %s has no `requires-python` in its PEP 723 block; its lock resolves against the default Python (e.g. >=3.11 locally vs >=3.12 in CI) and may not be reproducible — pin one, e.g. `# requires-python = \">=3.11\"`\n", p)
+			}
 		} else if fileExists(sidecar) {
 			orphanLocks = append(orphanLocks, sidecar)
 		}

--- a/cmd/dicode/python.go
+++ b/cmd/dicode/python.go
@@ -2,11 +2,8 @@ package main
 
 import (
 	"fmt"
-	"io/fs"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"sort"
 
 	pythonpkg "github.com/dicode/dicode/pkg/runtime/python"
 	uvpkg "github.com/dicode/dicode/pkg/uv"
@@ -42,26 +39,9 @@ func cmdPython(args []string) error {
 // (--check). With --check the sidecars are verified with `uv lock --check`
 // and left untouched; exit is non-zero if any is missing or stale.
 func cmdPythonRelock(args []string) error {
-	check := false
-	dir := ""
-	for _, a := range args {
-		switch {
-		case a == "--check":
-			check = true
-		case a == "--help", a == "-h":
-			fmt.Fprintln(os.Stderr, `Usage: dicode python relock [--check] [dir]   (dir defaults to "tasks")`)
-			return nil
-		case len(a) > 0 && a[0] == '-':
-			return fmt.Errorf("unknown flag %q — usage: dicode python relock [--check] [dir]", a)
-		default:
-			if dir != "" {
-				return fmt.Errorf("unexpected argument %q — only one dir is allowed", a)
-			}
-			dir = a
-		}
-	}
-	if dir == "" {
-		dir = "tasks"
+	check, dir, showedHelp, err := parseRelockArgs("python", args)
+	if err != nil || showedHelp {
+		return err
 	}
 
 	scripts, err := findPythonTaskScripts(dir)
@@ -155,19 +135,5 @@ func cmdPythonRelock(args []string) error {
 // findPythonTaskScripts returns every task.py under dir, sorted for a stable
 // command line and deterministic error ordering. Mirrors findTaskEntrypoints.
 func findPythonTaskScripts(dir string) ([]string, error) {
-	var out []string
-	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if !d.IsDir() && d.Name() == "task.py" {
-			out = append(out, path)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("scan %s for task.py: %w", dir, err)
-	}
-	sort.Strings(out)
-	return out, nil
+	return findTaskFiles(dir, "task.py")
 }

--- a/cmd/dicode/python.go
+++ b/cmd/dicode/python.go
@@ -43,7 +43,12 @@ func cmdPythonRelock(args []string) error {
 	if err != nil || showedHelp {
 		return err
 	}
+	return runPythonRelock(check, dir)
+}
 
+// runPythonRelock is the parse-free core of `dicode python relock`, shared
+// with the runtime-spanning `dicode relock` frontend.
+func runPythonRelock(check bool, dir string) error {
 	scripts, err := findPythonTaskScripts(dir)
 	if err != nil {
 		return err

--- a/cmd/dicode/python.go
+++ b/cmd/dicode/python.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+
+	pythonpkg "github.com/dicode/dicode/pkg/runtime/python"
+	uvpkg "github.com/dicode/dicode/pkg/uv"
+)
+
+// cmdPython implements `dicode python <subcommand>` — local, daemon-free
+// helpers around the pinned uv toolchain. Mirrors cmdDeno.
+func cmdPython(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: dicode python relock [--check] [dir]")
+	}
+	switch args[0] {
+	case "relock":
+		return cmdPythonRelock(args[1:])
+	default:
+		return fmt.Errorf("unknown python subcommand %q — supported: relock", args[0])
+	}
+}
+
+// cmdPythonRelock regenerates or verifies the per-script uv lock sidecars
+// (task.py.lock) for every Python task under dir, using the exact uv version
+// dicode itself runs tasks with (provisioned on demand), so locks are
+// deterministic across developer machines and CI regardless of any system uv.
+// The Deno-parity counterpart of cmdDenoRelock (issue #465).
+//
+//	dicode python relock [--check] [dir]
+//
+// dir defaults to "tasks". Unlike Deno's single shared deno.lock, uv locks
+// inline PEP 723 scripts individually: `uv lock --script task.py` writes a
+// task.py.lock sidecar next to the script. Only scripts that carry a PEP 723
+// metadata block are lockable; scripts without one are skipped (nothing to
+// pin), and their leftover sidecars are removed (write mode) or flagged
+// (--check). With --check the sidecars are verified with `uv lock --check`
+// and left untouched; exit is non-zero if any is missing or stale.
+func cmdPythonRelock(args []string) error {
+	check := false
+	dir := ""
+	for _, a := range args {
+		switch {
+		case a == "--check":
+			check = true
+		case a == "--help", a == "-h":
+			fmt.Fprintln(os.Stderr, `Usage: dicode python relock [--check] [dir]   (dir defaults to "tasks")`)
+			return nil
+		case len(a) > 0 && a[0] == '-':
+			return fmt.Errorf("unknown flag %q — usage: dicode python relock [--check] [dir]", a)
+		default:
+			if dir != "" {
+				return fmt.Errorf("unexpected argument %q — only one dir is allowed", a)
+			}
+			dir = a
+		}
+	}
+	if dir == "" {
+		dir = "tasks"
+	}
+
+	scripts, err := findPythonTaskScripts(dir)
+	if err != nil {
+		return err
+	}
+	if len(scripts) == 0 {
+		return fmt.Errorf("no task.py scripts found under %s", dir)
+	}
+
+	// Partition: scripts with a PEP 723 block get a lock sidecar; ones
+	// without cannot be locked (uv has nothing to resolve) — any sidecar
+	// they still carry is a leftover from a removed block.
+	var lockable, orphanLocks []string
+	for _, p := range scripts {
+		src, err := os.ReadFile(p) //nolint:gosec
+		if err != nil {
+			return fmt.Errorf("read %s: %w", p, err)
+		}
+		sidecar := pythonpkg.LockSidecarPath(p)
+		if pythonpkg.HasInlineMetadata(src) {
+			lockable = append(lockable, p)
+		} else if fileExists(sidecar) {
+			orphanLocks = append(orphanLocks, sidecar)
+		}
+	}
+
+	// Everything below that can fail fast does so before provisioning uv,
+	// so these paths stay testable without the toolchain or network.
+	if check {
+		for _, p := range lockable {
+			if sidecar := pythonpkg.LockSidecarPath(p); !fileExists(sidecar) {
+				return fmt.Errorf("no lock sidecar at %s (run `dicode python relock %s` to create it)", sidecar, dir)
+			}
+		}
+		if len(orphanLocks) > 0 {
+			return fmt.Errorf("orphaned lock sidecar %s — its script has no PEP 723 block (run `dicode python relock %s` to remove it)", orphanLocks[0], dir)
+		}
+	} else {
+		for _, sidecar := range orphanLocks {
+			if err := os.Remove(sidecar); err != nil {
+				return fmt.Errorf("remove orphaned lock sidecar %s: %w", sidecar, err)
+			}
+			fmt.Fprintf(os.Stderr, "dicode: removed orphaned lock sidecar %s\n", sidecar)
+		}
+	}
+
+	if len(lockable) == 0 {
+		fmt.Fprintf(os.Stderr, "dicode: no Python tasks with PEP 723 inline metadata under %s — nothing to lock\n", dir)
+		return nil
+	}
+
+	uvPath, err := uvpkg.EnsureUv(uvpkg.DefaultVersion)
+	if err != nil {
+		return fmt.Errorf("provision uv %s: %w", uvpkg.DefaultVersion, err)
+	}
+
+	for _, p := range lockable {
+		lockArgs := []string{"lock", "--script", p}
+		if check {
+			lockArgs = append(lockArgs, "--check")
+		}
+		cmd := exec.Command(uvPath, lockArgs...) // #nosec G204 — argv is the provisioned uv plus discovered task.py paths, no user shell injection.
+		// uv's resolution chatter goes to the operator terminal; stdout is
+		// kept clean for scripting (same contract as cmdDenoRelock).
+		cmd.Stdout = os.Stderr
+		cmd.Stderr = os.Stderr
+		if runErr := cmd.Run(); runErr != nil {
+			sidecar := pythonpkg.LockSidecarPath(p)
+			if check {
+				// uv prints the cause above — a lockfile diff if the sidecar
+				// is stale, otherwise a resolution/metadata error. Surface
+				// both so a non-lock failure isn't mistaken for drift.
+				return fmt.Errorf("uv lock --check failed for %s (see output above); if %s is stale, run `dicode python relock %s`: %w", p, sidecar, dir, runErr)
+			}
+			return fmt.Errorf("uv lock --script %s: %w", p, runErr)
+		}
+	}
+
+	if check {
+		fmt.Fprintf(os.Stderr, "dicode: Python lock sidecars under %s are up to date (%d scripts)\n", dir, len(lockable))
+	} else {
+		fmt.Fprintf(os.Stderr, "dicode: regenerated lock sidecars under %s (%d scripts)\n", dir, len(lockable))
+	}
+	return nil
+}
+
+// findPythonTaskScripts returns every task.py under dir, sorted for a stable
+// command line and deterministic error ordering. Mirrors findTaskEntrypoints.
+func findPythonTaskScripts(dir string) ([]string, error) {
+	var out []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && d.Name() == "task.py" {
+			out = append(out, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scan %s for task.py: %w", dir, err)
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/cmd/dicode/python_test.go
+++ b/cmd/dicode/python_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const pep723Block = "# /// script\n# dependencies = [\"httpx>=0.27\"]\n# ///\nimport httpx\n"
+
+func TestFindPythonTaskScripts(t *testing.T) {
+	root := t.TempDir()
+	// Two task.py (one nested), plus decoys that must be ignored.
+	mustWrite(t, filepath.Join(root, "a", "task.py"), "")
+	mustWrite(t, filepath.Join(root, "b", "nested", "task.py"), "")
+	mustWrite(t, filepath.Join(root, "b", "task.test.py"), "") // not an entrypoint
+	mustWrite(t, filepath.Join(root, "c", "task.ts"), "")      // other runtime
+
+	got, err := findPythonTaskScripts(root)
+	if err != nil {
+		t.Fatalf("findPythonTaskScripts: %v", err)
+	}
+	want := []string{
+		filepath.Join(root, "a", "task.py"),
+		filepath.Join(root, "b", "nested", "task.py"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] { // also asserts sorted order
+			t.Errorf("entry %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// The early validation paths must fail before provisioning uv, so they are
+// testable without the toolchain or network. Mirrors
+// TestCmdDenoRelock_EarlyErrors.
+func TestCmdPythonRelock_EarlyErrors(t *testing.T) {
+	empty := t.TempDir() // exists, but contains no task.py
+
+	// A dep-declaring task with no committed sidecar must fail --check
+	// before uv is ever provisioned.
+	missingLock := t.TempDir()
+	mustWrite(t, filepath.Join(missingLock, "t", "task.py"), pep723Block)
+
+	// A sidecar whose script no longer has a PEP 723 block is drift too:
+	// the pin no longer governs anything.
+	orphan := t.TempDir()
+	mustWrite(t, filepath.Join(orphan, "t", "task.py"), "print('no deps')\n")
+	mustWrite(t, filepath.Join(orphan, "t", "task.py.lock"), "version = 1\n")
+
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"unknown flag", []string{"--nope"}, "unknown flag"},
+		{"two dirs", []string{"a", "b"}, "only one dir"},
+		{"no scripts", []string{empty}, "no task.py scripts"},
+		{"check without sidecar", []string{"--check", missingLock}, "no lock sidecar"},
+		{"check with orphaned sidecar", []string{"--check", orphan}, "orphaned lock sidecar"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := cmdPythonRelock(tc.args)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("got %v, want error containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// Scripts without a PEP 723 block have nothing to pin: both modes must
+// succeed without touching uv (hermetic — no toolchain, no network), so a
+// tree of dependency-free Python tasks never fails CI.
+func TestCmdPythonRelock_NoInlineMetadata(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "t", "task.py"), "print('no deps')\n")
+
+	if err := cmdPythonRelock([]string{root}); err != nil {
+		t.Fatalf("write mode: %v", err)
+	}
+	if err := cmdPythonRelock([]string{"--check", root}); err != nil {
+		t.Fatalf("check mode: %v", err)
+	}
+}
+
+// Write mode removes a sidecar whose script lost its PEP 723 block, instead
+// of leaving a dead pin around for --check to trip on forever. Runs before
+// uv provisioning (no lockable scripts remain), so it is hermetic.
+func TestCmdPythonRelock_RemovesOrphanedSidecar(t *testing.T) {
+	root := t.TempDir()
+	script := filepath.Join(root, "t", "task.py")
+	sidecar := script + ".lock"
+	mustWrite(t, script, "print('no deps')\n")
+	mustWrite(t, sidecar, "version = 1\n")
+
+	if err := cmdPythonRelock([]string{root}); err != nil {
+		t.Fatalf("write mode: %v", err)
+	}
+	if _, err := os.Stat(sidecar); !os.IsNotExist(err) {
+		t.Fatalf("orphaned sidecar still present (stat err=%v)", err)
+	}
+}

--- a/cmd/dicode/relock.go
+++ b/cmd/dicode/relock.go
@@ -13,19 +13,24 @@ import (
 //
 //	relock [--check] [dir]     (dir defaults to "tasks")
 //
-// tool names the subcommand in usage/error text. showedHelp is true when
-// --help/-h was handled (the caller should return nil without doing work).
-// Extracting this keeps the two relock frontends from drifting apart.
+// tool names the subcommand in usage/error text ("" for the runtime-spanning
+// `dicode relock` frontend). showedHelp is true when --help/-h was handled
+// (the caller should return nil without doing work). Extracting this keeps
+// the relock frontends from drifting apart.
 func parseRelockArgs(tool string, args []string) (check bool, dir string, showedHelp bool, err error) {
+	name := "dicode relock"
+	if tool != "" {
+		name = "dicode " + tool + " relock"
+	}
 	for _, a := range args {
 		switch {
 		case a == "--check":
 			check = true
 		case a == "--help", a == "-h":
-			fmt.Fprintf(os.Stderr, "Usage: dicode %s relock [--check] [dir]   (dir defaults to \"tasks\")\n", tool)
+			fmt.Fprintf(os.Stderr, "Usage: %s [--check] [dir]   (dir defaults to \"tasks\")\n", name)
 			return false, "", true, nil
 		case len(a) > 0 && a[0] == '-':
-			return false, "", false, fmt.Errorf("unknown flag %q — usage: dicode %s relock [--check] [dir]", a, tool)
+			return false, "", false, fmt.Errorf("unknown flag %q — usage: %s [--check] [dir]", a, name)
 		default:
 			if dir != "" {
 				return false, "", false, fmt.Errorf("unexpected argument %q — only one dir is allowed", a)
@@ -37,6 +42,48 @@ func parseRelockArgs(tool string, args []string) (check bool, dir string, showed
 		dir = "tasks"
 	}
 	return check, dir, false, nil
+}
+
+// cmdRelock implements `dicode relock [--check] [dir]` — the runtime-spanning
+// frontend over the deno and python lock passes. It runs each runtime's
+// relock core for the runtimes actually present under dir (task.ts →
+// deno.lock, task.py → task.py.lock sidecars), skipping absent ones, and
+// errors only when the tree contains neither. `dicode deno relock` and
+// `dicode python relock` remain as single-runtime entry points delegating to
+// the same cores.
+func cmdRelock(args []string) error {
+	check, dir, showedHelp, err := parseRelockArgs("", args)
+	if err != nil || showedHelp {
+		return err
+	}
+
+	denoScripts, err := findTaskFiles(dir, "task.ts")
+	if err != nil {
+		return err
+	}
+	pyScripts, err := findTaskFiles(dir, "task.py")
+	if err != nil {
+		return err
+	}
+	if len(denoScripts) == 0 && len(pyScripts) == 0 {
+		return fmt.Errorf("no task.ts or task.py scripts found under %s", dir)
+	}
+
+	if len(denoScripts) > 0 {
+		if err := runDenoRelock(check, dir); err != nil {
+			return err
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "dicode: no task.ts under %s — skipping deno lock\n", dir)
+	}
+	if len(pyScripts) > 0 {
+		if err := runPythonRelock(check, dir); err != nil {
+			return err
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "dicode: no task.py under %s — skipping python lock\n", dir)
+	}
+	return nil
 }
 
 // findTaskFiles returns every file named name under dir, sorted for a stable

--- a/cmd/dicode/relock.go
+++ b/cmd/dicode/relock.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// parseRelockArgs parses the argument shape shared by `dicode deno relock`
+// and `dicode python relock`:
+//
+//	relock [--check] [dir]     (dir defaults to "tasks")
+//
+// tool names the subcommand in usage/error text. showedHelp is true when
+// --help/-h was handled (the caller should return nil without doing work).
+// Extracting this keeps the two relock frontends from drifting apart.
+func parseRelockArgs(tool string, args []string) (check bool, dir string, showedHelp bool, err error) {
+	for _, a := range args {
+		switch {
+		case a == "--check":
+			check = true
+		case a == "--help", a == "-h":
+			fmt.Fprintf(os.Stderr, "Usage: dicode %s relock [--check] [dir]   (dir defaults to \"tasks\")\n", tool)
+			return false, "", true, nil
+		case len(a) > 0 && a[0] == '-':
+			return false, "", false, fmt.Errorf("unknown flag %q — usage: dicode %s relock [--check] [dir]", a, tool)
+		default:
+			if dir != "" {
+				return false, "", false, fmt.Errorf("unexpected argument %q — only one dir is allowed", a)
+			}
+			dir = a
+		}
+	}
+	if dir == "" {
+		dir = "tasks"
+	}
+	return check, dir, false, nil
+}
+
+// findTaskFiles returns every file named name under dir, sorted for a stable
+// command line (deterministic lock/error ordering). Shared by the deno
+// (task.ts) and python (task.py) relock walkers.
+func findTaskFiles(dir, name string) ([]string, error) {
+	var out []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && d.Name() == name {
+			out = append(out, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scan %s for %s: %w", dir, name, err)
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/cmd/dicode/relock_test.go
+++ b/cmd/dicode/relock_test.go
@@ -24,6 +24,16 @@ func TestCmdRelock_RoutingAndEarlyErrors(t *testing.T) {
 	denoOnly := t.TempDir()
 	mustWrite(t, filepath.Join(denoOnly, "t", "task.ts"), "export default () => {};\n")
 
+	// Mixed tree (both runtimes present): the deno pass must NOT be skipped
+	// just because task.py files also exist — --check still trips on the
+	// missing deno.lock first. The complementary direction (python pass
+	// running after a successful deno pass) needs the provisioned toolchains,
+	// so it is covered by CI's `dicode relock --check` on the real mixed
+	// tasks/ tree rather than here.
+	mixed := t.TempDir()
+	mustWrite(t, filepath.Join(mixed, "d", "task.ts"), "export default () => {};\n")
+	mustWrite(t, filepath.Join(mixed, "p", "task.py"), pep723Block)
+
 	cases := []struct {
 		name string
 		args []string
@@ -34,6 +44,7 @@ func TestCmdRelock_RoutingAndEarlyErrors(t *testing.T) {
 		{"no scripts of either runtime", []string{empty}, "no task.ts or task.py"},
 		{"python-only: deno skipped, python enforced", []string{"--check", pyOnly}, "no lock sidecar"},
 		{"deno-only: deno enforced", []string{"--check", denoOnly}, "no deno.lock"},
+		{"mixed tree: deno pass not skipped", []string{"--check", mixed}, "no deno.lock"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/dicode/relock_test.go
+++ b/cmd/dicode/relock_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// cmdRelock's routing and early-validation paths are hermetic: runtime
+// presence is decided by file discovery, and each core's fail-fast checks run
+// before any toolchain is provisioned, so none of these touch the network.
+func TestCmdRelock_RoutingAndEarlyErrors(t *testing.T) {
+	empty := t.TempDir() // exists, but contains neither task.ts nor task.py
+
+	// Python-only tree whose dep-declaring task has no sidecar: the deno pass
+	// must be skipped (no task.ts) and the python pass must fail --check
+	// before uv is provisioned.
+	pyOnly := t.TempDir()
+	mustWrite(t, filepath.Join(pyOnly, "t", "task.py"), pep723Block)
+
+	// Deno-only tree without a committed deno.lock: the deno pass must run
+	// (and fail --check on the missing lock, before Deno is provisioned)
+	// without the python pass masking or preceding it.
+	denoOnly := t.TempDir()
+	mustWrite(t, filepath.Join(denoOnly, "t", "task.ts"), "export default () => {};\n")
+
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"unknown flag", []string{"--nope"}, "unknown flag"},
+		{"two dirs", []string{"a", "b"}, "only one dir"},
+		{"no scripts of either runtime", []string{empty}, "no task.ts or task.py"},
+		{"python-only: deno skipped, python enforced", []string{"--check", pyOnly}, "no lock sidecar"},
+		{"deno-only: deno enforced", []string{"--check", denoOnly}, "no deno.lock"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := cmdRelock(tc.args)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("got %v, want error containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// A tree whose only Python tasks are dependency-free must pass the unified
+// --check without provisioning any toolchain (the deno pass is skipped, the
+// python pass has nothing to pin).
+func TestCmdRelock_PythonOnlyNoDeps(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "t", "task.py"), "print('no deps')\n")
+
+	if err := cmdRelock([]string{"--check", root}); err != nil {
+		t.Fatalf("unified check on dep-free python tree: %v", err)
+	}
+}

--- a/docs/deno-runtime.md
+++ b/docs/deno-runtime.md
@@ -398,7 +398,7 @@ Deno caches packages on first run.
 
 If a `deno.lock` file exists at or near the task directory (the runtime walks up to three parent directories), Deno is invoked with `--lock=<path> --frozen`. This prevents per-run resolution of newer versions within a caret range (`^`) — packages are pinned to the exact versions recorded in the lockfile. Buildin tasks ship a `tasks/deno.lock` that is automatically detected and enforced.
 
-When a task's dependencies change, regenerate the lock with `dicode deno relock [dir]` (dir defaults to `tasks`). It provisions the pinned Deno and re-caches every `task.ts` under the tree, so the lock is deterministic regardless of any system Deno. `dicode deno relock --check` verifies the lock without modifying it (exit non-zero if stale) — run it in CI to catch drift before it reaches the runtime.
+When a task's dependencies change, regenerate the lock with `dicode deno relock [dir]` (dir defaults to `tasks`). It provisions the pinned Deno and re-caches every `task.ts` under the tree, so the lock is deterministic regardless of any system Deno. `dicode deno relock --check` verifies the lock without modifying it (exit non-zero if stale) — run it in CI to catch drift before it reaches the runtime. The runtime-spanning `dicode relock [--check] [dir]` runs this Deno pass and the Python sidecar pass (see [python-runtime.md](python-runtime.md)) together — one command covering every task lock.
 
 ---
 

--- a/docs/python-runtime.md
+++ b/docs/python-runtime.md
@@ -249,6 +249,14 @@ one is missing, stale, or orphaned) — run it in CI to catch drift before it
 reaches the runtime. Buildin/example tasks ship committed `task.py.lock`
 sidecars that are automatically detected and enforced.
 
+> **Pin `requires-python` for a reproducible lock.** A lock only reproduces if
+> the PEP 723 block declares a `requires-python` constraint. Without one, uv
+> resolves against whatever Python is default in the current environment
+> (e.g. `>=3.11` on a dev box vs `>=3.12` in CI), producing a *different* lock
+> that then fails `--locked` on the other machine. `dicode python relock` warns
+> when a lockable script omits it — add e.g. `# requires-python = ">=3.11"` to
+> the block.
+
 ---
 
 ## Run context

--- a/docs/python-runtime.md
+++ b/docs/python-runtime.md
@@ -228,6 +228,27 @@ The `# /// script` block must appear near the top of `task.py`. uv creates a
 dedicated virtual environment per script on first run and caches it for
 subsequent runs (`~/.cache/uv/`).
 
+### Dependency pinning
+
+If a `task.py.lock` sidecar exists next to `task.py` (written by
+`uv lock --script`), the runtime stages it alongside the temporary wrapper and
+invokes uv with `--locked`. This prevents per-run resolution of newer versions
+within a range (`>=`, `~=`, `^`-style caret ranges) — packages are pinned to
+the exact versions and hashes recorded in the sidecar, and a stale lock fails
+the run loudly instead of silently re-resolving. Tasks without a sidecar (for
+example, tasks with no PEP 723 block at all) run exactly as before — the same
+degrade behaviour as the Deno runtime when no `deno.lock` is present.
+
+When a task's dependencies change, regenerate the sidecar with
+`dicode python relock [dir]` (dir defaults to `tasks`). It provisions the
+pinned uv and runs `uv lock --script` for every `task.py` under the tree that
+carries a PEP 723 block, so the locks are deterministic regardless of any
+system uv; sidecars orphaned by a removed block are deleted. `dicode python
+relock --check` verifies the sidecars without modifying them (exit non-zero if
+one is missing, stale, or orphaned) — run it in CI to catch drift before it
+reaches the runtime. Buildin/example tasks ship committed `task.py.lock`
+sidecars that are automatically detected and enforced.
+
 ---
 
 ## Run context

--- a/docs/python-runtime.md
+++ b/docs/python-runtime.md
@@ -249,6 +249,11 @@ one is missing, stale, or orphaned) — run it in CI to catch drift before it
 reaches the runtime. Buildin/example tasks ship committed `task.py.lock`
 sidecars that are automatically detected and enforced.
 
+The runtime-spanning `dicode relock [--check] [dir]` runs the Deno and Python
+lock passes together for whichever task kinds exist under the tree — one
+command (and one CI step) covering both `tasks/deno.lock` and the
+`task.py.lock` sidecars.
+
 > **Pin `requires-python` for a reproducible lock.** A lock only reproduces if
 > the PEP 723 block declares a `requires-python` constraint. Without one, uv
 > resolves against whatever Python is default in the current environment

--- a/pkg/runtime/python/lock.go
+++ b/pkg/runtime/python/lock.go
@@ -3,6 +3,7 @@ package python
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 // LockSidecarPath returns the path of the per-script uv lock sidecar for a
@@ -19,6 +20,17 @@ func LockSidecarPath(scriptPath string) string {
 func HasInlineMetadata(src []byte) bool {
 	block, _ := extractPEP723(string(src))
 	return block != ""
+}
+
+// HasRequiresPython reports whether the script's PEP 723 block declares a
+// `requires-python` constraint. Without one, uv resolves against whatever
+// Python version is default in the current environment (e.g. 3.11 locally vs
+// 3.12 in CI), so the generated lock silently varies by machine and fails
+// `--locked` elsewhere — defeating the point of locking. relock warns when it
+// is missing so authors pin it for a truly reproducible lock.
+func HasRequiresPython(src []byte) bool {
+	block, _ := extractPEP723(string(src))
+	return strings.Contains(block, "requires-python")
 }
 
 // stageLockSidecar makes the task's committed lock sidecar visible to uv for

--- a/pkg/runtime/python/lock.go
+++ b/pkg/runtime/python/lock.go
@@ -1,0 +1,61 @@
+package python
+
+import (
+	"fmt"
+	"os"
+)
+
+// LockSidecarPath returns the path of the per-script uv lock sidecar for a
+// PEP 723 inline script, as written by `uv lock --script <script>`:
+// the script path with ".lock" appended (task.py → task.py.lock).
+func LockSidecarPath(scriptPath string) string {
+	return scriptPath + ".lock"
+}
+
+// HasInlineMetadata reports whether src contains a PEP 723 inline script
+// metadata block (`# /// script` … `# ///`). Only scripts with such a block
+// have dependencies for uv to resolve, so only they can (and should) carry a
+// lock sidecar.
+func HasInlineMetadata(src []byte) bool {
+	block, _ := extractPEP723(string(src))
+	return block != ""
+}
+
+// stageLockSidecar makes the task's committed lock sidecar visible to uv for
+// a wrapper run. uv discovers a script's lockfile strictly by filename
+// (<script>.lock next to the script), and the runtime executes a temporary
+// wrapper file rather than task.py itself — so the sidecar is copied to
+// <wrapper>.lock. Returns the staged path and true when a sidecar exists;
+// ("", false, nil) when the task has no lock (the run then proceeds unlocked,
+// matching how the Deno runtime degrades when no deno.lock is present).
+// A sidecar that exists but cannot be read/copied is a hard error: a task
+// that declares a lock must not silently fall back to unpinned resolution.
+func stageLockSidecar(scriptPath, wrapperPath string) (string, bool, error) {
+	src := LockSidecarPath(scriptPath)
+	data, err := os.ReadFile(src) //nolint:gosec
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("read lock sidecar %s: %w", src, err)
+	}
+	dst := LockSidecarPath(wrapperPath)
+	if err := os.WriteFile(dst, data, 0o600); err != nil {
+		return "", false, fmt.Errorf("stage lock sidecar %s: %w", dst, err)
+	}
+	return dst, true, nil
+}
+
+// buildUvRunArgs assembles the argv (minus the uv binary itself) for a task
+// run. When locked is true — a lock sidecar has been staged next to the
+// wrapper — `--locked` makes uv fail loudly if the lock is out of date with
+// the script's inline metadata, instead of silently re-resolving (and
+// rewriting the sidecar). Without a sidecar the flag is omitted so tasks with
+// no lock (including ones with no dependencies at all) keep running.
+func buildUvRunArgs(wrapperPath string, locked bool) []string {
+	args := []string{"run"}
+	if locked {
+		args = append(args, "--locked")
+	}
+	return append(args, wrapperPath)
+}

--- a/pkg/runtime/python/lock_test.go
+++ b/pkg/runtime/python/lock_test.go
@@ -33,6 +33,25 @@ func TestHasInlineMetadata(t *testing.T) {
 	}
 }
 
+func TestHasRequiresPython(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{"with requires-python", "# /// script\n# requires-python = \">=3.11\"\n# dependencies = [\"httpx\"]\n# ///\n", true},
+		{"deps only, no requires-python", "# /// script\n# dependencies = [\"httpx\"]\n# ///\n", false},
+		{"no block", "import httpx\n", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HasRequiresPython([]byte(tc.src)); got != tc.want {
+				t.Fatalf("HasRequiresPython = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // The runtime must pass --locked only when a lock sidecar exists for the
 // task, and run plain otherwise — a Python task with no lock (e.g. no
 // external deps) keeps working exactly as before (issue #465).

--- a/pkg/runtime/python/lock_test.go
+++ b/pkg/runtime/python/lock_test.go
@@ -1,0 +1,83 @@
+package python
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLockSidecarPath(t *testing.T) {
+	if got := LockSidecarPath("/x/tasks/t/task.py"); got != "/x/tasks/t/task.py.lock" {
+		t.Fatalf("LockSidecarPath = %q", got)
+	}
+}
+
+func TestHasInlineMetadata(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{"with block", "# /// script\n# dependencies = [\"httpx\"]\n# ///\nimport httpx\n", true},
+		{"no block", "print('hello')\n", false},
+		{"unterminated block", "# /// script\n# dependencies = []\nprint('x')\n", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HasInlineMetadata([]byte(tc.src)); got != tc.want {
+				t.Fatalf("HasInlineMetadata = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// The runtime must pass --locked only when a lock sidecar exists for the
+// task, and run plain otherwise — a Python task with no lock (e.g. no
+// external deps) keeps working exactly as before (issue #465).
+func TestBuildUvRunArgs(t *testing.T) {
+	got := buildUvRunArgs("/tmp/w.py", true)
+	if strings.Join(got, " ") != "run --locked /tmp/w.py" {
+		t.Fatalf("locked args = %v", got)
+	}
+	got = buildUvRunArgs("/tmp/w.py", false)
+	if strings.Join(got, " ") != "run /tmp/w.py" {
+		t.Fatalf("unlocked args = %v", got)
+	}
+}
+
+// stageLockSidecar copies the committed task.py.lock next to the temporary
+// wrapper (uv discovers a script's lock strictly by <script>.lock filename),
+// and reports false — not an error — when the task has no sidecar.
+func TestStageLockSidecar(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "task.py")
+	wrapper := filepath.Join(dir, "wrapper.py")
+
+	// No sidecar → no staging, no error, run proceeds unlocked.
+	staged, locked, err := stageLockSidecar(script, wrapper)
+	if err != nil || locked || staged != "" {
+		t.Fatalf("no sidecar: got (%q, %v, %v), want (\"\", false, nil)", staged, locked, err)
+	}
+
+	// Sidecar present → staged copy next to the wrapper.
+	const lockBody = "version = 1\n"
+	if err := os.WriteFile(script+".lock", []byte(lockBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	staged, locked, err = stageLockSidecar(script, wrapper)
+	if err != nil || !locked {
+		t.Fatalf("with sidecar: got (%q, %v, %v)", staged, locked, err)
+	}
+	if want := wrapper + ".lock"; staged != want {
+		t.Fatalf("staged path = %q, want %q", staged, want)
+	}
+	data, err := os.ReadFile(staged)
+	if err != nil {
+		t.Fatalf("read staged: %v", err)
+	}
+	if string(data) != lockBody {
+		t.Fatalf("staged content = %q, want %q", data, lockBody)
+	}
+}

--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -27,6 +27,11 @@
 // The runtime extracts any such block from task.py and places it at the top of
 // the temporary wrapper file so that uv can parse it correctly.
 //
+// When a task.py.lock sidecar exists (written by `dicode python relock` via
+// `uv lock --script`), it is staged next to the wrapper and enforced with
+// `uv run --locked`, pinning resolution to the recorded versions and hashes.
+// Without a sidecar the task runs unlocked, exactly as before (issue #465).
+//
 // # Permission enforcement
 //
 // Declared permissions.{fs,net,run} are enforced by a PEP 578 audit hook
@@ -360,7 +365,22 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	}
 	tmpFile.Close()
 
-	cmd := exec.CommandContext(execCtx, e.uvPath, "run", tmpFile.Name()) //nolint:gosec
+	// Reproducible dependency resolution (issue #465): when the task has a
+	// committed lock sidecar (task.py.lock, from `dicode python relock`),
+	// stage it next to the wrapper and run with --locked so drift fails
+	// loudly instead of silently resolving new versions. Tasks without a
+	// sidecar run exactly as before — mirrors the Deno runtime, which only
+	// enforces --frozen when a deno.lock is present.
+	stagedLock, locked, err := stageLockSidecar(scriptPath, tmpFile.Name())
+	if err != nil {
+		result.Error = err
+		return result, nil
+	}
+	if locked {
+		defer os.Remove(stagedLock)
+	}
+
+	cmd := exec.CommandContext(execCtx, e.uvPath, buildUvRunArgs(tmpFile.Name(), locked)...) //nolint:gosec
 	cmd.Env = pkgruntime.SubprocessEnv(spec, resolved, socketPath, token)
 
 	stderr, err := cmd.StderrPipe()

--- a/tasks/examples/hello-python/task.py
+++ b/tasks/examples/hello-python/task.py
@@ -1,4 +1,5 @@
 # /// script
+# requires-python = ">=3.11"
 # dependencies = ["httpx>=0.27"]
 # ///
 #

--- a/tasks/examples/hello-python/task.py.lock
+++ b/tasks/examples/hello-python/task.py.lock
@@ -1,0 +1,83 @@
+version = 1
+revision = 2
+requires-python = ">=3.11"
+
+[manifest]
+requirements = [{ name = "httpx", specifier = ">=0.27" }]
+
+[[package]]
+name = "anyio"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]


### PR DESCRIPTION
## Summary

Implements #465 — brings Deno-style dependency **pinning/reproducibility** to Python tasks. Closes #465.

Deno tasks get hash-pinned deps via a committed `tasks/deno.lock` + `--frozen` + `dicode deno relock`. Python tasks had no equivalent — `uv` resolved inline PEP 723 (`# /// script`) deps at run time with no committed lock. This adds the parallel machinery.

## Design (mirrors the Deno path)

- **Locked execution** (`pkg/runtime/python`): if a `task.py.lock` sidecar exists next to the task script, the runtime stages it beside the temp wrapper it executes and runs `uv run --locked` (drift fails loudly). If **no** sidecar exists, it runs plain `uv run` exactly as before — so dependency-free tasks are unaffected (same degrade as Deno's `--frozen`-only-when-`deno.lock`-exists). A sidecar that exists but can't be staged is a hard error (no silent unpinned fallback).
- **`dicode python relock [--check] [dir]`** (`cmd/dicode/python.go`, dir defaults to `tasks`): scans for `task.py` files, partitions lockable (has PEP 723 block) vs orphaned sidecars.
  - **write**: deletes orphaned sidecars, runs `uv lock --script <task.py>` per lockable script with the pinned `pkg/uv` version.
  - **`--check`**: fails (before provisioning uv) on missing/orphaned sidecars, then `uv lock --script --check` per script — non-zero exit on drift, writes nothing. For CI.
- **CI guard** (`.github/workflows/ci.yml`): runs `dicode python relock --check` alongside the existing deno check.
- **Committed lock**: `tasks/examples/hello-python/task.py.lock` (the only Python task under `tasks/` with deps — `httpx>=0.27`), generated with the pinned uv (registry URLs + sha256 hashes). The existing `TestExecute_HelloPythonSucceeds` now exercises the `--locked` path.

Scope kept to per-script `uv lock --script` sidecars (the issue's "Desired (Deno parity)" path) — no global lock, no new dependency manager.

## Test plan
- [x] `make build`, `go vet ./...`, `gofmt -l` clean
- [x] Hermetic unit tests (no network): sidecar path resolution, `--check` early-error/drift/orphan detection, PEP 723 detection, uv-arg construction, sidecar staging — all pass
- [x] `uv run --locked` / `uv lock --script --check` flags verified against the actually-pinned uv 0.7.3
- [ ] One pre-existing failure — `pkg/runtime/deno` `TestEnforcement_Env_RelayImportNeedsReadExposed` — fails identically on clean `origin/main` (sandbox TLS-intercepting proxy breaks the npm-registry fetch); unrelated to this change, passes in real CI.

Draft — will go through the security + code review loop before being marked ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJMqv1hzZzUZep13oyKrCD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `dicode python relock` to generate/verify `task.py.lock` files and remove orphaned sidecars.
  * Expanded `dicode relock` and `dicode deno relock` so one command can run lock checks for both runtimes.
* **Bug Fixes**
  * Improved `--check` to fail on missing/stale Python lock sidecars and unexpected orphan sidecars.
* **Documentation**
  * Updated “Dependency pinning” guidance, including `requires-python` expectations.
* **Tests**
  * Added unit tests and CLI tests for discovery, validation, staging, and orphan cleanup.
* **Chores**
  * CI now validates Python lock sidecars during lock verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->