### PR TITLE
feat(trigger): detect daemon crash-loops and surface a crashlooping status (#458)

### DIFF
--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -512,6 +512,13 @@ func (cs *ControlServer) handleList() ([]TaskSummary, error) {
 				summary.LastRunAt = r.StartedAt.UTC().Format(time.RFC3339)
 			}
 		}
+		// Crash-loop override (#458): a crash-looping daemon's latest run is
+		// intermittently a transient "running" (the brief spawn-before-crash
+		// window), which would present a hard-failing task as healthy. Show
+		// the loop state instead of the point-in-time snapshot.
+		if cl, ok := cs.engine.(CrashloopReporter); ok && cl.IsCrashLooping(s.ID) {
+			summary.LastStatus = StatusCrashLooping
+		}
 		out = append(out, summary)
 	}
 	return out, nil
@@ -566,7 +573,15 @@ func (cs *ControlServer) handleStatus(ctx context.Context, req Request) (any, er
 	if len(runs) == 0 {
 		return nil, fmt.Errorf("no runs found for task %q", req.TaskID)
 	}
-	return runs[0], nil
+	run := runs[0]
+	// Crash-loop override (#458): mirror handleList — while the daemon is
+	// crash-looping, never report the transient "running" of a spawn that is
+	// about to die. The Run value is freshly allocated per query, so mutating
+	// the returned copy's status is safe.
+	if cl, ok := cs.engine.(CrashloopReporter); ok && cl.IsCrashLooping(req.TaskID) {
+		run.Status = StatusCrashLooping
+	}
+	return run, nil
 }
 
 func (cs *ControlServer) handleSecretsList(ctx context.Context) ([]string, error) {

--- a/pkg/ipc/control_crashloop_test.go
+++ b/pkg/ipc/control_crashloop_test.go
@@ -1,0 +1,153 @@
+package ipc
+
+// Crash-loop status derivation over the control socket (issue #458).
+//
+// A crash-looping daemon's latest run row is intermittently a transient
+// "running" (the brief spawn-before-crash window), so cli.list / cli.status
+// must consult the engine's crash-loop tracker and report "crashlooping"
+// instead of the point-in-time snapshot. The engine side is covered in
+// pkg/trigger/crashloop_test.go; these tests pin the ipc choke points.
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
+)
+
+// crashloopMockEngine is mockEngine plus the optional CrashloopReporter
+// extension, mirroring how *trigger.Engine satisfies both.
+type crashloopMockEngine struct {
+	mockEngine
+	looping map[string]bool
+}
+
+func (m *crashloopMockEngine) IsCrashLooping(taskID string) bool { return m.looping[taskID] }
+
+// newCrashloopControlEnv builds a ControlServer over a real registry seeded
+// with one daemon task whose latest run is still "running" — the masking
+// snapshot from the issue report.
+func newCrashloopControlEnv(t *testing.T, eng EngineRunner) (*ControlServer, string) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+
+	spec := &task.Spec{
+		ID:      "loopy",
+		Name:    "loopy",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{Daemon: true},
+		Enabled: true,
+	}
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("reg.Register: %v", err)
+	}
+	// Latest run is in-flight: exactly the transient spawn window that must
+	// not surface as the task's status while the daemon is crash-looping.
+	runID, err := reg.StartRun(context.Background(), spec.ID, "")
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	dir := t.TempDir()
+	cs, err := NewControlServer(
+		filepath.Join(dir, "ctrl.sock"), filepath.Join(dir, "ctrl.token"),
+		reg, eng, nil, MetricsProvider{}, "test", zap.NewNop(), nil, "",
+	)
+	if err != nil {
+		t.Fatalf("NewControlServer: %v", err)
+	}
+	return cs, runID
+}
+
+func TestHandleList_CrashLoopingOverridesTransientRunning(t *testing.T) {
+	eng := &crashloopMockEngine{looping: map[string]bool{"loopy": true}}
+	cs, _ := newCrashloopControlEnv(t, eng)
+
+	summaries, err := cs.handleList()
+	if err != nil {
+		t.Fatalf("handleList: %v", err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("got %d summaries, want 1", len(summaries))
+	}
+	if got := summaries[0].LastStatus; got != StatusCrashLooping {
+		t.Fatalf("LastStatus = %q, want %q (transient 'running' must never mask a crash loop)",
+			got, StatusCrashLooping)
+	}
+}
+
+func TestHandleList_NotCrashLooping_KeepsLastRunStatus(t *testing.T) {
+	eng := &crashloopMockEngine{looping: map[string]bool{}}
+	cs, _ := newCrashloopControlEnv(t, eng)
+
+	summaries, err := cs.handleList()
+	if err != nil {
+		t.Fatalf("handleList: %v", err)
+	}
+	if got := summaries[0].LastStatus; got != registry.StatusRunning {
+		t.Fatalf("LastStatus = %q, want %q", got, registry.StatusRunning)
+	}
+}
+
+// TestHandleList_EngineWithoutReporter_DegradesGracefully: a plain
+// EngineRunner (no CrashloopReporter) must keep the old behaviour.
+func TestHandleList_EngineWithoutReporter_DegradesGracefully(t *testing.T) {
+	cs, _ := newCrashloopControlEnv(t, &mockEngine{})
+
+	summaries, err := cs.handleList()
+	if err != nil {
+		t.Fatalf("handleList: %v", err)
+	}
+	if got := summaries[0].LastStatus; got != registry.StatusRunning {
+		t.Fatalf("LastStatus = %q, want %q", got, registry.StatusRunning)
+	}
+}
+
+func TestHandleStatus_CrashLoopingOverridesTransientRunning(t *testing.T) {
+	eng := &crashloopMockEngine{looping: map[string]bool{"loopy": true}}
+	cs, runID := newCrashloopControlEnv(t, eng)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := cs.handleStatus(ctx, Request{TaskID: "loopy"})
+	if err != nil {
+		t.Fatalf("handleStatus: %v", err)
+	}
+	run, ok := res.(*registry.Run)
+	if !ok {
+		t.Fatalf("handleStatus result is %T, want *registry.Run", res)
+	}
+	if run.ID != runID {
+		t.Fatalf("run.ID = %q, want %q", run.ID, runID)
+	}
+	if run.Status != StatusCrashLooping {
+		t.Fatalf("run.Status = %q, want %q", run.Status, StatusCrashLooping)
+	}
+}
+
+func TestHandleStatus_NotCrashLooping_KeepsRunStatus(t *testing.T) {
+	eng := &crashloopMockEngine{looping: map[string]bool{}}
+	cs, _ := newCrashloopControlEnv(t, eng)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := cs.handleStatus(ctx, Request{TaskID: "loopy"})
+	if err != nil {
+		t.Fatalf("handleStatus: %v", err)
+	}
+	run := res.(*registry.Run)
+	if run.Status != registry.StatusRunning {
+		t.Fatalf("run.Status = %q, want %q", run.Status, registry.StatusRunning)
+	}
+}

--- a/pkg/ipc/control_crashloop_test.go
+++ b/pkg/ipc/control_crashloop_test.go
@@ -151,3 +151,21 @@ func TestHandleStatus_NotCrashLooping_KeepsRunStatus(t *testing.T) {
 		t.Fatalf("run.Status = %q, want %q", run.Status, registry.StatusRunning)
 	}
 }
+
+// TestHandleStatus_EngineWithoutReporter_DegradesGracefully mirrors the
+// handleList degrade test: a plain EngineRunner (no CrashloopReporter) must
+// keep the old behaviour on the status path too.
+func TestHandleStatus_EngineWithoutReporter_DegradesGracefully(t *testing.T) {
+	cs, _ := newCrashloopControlEnv(t, &mockEngine{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res, err := cs.handleStatus(ctx, Request{TaskID: "loopy"})
+	if err != nil {
+		t.Fatalf("handleStatus: %v", err)
+	}
+	run := res.(*registry.Run)
+	if run.Status != registry.StatusRunning {
+		t.Fatalf("run.Status = %q, want %q", run.Status, registry.StatusRunning)
+	}
+}

--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -199,13 +199,33 @@ type HTTPInboundRequest struct {
 	ReqBody    []byte            `json:"reqBody,omitempty"` // base64-encoded in JSON
 }
 
+// StatusCrashLooping is the synthesized task-level status reported by
+// cli.list / cli.status for a daemon task the trigger engine has flagged as
+// crash-looping (issue #458). It replaces whatever the latest run row says —
+// notably the transient "running" of a spawn that is about to die — so a
+// hard-failing daemon never samples as healthy. Mirrors the wire value of
+// trigger.DaemonCrashLooping; duplicated here because pkg/trigger imports
+// pkg/ipc, so this package cannot import the constant.
+const StatusCrashLooping = "crashlooping"
+
+// CrashloopReporter is an optional extension of EngineRunner. The trigger
+// engine implements it; test fakes may not. The control server type-asserts
+// for it when deriving the displayed status of a task, so crash-loop
+// surfacing degrades gracefully to plain last-run status when absent.
+type CrashloopReporter interface {
+	// IsCrashLooping reports whether the daemon task's body has failed
+	// several consecutive starts and is currently in a spawn/crash/backoff
+	// loop. See pkg/trigger/crashloop.go for the exact detection rule.
+	IsCrashLooping(taskID string) bool
+}
+
 // TaskSummary is a single row in the cli.list response.
 type TaskSummary struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 	Trigger     string `json:"trigger"`    // "manual" | "cron:..." | "webhook:..." | "daemon"
-	LastStatus  string `json:"lastStatus"` // "success" | "failure" | "running" | ""
+	LastStatus  string `json:"lastStatus"` // "success" | "failure" | "running" | "crashlooping" | ""
 	LastRunID   string `json:"lastRunID"`  // "" if never run
 	LastRunAt   string `json:"lastRunAt"`  // RFC3339 or ""
 }

--- a/pkg/trigger/crashloop.go
+++ b/pkg/trigger/crashloop.go
@@ -1,0 +1,149 @@
+package trigger
+
+// Crash-loop detection for daemon tasks (issue #458).
+//
+// A daemon that crash-loops (spawn → crash within seconds → backoff →
+// respawn) intermittently shows a transient "running" run as its latest run,
+// because status sampling can land in the brief spawn-before-crash window.
+// The crashloopTracker counts consecutive quick failures per daemon so status
+// consumers (CLI list/status, WebUI, REST API) can surface a distinct
+// "crashlooping" state instead of a misleading "running".
+//
+// Detection rule:
+//   - a "quick failure" is a daemon-body exit with a non-success, non-cancelled
+//     status whose run lasted less than crashloopSustainWindow;
+//   - after crashloopThreshold consecutive quick failures the daemon is
+//     considered crash-looping;
+//   - the counter resets on any clean (success) exit, on any exit that
+//     outlasted the sustain window, on operator cancellation, on task
+//     unregistration, and — lazily — once an in-flight spawn has survived
+//     the sustain window (so a daemon that finally sustains stops reporting
+//     "crashlooping" without waiting for its next exit).
+
+import (
+	"sync"
+	"time"
+
+	"github.com/dicode/dicode/pkg/ipc"
+)
+
+// The control server surfaces crash-loop state via an optional type
+// assertion on its EngineRunner; pin the contract at compile time so a
+// signature drift can't silently disable the cli.list / cli.status override.
+var _ ipc.CrashloopReporter = (*Engine)(nil)
+
+const (
+	// crashloopThreshold is the number of consecutive quick failures after
+	// which a daemon task is reported as crash-looping.
+	crashloopThreshold = 3
+
+	// crashloopSustainWindow is how long a daemon run must survive for its
+	// start to count as sustained (resetting the quick-failure counter).
+	// Deliberately the same value as the restart-backoff's stable threshold:
+	// both answer "did this daemon actually come up?".
+	crashloopSustainWindow = daemonStableThreshold
+)
+
+// crashloopEntry is the per-daemon tracking record.
+type crashloopEntry struct {
+	// quickFails is the count of consecutive daemon-body exits that were
+	// quick failures (see package comment for the exact rule).
+	quickFails int
+	// spawnedAt is the time of the most recent in-flight spawn, or the zero
+	// time when no spawn is live. Used only for the lazy "the current run
+	// has sustained" recovery check.
+	spawnedAt time.Time
+}
+
+// crashloopTracker is a thread-safe taskID → crashloopEntry map. Purely
+// in-memory: crash-loop state is daemon-lifecycle state, not history, and a
+// daemon restart starts every counter fresh (matching daemonBackoffs).
+type crashloopTracker struct {
+	mu      sync.Mutex
+	entries map[string]*crashloopEntry
+	now     func() time.Time // injectable for tests; defaults to time.Now
+}
+
+func newCrashloopTracker() *crashloopTracker {
+	return &crashloopTracker{
+		entries: make(map[string]*crashloopEntry),
+		now:     time.Now,
+	}
+}
+
+// noteSpawn records that a daemon body was just (re)started. Only tracked for
+// daemons that already have quick failures on record — healthy daemons never
+// allocate an entry, keeping the map footprint proportional to the number of
+// currently-unhealthy daemons.
+func (t *crashloopTracker) noteSpawn(taskID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if e, ok := t.entries[taskID]; ok {
+		e.spawnedAt = t.now()
+	}
+}
+
+// noteExit records a daemon-body exit and returns the updated consecutive
+// quick-failure count. clean marks a success exit; elapsed is the run's
+// lifetime (FinishedAt − StartedAt; callers pass 0 when FinishedAt is
+// missing, which pessimistically counts as an instant crash — matching the
+// restart-backoff's treatment of abnormal exits).
+//
+// Operator cancellations must NOT be routed here — call reset instead: a
+// killed daemon is deliberate operator intent, not a crash.
+func (t *crashloopTracker) noteExit(taskID string, elapsed time.Duration, clean bool) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if clean || elapsed >= crashloopSustainWindow {
+		delete(t.entries, taskID)
+		return 0
+	}
+	e, ok := t.entries[taskID]
+	if !ok {
+		e = &crashloopEntry{}
+		t.entries[taskID] = e
+	}
+	e.quickFails++
+	e.spawnedAt = time.Time{} // no live spawn anymore
+	return e.quickFails
+}
+
+// reset clears all crash-loop state for a task. Called on operator
+// cancellation and on unregistration.
+func (t *crashloopTracker) reset(taskID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.entries, taskID)
+}
+
+// isCrashLooping reports whether the daemon has crossed crashloopThreshold
+// consecutive quick failures. If an in-flight spawn has already survived the
+// sustain window, the daemon has recovered: the counter is reset eagerly and
+// false is returned, so a finally-sustaining daemon stops reporting
+// "crashlooping" without waiting for its next exit.
+func (t *crashloopTracker) isCrashLooping(taskID string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	e, ok := t.entries[taskID]
+	if !ok || e.quickFails < crashloopThreshold {
+		return false
+	}
+	if !e.spawnedAt.IsZero() && t.now().Sub(e.spawnedAt) >= crashloopSustainWindow {
+		delete(t.entries, taskID)
+		return false
+	}
+	return true
+}
+
+// IsCrashLooping reports whether the daemon task is currently crash-looping —
+// i.e. its body has failed crashloopThreshold consecutive starts, each dying
+// within crashloopSustainWindow, and no in-flight run has sustained yet.
+//
+// This is the single source of truth for every status consumer (CLI
+// list/status via pkg/ipc, the WebUI task list, and the REST API's
+// daemon_state): while it returns true, the task's displayed status must be
+// "crashlooping" — never the transient "running" of a spawn that is about to
+// die. Safe for concurrent use. Always false for non-daemon / unknown IDs.
+func (e *Engine) IsCrashLooping(taskID string) bool {
+	return e.crashloops.isCrashLooping(taskID)
+}

--- a/pkg/trigger/crashloop.go
+++ b/pkg/trigger/crashloop.go
@@ -108,6 +108,17 @@ func (t *crashloopTracker) noteExit(taskID string, elapsed time.Duration, clean 
 	return e.quickFails
 }
 
+// clearSpawn drops the live-spawn timestamp without touching the failure
+// count. Called when a spawn recorded via noteSpawn failed to launch (no run
+// is live), so the timestamp cannot age into a fake "sustained run".
+func (t *crashloopTracker) clearSpawn(taskID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if e, ok := t.entries[taskID]; ok {
+		e.spawnedAt = time.Time{}
+	}
+}
+
 // reset clears all crash-loop state for a task. Called on operator
 // cancellation and on unregistration.
 func (t *crashloopTracker) reset(taskID string) {

--- a/pkg/trigger/crashloop_test.go
+++ b/pkg/trigger/crashloop_test.go
@@ -1,0 +1,324 @@
+package trigger
+
+// Crash-loop detection tests (issue #458).
+//
+// Two layers of coverage:
+//
+//   - crashloopTracker unit tests: the counting rule in isolation (threshold,
+//     N-1 boundary, sustained/clean-exit resets, lazy in-flight recovery);
+//   - engine-level tests: onDaemonRunFinished feeds the tracker, and the
+//     status-derivation choke point (Engine.DaemonState / IsCrashLooping)
+//     reports "crashlooping" even while a respawn is momentarily in flight
+//     with daemonStates saying Running — the exact masking window from the
+//     issue report.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
+)
+
+// quickFail is any run lifetime comfortably below crashloopSustainWindow.
+const quickFail = 500 * time.Millisecond
+
+func TestCrashloopTracker_ThresholdConsecutiveQuickFailures(t *testing.T) {
+	tr := newCrashloopTracker()
+
+	// N-1 quick failures must NOT trip the detector.
+	for i := 0; i < crashloopThreshold-1; i++ {
+		tr.noteExit("d", quickFail, false)
+		if tr.isCrashLooping("d") {
+			t.Fatalf("crashlooping after %d quick failures, want threshold %d", i+1, crashloopThreshold)
+		}
+	}
+	// The Nth consecutive quick failure trips it.
+	if got := tr.noteExit("d", quickFail, false); got != crashloopThreshold {
+		t.Fatalf("noteExit count = %d, want %d", got, crashloopThreshold)
+	}
+	if !tr.isCrashLooping("d") {
+		t.Fatalf("not crashlooping after %d consecutive quick failures", crashloopThreshold)
+	}
+	// Other tasks are unaffected.
+	if tr.isCrashLooping("other") {
+		t.Error("unrelated task reports crashlooping")
+	}
+}
+
+func TestCrashloopTracker_SustainedExitResets(t *testing.T) {
+	tr := newCrashloopTracker()
+	for i := 0; i < crashloopThreshold; i++ {
+		tr.noteExit("d", quickFail, false)
+	}
+	if !tr.isCrashLooping("d") {
+		t.Fatal("precondition: expected crashlooping")
+	}
+	// A failure exit that outlasted the sustain window resets the counter —
+	// the daemon came up properly; this is a fresh crash, not part of a loop.
+	if got := tr.noteExit("d", crashloopSustainWindow, false); got != 0 {
+		t.Fatalf("sustained exit: count = %d, want 0", got)
+	}
+	if tr.isCrashLooping("d") {
+		t.Error("still crashlooping after a sustained run")
+	}
+	// And the next quick failure starts counting from 1 again.
+	if got := tr.noteExit("d", quickFail, false); got != 1 {
+		t.Errorf("count after reset = %d, want 1", got)
+	}
+}
+
+func TestCrashloopTracker_CleanExitResets(t *testing.T) {
+	tr := newCrashloopTracker()
+	for i := 0; i < crashloopThreshold; i++ {
+		tr.noteExit("d", quickFail, false)
+	}
+	// A success exit resets even when it was quick.
+	if got := tr.noteExit("d", quickFail, true); got != 0 {
+		t.Fatalf("clean exit: count = %d, want 0", got)
+	}
+	if tr.isCrashLooping("d") {
+		t.Error("still crashlooping after a clean exit")
+	}
+}
+
+func TestCrashloopTracker_ResetClears(t *testing.T) {
+	tr := newCrashloopTracker()
+	for i := 0; i < crashloopThreshold; i++ {
+		tr.noteExit("d", quickFail, false)
+	}
+	tr.reset("d") // operator cancel / unregister path
+	if tr.isCrashLooping("d") {
+		t.Error("still crashlooping after reset")
+	}
+	if got := tr.noteExit("d", quickFail, false); got != 1 {
+		t.Errorf("count after reset = %d, want 1", got)
+	}
+}
+
+// TestCrashloopTracker_InFlightSustainedSpawnRecovers pins the lazy recovery
+// rule: once a live respawn has survived crashloopSustainWindow, the daemon
+// has recovered and isCrashLooping self-clears — without waiting for the run
+// to exit (a healthy daemon may run for days).
+func TestCrashloopTracker_InFlightSustainedSpawnRecovers(t *testing.T) {
+	now := time.Now()
+	tr := newCrashloopTracker()
+	tr.now = func() time.Time { return now }
+
+	for i := 0; i < crashloopThreshold; i++ {
+		tr.noteExit("d", quickFail, false)
+	}
+	tr.noteSpawn("d")
+
+	// While the spawn is younger than the window, still crashlooping — this
+	// is exactly the spawn-before-crash window that must not read healthy.
+	now = now.Add(crashloopSustainWindow / 2)
+	if !tr.isCrashLooping("d") {
+		t.Fatal("young in-flight spawn cleared crashlooping prematurely")
+	}
+
+	// Once the spawn has sustained the window, the daemon has recovered.
+	now = now.Add(crashloopSustainWindow)
+	if tr.isCrashLooping("d") {
+		t.Fatal("sustained in-flight spawn did not clear crashlooping")
+	}
+	// The reset is sticky: a later quick failure counts from 1.
+	if got := tr.noteExit("d", quickFail, false); got != 1 {
+		t.Errorf("count after lazy recovery = %d, want 1", got)
+	}
+}
+
+// crashloopEnv is finishedRunEnv's sibling for the crash-loop tests: a test
+// engine with a registered restart=never daemon spec (so onDaemonRunFinished
+// returns without sleeping through the restart backoff), daemonStates
+// pre-seeded to Running, and the raw db handle returned so tests can backdate
+// run rows.
+func crashloopEnv(t *testing.T) (*Engine, *task.Spec, db.DB) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+	exec := newPreflightExec(reg)
+	eng := New(reg, exec, zap.NewNop())
+	eng.RegisterExecutor(task.RuntimeDocker, exec)
+
+	spec := &task.Spec{
+		ID:      "d",
+		Name:    "d",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{Daemon: true, Restart: "never"},
+		Enabled: true,
+	}
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("reg.Register: %v", err)
+	}
+	// Mark the daemon as still-registered with the engine so the
+	// onDaemonRunFinished early-return guard doesn't bail out.
+	eng.daemonMu.Lock()
+	eng.daemonSpecs[spec.ID] = spec
+	eng.daemonMu.Unlock()
+	eng.setDaemonState(spec.ID, DaemonRunning)
+	return eng, spec, d
+}
+
+// quickFailureRun seeds a run row that started recently and finished with the
+// given status — i.e. a quick exit (< crashloopSustainWindow) as seen by
+// onDaemonRunFinished's elapsed computation.
+func quickFailureRun(t *testing.T, eng *Engine, taskID, status string) string {
+	t.Helper()
+	ctx := context.Background()
+	runID, err := eng.registry.StartRun(ctx, taskID, "")
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	if err := eng.registry.FinishRun(ctx, runID, status); err != nil {
+		t.Fatalf("FinishRun: %v", err)
+	}
+	return runID
+}
+
+// TestOnDaemonRunFinished_QuickFailures_ReportCrashLooping drives the real
+// engine hook with consecutive quick failures (restart=never so the hook
+// returns without sleeping through the restart backoff) and asserts the
+// status-derivation choke point flips to crashlooping at the threshold —
+// and, crucially, keeps reporting crashlooping even while a respawn is
+// momentarily in flight (daemonStates says Running).
+func TestOnDaemonRunFinished_QuickFailures_ReportCrashLooping(t *testing.T) {
+	eng, spec, _ := crashloopEnv(t)
+
+	for i := 0; i < crashloopThreshold-1; i++ {
+		runID := quickFailureRun(t, eng, spec.ID, registry.StatusFailure)
+		eng.onDaemonRunFinished(spec, runID)
+		if eng.IsCrashLooping(spec.ID) {
+			t.Fatalf("crashlooping after %d quick failures, want threshold %d", i+1, crashloopThreshold)
+		}
+	}
+	// Boundary at N-1: still the plain no-restart state.
+	if got := eng.DaemonState(spec.ID); got != DaemonCrashed {
+		t.Fatalf("DaemonState at N-1 failures = %q, want %q", got, DaemonCrashed)
+	}
+
+	// Nth quick failure → crashlooping.
+	runID := quickFailureRun(t, eng, spec.ID, registry.StatusFailure)
+	eng.onDaemonRunFinished(spec, runID)
+	if !eng.IsCrashLooping(spec.ID) {
+		t.Fatalf("not crashlooping after %d consecutive quick failures", crashloopThreshold)
+	}
+	if got := eng.DaemonState(spec.ID); got != DaemonCrashLooping {
+		t.Fatalf("DaemonState = %q, want %q", got, DaemonCrashLooping)
+	}
+
+	// The masking window from issue #458: a respawn is momentarily in flight,
+	// so the underlying lifecycle map says Running — the derived status must
+	// still be crashlooping, never the transient running.
+	eng.crashloops.noteSpawn(spec.ID)
+	eng.setDaemonState(spec.ID, DaemonRunning)
+	if got := eng.DaemonState(spec.ID); got != DaemonCrashLooping {
+		t.Fatalf("DaemonState during transient spawn = %q, want %q (running must never mask a crash loop)",
+			got, DaemonCrashLooping)
+	}
+	if !eng.IsCrashLooping(spec.ID) {
+		t.Fatal("IsCrashLooping = false during transient spawn window")
+	}
+}
+
+// TestOnDaemonRunFinished_CleanExitResetsCrashLoop: a success exit ends the
+// loop state and normal status derivation resumes.
+func TestOnDaemonRunFinished_CleanExitResetsCrashLoop(t *testing.T) {
+	eng, spec, _ := crashloopEnv(t)
+
+	for i := 0; i < crashloopThreshold; i++ {
+		runID := quickFailureRun(t, eng, spec.ID, registry.StatusFailure)
+		eng.onDaemonRunFinished(spec, runID)
+	}
+	if !eng.IsCrashLooping(spec.ID) {
+		t.Fatal("precondition: expected crashlooping")
+	}
+
+	runID := quickFailureRun(t, eng, spec.ID, registry.StatusSuccess)
+	eng.onDaemonRunFinished(spec, runID)
+	if eng.IsCrashLooping(spec.ID) {
+		t.Fatal("still crashlooping after a clean exit")
+	}
+	if got := eng.DaemonState(spec.ID); got != DaemonStopped {
+		t.Errorf("DaemonState after clean exit = %q, want %q", got, DaemonStopped)
+	}
+}
+
+// TestOnDaemonRunFinished_SustainedRunResetsCrashLoop: an exit whose run
+// outlasted the sustain window resets the counter even when it failed.
+func TestOnDaemonRunFinished_SustainedRunResetsCrashLoop(t *testing.T) {
+	eng, spec, d := crashloopEnv(t)
+
+	for i := 0; i < crashloopThreshold; i++ {
+		runID := quickFailureRun(t, eng, spec.ID, registry.StatusFailure)
+		eng.onDaemonRunFinished(spec, runID)
+	}
+	if !eng.IsCrashLooping(spec.ID) {
+		t.Fatal("precondition: expected crashlooping")
+	}
+
+	// Seed a failed run that lasted past the sustain window by backdating
+	// its started_at (stored as unix milliseconds).
+	ctx := context.Background()
+	runID := quickFailureRun(t, eng, spec.ID, registry.StatusFailure)
+	backdated := time.Now().Add(-2 * crashloopSustainWindow).UnixMilli()
+	if err := d.Exec(ctx,
+		`UPDATE runs SET started_at = ? WHERE id = ?`, backdated, runID,
+	); err != nil {
+		t.Fatalf("backdate started_at: %v", err)
+	}
+	eng.onDaemonRunFinished(spec, runID)
+	if eng.IsCrashLooping(spec.ID) {
+		t.Fatal("still crashlooping after a sustained run")
+	}
+}
+
+// TestOnDaemonRunFinished_CancelledResetsCrashLoop: an operator kill is
+// deliberate intent — the stopped daemon must not keep reporting the loop.
+func TestOnDaemonRunFinished_CancelledResetsCrashLoop(t *testing.T) {
+	eng, spec, _ := crashloopEnv(t)
+
+	for i := 0; i < crashloopThreshold; i++ {
+		runID := quickFailureRun(t, eng, spec.ID, registry.StatusFailure)
+		eng.onDaemonRunFinished(spec, runID)
+	}
+	if !eng.IsCrashLooping(spec.ID) {
+		t.Fatal("precondition: expected crashlooping")
+	}
+
+	runID := quickFailureRun(t, eng, spec.ID, registry.StatusCancelled)
+	eng.onDaemonRunFinished(spec, runID)
+	if eng.IsCrashLooping(spec.ID) {
+		t.Fatal("still crashlooping after operator cancellation")
+	}
+	if got := eng.DaemonState(spec.ID); got != DaemonStopped {
+		t.Errorf("DaemonState after cancellation = %q, want %q", got, DaemonStopped)
+	}
+}
+
+// TestUnregister_ResetsCrashLoop: unregistration wipes the tracker so a
+// removed/reloaded task starts with a fresh counter.
+func TestUnregister_ResetsCrashLoop(t *testing.T) {
+	eng, spec, _ := crashloopEnv(t)
+
+	for i := 0; i < crashloopThreshold; i++ {
+		runID := quickFailureRun(t, eng, spec.ID, registry.StatusFailure)
+		eng.onDaemonRunFinished(spec, runID)
+	}
+	if !eng.IsCrashLooping(spec.ID) {
+		t.Fatal("precondition: expected crashlooping")
+	}
+
+	eng.Unregister(spec.ID)
+	if eng.IsCrashLooping(spec.ID) {
+		t.Fatal("still crashlooping after Unregister")
+	}
+}

--- a/pkg/trigger/crashloop_test.go
+++ b/pkg/trigger/crashloop_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/ipc"
 	"github.com/dicode/dicode/pkg/registry"
 	"github.com/dicode/dicode/pkg/task"
 	"go.uber.org/zap"
@@ -320,5 +321,62 @@ func TestUnregister_ResetsCrashLoop(t *testing.T) {
 	eng.Unregister(spec.ID)
 	if eng.IsCrashLooping(spec.ID) {
 		t.Fatal("still crashlooping after Unregister")
+	}
+}
+
+// TestCrashloopTracker_ExitAfterSpawnKeepsLooping pins the spawn/exit
+// ordering fix: noteSpawn is recorded in the launch path BEFORE the body can
+// exit, and a subsequent quick failure zeroes the timestamp — so a dead run's
+// spawn time can never age past the sustain window and be misread as a
+// sustained run during a long restart backoff.
+func TestCrashloopTracker_ExitAfterSpawnKeepsLooping(t *testing.T) {
+	now := time.Now()
+	tr := newCrashloopTracker()
+	tr.now = func() time.Time { return now }
+
+	for i := 0; i < crashloopThreshold; i++ {
+		tr.noteExit("d", quickFail, false)
+	}
+	if !tr.isCrashLooping("d") {
+		t.Fatal("expected crashlooping after threshold quick failures")
+	}
+
+	// Respawn recorded, then the run dies quickly: the exit must zero the
+	// spawn timestamp, so even well past the sustain window the daemon still
+	// reports crashlooping (nothing sustained).
+	tr.noteSpawn("d")
+	tr.noteExit("d", quickFail, false)
+	now = now.Add(crashloopSustainWindow + time.Second)
+	if !tr.isCrashLooping("d") {
+		t.Fatal("stale spawn timestamp from a dead run cleared crashlooping")
+	}
+}
+
+// TestCrashloopTracker_ClearSpawnDropsTimestamp pins clearSpawn (used when
+// fireAsync fails to launch): the failure count survives, but the orphaned
+// spawn timestamp must not age into a fake sustained run.
+func TestCrashloopTracker_ClearSpawnDropsTimestamp(t *testing.T) {
+	now := time.Now()
+	tr := newCrashloopTracker()
+	tr.now = func() time.Time { return now }
+
+	for i := 0; i < crashloopThreshold; i++ {
+		tr.noteExit("d", quickFail, false)
+	}
+	tr.noteSpawn("d")
+	tr.clearSpawn("d")
+	now = now.Add(crashloopSustainWindow + time.Second)
+	if !tr.isCrashLooping("d") {
+		t.Fatal("clearSpawn'd timestamp still cleared crashlooping")
+	}
+}
+
+// TestCrashLoopingStatusMirrorsIPC guards the hand-mirrored wire value:
+// pkg/ipc cannot import pkg/trigger, so StatusCrashLooping duplicates
+// DaemonCrashLooping's string by hand — this pins them equal.
+func TestCrashLoopingStatusMirrorsIPC(t *testing.T) {
+	if string(DaemonCrashLooping) != ipc.StatusCrashLooping {
+		t.Fatalf("trigger.DaemonCrashLooping = %q, want ipc.StatusCrashLooping = %q",
+			DaemonCrashLooping, ipc.StatusCrashLooping)
 	}
 }

--- a/pkg/trigger/daemon_state.go
+++ b/pkg/trigger/daemon_state.go
@@ -60,6 +60,21 @@ const (
 	// the daemon (e.g. via manual run or a registry reload) to retry. The
 	// engine does not automatically transition out of this state.
 	DaemonCrashed DaemonState = "crashed"
+
+	// DaemonCrashLooping indicates the daemon's body has failed
+	// crashloopThreshold consecutive starts, each dying within
+	// crashloopSustainWindow (issue #458). Unlike DaemonCrashed the engine IS
+	// still restarting the body (restart=always / on-failure), so a
+	// point-in-time snapshot would intermittently land in the brief
+	// spawn-before-crash window and report a hard-failing task as "running".
+	// This state overrides that transient: while the crash-loop tracker is
+	// tripped, DaemonState reports crashlooping regardless of whether a spawn
+	// is momentarily in flight.
+	//
+	// Self-clearing: the state ends as soon as a run sustains past the
+	// window, exits cleanly, is cancelled by an operator, or the task is
+	// unregistered — see pkg/trigger/crashloop.go for the exact rule.
+	DaemonCrashLooping DaemonState = "crashlooping"
 )
 
 // daemonStateMap is a thread-safe taskID → DaemonState map. Kept as a
@@ -98,8 +113,17 @@ func (d *daemonStateMap) set(taskID string, s DaemonState) {
 // DaemonState returns the current lifecycle phase of the daemon with the
 // given task ID. Returns DaemonStopped for unknown / never-started tasks.
 //
+// Crash-loop override (issue #458): while the crash-loop tracker is tripped
+// for this task, the reported state is DaemonCrashLooping even if the
+// underlying map says DaemonRunning — a crash-looping daemon's respawns set
+// DaemonRunning for the brief spawn-before-crash window, and surfacing that
+// transient would present a hard-failing task as healthy.
+//
 // Safe for concurrent use.
 func (e *Engine) DaemonState(taskID string) DaemonState {
+	if e.crashloops.isCrashLooping(taskID) {
+		return DaemonCrashLooping
+	}
 	return e.daemonStates.get(taskID)
 }
 

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -868,6 +868,13 @@ func (e *Engine) registerDaemon(spec *task.Spec) {
 // start are expressed as a kind: PipelineTask whose terminal stage is this
 // daemon Task — the render stages run in the pipeline runner, not here.
 func (e *Engine) startDaemon(spec *task.Spec) {
+	// Record the spawn time for lazy crash-loop recovery BEFORE the body can
+	// possibly exit: fireAsync launches the run goroutine, so a very fast
+	// crash could otherwise run noteExit first and a late noteSpawn would
+	// stamp a spawn time onto a dead run — which isCrashLooping's lazy
+	// recovery would later misread as a sustained run and wrongly clear the
+	// crash-loop state (#458).
+	e.crashloops.noteSpawn(spec.ID)
 	runID, err := e.fireAsync(context.Background(), spec, pkgruntime.RunOptions{}, registry.TriggerDaemon)
 	if err != nil {
 		// fireAsync error here is a daemon-body launch failure — binary
@@ -875,6 +882,10 @@ func (e *Engine) startDaemon(spec *task.Spec) {
 		// from DaemonStopped so operators can tell "deliberately stopped /
 		// never started" apart from "daemon body broke" in the WebUI. See
 		// issue #318.
+		//
+		// No run is live, so drop the spawn timestamp recorded above — it
+		// must not age into a fake "sustained run".
+		e.crashloops.clearSpawn(spec.ID)
 		e.setDaemonState(spec.ID, DaemonFailedAfterPreflight)
 		e.log.Error("daemon start failed",
 			zap.String("task", spec.ID),
@@ -885,9 +896,6 @@ func (e *Engine) startDaemon(spec *task.Spec) {
 	e.daemonMu.Lock()
 	e.daemonRuns[spec.ID] = runID
 	e.daemonMu.Unlock()
-	// Record the spawn time for lazy crash-loop recovery: once this run
-	// survives crashloopSustainWindow, isCrashLooping self-clears (#458).
-	e.crashloops.noteSpawn(spec.ID)
 	e.setDaemonState(spec.ID, DaemonRunning)
 }
 

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -151,6 +151,12 @@ type Engine struct {
 	// growth is monotone. Values are time.Duration; nil entry means "use init".
 	daemonBackoffs sync.Map
 
+	// crashloops counts consecutive quick daemon-body failures per task so a
+	// crash-looping daemon reports DaemonCrashLooping instead of the transient
+	// "running" of a spawn that is about to die (issue #458). In-memory only,
+	// like daemonBackoffs. See crashloop.go.
+	crashloops *crashloopTracker
+
 	// restartGates is a per-daemon at-most-one-in-flight lock for daemon
 	// restarts. See daemon_state.go for the coalescing rationale. Also reused
 	// by handlePipelineStageRerun, keyed by pipeline ID, so a flurry of
@@ -236,6 +242,7 @@ func New(r *registry.Registry, defaultExec pkgruntime.Executor, log *zap.Logger)
 		daemonRuns:         make(map[string]string),
 		daemonSpecs:        make(map[string]*task.Spec),
 		daemonStates:       newDaemonStateMap(),
+		crashloops:         newCrashloopTracker(),
 		restartGates:       newRestartGate(),
 		livePipelines:      make(map[string]*PipelineRunner),
 		deferredPipelines:  make(map[string]*task.PipelineTask),
@@ -620,6 +627,11 @@ func (e *Engine) unregisterTriggers(id string) {
 	delete(e.daemonRuns, id)
 	e.daemonMu.Unlock()
 
+	// Unregistration wipes crash-loop tracking (#458): a removed (or
+	// reloaded-with-new-content) task starts with a fresh failure counter,
+	// mirroring how daemonStates entries don't outlive the registration.
+	e.crashloops.reset(id)
+
 	if runID != "" {
 		e.log.Info("stopping daemon — task unregistered", zap.String("task", id), zap.String("run", runID))
 		e.KillRun(runID)
@@ -873,6 +885,9 @@ func (e *Engine) startDaemon(spec *task.Spec) {
 	e.daemonMu.Lock()
 	e.daemonRuns[spec.ID] = runID
 	e.daemonMu.Unlock()
+	// Record the spawn time for lazy crash-loop recovery: once this run
+	// survives crashloopSustainWindow, isCrashLooping self-clears (#458).
+	e.crashloops.noteSpawn(spec.ID)
 	e.setDaemonState(spec.ID, DaemonRunning)
 }
 
@@ -893,6 +908,15 @@ func (e *Engine) onDaemonRunFinished(spec *task.Spec, runID string) {
 		e.log.Error("daemon: failed to get run status", zap.String("run", runID), zap.Error(err))
 		return
 	}
+	// Elapsed run time, shared by the crash-loop tracker and the restart
+	// backoff below. run.StartedAt is always set by startRun; run.FinishedAt
+	// may be nil on abnormal exit — treat that as an instant crash so the
+	// pessimistic branch applies in both consumers.
+	var elapsed time.Duration
+	if run.FinishedAt != nil {
+		elapsed = run.FinishedAt.Sub(run.StartedAt)
+	}
+
 	if run.Status == registry.StatusCancelled {
 		// Operator-initiated cancellation (e.g. per-run kill button).
 		// The daemon was running; treat the deliberate stop as a clean
@@ -902,8 +926,26 @@ func (e *Engine) onDaemonRunFinished(spec *task.Spec, runID string) {
 		// below because cancellation short-circuits the restart-policy
 		// decision entirely — a killed daemon stays stopped regardless
 		// of restart=always/on-failure/never.
+		//
+		// Cancellation also clears crash-loop tracking (#458): a kill is
+		// deliberate operator intent, not another crashed start, and the
+		// stopped daemon must not keep reporting "crashlooping".
+		e.crashloops.reset(spec.ID)
 		e.setDaemonState(spec.ID, DaemonStopped)
 		return
+	}
+
+	// Crash-loop accounting (#458): a quick non-success exit bumps the
+	// consecutive-failure counter; a clean or sustained exit resets it.
+	// Tracked for every non-cancelled exit regardless of restart policy so
+	// the rule stays a single invariant; in practice only auto-restarting
+	// daemons accumulate enough consecutive starts to trip the threshold.
+	if fails := e.crashloops.noteExit(spec.ID, elapsed, run.Status == registry.StatusSuccess); fails == crashloopThreshold {
+		e.log.Warn("daemon is crash-looping — status reports 'crashlooping' until a run sustains",
+			zap.String("task", spec.ID),
+			zap.Int("consecutive_quick_failures", fails),
+			zap.Duration("sustain_window", crashloopSustainWindow),
+		)
 	}
 
 	restart := spec.Trigger.Restart
@@ -949,14 +991,8 @@ func (e *Engine) onDaemonRunFinished(spec *task.Spec, runID string) {
 
 	// Exponential backoff for crash-looping daemons. Constants are package-level
 	// (see daemonBackoffInit etc.) so tests can inspect them without repetition.
-	// Compute elapsed run time from the run record. run.StartedAt is always set
-	// by startRun; run.FinishedAt may be nil on abnormal exit — treat that as
-	// an instant crash so the pessimistic branch applies.
-	var elapsed time.Duration
-	if run.FinishedAt != nil {
-		elapsed = run.FinishedAt.Sub(run.StartedAt)
-	}
-
+	// elapsed was computed above (shared with the crash-loop tracker).
+	//
 	// Load the current backoff for this daemon (stored across restarts in a
 	// sync.Map keyed by task ID). Reset to init after a stable run.
 	backoffKey := "daemon-backoff:" + spec.ID

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -1485,6 +1485,13 @@ func (s *Server) apiListTasks(w http.ResponseWriter, r *http.Request) {
 			lastRunID = runs[0].ID
 			lastRunStatus = runs[0].Status
 		}
+		// Crash-loop override (#458): a crash-looping daemon's latest run is
+		// intermittently a transient "running" (spawn-before-crash window).
+		// Surface the loop state so the list never shows a hard-failing
+		// daemon as healthy. Matches the CLI's cli.list derivation.
+		if s.engine.IsCrashLooping(k.TaskID()) {
+			lastRunStatus = string(trigger.DaemonCrashLooping)
+		}
 		pendingApproval := s.taskPendingApproval(k.TaskID())
 		switch v := k.(type) {
 		case *task.Spec:
@@ -1541,10 +1548,12 @@ type TaskDetail struct {
 
 	// DaemonState surfaces the engine's lifecycle phase for daemon tasks.
 	// Empty for non-daemon tasks so the WebUI can hide the row entirely.
-	// Five-value enum — see pkg/trigger.DaemonState for the canonical list.
+	// Six-value enum — see pkg/trigger.DaemonState for the canonical list.
 	// The "failed_after_preflight" and "crashed" values are distinct from
 	// "stopped" so operators can tell "fireAsync broke" (#318) and "body
-	// crashed without auto-restart" (#325) apart from "deliberately stopped".
+	// crashed without auto-restart" (#325) apart from "deliberately stopped";
+	// "crashlooping" (#458) marks a daemon stuck in a spawn/crash/backoff
+	// loop that would otherwise sample as "running".
 	DaemonState string `json:"daemon_state,omitempty"`
 
 	// PendingApproval flags a task held by the trust-on-change approval gate.

--- a/tasks/buildin/webui/app/components/dc-task-detail.js
+++ b/tasks/buildin/webui/app/components/dc-task-detail.js
@@ -373,12 +373,13 @@ class DcTaskDetail extends LitElement {
   }
 
   // Renders the daemon lifecycle phase as a colored badge in the trigger
-  // row. The engine reports a five-value enum (see pkg/trigger.DaemonState);
+  // row. The engine reports a six-value enum (see pkg/trigger.DaemonState);
   // the mapping below keeps colors aligned with the surrounding UI palette:
   // green for healthy, yellow for transient, red for failure, muted for
-  // resting. The two failure badges are deliberately distinguishable so
+  // resting. The failure badges are deliberately distinguishable so
   // operators can tell "daemon body launch failed" (issue #318) from
-  // "daemon body ran then crashed without an auto-restart" (issue #325).
+  // "daemon body ran then crashed without an auto-restart" (issue #325)
+  // from "daemon body is stuck in a spawn/crash/backoff loop" (issue #458).
   _renderDaemonState(state) {
     // Keep keys in sync with the DaemonState constants in
     // pkg/trigger/daemon_state.go — out-of-sync entries fall through
@@ -390,6 +391,7 @@ class DcTaskDetail extends LitElement {
       stopping:               { bg: 'rgba(249, 226, 175, .15)', fg: 'var(--yellow)', text: 'Stopping…' },
       failed_after_preflight: { bg: 'rgba(243, 139, 168, .15)', fg: 'var(--red)',    text: '⨯ Launch failed' },
       crashed:                { bg: 'rgba(243, 139, 168, .28)', fg: 'var(--red)',    text: '⨯ Crashed (no restart)' },
+      crashlooping:           { bg: 'rgba(243, 139, 168, .28)', fg: 'var(--red)',    text: '⟳ Crash-looping' },
       stopped:                { bg: 'rgba(166, 173, 200, .15)', fg: 'var(--muted)',  text: 'Stopped' },
     };
     const s = STYLES[state] || { bg: 'rgba(166, 173, 200, .15)', fg: 'var(--muted)', text: state };

--- a/tasks/buildin/webui/app/global.css
+++ b/tasks/buildin/webui/app/global.css
@@ -130,6 +130,9 @@ tr:last-child td { border-bottom: none; }
 .badge-success   { background: rgba(166, 227, 161, .15); color: var(--green);  border-color: rgba(166, 227, 161, .3); }
 .badge-failure   { background: rgba(243, 139, 168, .15); color: var(--red);    border-color: rgba(243, 139, 168, .3); }
 .badge-running   { background: rgba(249, 226, 175, .15); color: var(--yellow); border-color: rgba(249, 226, 175, .3); }
+/* crashlooping (#458): a daemon stuck in a spawn/crash/backoff loop — stronger
+   red than badge-failure so a persistently-broken daemon stands out. */
+.badge-crashlooping { background: rgba(243, 139, 168, .28); color: var(--red); border-color: rgba(243, 139, 168, .4); }
 .badge-cancelled { background: var(--card-bg); color: var(--muted); border-color: var(--border); }
 .badge-manual    { background: var(--card-bg); color: var(--muted); border-color: var(--border); }
 


### PR DESCRIPTION
## Summary

Fixes #458 — a crash-looping daemon task can no longer masquerade as `running`. Closes #458.

A `restart: always`/daemon task that dies within seconds of every spawn cycles `running → failure → backoff → running…`; sampling `dicode list`/`status` during the spawn window showed `running` for a task that has never stayed up. This adds explicit crash-loop detection and surfaces a distinct **`crashlooping`** status everywhere.

## Design

**Detection** (`pkg/trigger/crashloop.go`, wired into `onDaemonRunFinished`):
- *Quick failure* = non-success, non-cancelled daemon exit with lifetime < **10s** (reuses the existing `daemonStableThreshold`; missing `FinishedAt` counts as instant).
- **Crashlooping after 3 consecutive quick failures** (package constants, mirroring the existing backoff constants — no new config surface).
- Resets on: clean exit · any exit that sustained ≥10s · operator cancel · task unregister/reload · **lazy recovery** (an in-flight respawn that has already survived ≥10s self-clears without waiting to exit).
- In-memory, like `daemonBackoffs`; pipeline-stage daemons excluded; a warn log fires when the threshold trips.

**Surfacing — every status consumer**:
| Consumer | Now shows |
|---|---|
| `dicode list` | `LastStatus: crashlooping` (new `ipc.StatusCrashLooping`, via an optional `ipc.CrashloopReporter` interface — compile-time pinned on `*Engine`, fakes degrade gracefully) |
| `dicode status <task>` | latest-run status overridden — never the transient `running` |
| `GET /api/tasks` | `last_run_status: crashlooping` |
| `GET /api/tasks/{id}` / daemon state | new `DaemonCrashLooping` enum overrides `DaemonRunning` while tripped |
| WebUI | `⟳ Crash-looping` badge (task detail + list CSS) |

## Test plan
- [x] Tracker units: threshold trip + N−1 boundary, sustained/clean/cancel/unregister resets, lazy in-flight recovery (injected clock)
- [x] Engine-level: 3 quick failures via the real `onDaemonRunFinished` → `DaemonCrashLooping` **even while the daemon state says Running** (the exact masking window from the issue)
- [x] IPC: `handleList`/`handleStatus` override transient `running`; non-looping and non-reporter engines unaffected
- [x] `make build`, `go vet`, `gofmt -l` clean; `go test ./...` green (sole exception: the known sandbox-TLS deno test, fails on clean main too)

Noted limitation (pre-existing behavior, unchanged): the WebUI list's live WebSocket patches can transiently flip the badge between refetches; any API refetch shows `crashlooping`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJMqv1hzZzUZep13oyKrCD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Crash-looping** status for daemon tasks across IPC, engine status, and Web UI.

* **Bug Fixes**
  * Task lists, status views, and Web UI details now report **Crash-looping** instead of transient **Running** during spawn-before-crash windows.
  * Crash-looping status is now correctly overridden and cleared on healthy runs, sustained failures, cancellations, and task removal.

* **Style**
  * Added a dedicated red badge style for the **Crash-looping** state in the Web UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->