### PR TITLE
fix(daemon): gate CLI task ops on a first-reconcile readiness barrier (#464)

### DIFF
--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -129,6 +129,9 @@ func dispatch(c *ipc.ControlClient, args []string) error {
 		if len(args) < 2 {
 			return fmt.Errorf("usage: dicode run <task-id> [key=value ...]")
 		}
+		if err := waitDaemonReady(c, readyWaitTimeout); err != nil {
+			return err
+		}
 		return cmdRun(c, args[1], args[2:])
 	case "logs":
 		if len(args) < 2 {
@@ -139,6 +142,13 @@ func dispatch(c *ipc.ControlClient, args []string) error {
 		taskID := ""
 		if len(args) >= 2 {
 			taskID = args[1]
+		}
+		// Only the task-scoped form needs the registry populated; bare
+		// `dicode status` is daemon health and must answer even mid-sync.
+		if taskID != "" {
+			if err := waitDaemonReady(c, readyWaitTimeout); err != nil {
+				return err
+			}
 		}
 		return cmdStatus(c, taskID)
 	case "secrets":
@@ -511,6 +521,9 @@ func cmdTask(c *ipc.ControlClient, args []string) error {
 	case "test":
 		if len(args) < 2 {
 			return fmt.Errorf("usage: dicode task test <task-id> [--format=text|junit|gh-summary]")
+		}
+		if err := waitDaemonReady(c, readyWaitTimeout); err != nil {
+			return err
 		}
 		return cmdTaskTest(c, args[1:])
 	case "create":
@@ -1034,6 +1047,46 @@ func cmdAI(c *ipc.ControlClient, args []string) error {
 		fmt.Fprintf(os.Stderr, "session: %s\n", result.SessionID)
 	}
 	fmt.Println(result.Reply)
+	return nil
+}
+
+// readyWaitTimeout bounds how long task-scoped commands (run, status <task>,
+// task test) wait for the daemon's first task sync after the control socket
+// is reachable. The first sync may include a git clone of the task sources,
+// so this is deliberately more generous than ensureDaemon's socket poll.
+const readyWaitTimeout = 30 * time.Second
+
+// waitDaemonReady blocks until the daemon reports its initial task sync is
+// complete, or timeout elapses. Socket-up does not imply ready-to-serve-
+// lookups (#464): the control socket accepts connections before the
+// reconciler's first sync has registered the task inventory, so a task-scoped
+// command issued right after daemon start could see a spurious "task not
+// found". The wait happens daemon-side (single blocking cli.ready round-trip,
+// no polling); on a daemon that shuts down mid-wait the request errors out.
+// An older daemon that predates cli.ready is treated as ready so mixed
+// CLI/daemon versions keep working.
+func waitDaemonReady(c *ipc.ControlClient, timeout time.Duration) error {
+	resp, err := c.Send(ipc.Request{
+		Method: "cli.ready",
+		WaitMs: int(timeout / time.Millisecond),
+	})
+	if err != nil {
+		return fmt.Errorf("query daemon readiness: %w", err)
+	}
+	if resp.Error != "" {
+		if strings.Contains(resp.Error, "unknown method") {
+			return nil // pre-#464 daemon: no readiness barrier, keep old behaviour
+		}
+		return fmt.Errorf("query daemon readiness: %s", resp.Error)
+	}
+	var r ipc.ReadyResult
+	if err := remarshal(resp.Result, &r); err != nil {
+		return fmt.Errorf("decode readiness result: %w", err)
+	}
+	if !r.Ready {
+		return fmt.Errorf("daemon not ready after %s — initial task sync still running (retry shortly, or check %s)",
+			timeout, filepath.Join(defaultDataDir(), "daemon.log"))
+	}
 	return nil
 }
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -654,6 +654,14 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	// fire paths and the REST test endpoint.
 	ctrlSrv.SetTestGuard(approvalGate.FireGuard)
 
+	// Readiness barrier (#464): the control socket comes up before the
+	// reconciler's first sync has registered the initial task inventory, so a
+	// CLI command racing daemon startup could observe a spurious "task not
+	// found". cli.ready lets task-scoped CLI commands block (bounded) until
+	// the first sync completes. The channel never closes if ctx is cancelled
+	// mid-sync; the IPC handler's own ctx/timeout select keeps shutdown clean.
+	ctrlSrv.SetReadySignal(rec.Ready())
+
 	// `dicode task approve` — the control socket is a trusted local channel.
 	ctrlSrv.SetTaskApprover(approvalGate.Approve)
 

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -58,9 +58,20 @@ type ControlServer struct {
 	// CLI. Nil means allow.
 	testGuard func(taskID string) error
 
+	// ready closes once the daemon has finished registering its initial task
+	// inventory — the reconciler's first-sync signal, wired via
+	// SetReadySignal (#464). Nil (tests / stripped builds) means always
+	// ready, preserving pre-barrier behaviour.
+	ready <-chan struct{}
+
 	startedAt time.Time
 	version   string
 }
+
+// maxReadyWait caps how long a single cli.ready request may block waiting
+// for the first task sync, regardless of the client-requested WaitMs. Keeps
+// a stray client from parking a handler goroutine indefinitely.
+const maxReadyWait = 60 * time.Second
 
 // NewControlServer creates a ControlServer. Call Start to begin accepting
 // connections. socketPath is the Unix socket path; tokenPath is where the CLI
@@ -209,6 +220,9 @@ func (cs *ControlServer) dispatch(ctx context.Context, req Request) (any, error)
 	switch req.Method {
 	case "cli.ping":
 		return cs.handlePing(), nil
+
+	case "cli.ready":
+		return cs.handleReady(ctx, req)
 
 	case "cli.list":
 		return cs.handleList()
@@ -484,12 +498,60 @@ func (cs *ControlServer) handleAuthResetPassphrase(ctx context.Context) (any, er
 	return AuthResetPassphraseResult{Value: plaintext}, nil
 }
 
+// SetReadySignal wires the reconciler's first-sync channel so cli.ready (and
+// the Ready field on cli.ping) can report when the initial task inventory is
+// registered (#464). Must be called before Start. Nil (tests / configurations
+// without a reconciler) means always ready.
+func (cs *ControlServer) SetReadySignal(ch <-chan struct{}) { cs.ready = ch }
+
+// isReady is a non-blocking readiness probe.
+func (cs *ControlServer) isReady() bool {
+	if cs.ready == nil {
+		return true
+	}
+	select {
+	case <-cs.ready:
+		return true
+	default:
+		return false
+	}
+}
+
+// handleReady reports whether the daemon's first task sync has completed,
+// optionally blocking up to req.WaitMs (capped at maxReadyWait) for it. The
+// wait also unblocks on connection/daemon shutdown via ctx, so a daemon that
+// never finishes its first sync (e.g. cancelled mid-clone) cannot strand the
+// handler goroutine — shutdown-safety for the readiness barrier (#464).
+func (cs *ControlServer) handleReady(ctx context.Context, req Request) (ReadyResult, error) {
+	if cs.isReady() {
+		return ReadyResult{Ready: true}, nil
+	}
+	wait := time.Duration(req.WaitMs) * time.Millisecond
+	if wait <= 0 {
+		return ReadyResult{Ready: false}, nil
+	}
+	if wait > maxReadyWait {
+		wait = maxReadyWait
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-cs.ready:
+		return ReadyResult{Ready: true}, nil
+	case <-timer.C:
+		return ReadyResult{Ready: false}, nil
+	case <-ctx.Done():
+		return ReadyResult{Ready: false}, ctx.Err()
+	}
+}
+
 func (cs *ControlServer) handlePing() DaemonStatus {
 	all := cs.reg.All()
 	return DaemonStatus{
 		Version:   cs.version,
 		UptimeSec: int64(time.Since(cs.startedAt).Seconds()),
 		TaskCount: len(all),
+		Ready:     cs.isReady(),
 	}
 }
 

--- a/pkg/ipc/control_ready_test.go
+++ b/pkg/ipc/control_ready_test.go
@@ -1,0 +1,270 @@
+package ipc
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
+)
+
+// Tests for the cli.ready readiness barrier (#464). Handler-level tests
+// exercise the wait/timeout/shutdown paths in isolation; the socket-level
+// regression test reproduces the CI race: a task lookup issued after the
+// control socket is up but before the first reconcile registers the task.
+
+func TestControl_Ready_NilSignalAlwaysReady(t *testing.T) {
+	t.Parallel()
+	cs := &ControlServer{log: zap.NewNop()} // no SetReadySignal — tests / stripped builds
+	res, err := cs.handleReady(context.Background(), Request{})
+	if err != nil {
+		t.Fatalf("handleReady: %v", err)
+	}
+	if !res.Ready {
+		t.Fatal("nil ready signal must report ready")
+	}
+}
+
+func TestControl_Ready_ProbeReturnsImmediately(t *testing.T) {
+	t.Parallel()
+	cs := &ControlServer{log: zap.NewNop()}
+	cs.SetReadySignal(make(chan struct{})) // never closed
+
+	// WaitMs 0 is a pure probe — must not block.
+	res, err := cs.handleReady(context.Background(), Request{})
+	if err != nil {
+		t.Fatalf("handleReady: %v", err)
+	}
+	if res.Ready {
+		t.Fatal("unclosed ready signal must report not-ready")
+	}
+}
+
+func TestControl_Ready_TimesOutCleanly(t *testing.T) {
+	t.Parallel()
+	cs := &ControlServer{log: zap.NewNop()}
+	cs.SetReadySignal(make(chan struct{})) // never closed
+
+	start := time.Now()
+	res, err := cs.handleReady(context.Background(), Request{WaitMs: 50})
+	if err != nil {
+		t.Fatalf("handleReady: %v", err)
+	}
+	if res.Ready {
+		t.Fatal("timed-out wait must report not-ready")
+	}
+	if elapsed := time.Since(start); elapsed < 50*time.Millisecond {
+		t.Fatalf("wait returned after %v, want >= 50ms", elapsed)
+	}
+}
+
+func TestControl_Ready_UnblocksOnSignal(t *testing.T) {
+	t.Parallel()
+	cs := &ControlServer{log: zap.NewNop()}
+	ready := make(chan struct{})
+	cs.SetReadySignal(ready)
+
+	done := make(chan ReadyResult, 1)
+	go func() {
+		res, _ := cs.handleReady(context.Background(), Request{WaitMs: int((10 * time.Second).Milliseconds())})
+		done <- res
+	}()
+	close(ready)
+
+	select {
+	case res := <-done:
+		if !res.Ready {
+			t.Fatal("wait must report ready once the signal closes")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleReady did not unblock on the ready signal")
+	}
+}
+
+// TestControl_Ready_UnblocksOnShutdown pins the shutdown-safety contract: a
+// wait against a first sync that never completes must not outlive the
+// connection/daemon context — no goroutine may be stranded selecting on a
+// channel that never closes.
+func TestControl_Ready_UnblocksOnShutdown(t *testing.T) {
+	t.Parallel()
+	cs := &ControlServer{log: zap.NewNop()}
+	cs.SetReadySignal(make(chan struct{})) // never closed — sync never finishes
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := cs.handleReady(ctx, Request{WaitMs: int((10 * time.Second).Milliseconds())})
+		done <- err
+	}()
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("shutdown during wait must surface ctx error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleReady did not unblock on ctx cancellation")
+	}
+}
+
+// readyRegressionEnv is controlTestEnv with a real registry and a
+// caller-controlled ready signal, so a test can drive the socket-up-but-not-
+// reconciled startup window.
+func readyRegressionEnv(t *testing.T, ready <-chan struct{}) (net.Conn, *registry.Registry, func()) {
+	t.Helper()
+
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "ctrl.sock")
+	tokenPath := filepath.Join(dir, "ctrl.token")
+
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	reg := registry.New(d)
+
+	cs, err := NewControlServer(socketPath, tokenPath, reg, &mockEngine{}, nil, MetricsProvider{}, "test", zap.NewNop(), nil, "")
+	if err != nil {
+		t.Fatalf("NewControlServer: %v", err)
+	}
+	cs.SetReadySignal(ready)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = cs.Start(ctx)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(socketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatal("control socket never appeared within 2s")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	tok, err := readCLITokenFile(tokenPath)
+	if err != nil {
+		cancel()
+		t.Fatalf("read token: %v", err)
+	}
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		cancel()
+		t.Fatalf("dial control: %v", err)
+	}
+	if err := writeMsg(conn, handshakeReq{Token: string(tok)}); err != nil {
+		conn.Close()
+		cancel()
+		t.Fatalf("handshake send: %v", err)
+	}
+	var hs struct {
+		Proto int      `json:"proto"`
+		Caps  []string `json:"caps"`
+		Error string   `json:"error"`
+	}
+	if err := readMsg(conn, &hs); err != nil {
+		conn.Close()
+		cancel()
+		t.Fatalf("handshake recv: %v", err)
+	}
+	if hs.Error != "" {
+		conn.Close()
+		cancel()
+		t.Fatalf("handshake rejected: %s", hs.Error)
+	}
+
+	cleanup := func() {
+		conn.Close()
+		cancel()
+		<-done
+	}
+	return conn, reg, cleanup
+}
+
+// TestControl_Ready_RegressionTaskLookupAfterFirstSync reproduces issue #464
+// end-to-end over the socket: the control socket accepts connections before
+// the first reconcile has registered any task, so an immediate lookup fails
+// with `task "X" not found`. A client that gates on cli.ready instead blocks
+// until the first sync lands and then finds the task.
+func TestControl_Ready_RegressionTaskLookupAfterFirstSync(t *testing.T) {
+	t.Parallel()
+
+	ready := make(chan struct{})
+	conn, reg, cleanup := readyRegressionEnv(t, ready)
+	defer cleanup()
+
+	// Socket is up, daemon not ready: the pre-#464 failure mode. A direct
+	// task lookup sees "not found" for a task about to be registered.
+	if err := writeMsg(conn, Request{ID: "r1", Method: "cli.task.test", TaskID: "buildin/webui"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	var resp Response
+	if err := readMsg(conn, &resp); err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+	if !strings.Contains(resp.Error, `task "buildin/webui" not found`) {
+		t.Fatalf("pre-sync lookup error = %q, want task-not-found", resp.Error)
+	}
+
+	// Simulate the first reconcile completing while a cli.ready wait is
+	// pending: register the task, then close the ready signal.
+	taskDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(taskDir, "task.yaml"), []byte("name: webui\ntrigger:\n  manual: true\nruntime: deno\n"), 0644)
+	_ = os.WriteFile(filepath.Join(taskDir, "task.ts"), []byte("export default () => ({})\n"), 0644)
+	spec := &task.Spec{
+		ID: "buildin/webui", Name: "webui", Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true}, Timeout: 5 * time.Second, TaskDir: taskDir,
+	}
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	close(ready)
+
+	// The bounded wait now reports ready...
+	if err := writeMsg(conn, Request{ID: "r2", Method: "cli.ready", WaitMs: int((10 * time.Second).Milliseconds())}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	resp = Response{}
+	if err := readMsg(conn, &resp); err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("cli.ready error: %s", resp.Error)
+	}
+	rm, ok := resp.Result.(map[string]any)
+	if !ok || rm["ready"] != true {
+		t.Fatalf("cli.ready result = %#v, want ready:true", resp.Result)
+	}
+
+	// ...and the same lookup no longer reports not-found. (The registered
+	// task has no test file, so the handler fails later with a different,
+	// registration-independent error.)
+	if err := writeMsg(conn, Request{ID: "r3", Method: "cli.task.test", TaskID: "buildin/webui"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	resp = Response{}
+	if err := readMsg(conn, &resp); err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+	if strings.Contains(resp.Error, "not found") {
+		t.Fatalf("post-sync lookup still not-found: %q", resp.Error)
+	}
+	if !strings.Contains(resp.Error, "no test file") {
+		t.Fatalf("post-sync lookup error = %q, want no-test-file (proves registry hit)", resp.Error)
+	}
+}

--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -93,6 +93,7 @@ type Request struct {
 	RunID       string `json:"runID,omitempty"`
 	StringValue string `json:"stringValue,omitempty"` // cli.secrets.set value
 	Follow      bool   `json:"follow,omitempty"`      // cli.logs — reserved for streaming
+	WaitMs      int    `json:"waitMs,omitempty"`      // cli.ready — max ms to block for readiness (0 = probe only)
 
 	// dicode.runs.* — run-input retention management (#233)
 	BeforeTs int64 `json:"before_ts,omitempty"` // dicode.runs.list_expired: unix timestamp cutoff
@@ -244,6 +245,17 @@ type DaemonStatus struct {
 	UptimeSec int64  `json:"uptimeSec"`
 	TaskCount int    `json:"taskCount"`
 	RunCount  int    `json:"runCount"` // runs in the last 24h
+	// Ready reports whether the reconciler's first sync has completed —
+	// i.e. the initial task inventory is registered and lookups by task ID
+	// are meaningful (#464). Point-in-time snapshot; cli.ready is the
+	// blocking wait.
+	Ready bool `json:"ready"`
+}
+
+// ReadyResult is the cli.ready response. Ready is false when the daemon's
+// first task sync had not completed within the requested wait window.
+type ReadyResult struct {
+	Ready bool `json:"ready"`
 }
 
 // RunResult is returned by EngineRunner.WaitRun.

--- a/pkg/registry/reconciler.go
+++ b/pkg/registry/reconciler.go
@@ -10,6 +10,14 @@ import (
 	"go.uber.org/zap"
 )
 
+// initialSyncBarrier is an internal sentinel event kind injected by the
+// reconciler itself — never emitted by real sources. Each initially-configured
+// source's forwarding goroutine pushes one barrier into the merged channel
+// right after the source's initial scan batch, so by the time the Run loop
+// dequeues the barrier every task from that batch has been handled (registered
+// or rejected). Once all barriers have been seen the Ready channel closes.
+const initialSyncBarrier source.EventKind = "dicode-internal/initial-sync-barrier"
+
 // Reconciler fans-in events from multiple sources and applies them to the registry.
 type Reconciler struct {
 	registry *Registry
@@ -36,6 +44,15 @@ type Reconciler struct {
 	// repeated failure for the same task replaces the previous attempt
 	// (always retrying the most recent event).
 	pending map[string]source.Event
+
+	// ready closes once the first sync completes: every initially-configured
+	// source has started AND its initial scan batch has been handled (#464).
+	// It never closes when the run context is cancelled first, so consumers
+	// must select on their own timeout/context alongside it. initPending
+	// (guarded by mu) counts sources whose barrier has not yet been seen.
+	ready       chan struct{}
+	readyOnce   sync.Once
+	initPending int
 }
 
 // NewReconciler creates a Reconciler for the given registry and sources.
@@ -50,6 +67,26 @@ func NewReconciler(r *Registry, sources []source.Source, dataDir string, log *za
 		log:      log,
 		cancels:  make(map[string]context.CancelFunc),
 		pending:  make(map[string]source.Event),
+		ready:    make(chan struct{}),
+	}
+}
+
+// Ready returns a channel that closes once the reconciler's first sync has
+// completed — every initially-configured source has started and the tasks
+// from its initial scan have been registered (or rejected). The channel never
+// closes if the run context is cancelled before the first sync finishes, so
+// consumers must select on their own timeout/context alongside it.
+func (rc *Reconciler) Ready() <-chan struct{} { return rc.ready }
+
+// markInitialSourceSynced records one source's initial-sync barrier passing
+// through the Run loop; when the last one lands, Ready closes.
+func (rc *Reconciler) markInitialSourceSynced() {
+	rc.mu.Lock()
+	rc.initPending--
+	done := rc.initPending <= 0
+	rc.mu.Unlock()
+	if done {
+		rc.readyOnce.Do(func() { close(rc.ready) })
 	}
 }
 
@@ -58,15 +95,18 @@ func (rc *Reconciler) Run(ctx context.Context) error {
 	rc.mu.Lock()
 	rc.runCtx = ctx
 	rc.merged = make(chan source.Event, 64)
+	rc.initPending = len(rc.sources)
 	rc.mu.Unlock()
 
 	if len(rc.sources) == 0 {
+		// Nothing to sync — the first sync is trivially complete.
+		rc.readyOnce.Do(func() { close(rc.ready) })
 		// Still need to run so dynamic AddSource works.
 		goto loop
 	}
 
 	for _, src := range rc.sources {
-		if err := rc.startSource(src); err != nil {
+		if err := rc.startSource(src, true); err != nil {
 			return fmt.Errorf("start source %s: %w", src.ID(), err)
 		}
 	}
@@ -77,6 +117,10 @@ loop:
 		case <-ctx.Done():
 			return nil
 		case ev := <-rc.merged:
+			if ev.Kind == initialSyncBarrier {
+				rc.markInitialSourceSynced()
+				continue
+			}
 			rc.handle(ev)
 		}
 	}
@@ -84,8 +128,10 @@ loop:
 
 // AddSource adds a new source at runtime and starts it immediately.
 // Safe to call from any goroutine after Run has been called.
+// Runtime-added sources never participate in the first-sync readiness
+// barrier — Ready tracks only the initially-configured set.
 func (rc *Reconciler) AddSource(src source.Source) error {
-	return rc.startSource(src)
+	return rc.startSource(src, false)
 }
 
 // RemoveSource stops and removes a source by its ID.
@@ -101,7 +147,17 @@ func (rc *Reconciler) RemoveSource(id string) {
 }
 
 // startSource begins watching a source and forwarding its events to merged.
-func (rc *Reconciler) startSource(src source.Source) error {
+//
+// trackInitial marks the source as part of the first-sync readiness barrier:
+// sources emit their initial scan synchronously inside Start (into the
+// buffered channel), so len(ch) captured here is the initial batch size. The
+// forwarding goroutine pushes an initialSyncBarrier sentinel into merged right
+// after that batch; when the Run loop dequeues it, every initial task from
+// this source has already been handled. Any watch-phase events that slipped
+// into the buffer before the snapshot only inflate the count — they are
+// already buffered, so the barrier still lands without waiting on future
+// activity.
+func (rc *Reconciler) startSource(src source.Source, trackInitial bool) error {
 	rc.mu.Lock()
 	ctx := rc.runCtx
 	rc.mu.Unlock()
@@ -115,12 +171,34 @@ func (rc *Reconciler) startSource(src source.Source) error {
 		cancel()
 		return err
 	}
+	initialBatch := 0
+	if trackInitial {
+		initialBatch = len(ch)
+	}
 
 	rc.mu.Lock()
 	rc.cancels[src.ID()] = cancel
 	rc.mu.Unlock()
 
 	go func() {
+		// sendBarrier signals this source's initial batch has been forwarded.
+		// It reports false when ctx is done, so the forwarder can bail out.
+		// On shutdown before the barrier lands, Ready simply never closes —
+		// readiness consumers select on their own timeout/context.
+		sendBarrier := func() bool {
+			select {
+			case rc.merged <- source.Event{Kind: initialSyncBarrier}:
+				return true
+			case <-ctx.Done():
+				return false
+			}
+		}
+		if trackInitial && initialBatch == 0 {
+			if !sendBarrier() {
+				return
+			}
+			trackInitial = false
+		}
 		for ev := range ch {
 			// Without the ctx select, a slow main loop plus a closed merged
 			// reader during shutdown would block this goroutine forever
@@ -131,6 +209,14 @@ func (rc *Reconciler) startSource(src source.Source) error {
 			case rc.merged <- ev:
 			case <-ctx.Done():
 				return
+			}
+			if trackInitial {
+				if initialBatch--; initialBatch == 0 {
+					if !sendBarrier() {
+						return
+					}
+					trackInitial = false
+				}
 			}
 		}
 	}()

--- a/pkg/registry/reconciler_ready_test.go
+++ b/pkg/registry/reconciler_ready_test.go
@@ -1,0 +1,146 @@
+package registry
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/source"
+)
+
+// Tests for the first-sync readiness barrier (#464). Ready must close only
+// after every initially-configured source's initial scan batch has been
+// handled — a consumer woken by Ready must be able to Get the initial tasks.
+
+func TestReconciler_Ready_AfterInitialSync(t *testing.T) {
+	dir := t.TempDir()
+	td := writeTask(t, dir, "init-task")
+
+	fs := newFakeSource("test")
+	// Buffer the initial inventory BEFORE Run starts, mirroring how real
+	// sources emit their initial scan synchronously inside Start.
+	fs.ch <- source.Event{Kind: source.EventAdded, TaskID: "init-task", TaskDir: td, Source: "test"}
+
+	reg, rec := newTestReconciler(t, fs)
+
+	select {
+	case <-rec.Ready():
+		t.Fatal("ready closed before Run")
+	default:
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go rec.Run(ctx)
+
+	select {
+	case <-rec.Ready():
+	case <-time.After(5 * time.Second):
+		t.Fatal("reconciler never became ready")
+	}
+	// The barrier orders after the initial batch: the task must already be
+	// registered by the time Ready fires — this is the #464 guarantee.
+	if _, ok := reg.Get("init-task"); !ok {
+		t.Fatal("initial task not registered when Ready fired")
+	}
+}
+
+func TestReconciler_Ready_NoSources(t *testing.T) {
+	_, rec := newTestReconciler(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go rec.Run(ctx)
+
+	select {
+	case <-rec.Ready():
+	case <-time.After(5 * time.Second):
+		t.Fatal("zero-source reconciler never became ready")
+	}
+}
+
+func TestReconciler_Ready_WaitsForAllSources(t *testing.T) {
+	dir := t.TempDir()
+	td := writeTask(t, dir, "multi-task")
+
+	// One source with a buffered initial event, one that starts empty.
+	full := newFakeSource("full")
+	full.ch <- source.Event{Kind: source.EventAdded, TaskID: "multi-task", TaskDir: td, Source: "full"}
+	empty := newFakeSource("empty")
+
+	reg, rec := newTestReconciler(t, full, empty)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go rec.Run(ctx)
+
+	select {
+	case <-rec.Ready():
+	case <-time.After(5 * time.Second):
+		t.Fatal("multi-source reconciler never became ready")
+	}
+	if _, ok := reg.Get("multi-task"); !ok {
+		t.Fatal("initial task not registered when Ready fired")
+	}
+}
+
+// TestReconciler_Ready_NoDeadlockOnEarlyShutdown pins the shutdown-safety
+// contract: cancelling the run context before the first sync completes must
+// not deadlock Run — it returns nil promptly whether or not Ready ever
+// closed (consumers of Ready select on their own timeout/context).
+func TestReconciler_Ready_NoDeadlockOnEarlyShutdown(t *testing.T) {
+	fs := newFakeSource("test")
+	_, rec := newTestReconciler(t, fs)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // shut down before the first sync can complete
+
+	done := make(chan error, 1)
+	go func() { done <- rec.Run(ctx) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error on cancelled ctx: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after ctx cancellation")
+	}
+}
+
+// TestReconciler_Ready_ConcurrentReaders exercises the close-once semantics
+// under the race detector: many goroutines block on Ready while the Run loop
+// closes it.
+func TestReconciler_Ready_ConcurrentReaders(t *testing.T) {
+	dir := t.TempDir()
+	td := writeTask(t, dir, "race-task")
+
+	fs := newFakeSource("test")
+	fs.ch <- source.Event{Kind: source.EventAdded, TaskID: "race-task", TaskDir: td, Source: "test"}
+	_, rec := newTestReconciler(t, fs)
+
+	var wg sync.WaitGroup
+	errs := make(chan string, 8)
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case <-rec.Ready():
+			case <-time.After(5 * time.Second):
+				errs <- "reader timed out waiting for Ready"
+			}
+		}()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go rec.Run(ctx)
+
+	wg.Wait()
+	close(errs)
+	for msg := range errs {
+		t.Error(msg)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #464. The daemon's IPC control socket accepts connections **before** the reconciler's first sync registers tasks from their sources, so a CLI command issued the instant the socket is live can observe a spurious `task "X" not found` for a task about to be registered moments later. This is the intermittent CI failure (`dicode task test buildin/webui` → `not found`) and the transient local `not found` right after a daemon (re)start. Socket-up ≠ ready-to-serve-lookups.

## Fix — control-plane readiness signal (the issue's preferred option)

**Produce (`pkg/registry/reconciler.go`):** new `Reconciler.Ready() <-chan struct{}`. There was no pre-existing first-sync signal, so this adds one via an internal `initialSyncBarrier` sentinel: sources emit their initial scan **synchronously** into a buffered channel inside `Start()`, so each initially-configured source's forwarding goroutine snapshots `len(ch)` right after `Start()` and injects the barrier after that batch. Because `Run` consumes the merged channel serially, dequeuing a source's barrier proves its initial tasks were already registered/rejected. `Ready` closes (once) when the last barrier lands. Zero sources → ready immediately; runtime `AddSource` sources don't participate.

**Expose (`pkg/ipc`):** new `cli.ready` control method that reports readiness, optionally blocking up to `waitMs` (server-capped at 60s) for the first sync; it also selects on the connection ctx, so a daemon cancelled mid-sync can't strand the handler. `cli.ping`'s `DaemonStatus` gains a point-in-time `Ready` field. `SetReadySignal(rec.Ready())` is wired in `pkg/daemon/daemon.go`.

**Consume (`cmd/dicode/main.go`):** task-scoped commands (`run`, `status <task>`, `task test`) call `waitDaemonReady` (a single daemon-side blocking round-trip, **no polling**, 30s timeout) after `ensureDaemon` + dial. The socket poll is untouched — this is an additional gate. Ungated: `list`, `logs`, bare `status`, `secrets`, `version`, `daemon`, etc. A pre-#464 daemon (unknown method) is treated as ready, so mixed CLI/daemon versions keep working.

## Shutdown safety
`Ready` never closes if the run ctx is cancelled before the first sync finishes; the barrier sends and the IPC wait all select on their contexts, so nothing strands or deadlocks shutdown. The CLI wait is bounded (30s) and degrades to a clear error rather than hanging.

## Test plan
- [x] `pkg/registry/reconciler_ready_test.go` — ready-after-sync w/ registration ordering, no-sources, multi-source, early-shutdown (no deadlock), concurrent readers.
- [x] `pkg/ipc/control_ready_test.go` — socket-level regression: `cli.task.test buildin/webui` returns `not found` pre-sync, then resolves after register+ready; plus probe / timeout / unblock-on-signal / unblock-on-shutdown.
- [x] `go build`, `go vet ./...`, `gofmt -l .` clean; `pkg/daemon` + `pkg/ipc` + `pkg/registry` + `cmd` suites green, incl. `-race`. (Sole full-suite failure is the documented offline-only deno npm test.)

## Notes
- Known-issue #462 tracks the broader start-delay/ordering theme.
- Independent of the in-flight #482 (verified conflict-free).

Found in the whole-codebase audit follow-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJMqv1hzZzUZep13oyKrCD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a readiness check for task-related commands so they wait until the daemon has finished its initial sync.
  * Improved daemon status responses to include whether it is ready.
  * Added support for reporting readiness over the control socket.

* **Bug Fixes**
  * Prevented “task not found” errors caused by startup timing issues.
  * Older daemon versions remain compatible during mixed-version use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->