### PR TITLE
fix(auth): revoke trusted-device cookie by token_hash on logout (#474)

### DIFF
--- a/pkg/webui/auth_test.go
+++ b/pkg/webui/auth_test.go
@@ -174,6 +174,101 @@ func TestAuth_Logout_RevokesSession(t *testing.T) {
 	}
 }
 
+// TestAuth_Logout_RevokesDeviceToken is a regression test for the bug where
+// apiLogout passed the raw device-cookie value to the id-keyed revokeDevice,
+// matching zero rows and leaving the trusted-device token replayable until its
+// 30-day expiry. Logout must delete the row by token_hash so the cookie is
+// dead immediately.
+func TestAuth_Logout_RevokesDeviceToken(t *testing.T) {
+	srv := newAuthServer(t, "hunter2")
+	h := srv.Handler()
+
+	// Login with trust=true to get both a session cookie and a device cookie.
+	body, _ := json.Marshal(map[string]any{"password": "hunter2", "trust": true})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "TestBrowser/1.0")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("login failed: %d: %s", w.Code, w.Body)
+	}
+	var sessCookie, devCookie *http.Cookie
+	for _, c := range w.Result().Cookies() {
+		switch c.Name {
+		case sessionCookie:
+			sessCookie = c
+		case deviceCookie:
+			devCookie = c
+		}
+	}
+	if sessCookie == nil || devCookie == nil {
+		t.Fatalf("expected session and device cookies, got session=%v device=%v", sessCookie, devCookie)
+	}
+
+	devices, err := srv.dbSessions.listDevices(t.Context())
+	if err != nil {
+		t.Fatalf("listDevices: %v", err)
+	}
+	if len(devices) != 1 {
+		t.Fatalf("expected 1 device row after trusted login, got %d", len(devices))
+	}
+
+	// Logout with the device cookie attached.
+	req2 := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
+	req2.AddCookie(sessCookie)
+	req2.AddCookie(devCookie)
+	w2 := httptest.NewRecorder()
+	h.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("logout failed: %d", w2.Code)
+	}
+
+	// The device row must be gone, not just the session.
+	devices, err = srv.dbSessions.listDevices(t.Context())
+	if err != nil {
+		t.Fatalf("listDevices: %v", err)
+	}
+	if len(devices) != 0 {
+		t.Fatalf("device row must be deleted on logout, got %d rows", len(devices))
+	}
+
+	// Replaying the raw device token must fail — the cookie is dead.
+	if _, ok, _ := srv.dbSessions.renewFromDevice(t.Context(), devCookie.Value, "127.0.0.1", "TestBrowser/1.0", "off"); ok {
+		t.Fatal("device token still accepted after logout; logout must revoke by token_hash")
+	}
+}
+
+// Guard: the id-keyed revokeDevice used by apiRevokeDevice (revoke a device
+// from the /security list) must keep working alongside the token-keyed revoke.
+func TestAuth_RevokeDeviceByID_StillWorks(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := t.Context()
+
+	raw, err := store.issueDeviceToken(ctx, "203.0.113.10", "TestBrowser/1.0")
+	if err != nil {
+		t.Fatalf("issueDeviceToken: %v", err)
+	}
+	devices, err := store.listDevices(ctx)
+	if err != nil {
+		t.Fatalf("listDevices: %v", err)
+	}
+	if len(devices) != 1 {
+		t.Fatalf("expected 1 device, got %d", len(devices))
+	}
+
+	if err := store.revokeDevice(ctx, devices[0].ID); err != nil {
+		t.Fatalf("revokeDevice: %v", err)
+	}
+	devices, _ = store.listDevices(ctx)
+	if len(devices) != 0 {
+		t.Fatalf("id-based revoke must delete the row, got %d rows", len(devices))
+	}
+	if _, ok, _ := store.renewFromDevice(ctx, raw, "203.0.113.10", "TestBrowser/1.0", "off"); ok {
+		t.Fatal("device token still accepted after id-based revoke")
+	}
+}
+
 func TestAuth_TrustedDevice_IssuedOnLogin(t *testing.T) {
 	srv := newAuthServer(t, "secret")
 	h := srv.Handler()

--- a/pkg/webui/sessions_db.go
+++ b/pkg/webui/sessions_db.go
@@ -458,7 +458,12 @@ func (s *Server) apiLogout(w http.ResponseWriter, r *http.Request) {
 	_ = s.sm.Destroy(r.Context())
 	if s.dbSessions != nil {
 		if dc, err := r.Cookie(deviceCookie); err == nil {
-			_ = s.dbSessions.revokeDeviceByToken(r.Context(), dc.Value)
+			// Surface a failed revoke: the cookie is cleared client-side
+			// regardless, but if the row survives (DB error / contention) a
+			// captured cookie stays usable, so the failure must not be silent.
+			if err := s.dbSessions.revokeDeviceByToken(r.Context(), dc.Value); err != nil {
+				s.log.Warn("device.revoke_on_logout_failed", zap.Error(err))
+			}
 		}
 	}
 	clearDeviceCookie(w)

--- a/pkg/webui/sessions_db.go
+++ b/pkg/webui/sessions_db.go
@@ -323,6 +323,13 @@ func (s *dbSessionStore) revokeDevice(ctx context.Context, id string) error {
 	return s.db.Exec(ctx, `DELETE FROM sessions WHERE id = ? AND kind = 'device'`, id)
 }
 
+// revokeDeviceByToken deletes the device row matching a raw device-cookie
+// value. apiLogout has the raw cookie, not the row id, so it must revoke by
+// token_hash — the same key renewFromDevice looks the row up by.
+func (s *dbSessionStore) revokeDeviceByToken(ctx context.Context, rawToken string) error {
+	return s.db.Exec(ctx, `DELETE FROM sessions WHERE token_hash = ? AND kind = 'device'`, hashToken(rawToken))
+}
+
 // RevokeAllDevices clears all trusted device tokens (emergency lockout).
 func (s *dbSessionStore) revokeAllDevices(ctx context.Context) error {
 	return s.db.Exec(ctx, `DELETE FROM sessions WHERE kind = 'device'`)
@@ -451,7 +458,7 @@ func (s *Server) apiLogout(w http.ResponseWriter, r *http.Request) {
 	_ = s.sm.Destroy(r.Context())
 	if s.dbSessions != nil {
 		if dc, err := r.Cookie(deviceCookie); err == nil {
-			_ = s.dbSessions.revokeDevice(r.Context(), dc.Value)
+			_ = s.dbSessions.revokeDeviceByToken(r.Context(), dc.Value)
 		}
 	}
 	clearDeviceCookie(w)


### PR DESCRIPTION
## Summary

Fixes #474 — a verified security bug where logging out **doesn't** revoke the trusted-device cookie. Closes #474.

## The bug
`apiLogout` had the raw device-cookie token and called `revokeDevice(dc.Value)`, but that function deletes `WHERE id = ?` (a UUID column) — so passing the raw 64-hex token matched **zero rows**. The device row (looked up everywhere else by `token_hash`) survived its full 30-day TTL, letting a captured cookie keep minting sessions via `/api/auth/refresh` after "logout." (`apiRevokeDevice` and `apiLogoutAll` were already correct.)

## Fix
Add `revokeDeviceByToken` (deletes by `token_hash = hashToken(raw)` — the same key `renewFromDevice` uses) and call it from `apiLogout`. `revokeDevice` is left as-is for `apiRevokeDevice`, which correctly holds the row id.

```go
func (s *dbSessionStore) revokeDeviceByToken(ctx context.Context, rawToken string) error {
    return s.db.Exec(ctx, `DELETE FROM sessions WHERE token_hash = ? AND kind = 'device'`, hashToken(rawToken))
}
```

## Test plan
- [x] `TestAuth_Logout_RevokesDeviceToken` — login `trust=true`, capture raw cookie, `POST /api/auth/logout`, assert the row is gone (1→0) **and** a subsequent `renewFromDevice` with that token returns `ok=false`
- [x] `TestAuth_RevokeDeviceByID_StillWorks` — guards that the id-based `revokeDevice` (used by `apiRevokeDevice`) still works
- [x] `make build`, `go vet`, `gofmt -l` clean; full `pkg/webui` suite green

Found in the whole-codebase security audit (#474–#478 filed from it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJMqv1hzZzUZep13oyKrCD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated logout so trusted device cookies are revoked via token-hash lookup, preventing previously logged-out devices from being renewed.
  * Kept existing behavior intact for revoking trusted devices by device ID.
  * Improved consistency between trusted-session logout and device renewal behavior.
* **Tests**
  * Added regression coverage for logout revoking device tokens.
  * Added a regression test ensuring device revocation by device ID continues to work alongside token-hash revocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->