### PR TITLE
fix(relay-client): survive ws abortHandshake null-deref and reconnect (#460)

### DIFF
--- a/tasks/buildin/relay-client/task.test.ts
+++ b/tasks/buildin/relay-client/task.test.ts
@@ -1,0 +1,99 @@
+/**
+ * task.test.ts — unit tests for buildin/relay-client.
+ *
+ * Covers the scoping predicate for issue #460: when the relay broker is
+ * unreachable, npm ws@8.x can throw a TypeError from an AbortSignal timeout
+ * callback (abortHandshake on an already-nulled ClientRequest) OUTSIDE the
+ * promise chain the task awaits. isAbortedHandshakeFault() decides which
+ * uncaught errors the process-level handler converts into a reconnect —
+ * everything else must stay fatal so real bugs aren't masked.
+ *
+ * main() is an infinite daemon loop, so these tests exercise the exported
+ * predicate directly rather than going through the sdk-test harness's
+ * runTask(). Deliberately dependency-free (no jsr imports): plain Deno.test
+ * with an inline assert so the file runs without registry access.
+ */
+
+import { isAbortedHandshakeFault } from "./task.ts";
+
+function assertEq(got: unknown, want: unknown, msg: string): void {
+  if (got !== want) {
+    throw new Error(`${msg}: got ${JSON.stringify(got)}, want ${JSON.stringify(want)}`);
+  }
+}
+
+// Fabricates the fault shape from issue #460: a TypeError whose stack ends
+// in ws's handshake path, thrown from an AbortSignal timeout callback.
+function wsFault(message: string, stack: string): TypeError {
+  const err = new TypeError(message);
+  err.stack = `TypeError: ${message}\n${stack}`;
+  return err;
+}
+
+const ABORT_HANDSHAKE_STACK = [
+  "    at abortHandshake (file:///data/node_modules/.deno/ws@8.20.0/node_modules/ws/lib/websocket.js:1094:14)",
+  "    at ClientRequest.<anonymous> (file:///data/node_modules/.deno/ws@8.20.0/node_modules/ws/lib/websocket.js:878:7)",
+  "    at AbortSignal._timeoutCb (node:http:695:32)",
+].join("\n");
+
+Deno.test("swallows the issue #460 fault: abortHandshake null setHeader deref", () => {
+  const err = wsFault(
+    "Cannot read properties of null (reading 'setHeader')",
+    ABORT_HANDSHAKE_STACK,
+  );
+  assertEq(isAbortedHandshakeFault(err), true, "abortHandshake null-deref");
+});
+
+Deno.test("swallows a ws handshake null-deref without an abortHandshake frame", () => {
+  // Error.captureStackTrace can trim the abortHandshake frame; the
+  // ws/lib/websocket.js path alone still identifies the handshake path.
+  const err = wsFault(
+    "Cannot read properties of null (reading 'socket')",
+    "    at ClientRequest.<anonymous> (node_modules/ws/lib/websocket.js:878:7)\n" +
+      "    at AbortSignal._timeoutCb (node:http:695:32)",
+  );
+  assertEq(isAbortedHandshakeFault(err), true, "ws websocket.js null-deref");
+});
+
+Deno.test("swallows the older V8 null-deref phrasing", () => {
+  const err = wsFault(
+    "Cannot read property 'setHeader' of null",
+    ABORT_HANDSHAKE_STACK,
+  );
+  assertEq(isAbortedHandshakeFault(err), true, "legacy V8 phrasing");
+});
+
+Deno.test("does not swallow the same message from non-ws code", () => {
+  const err = wsFault(
+    "Cannot read properties of null (reading 'setHeader')",
+    "    at runOnce (file:///data/tasks/buildin/relay-client/task.ts:98:3)",
+  );
+  assertEq(isAbortedHandshakeFault(err), false, "non-ws stack must stay fatal");
+});
+
+Deno.test("does not swallow non-TypeError handshake errors", () => {
+  // "Opening handshake has timed out" is emitted on the websocket's normal
+  // error path — RelayClient's own backoff handles it; the process-level
+  // handler must not.
+  const err = new Error("Opening handshake has timed out");
+  err.stack = `Error: Opening handshake has timed out\n${ABORT_HANDSHAKE_STACK}`;
+  assertEq(isAbortedHandshakeFault(err), false, "plain Error must stay fatal");
+});
+
+Deno.test("does not swallow other TypeErrors from ws internals", () => {
+  const err = wsFault(
+    "Cannot read properties of undefined (reading 'send')",
+    ABORT_HANDSHAKE_STACK,
+  );
+  assertEq(isAbortedHandshakeFault(err), false, "undefined-deref must stay fatal");
+});
+
+Deno.test("does not swallow non-Error values", () => {
+  assertEq(
+    isAbortedHandshakeFault("Cannot read properties of null (reading 'setHeader')"),
+    false,
+    "string reason must stay fatal",
+  );
+  assertEq(isAbortedHandshakeFault(null), false, "null must stay fatal");
+  assertEq(isAbortedHandshakeFault(undefined), false, "undefined must stay fatal");
+});

--- a/tasks/buildin/relay-client/task.ts
+++ b/tasks/buildin/relay-client/task.ts
@@ -11,6 +11,8 @@ import {
   type TofuResult,
 } from "npm:dicode-relay@^0.1.4/client";
 
+import type { DicodeSdk } from "../../sdk.ts";
+
 const IDENTITY_CTX   = "dicode/relay-identity/v1";
 const BROKER_PIN_CTX = "dicode/relay-broker-pin/v1";
 const PREFIX         = "relay/";
@@ -37,7 +39,50 @@ function b64decode(s: string): Uint8Array {
 const OUTER_BACKOFF_INITIAL_MS = 5_000;
 const OUTER_BACKOFF_MAX_MS = 60_000;
 
+// ── ws abortHandshake fault containment (#460) ──────────────────────────
+// When the relay is unreachable, npm ws@8.x can run abortHandshake() from
+// an AbortSignal timeout callback after the 'error' handler already nulled
+// the underlying ClientRequest, deref'ing req.setHeader. That TypeError is
+// thrown OUTSIDE the promise chain RelayClient.run() is awaited on, so the
+// outer backoff loop can't catch it — Deno exits 1 and, with restart: never,
+// the tunnel stays dead until manual intervention.
+
+// True only for that fault family: a TypeError raised inside ws's
+// websocket.js handshake path deref'ing a nulled request. Anything else
+// must stay fatal so real bugs aren't masked by the reconnect loop.
+export function isAbortedHandshakeFault(err: unknown): boolean {
+  if (!(err instanceof TypeError)) return false;
+  const stack = err.stack ?? "";
+  const inWsHandshake = stack.includes("abortHandshake") ||
+    /\bws(@[^/\s]+)?\/lib\/websocket\.js/.test(stack);
+  // Both V8 phrasings: "Cannot read properties of null (reading 'x')" and
+  // the older "Cannot read property 'x' of null".
+  return inWsHandshake && /Cannot read propert(?:y|ies).* of null/.test(err.message);
+}
+
+// Set while a RelayClient.run() is in flight; a swallowed fault rejects
+// that run's race so the outer backoff loop drives the reconnect.
+let onWsFault: ((err: Error) => void) | null = null;
+
+function installWsFaultHandlers(): void {
+  const swallow = (ev: Event, err: unknown, kind: string) => {
+    if (!isAbortedHandshakeFault(err)) return; // real bug — stay fatal
+    ev.preventDefault();
+    console.warn(
+      `relay-client: swallowed ws handshake fault (${kind}), reconnecting:`,
+      (err as Error).message,
+    );
+    onWsFault?.(err as Error);
+  };
+  globalThis.addEventListener("error", (ev) => swallow(ev, ev.error, "error"));
+  globalThis.addEventListener(
+    "unhandledrejection",
+    (ev) => swallow(ev, ev.reason, "unhandledrejection"),
+  );
+}
+
 export default async function main(sdk: DicodeSdk): Promise<void> {
+  installWsFaultHandlers();
   let backoff = OUTER_BACKOFF_INITIAL_MS;
 
   // Outer loop: never exit. task.yaml has restart: never so engine won't
@@ -95,7 +140,19 @@ async function runOnce(sdk: DicodeSdk): Promise<void> {
     },
   });
 
-  await client.run();
+  // Race run() against the process-level fault channel: a swallowed ws
+  // handshake fault rejects the race (caught by main's backoff loop) and
+  // the abort tears down the abandoned client so reconnects don't stack.
+  const abort = new AbortController();
+  const fault = new Promise<never>((_, reject) => {
+    onWsFault = reject;
+  });
+  try {
+    await Promise.race([client.run(abort.signal), fault]);
+  } finally {
+    onWsFault = null;
+    abort.abort();
+  }
 }
 
 async function loadOrGenerateIdentity(


### PR DESCRIPTION
## Summary

Fixes #460 — `buildin/relay-client` no longer dies (permanently, given `restart: never`) when the relay broker is unreachable. Closes #460.

## Problem

With the relay down, npm `ws@8.x` runs `abortHandshake()` from an **AbortSignal timeout callback** after the `error` handler has already nulled the underlying `ClientRequest`, deref'ing `req.setHeader`:

```
Uncaught TypeError: Cannot read properties of null (reading 'setHeader')
    at abortHandshake (ws@8.20.0/lib/websocket.js:1094:14)
```

That TypeError is thrown **outside** the promise chain `RelayClient.run()` is awaited on, so the task's backoff loop can't catch it → Deno exits 1 → the tunnel stays dead until manual re-trigger, even after the relay recovers.

## Fix (task-only; engine `restart: never` semantics untouched)

- **Narrow scoping predicate** `isAbortedHandshakeFault(err)` (exported, unit-testable): swallows only `TypeError` ∧ ws handshake stack (`abortHandshake` frame or `ws/lib/websocket.js` path) ∧ null-deref message (both V8 phrasings). Everything else — same message from non-ws code, non-TypeError handshake errors like `Opening handshake has timed out` (RelayClient's own error path handles those), `undefined`-derefs, non-Error reasons — **stays fatal** so real bugs aren't masked.
- **Recovery wiring**: `globalThis` `error` + `unhandledrejection` handlers `preventDefault()` on a match, warn, and reject a per-run fault promise; `runOnce()` races `client.run(abort.signal)` against it and aborts the abandoned client in `finally`, so the **existing** 5s→60s backoff loop drives the reconnect and reconnects don't stack. A fault landing between runs no-ops harmlessly.

## Why no `ws` bump

Checked upstream: `ws@8.21.0`'s `lib/websocket.js` **still has the bug** (`abortHandshake` still derefs a possibly-null stream; the timeout handler still closes over the nullable `req`) — 8.21.0 only adds receiver options. `ws` is also a transitive dep of `dicode-relay` (`^8.18.0` range), not pinned by the task. A bump would churn `tasks/deno.lock` for zero benefit.

## Test plan
- [x] 7 new predicate tests in `task.test.ts` (3 swallow / 4 stay-fatal), dependency-free (no jsr imports) so they run offline
- [x] `dicode task test buildin/relay-client` → 7 passed, 0 failed
- [x] `deno check` on task.ts clean; `make build` / `go vet` / `gofmt -l` clean (no Go touched)
- [ ] Live unreachable-broker reproduction deferred to a networked environment (no relay broker in this sandbox)

Follow-up candidate (issue's direction 3, out of scope here): engine-level restart-on-abnormal-exit for `restart: never` daemon tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJMqv1hzZzUZep13oyKrCD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay client resilience by handling a specific connection handshake failure more gracefully.
  * The app now avoids exiting unexpectedly on this error and will attempt to reconnect instead.

* **Tests**
  * Added coverage for handshake-related failures, including cases that should and should not trigger the reconnect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->