### PR TITLE
security(webui): restrict branches token_env + block SSRF to internal hosts (#475)

### DIFF
--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -241,14 +242,51 @@ func (g *GitSource) syncAndEmit(ctx context.Context, ch chan<- source.Event) err
 	return nil
 }
 
+// validateRemoteHost rejects remote endpoints that point at loopback,
+// private, link-local, or otherwise internal network targets (SSRF guard,
+// #475). It inspects the literal host only: IP literals are classified with
+// the net package; hostnames are matched against well-known internal
+// suffixes (localhost, *.local mDNS, *.internal cloud-metadata style names).
+// DNS resolution is deliberately not performed here — resolving would add a
+// network dependency and the result would be TOCTOU-racy against the actual
+// dial anyway.
+func validateRemoteHost(ep *gogittransport.Endpoint) error {
+	// go-git stores IPv6 literals bracketed ("[::1]"); strip for parsing.
+	host := strings.ToLower(strings.Trim(ep.Host, "[]"))
+	if host == "" {
+		return fmt.Errorf("url has no remote host")
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+			ip.IsLinkLocalMulticast() || ip.IsUnspecified() || ip.IsMulticast() {
+			return fmt.Errorf("host %q is a private or internal address; refusing to contact it", host)
+		}
+		return nil
+	}
+	if host == "localhost" ||
+		strings.HasSuffix(host, ".localhost") ||
+		strings.HasSuffix(host, ".local") ||
+		strings.HasSuffix(host, ".internal") {
+		return fmt.Errorf("host %q is a private or internal address; refusing to contact it", host)
+	}
+	return nil
+}
+
 // ListBranches contacts the remote and returns branch names sorted alphabetically.
 // tokenEnv is the name of an env var holding an HTTP auth token; pass "" for public repos.
+//
+// Remotes on loopback/private/link-local/internal hosts are rejected before
+// any connection is attempted — this function is reachable from the REST API
+// with a caller-supplied URL, so it must not be usable to probe the daemon's
+// internal network (#475).
 func ListBranches(ctx context.Context, repoURL, tokenEnv string) ([]string, error) {
 	ep, err := gogittransport.NewEndpoint(repoURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid url: %w", err)
 	}
-	_ = ep // endpoint validated; use go-git remote directly
+	if err := validateRemoteHost(ep); err != nil {
+		return nil, err
+	}
 
 	var auth gogittransport.AuthMethod
 	if tokenEnv != "" {

--- a/pkg/source/git/listbranches_test.go
+++ b/pkg/source/git/listbranches_test.go
@@ -1,0 +1,104 @@
+package git
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	gogittransport "github.com/go-git/go-git/v5/plumbing/transport"
+)
+
+// Tests for the ListBranches SSRF guard (#475). ListBranches is reachable
+// from the REST API with a caller-supplied URL, so it must refuse to contact
+// loopback/private/link-local/internal hosts before any dial happens.
+//
+// Hermetic: private-host cases must fail in validation (never reaching the
+// "list remote" dial stage), and the public-host case uses a pre-cancelled
+// context so go-git aborts before touching the network.
+
+func TestListBranches_RejectsPrivateHosts(t *testing.T) {
+	cases := []string{
+		"http://127.0.0.1/repo.git",
+		"http://127.0.0.1:8080/repo.git",
+		"https://10.0.0.8/repo.git",
+		"https://172.16.0.1/repo.git",
+		"https://192.168.1.10/repo.git",
+		"http://169.254.169.254/latest/meta-data",
+		"http://[::1]/repo.git",
+		"http://[fe80::1]/repo.git",
+		"http://[fd00::1]/repo.git",
+		"http://0.0.0.0/repo.git",
+		"http://localhost/repo.git",
+		"http://localhost:3000/repo.git",
+		"https://gitserver.local/repo.git",
+		"http://metadata.google.internal/computeMetadata/v1",
+		"https://foo.corp.internal/repo.git",
+	}
+	for _, u := range cases {
+		_, err := ListBranches(context.Background(), u, "")
+		if err == nil {
+			t.Errorf("ListBranches(%q) = nil error, want private-host rejection", u)
+			continue
+		}
+		if !strings.Contains(err.Error(), "private or internal") {
+			t.Errorf("ListBranches(%q) error = %q, want private/internal host rejection", u, err)
+		}
+		// "list remote:" wraps errors from the dial stage — its presence
+		// would mean validation was bypassed and a connection was attempted.
+		if strings.Contains(err.Error(), "list remote") {
+			t.Errorf("ListBranches(%q) reached the dial stage: %q", u, err)
+		}
+	}
+}
+
+func TestValidateRemoteHost_AllowsPublicHosts(t *testing.T) {
+	cases := []string{
+		"https://github.com/example/repo.git",
+		"http://gitlab.example.com/group/repo.git",
+		"https://8.8.8.8/repo.git",
+		"ssh://git@github.com/example/repo.git",
+		"git@github.com:example/repo.git",
+		"git://example.com/repo.git",
+	}
+	for _, u := range cases {
+		ep, err := gogittransport.NewEndpoint(u)
+		if err != nil {
+			t.Fatalf("NewEndpoint(%q): %v", u, err)
+		}
+		if err := validateRemoteHost(ep); err != nil {
+			t.Errorf("validateRemoteHost(%q) = %v, want nil", u, err)
+		}
+	}
+}
+
+func TestValidateRemoteHost_RejectsMissingHost(t *testing.T) {
+	// file:// endpoints carry no remote host — the guard must reject them
+	// even though the webui scheme allowlist also blocks file:// upstream.
+	ep, err := gogittransport.NewEndpoint("file:///etc/passwd")
+	if err != nil {
+		t.Fatalf("NewEndpoint: %v", err)
+	}
+	if err := validateRemoteHost(ep); err == nil {
+		t.Error("validateRemoteHost(file:///etc/passwd) = nil, want no-host rejection")
+	}
+}
+
+// TestListBranches_PublicHostReachesDialStage proves a legitimate public URL
+// passes the host guard: with a pre-cancelled context the call must fail at
+// the "list remote" stage (wrapped context error), not in validation. No
+// network traffic occurs because the transport aborts on the dead context.
+func TestListBranches_PublicHostReachesDialStage(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := ListBranches(ctx, "https://github.com/example/repo.git", "")
+	if err == nil {
+		t.Fatal("ListBranches with cancelled ctx returned nil error")
+	}
+	if strings.Contains(err.Error(), "private or internal") {
+		t.Fatalf("public host was rejected by the SSRF guard: %v", err)
+	}
+	if !strings.Contains(err.Error(), "list remote") {
+		t.Fatalf("expected failure from the dial stage (list remote), got: %v", err)
+	}
+}

--- a/pkg/webui/security_test.go
+++ b/pkg/webui/security_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/dicode/dicode/pkg/config"
+	"github.com/dicode/dicode/pkg/taskset"
 )
 
 // ── 1. apiGetConfigRaw redaction ──────────────────────────────────────────────
@@ -260,6 +262,146 @@ func TestIsAllowedGitScheme_Rejected(t *testing.T) {
 	for _, u := range cases {
 		if isAllowedGitScheme(u) {
 			t.Errorf("isAllowedGitScheme(%q) = true, want false", u)
+		}
+	}
+}
+
+// ── 3b. apiListGitBranches — token_env restriction + SSRF host block (#475) ──
+
+// branchesTestServer builds a minimal Server whose config has one git source
+// with an operator-designated credential env var. apiListGitBranches only
+// touches cfg/cfgMu, so no full test server (and no deno) is needed.
+func branchesTestServer() *Server {
+	cfg := &config.Config{Server: config.ServerConfig{Port: 8080}}
+	cfg.Spec.Entries = map[string]*taskset.Entry{
+		"corp-tasks": {Ref: &taskset.Ref{
+			URL:    "https://github.com/corp/tasks.git",
+			Branch: "main",
+			Auth:   taskset.RefAuth{TokenEnv: "GH_TOKEN"},
+		}},
+		"local": {Ref: &taskset.Ref{Path: "/tmp/tasks"}},
+	}
+	return &Server{cfg: cfg}
+}
+
+func listBranchesReq(srv *Server, target string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	w := httptest.NewRecorder()
+	srv.apiListGitBranches(w, req)
+	return w
+}
+
+// TestApiListGitBranches_RejectsPrivateHosts asserts that URLs pointing at
+// loopback/private/link-local/internal hosts are rejected with a clear error
+// and never reach the dial stage ("list remote" only appears in errors
+// wrapped after a connection attempt).
+func TestApiListGitBranches_RejectsPrivateHosts(t *testing.T) {
+	srv := branchesTestServer()
+	cases := []string{
+		"http://127.0.0.1/repo.git",
+		"https://10.0.0.8/repo.git",
+		"http://169.254.169.254/latest/meta-data",
+		"http://[::1]/repo.git",
+		"http://localhost:3000/repo.git",
+		"http://metadata.google.internal/computeMetadata/v1",
+	}
+	for _, u := range cases {
+		w := listBranchesReq(srv, "/api/settings/sources/git/branches?url="+url.QueryEscape(u))
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("url=%q: code = %d, want 400", u, w.Code)
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, "private or internal") {
+			t.Errorf("url=%q: body = %q, want private/internal host rejection", u, body)
+		}
+		if strings.Contains(body, "list remote") {
+			t.Errorf("url=%q: reached the dial stage: %q", u, body)
+		}
+	}
+}
+
+// TestApiListGitBranches_RejectsUnknownTokenEnv asserts that naming an env
+// var that is not an operator-configured git credential is refused outright —
+// the value must never be attached as basic auth (this was the secret
+// exfiltration vector in #475).
+func TestApiListGitBranches_RejectsUnknownTokenEnv(t *testing.T) {
+	t.Setenv("SUPER_SECRET_TOKEN", "hunter2") // present in the daemon env, still must not be usable
+	srv := branchesTestServer()
+
+	w := listBranchesReq(srv,
+		"/api/settings/sources/git/branches?url="+url.QueryEscape("https://github.com/evil/exfil.git")+
+			"&token_env=SUPER_SECRET_TOKEN")
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("code = %d, want 403; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "not permitted") {
+		t.Errorf("body = %q, want token_env rejection message", w.Body.String())
+	}
+}
+
+// TestApiListGitBranches_LegitPublicURLPassesGates asserts the two security
+// gates do not break the legitimate case: a public host with no token_env
+// must get past both checks. The request context is pre-cancelled so go-git
+// fails at the dial stage ("list remote") without touching the network.
+func TestApiListGitBranches_LegitPublicURLPassesGates(t *testing.T) {
+	srv := branchesTestServer()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/settings/sources/git/branches?url="+url.QueryEscape("https://github.com/example/repo.git"), nil)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+	srv.apiListGitBranches(w, req)
+
+	body := w.Body.String()
+	if strings.Contains(body, "private or internal") || strings.Contains(body, "not permitted") {
+		t.Fatalf("legitimate request was blocked by a security gate: %s", body)
+	}
+	if !strings.Contains(body, "list remote") {
+		t.Fatalf("expected failure from the dial stage (list remote), got: %s", body)
+	}
+}
+
+// TestResolveBranchesTokenEnv covers the credential-resolution rule directly:
+// configured-source URLs use their own token_env (request input ignored);
+// unknown URLs may only use an env var already designated as a git credential.
+func TestResolveBranchesTokenEnv(t *testing.T) {
+	srv := branchesTestServer()
+
+	cases := []struct {
+		name      string
+		url       string
+		requested string
+		want      string
+		wantErr   bool
+	}{
+		{"configured URL uses own credential, request ignored",
+			"https://github.com/corp/tasks.git", "SUPER_SECRET_TOKEN", "GH_TOKEN", false},
+		{"configured URL matches without .git suffix",
+			"https://github.com/corp/tasks", "PATH", "GH_TOKEN", false},
+		{"unknown URL, empty token_env allowed",
+			"https://github.com/other/repo.git", "", "", false},
+		{"unknown URL, operator-designated credential allowed",
+			"https://github.com/other/repo.git", "GH_TOKEN", "GH_TOKEN", false},
+		{"unknown URL, arbitrary env var rejected",
+			"https://github.com/other/repo.git", "AWS_SECRET_ACCESS_KEY", "", true},
+	}
+	for _, tc := range cases {
+		got, err := srv.resolveBranchesTokenEnv(tc.url, tc.requested)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("%s: err = nil, want rejection", tc.name)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, got, tc.want)
 		}
 	}
 }

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -2360,6 +2360,25 @@ func (s *Server) apiAddSource(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]string{"status": "ok"})
 }
 
+// apiListGitBranches lists remote branches for a git URL — used by the config
+// UI when adding or inspecting a source.
+//
+// Security (#475): the token_env query parameter names an environment
+// variable whose value is sent as an HTTP basic-auth password to the remote.
+// Honouring an arbitrary name would let any authenticated caller exfiltrate
+// any daemon env var by pointing url at a server they control. The rule
+// enforced by resolveBranchesTokenEnv:
+//
+//  1. If url matches an already-configured git source, that source's
+//     configured auth.token_env is used and the request's token_env is
+//     ignored.
+//  2. Otherwise (previewing a source that has not been added yet), token_env
+//     must be empty or exactly match an auth.token_env already configured on
+//     some git source in dicode.yaml — i.e. an env var the operator has
+//     explicitly designated as a git credential.
+//
+// SSRF against loopback/private/link-local/internal hosts is rejected inside
+// gitSource.ListBranches before any connection is made.
 func (s *Server) apiListGitBranches(w http.ResponseWriter, r *http.Request) {
 	repoURL := r.URL.Query().Get("url")
 	if repoURL == "" {
@@ -2370,13 +2389,55 @@ func (s *Server) apiListGitBranches(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, "url scheme not allowed", http.StatusBadRequest)
 		return
 	}
-	tokenEnv := r.URL.Query().Get("token_env")
+	tokenEnv, err := s.resolveBranchesTokenEnv(repoURL, r.URL.Query().Get("token_env"))
+	if err != nil {
+		jsonErr(w, err.Error(), http.StatusForbidden)
+		return
+	}
 	branches, err := gitSource.ListBranches(r.Context(), repoURL, tokenEnv)
 	if err != nil {
 		jsonErr(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	jsonOK(w, branches)
+}
+
+// resolveBranchesTokenEnv decides which environment variable, if any, may be
+// used as the git credential for a branch-listing request. See the security
+// note on apiListGitBranches for the rule it enforces.
+func (s *Server) resolveBranchesTokenEnv(repoURL, requested string) (string, error) {
+	s.cfgMu.RLock()
+	defer s.cfgMu.RUnlock()
+
+	want := normalizeGitURL(repoURL)
+	allowed := make(map[string]bool)
+	if s.cfg != nil {
+		for _, entry := range s.cfg.Spec.Entries {
+			if entry == nil || entry.Ref == nil || !entry.Ref.IsGit() {
+				continue
+			}
+			if normalizeGitURL(entry.Ref.URL) == want {
+				// Configured source: always use its own credential.
+				return entry.Ref.Auth.TokenEnv, nil
+			}
+			if entry.Ref.Auth.TokenEnv != "" {
+				allowed[entry.Ref.Auth.TokenEnv] = true
+			}
+		}
+	}
+	if requested == "" || allowed[requested] {
+		return requested, nil
+	}
+	return "", fmt.Errorf("token_env %q is not permitted: it must match the auth.token_env of a git source configured in dicode.yaml", requested)
+}
+
+// normalizeGitURL canonicalises a git remote URL for equality comparison:
+// trims surrounding whitespace, a trailing slash, and a trailing ".git".
+func normalizeGitURL(raw string) string {
+	u := strings.TrimSpace(raw)
+	u = strings.TrimSuffix(u, "/")
+	u = strings.TrimSuffix(u, ".git")
+	return u
 }
 
 func (s *Server) apiRemoveSource(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Fixes #475 — `apiListGitBranches` could be used to exfiltrate any daemon env-var secret to an attacker-controlled host, and to SSRF-probe internal services. Closes #475.

## The bug
The endpoint took **both** `url` and `token_env` from query params and passed them to `git.ListBranches`, which did `os.Getenv(token_env)` and attached the value as HTTP BasicAuth to a `ls-remote` against the caller-supplied `url` (http/https allowed). An authenticated caller could set `token_env=<any secret env>` + `url=http://attacker/` to leak the secret in the Authorization header, and probe internal hosts regardless.

## Fix (two layers)
- **`resolveBranchesTokenEnv`** (server.go) — the credential rule: if the `url` matches an **already-configured** git source, that source's own `auth.token_env` is used and the request's `token_env` is **ignored**; otherwise (previewing a not-yet-added source) `token_env` must be empty **or** exactly match an `auth.token_env` already designated on some configured git source. Anything else → `403`. URL matching is normalization-aware (trailing `/`, `.git`).
- **`validateRemoteHost`** (git.go) — reject loopback / private / link-local / multicast / unspecified IP literals and `localhost` / `.local` / `.internal` hostnames **before any dial**. DNS is deliberately *not* resolved (avoids a network dependency and a TOCTOU race against the actual dial); the scheme allowlist is unchanged.

## Test plan
- [x] `listbranches_test.go` — SSRF guard rejects 127.0.0.1/10.x/172.16/192.168/169.254/`::1`/`fe80::`/`fd00::`/`0.0.0.0`/`localhost`/`*.local`/cloud-metadata hosts before the dial stage; allows public hosts
- [x] `TestResolveBranchesTokenEnv` + handler-level tests — configured-source uses its own token (request ignored), empty allowed, allowlisted reuse allowed, arbitrary env var → 403
- [x] `make build`, `go vet`, `gofmt -l` clean; `pkg/webui` + `pkg/source/git` suites green

Found in the whole-codebase security audit.

> Maintainer note: the "preview an unconfigured source" case allows any env var already designated as a git credential on *some* configured source — the least-surprising rule without a new config surface. If you'd prefer stricter (only the exact source being previewed, no cross-source reuse), say so and I'll tighten it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJMqv1hzZzUZep13oyKrCD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Strengthened git branch listing to block requests to private, loopback, link-local, and other internal hosts.
  * Restricted use of custom credential environment settings so only permitted values are accepted.

* **Bug Fixes**
  * Requests to protected or invalid git URLs now fail earlier with clearer access errors instead of proceeding to connection attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->