### PR TITLE
fix(trigger): close daemon lifecycle races — slot reservation, gated backoff restart (#470)

### DIFF
--- a/pkg/trigger/daemon.go
+++ b/pkg/trigger/daemon.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dicode/dicode/pkg/registry"
 	pkgruntime "github.com/dicode/dicode/pkg/runtime"
 	"github.com/dicode/dicode/pkg/task"
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 )
 
@@ -38,8 +39,8 @@ func (e *Engine) registerDaemon(spec *task.Spec) {
 	// firing OnRegister twice, or a manual re-register racing the reconciler)
 	// would otherwise both observe `alreadyRunning=false` and both spawn a
 	// daemon body. The lock ensures at most one in-flight start per task ID.
-	// Release happens inside startDaemon after the daemon's run slot is
-	// recorded (or after a dispatch failure has been logged).
+	// Released once startDaemon has recorded the daemon's run slot (or
+	// logged a launch failure).
 	if !e.restartGates.tryAcquire(spec.ID) {
 		e.log.Debug("daemon start coalesced — another start is already in flight",
 			zap.String("task", spec.ID))
@@ -61,28 +62,48 @@ func (e *Engine) startDaemon(spec *task.Spec) {
 	// recovery would later misread as a sustained run and wrongly clear the
 	// crash-loop state (#458).
 	e.crashloops.noteSpawn(spec.ID)
-	runID, err := e.fireAsync(context.Background(), spec, pkgruntime.RunOptions{}, registry.TriggerDaemon)
-	if err != nil {
+
+	// Reserve the run slot and publish DaemonRunning BEFORE firing the body
+	// (#470, race 1). fireAsync launches the run goroutine and returns; an
+	// instant crash can drive onDaemonRunFinished before control returns
+	// here. If the slot were written after fireAsync (as it used to be), the
+	// finish path's `daemonRuns[spec.ID] == runID` cleanup would miss —
+	// leaving a stale slot that makes registerDaemon think the daemon is
+	// still up — and the late setDaemonState(DaemonRunning) would overwrite
+	// the terminal DaemonStopped/DaemonCrashed the finish path just
+	// recorded. Pre-generating the run ID (fireAsync honors a non-empty
+	// opts.RunID) makes the reservation observable before the body can
+	// possibly exit, and leaves nothing to do after fireAsync succeeds.
+	runID := uuid.New().String()
+	e.daemonMu.Lock()
+	e.daemonRuns[spec.ID] = runID
+	e.daemonMu.Unlock()
+	e.setDaemonState(spec.ID, DaemonRunning)
+
+	if _, err := e.fireAsync(context.Background(), spec, pkgruntime.RunOptions{RunID: runID}, registry.TriggerDaemon); err != nil {
 		// fireAsync error here is a daemon-body launch failure — binary
 		// missing, port already bound, runtime resource exhaustion. Distinct
 		// from DaemonStopped so operators can tell "deliberately stopped /
 		// never started" apart from "daemon body broke" in the WebUI. See
 		// issue #318.
 		//
-		// No run is live, so drop the spawn timestamp recorded above — it
-		// must not age into a fake "sustained run".
+		// No run is live: roll back the reservation made above. The
+		// slot-matches guard mirrors onDaemonRunFinished so a concurrent
+		// starter's fresh reservation is never clobbered.
+		e.daemonMu.Lock()
+		if e.daemonRuns[spec.ID] == runID {
+			delete(e.daemonRuns, spec.ID)
+		}
+		e.daemonMu.Unlock()
+		// Drop the spawn timestamp recorded above — it must not age into a
+		// fake "sustained run".
 		e.crashloops.clearSpawn(spec.ID)
 		e.setDaemonState(spec.ID, DaemonFailedAfterPreflight)
 		e.log.Error("daemon start failed",
 			zap.String("task", spec.ID),
 			zap.Error(err),
 		)
-		return
 	}
-	e.daemonMu.Lock()
-	e.daemonRuns[spec.ID] = runID
-	e.daemonMu.Unlock()
-	e.setDaemonState(spec.ID, DaemonRunning)
 }
 
 func (e *Engine) onDaemonRunFinished(spec *task.Spec, runID string) {

--- a/pkg/trigger/daemon.go
+++ b/pkg/trigger/daemon.go
@@ -39,8 +39,9 @@ func (e *Engine) registerDaemon(spec *task.Spec) {
 	// firing OnRegister twice, or a manual re-register racing the reconciler)
 	// would otherwise both observe `alreadyRunning=false` and both spawn a
 	// daemon body. The lock ensures at most one in-flight start per task ID.
-	// Released once startDaemon has recorded the daemon's run slot (or
-	// logged a launch failure).
+	// The backoff-restart path in onDaemonRunFinished routes through the same
+	// gate (#470, race 2). Released once startDaemon has recorded the daemon's
+	// run slot (or logged a launch failure).
 	if !e.restartGates.tryAcquire(spec.ID) {
 		e.log.Debug("daemon start coalesced — another start is already in flight",
 			zap.String("task", spec.ID))
@@ -247,8 +248,49 @@ func (e *Engine) onDaemonRunFinished(spec *task.Spec, runID string) {
 	}
 	e.daemonBackoffs.Store(backoffKey, nextBackoff)
 
-	if !e.isShuttingDown() {
-		e.log.Info("restarting daemon task", zap.String("task", spec.ID))
-		e.startDaemon(spec)
+	if e.isShuttingDown() {
+		return
 	}
+
+	// Route the backoff restart through the same per-daemon gate as
+	// registerDaemon (#470, race 2). Without it, a re-register during the
+	// backoff sleep (e.g. the reconciler firing OnRegister after a content
+	// reload) could start the daemon body while this goroutine also calls
+	// startDaemon — a double-start of the same task body. When the gate is
+	// held, the concurrent starter owns the daemon now: coalesce and exit
+	// without touching any state.
+	if !e.restartGates.tryAcquire(spec.ID) {
+		e.log.Debug("daemon start coalesced — another start is already in flight",
+			zap.String("task", spec.ID))
+		return
+	}
+	defer e.restartGates.release(spec.ID)
+
+	// Re-check under the gate: the backoff sleep is up to daemonBackoffMax,
+	// plenty of time for the world to have moved on.
+	//   - An Unregister during the sleep must not resurrect the daemon (the
+	//     stillRegistered check at the top of this function predates the
+	//     sleep, so it cannot cover this).
+	//   - A re-register that already completed (gate released) has a live
+	//     run slot; starting again would double-start the body. With the
+	//     slot now reserved before the body fires (race 1 fix above), slot
+	//     presence is a reliable "body in flight" signal — the same check
+	//     registerDaemon uses.
+	e.daemonMu.Lock()
+	_, stillRegistered = e.daemonSpecs[spec.ID]
+	_, alreadyRunning := e.daemonRuns[spec.ID]
+	e.daemonMu.Unlock()
+	if !stillRegistered {
+		e.log.Debug("daemon restart skipped — task unregistered during backoff",
+			zap.String("task", spec.ID))
+		return
+	}
+	if alreadyRunning {
+		e.log.Debug("daemon restart skipped — daemon already restarted concurrently",
+			zap.String("task", spec.ID))
+		return
+	}
+
+	e.log.Info("restarting daemon task", zap.String("task", spec.ID))
+	e.startDaemon(spec)
 }

--- a/pkg/trigger/daemon_races_test.go
+++ b/pkg/trigger/daemon_races_test.go
@@ -1,0 +1,173 @@
+package trigger
+
+// Daemon-lifecycle race regression tests (issue #470).
+//
+// Two pre-existing races surfaced by the #469 decomposition review:
+//
+//   Race 1 — startDaemon used to write daemonRuns[spec.ID] and set
+//   DaemonRunning only AFTER fireAsync had already launched the run
+//   goroutine. An instant crash could drive onDaemonRunFinished before the
+//   slot write: the finish path's `daemonRuns[spec.ID] == runID` cleanup
+//   missed (stale slot left behind) and the late setDaemonState(Running)
+//   overwrote the terminal DaemonStopped/DaemonCrashed. Fixed by
+//   pre-generating the run ID (fireAsync honors a caller-provided
+//   opts.RunID) and reserving slot + Running state before the body fires.
+//
+//   Race 2 — the backoff-restart tail of onDaemonRunFinished called
+//   startDaemon without acquiring restartGates, so a re-register during a
+//   pending backoff could double-start the same task body. Fixed by routing
+//   the restart through the same gate as registerDaemon, plus re-checking
+//   registration and the run slot after the backoff sleep.
+//
+// Determinism notes: the interleavings are produced structurally, not by
+// timing. For race 1, the crashDaemonExec inspects the daemonRuns slot at
+// body START — the reservation is now made before fireAsync is even called,
+// so the body must always observe it. For race 2, the test acquires the
+// restart gate itself (playing the concurrent re-register) and holds it
+// across the entire backoff window, so the restart path deterministically
+// hits the held gate.
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+	"github.com/dicode/dicode/pkg/task"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+// crashDaemonExec is an Executor whose runs complete IMMEDIATELY with a
+// failure — the instant-crash daemon body from race 1. At body start it
+// checks whether the engine's daemonRuns slot already carries this run's ID,
+// recording how many runs observed their reservation.
+type crashDaemonExec struct {
+	eng            *Engine
+	runs           atomic.Int32 // total bodies executed
+	reservedAtBody atomic.Int32 // bodies that saw daemonRuns[spec.ID] == opts.RunID at start
+}
+
+func (c *crashDaemonExec) Execute(_ context.Context, spec *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
+	c.runs.Add(1)
+	c.eng.daemonMu.Lock()
+	reserved := c.eng.daemonRuns[spec.ID] == opts.RunID
+	c.eng.daemonMu.Unlock()
+	if reserved {
+		c.reservedAtBody.Add(1)
+	}
+	return &pkgruntime.RunResult{RunID: opts.RunID, Error: errors.New("instant crash")}, nil
+}
+
+// daemonRaceEnv returns a test engine wired to a crashDaemonExec, with the
+// given daemon spec registered in the registry AND seeded into daemonSpecs
+// (so onDaemonRunFinished's stillRegistered guard doesn't bail out). Mirrors
+// newPreflightEnv / crashloopEnv.
+func daemonRaceEnv(t *testing.T, restartPolicy string) (*Engine, *task.Spec, *crashDaemonExec) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+	exec := &crashDaemonExec{}
+	eng := New(reg, exec, zap.NewNop())
+	eng.RegisterExecutor(task.RuntimeDocker, exec)
+	exec.eng = eng
+
+	spec := &task.Spec{
+		ID:      "d-race",
+		Name:    "d-race",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{Daemon: true, Restart: restartPolicy},
+		Enabled: true,
+	}
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("reg.Register: %v", err)
+	}
+	eng.daemonMu.Lock()
+	eng.daemonSpecs[spec.ID] = spec
+	eng.daemonMu.Unlock()
+	return eng, spec, exec
+}
+
+// TestFireAsync_HonorsCallerRunID pins the mechanism race 1 relies on: a
+// non-empty opts.RunID must be used verbatim (generated only when empty), so
+// startDaemon can reserve the daemonRuns slot before firing the body.
+func TestFireAsync_HonorsCallerRunID(t *testing.T) {
+	eng, reg, _ := newPreflightEnv(t)
+	spec := &task.Spec{
+		ID:      "oneshot",
+		Name:    "oneshot",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Enabled: true,
+	}
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("reg.Register: %v", err)
+	}
+
+	want := uuid.New().String()
+	got, err := eng.fireAsync(context.Background(), spec, pkgruntime.RunOptions{RunID: want}, "test")
+	if err != nil {
+		t.Fatalf("fireAsync: %v", err)
+	}
+	if got != want {
+		t.Fatalf("fireAsync returned run ID %q, want caller-provided %q", got, want)
+	}
+	// The run record must exist under the caller-provided ID.
+	if _, err := reg.GetRun(context.Background(), want); err != nil {
+		t.Fatalf("GetRun(%q): %v", want, err)
+	}
+
+	// And the empty-RunID path still generates one.
+	gen, err := eng.fireAsync(context.Background(), spec, pkgruntime.RunOptions{}, "test")
+	if err != nil {
+		t.Fatalf("fireAsync (generated): %v", err)
+	}
+	if gen == "" || gen == want {
+		t.Fatalf("fireAsync with empty RunID returned %q, want a fresh generated ID", gen)
+	}
+}
+
+// TestStartDaemon_InstantCrash_NoStaleSlot_TerminalStateSticks — race 1: a
+// daemon body that exits before startDaemon regains control must still find
+// its reservation. Assert: the body observed daemonRuns[spec.ID] == its run
+// ID at start; after the terminal transition no stale daemonRuns entry
+// remains; and with restart:never the terminal DaemonCrashed sticks —
+// DaemonState never reports Running again.
+func TestStartDaemon_InstantCrash_NoStaleSlot_TerminalStateSticks(t *testing.T) {
+	eng, spec, exec := daemonRaceEnv(t, "never")
+
+	eng.startDaemon(spec)
+
+	waitUntil(t, 5*time.Second, func() bool {
+		return eng.DaemonState(spec.ID) == DaemonCrashed
+	}, "daemon never reached the terminal DaemonCrashed state")
+
+	if runs, reserved := exec.runs.Load(), exec.reservedAtBody.Load(); runs != 1 || reserved != runs {
+		t.Fatalf("runs=%d, bodies that observed their reservation=%d — the run slot must be written before the body fires",
+			runs, reserved)
+	}
+
+	eng.daemonMu.Lock()
+	staleRun, stale := eng.daemonRuns[spec.ID]
+	eng.daemonMu.Unlock()
+	if stale {
+		t.Fatalf("stale daemonRuns entry %q left behind after the daemon body finished", staleRun)
+	}
+
+	// The terminal state must stick: startDaemon has nothing left to do after
+	// fireAsync, so no late DaemonRunning can overwrite DaemonCrashed.
+	time.Sleep(100 * time.Millisecond)
+	if got := eng.DaemonState(spec.ID); got != DaemonCrashed {
+		t.Fatalf("DaemonState = %q after terminal transition, want %q (a late Running overwrite is race 1)",
+			got, DaemonCrashed)
+	}
+}

--- a/pkg/trigger/daemon_races_test.go
+++ b/pkg/trigger/daemon_races_test.go
@@ -171,3 +171,88 @@ func TestStartDaemon_InstantCrash_NoStaleSlot_TerminalStateSticks(t *testing.T) 
 			got, DaemonCrashed)
 	}
 }
+
+// TestDaemon_BackoffRestartCoalescesWithConcurrentStart — race 2, end to
+// end: the test acquires the per-daemon restart gate up front, playing a
+// concurrent re-register (registerDaemon holds the same gate across its
+// startDaemon call). The instant-crash body's finish handler schedules a
+// backoff restart; when the backoff elapses it must hit the held gate and
+// coalesce — so exactly ONE body ever starts.
+func TestDaemon_BackoffRestartCoalescesWithConcurrentStart(t *testing.T) {
+	eng, spec, exec := daemonRaceEnv(t, "always")
+
+	// Play the concurrent re-register: hold the gate for the whole test so
+	// the backoff-restart path deterministically finds it taken.
+	if !eng.restartGates.tryAcquire(spec.ID) {
+		t.Fatal("could not acquire restart gate")
+	}
+	defer eng.restartGates.release(spec.ID)
+
+	// registerDaemon calls startDaemon while holding the gate; mirror that.
+	eng.startDaemon(spec)
+
+	// Body crashes instantly; the finish handler sleeps daemonBackoffInit and
+	// must then coalesce on the held gate instead of double-starting.
+	time.Sleep(daemonBackoffInit + 1500*time.Millisecond)
+	if got := exec.runs.Load(); got != 1 {
+		t.Fatalf("executed %d daemon bodies, want exactly 1 — the backoff restart must coalesce on the held restart gate", got)
+	}
+}
+
+// TestOnDaemonRunFinished_BackoffRestart_SkipsWhenAlreadyRestarted — race 2,
+// completed-restart flavor: by the time the backoff elapses, a re-register
+// has already started a fresh body (live daemonRuns slot, gate released).
+// The restart path must observe the slot and skip rather than start a second
+// body next to the live one.
+func TestOnDaemonRunFinished_BackoffRestart_SkipsWhenAlreadyRestarted(t *testing.T) {
+	eng, spec, exec := daemonRaceEnv(t, "always")
+
+	// Seed a finished quick-failure run for the OLD body.
+	runID := quickFailureRun(t, eng, spec.ID, registry.StatusFailure)
+
+	// Simulate the re-register having completed during the backoff: a fresh
+	// body is live under a different run ID (reservation written before the
+	// body fires — race 1 fix — so slot presence means "body in flight").
+	eng.daemonMu.Lock()
+	eng.daemonRuns[spec.ID] = "live-restarted-run"
+	eng.daemonMu.Unlock()
+
+	// Synchronous: sleeps daemonBackoffInit, then must skip on the live slot.
+	eng.onDaemonRunFinished(spec, runID)
+
+	if got := exec.runs.Load(); got != 0 {
+		t.Fatalf("executed %d daemon bodies, want 0 — a live run slot must suppress the backoff restart", got)
+	}
+	eng.daemonMu.Lock()
+	slot := eng.daemonRuns[spec.ID]
+	eng.daemonMu.Unlock()
+	if slot != "live-restarted-run" {
+		t.Fatalf("daemonRuns slot = %q, want the concurrent starter's %q left untouched", slot, "live-restarted-run")
+	}
+}
+
+// TestOnDaemonRunFinished_BackoffRestart_SkipsWhenUnregisteredDuringBackoff —
+// the unregister-during-backoff hole adjacent to race 2: the stillRegistered
+// check at the top of onDaemonRunFinished predates the backoff sleep, so an
+// Unregister during the sleep must be re-checked before restarting — an
+// unregistered daemon must not be resurrected.
+func TestOnDaemonRunFinished_BackoffRestart_SkipsWhenUnregisteredDuringBackoff(t *testing.T) {
+	eng, spec, exec := daemonRaceEnv(t, "always")
+
+	runID := quickFailureRun(t, eng, spec.ID, registry.StatusFailure)
+
+	// Unregister mid-backoff: the delay is well past the (instant, in-memory)
+	// top-of-function checks and well inside the 1s backoff sleep.
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		eng.daemonMu.Lock()
+		delete(eng.daemonSpecs, spec.ID)
+		eng.daemonMu.Unlock()
+	}()
+
+	eng.onDaemonRunFinished(spec, runID)
+
+	if got := exec.runs.Load(); got != 0 {
+		t.Fatalf("executed %d daemon bodies, want 0 — an unregister during the backoff must not resurrect the daemon", got)
+	}
+}

--- a/pkg/trigger/run.go
+++ b/pkg/trigger/run.go
@@ -401,7 +401,14 @@ func (e *Engine) fireKinded(ctx context.Context, k task.Kinded, opts pkgruntime.
 }
 
 func (e *Engine) fireAsync(ctx context.Context, spec *task.Spec, opts pkgruntime.RunOptions, source registry.TriggerSource) (string, error) {
-	opts.RunID = uuid.New().String()
+	// Honor a caller-provided run ID; generate one only when absent. The only
+	// caller that pre-sets opts.RunID is startDaemon (#470): it must reserve
+	// the daemonRuns slot BEFORE the run goroutine can exit, which requires
+	// knowing the run ID before fireAsync launches the body. Every other call
+	// site passes a fresh RunOptions with an empty RunID.
+	if opts.RunID == "" {
+		opts.RunID = uuid.New().String()
+	}
 
 	runCtx, cleanup, err := e.startRun(spec, &opts, source)
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes #470 — the two Major daemon-lifecycle races CodeRabbit surfaced on the #469 decomposition, plus a third hole found while fixing them. Closes #470.

## Race 1 — run slot written after `fireAsync` launched the body

`startDaemon` wrote `daemonRuns[spec.ID]` and set `DaemonRunning` **after** `fireAsync` returned — but `fireAsync` launches the run goroutine, so an instant crash could drive `onDaemonRunFinished` first: the finish path's slot-matches cleanup missed (stale slot → `registerDaemon` thinks the daemon is up), and the late `DaemonRunning` overwrote the just-recorded terminal state.

**Fix (design a):** `fireAsync` now honors a caller-provided `opts.RunID` (generates only when empty; verified no other call site pre-sets it). `startDaemon` pre-generates the ID and publishes the reservation **before** firing the body — nothing left to do post-launch, so the finish handler always observes the slot. Launch failure rolls the reservation back under the same slot-matches guard the finish path uses. The #468 `noteSpawn`-first ordering is preserved.

## Race 2 — backoff restart bypassed `restartGates`

The restart goroutine called `startDaemon` directly after the backoff sleep, while the register path holds `restartGates` — a re-register during the sleep could double-start the same task body. The backoff restart now routes through the same gate (coalescing with the same debug wording), and **re-checks under the gate**: `stillRegistered` and `alreadyRunning` (slot presence is now a reliable in-flight signal thanks to race 1's pre-reservation).

## Bonus: unregister-during-backoff resurrection

The `stillRegistered` check at the top of `onDaemonRunFinished` predates the up-to-30s backoff sleep, so an `Unregister` during the sleep resurrected the daemon (and unregister-time `KillRun` was a no-op since the slot was already deleted). The under-gate re-check closes it, pinned by its own test.

## Test plan
- [x] 5 new deterministic tests (`daemon_races_test.go`): caller-RunID mechanism; instant-crash → no stale slot + terminal state sticks (the executor asserts its reservation is visible at body **start** — structurally impossible to fail post-fix, exactly the race pre-fix); backoff-vs-concurrent-start coalescing via the gate (counting executor, exactly one body); already-restarted skip; unregistered-during-backoff skip
- [x] Full `pkg/trigger` suite green (40s) — daemon lifecycle/crashloop/pipeline tests as the regression oracle
- [x] **`go test ./pkg/trigger/... -race` clean** (59s)
- [x] `make build`, `go vet`, `gofmt -l` clean; repo sweep green except the known sandbox deno-TLS environmental failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJMqv1hzZzUZep13oyKrCD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon startup reliability so running status is tracked more accurately, even during fast failures.
  * Prevented duplicate daemon restarts during backoff, reducing race conditions and unexpected double launches.
  * Preserved the final crash/failed state instead of briefly showing a running state after an immediate failure.
  * Kept daemon restarts from happening after a daemon has already been restarted or unregistered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->