### PR TITLE
refactor: split daemon.run / FireChain / WebhookHandler / propagatePipelineStageRerun + webui handler helpers (#478)

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -154,13 +154,9 @@ func hasDisplay() bool {
 
 func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, configPath, version string, logBroadcaster *webui.LogBroadcaster, log *zap.Logger) error {
 	// 1. Open database.
-	database, err := db.Open(db.Config{
-		Type:   cfg.Database.Type,
-		Path:   cfg.Database.Path,
-		URLEnv: cfg.Database.URLEnv,
-	})
+	database, err := openDatabase(cfg)
 	if err != nil {
-		return fmt.Errorf("open database: %w", err)
+		return err
 	}
 	defer database.Close()
 
@@ -174,6 +170,72 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	secretsChain, localSecrets := buildSecretsChain(cfg, dataDir, database, log)
 
 	// 4. Task registry + startup cleanup.
+	reg := setupRegistry(ctx, database, log)
+
+	// 5. HTTP gateway.
+	gateway := ipc.NewGateway()
+
+	// 6. Managed runtimes + trigger engine.
+	managedRuntimes, eng, denoRT, pythonRT, err := buildRuntimes(ctx, cfg, reg, secretsChain, localSecrets, database, log, gateway)
+	if err != nil {
+		return err
+	}
+
+	// 6a. Run-input persistence (Task 14): wire InputStore when enabled.
+	// replayer is nil when persistence is disabled; consumed after webui.New.
+	replayer := wireRunInputPersistence(cfg, secretsChain, reg, eng, denoRT, pythonRT, log)
+
+	// 7. Sources + reconciler.
+	sourceMgr, rec, err := initSources(cfg, dataDir, reg, denoRT, pythonRT, log)
+	if err != nil {
+		return err
+	}
+	arm, disarm := newArmDisarm(cfg, eng, gateway, log)
+
+	// 7a. Approval gate (#392 phase 1): every new or changed task passes the
+	// trust-on-change gate before its triggers arm. Approval records live in
+	// dicode.lock next to dicode.yaml; trust policy lives in cfg.Approval.
+	approvalGate, err := setupApprovalGate(ctx, cfg, configPath, database, secretsChain, eng, denoRT, pythonRT, rec, arm, disarm, log)
+	if err != nil {
+		return err
+	}
+
+	// 8. Web UI (including the 8.5 relay env exports).
+	srv, err := buildWebUI(ctx, cfg, configPath, version, dataDir, database, reg, eng, localSecrets, rec, sourceMgr, gateway, logBroadcaster, managedRuntimes, approvalGate, replayer, log)
+	if err != nil {
+		return err
+	}
+
+	// 9. Control socket for CLI clients.
+	ctrlSrv, err := buildControlServer(cfg, dataDir, version, database, reg, eng, localSecrets, srv, sourceMgr, approvalGate, log)
+	if err != nil {
+		return err
+	}
+	wireCryptoIPC(secretsChain, denoRT, log)
+
+	// 9.5. Audit-log retention (#45).
+	auditStore, auditRetentionDays := initAuditPruning(ctx, cfg, database, log)
+
+	// 10. Run everything concurrently.
+	return runServices(ctx, rec, eng, srv, ctrlSrv, reg, auditStore, auditRetentionDays, log)
+}
+
+// openDatabase opens the daemon's database from the config (step 1).
+func openDatabase(cfg *config.Config) (db.DB, error) {
+	database, err := db.Open(db.Config{
+		Type:   cfg.Database.Type,
+		Path:   cfg.Database.Path,
+		URLEnv: cfg.Database.URLEnv,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("open database: %w", err)
+	}
+	return database, nil
+}
+
+// setupRegistry cleans up container/run state left over from a previous
+// session and builds the task registry (step 4).
+func setupRegistry(ctx context.Context, database db.DB, log *zap.Logger) *registry.Registry {
 	dockerruntime.CleanupOrphanedContainers(ctx, log)
 	podmanruntime.CleanupOrphanedContainers(ctx, log)
 
@@ -190,61 +252,59 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	} else {
 		log.Warn("sweep stale input pins failed", zap.Error(err))
 	}
+	return reg
+}
 
-	// 5. HTTP gateway.
-	gateway := ipc.NewGateway()
-
-	// 6. Managed runtimes + trigger engine.
-	managedRuntimes, eng, denoRT, pythonRT, err := buildRuntimes(ctx, cfg, reg, secretsChain, localSecrets, database, log, gateway)
-	if err != nil {
-		return err
-	}
-
-	// replayer is built inside the run-input block below (needs the InputStore)
-	// and consumed after webui.New. Declared here so both sites see it.
-	var replayer *registry.Replayer
-
-	// 6a. Run-input persistence (Task 14): wire InputStore when enabled.
-	if cfg.Defaults.RunInputs.IsEnabled() {
-		var deriver secrets.SubKeyDeriver
-		for _, p := range secretsChain {
-			if d, ok := p.(secrets.SubKeyDeriver); ok {
-				deriver = d
-				break
-			}
-		}
-		if deriver == nil {
-			log.Warn("run-input persistence: no SubKeyDeriver available in secrets chain — persistence disabled")
-		} else {
-			key, err := deriver.DeriveSubKey("dicode/run-inputs/v1")
-			if err != nil {
-				log.Warn("run-input persistence: sub-key derive failed", zap.Error(err))
-			} else {
-				runner := trigger.NewInputStoreTaskRunner(eng)
-				is := registry.NewInputStore(registry.NewInputCrypto(key), runner, cfg.Defaults.RunInputs.StorageTask)
-				eng.SetInputStore(is)
-				denoRT.SetInputStore(is)
-				pythonRT.SetInputStore(is)
-				// Replayer composes InputStore.Fetch + the engine's fireAsync.
-				// Wired after InputStore so dicode.runs.replay finds a populated store.
-				replayer = registry.NewReplayer(reg, is, trigger.NewReplayRunner(eng))
-				denoRT.SetReplayer(replayer)
-				pythonRT.SetReplayer(replayer)
-				// srv.SetReplayer is called below after webui is built.
-				log.Info("run-input persistence enabled",
-					zap.Duration("retention", cfg.Defaults.RunInputs.Retention),
-					zap.String("storage_task", cfg.Defaults.RunInputs.StorageTask),
-				)
-			}
-		}
-	} else {
+// wireRunInputPersistence wires the run-input persistence InputStore into the
+// engine and both runtimes when enabled (step 6a, Task 14). Returns the
+// Replayer composing InputStore.Fetch + the engine's fireAsync — wired after
+// the InputStore so dicode.runs.replay finds a populated store — or nil when
+// persistence is disabled or unavailable. srv.SetReplayer is called by run()
+// after webui is built.
+func wireRunInputPersistence(cfg *config.Config, secretsChain secrets.Chain, reg *registry.Registry, eng *trigger.Engine, denoRT *denoruntime.Runtime, pythonRT *pythonruntime.Runtime, log *zap.Logger) *registry.Replayer {
+	if !cfg.Defaults.RunInputs.IsEnabled() {
 		log.Info("run-input persistence disabled by config")
+		return nil
 	}
+	var deriver secrets.SubKeyDeriver
+	for _, p := range secretsChain {
+		if d, ok := p.(secrets.SubKeyDeriver); ok {
+			deriver = d
+			break
+		}
+	}
+	if deriver == nil {
+		log.Warn("run-input persistence: no SubKeyDeriver available in secrets chain — persistence disabled")
+		return nil
+	}
+	key, err := deriver.DeriveSubKey("dicode/run-inputs/v1")
+	if err != nil {
+		log.Warn("run-input persistence: sub-key derive failed", zap.Error(err))
+		return nil
+	}
+	runner := trigger.NewInputStoreTaskRunner(eng)
+	is := registry.NewInputStore(registry.NewInputCrypto(key), runner, cfg.Defaults.RunInputs.StorageTask)
+	eng.SetInputStore(is)
+	denoRT.SetInputStore(is)
+	pythonRT.SetInputStore(is)
+	// Replayer composes InputStore.Fetch + the engine's fireAsync.
+	// Wired after InputStore so dicode.runs.replay finds a populated store.
+	replayer := registry.NewReplayer(reg, is, trigger.NewReplayRunner(eng))
+	denoRT.SetReplayer(replayer)
+	pythonRT.SetReplayer(replayer)
+	log.Info("run-input persistence enabled",
+		zap.Duration("retention", cfg.Defaults.RunInputs.Retention),
+		zap.String("storage_task", cfg.Defaults.RunInputs.StorageTask),
+	)
+	return replayer
+}
 
-	// 7. Sources + reconciler.
+// initSources builds the task sources + source manager, wires them into both
+// runtimes, and creates the reconciler (step 7).
+func initSources(cfg *config.Config, dataDir string, reg *registry.Registry, denoRT *denoruntime.Runtime, pythonRT *pythonruntime.Runtime, log *zap.Logger) (*webui.SourceManager, *registry.Reconciler, error) {
 	sources, sourceMgr, err := buildSources(cfg, dataDir, log)
 	if err != nil {
-		return fmt.Errorf("build sources: %w", err)
+		return nil, nil, fmt.Errorf("build sources: %w", err)
 	}
 	// *webui.SourceManager satisfies both SourceDevModeSetter (Task 6) and
 	// RepoPathResolver (Task 8); wire both interfaces into both runtimes so
@@ -254,6 +314,11 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	pythonRT.SetSourceManager(sourceMgr)
 	pythonRT.SetRepoResolver(sourceMgr)
 	rec := registry.NewReconciler(reg, sources, dataDir, log)
+	return sourceMgr, rec, nil
+}
+
+// newArmDisarm builds the arm/disarm pair the approval gate drives (step 7).
+func newArmDisarm(cfg *config.Config, eng *trigger.Engine, gateway *ipc.Gateway, log *zap.Logger) (arm func(task.Kinded) error, disarm func(string)) {
 	webhookH := eng.WebhookHandler()
 	var webhookMu sync.Mutex
 	webhookPaths := make(map[string]string)
@@ -267,7 +332,7 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	// daemon-level gateway webhook route and footgun warnings. Called by the
 	// approval gate for every task that passes it (immediately for trusted /
 	// builtin / already-approved tasks, later from Approve for pending ones).
-	arm := func(k task.Kinded) error {
+	arm = func(k task.Kinded) error {
 		// The footgun checks below only apply to kind: Task; the gateway-webhook
 		// route, however, applies to BOTH kind: Task and kind: PipelineTask —
 		// see registerGatewayWebhook (GAP 1: a pipeline's webhook 404'd because
@@ -339,7 +404,7 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	// disarm tears down a task's triggers and gateway route. Used both for
 	// removed tasks and for changed tasks held pending approval (their
 	// previous version may still be armed).
-	disarm := func(id string) {
+	disarm = func(id string) {
 		webhookMu.Lock()
 		path := webhookPaths[id]
 		delete(webhookPaths, id)
@@ -349,13 +414,17 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 		}
 		eng.Unregister(id)
 	}
+	return arm, disarm
+}
 
-	// 7a. Approval gate (#392 phase 1): every new or changed task passes the
-	// trust-on-change gate before its triggers arm. Approval records live in
-	// dicode.lock next to dicode.yaml; trust policy lives in cfg.Approval.
+// setupApprovalGate builds the trust-on-change approval gate (step 7a, #392
+// phase 1): protected-path denies, the signed dicode.lock, the bootstrap
+// marker/window handling, the engine/runtime fire-guard wiring, and the
+// reconciler's OnRegister/OnUnregister hooks that drive arm/disarm.
+func setupApprovalGate(ctx context.Context, cfg *config.Config, configPath string, database db.DB, secretsChain secrets.Chain, eng *trigger.Engine, denoRT *denoruntime.Runtime, pythonRT *pythonruntime.Runtime, rec *registry.Reconciler, arm func(task.Kinded) error, disarm func(string), log *zap.Logger) (*approval.Gate, error) {
 	configDir, err := filepath.Abs(filepath.Dir(configPath))
 	if err != nil {
-		return fmt.Errorf("resolve config dir: %w", err)
+		return nil, fmt.Errorf("resolve config dir: %w", err)
 	}
 	lockPath := filepath.Join(configDir, approval.LockFileName)
 	// Approval-gate state must never be writable by a task. A task with a broad
@@ -375,7 +444,7 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	lockExisted := lockStatErr == nil
 	dbMarkerExists, err := bootstrapMarkerExists(ctx, database)
 	if err != nil {
-		return fmt.Errorf("read approval bootstrap marker: %w", err)
+		return nil, fmt.Errorf("read approval bootstrap marker: %w", err)
 	}
 	// Derive the lock-signing key from the master key so the HMAC key is
 	// never task-reachable and survives across restarts even if the SQLite DB
@@ -399,7 +468,7 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	}
 	lock, err := approval.LoadSignedLock(lockPath, lockSigningKey)
 	if err != nil {
-		return fmt.Errorf("load approval lock: %w", err)
+		return nil, fmt.Errorf("load approval lock: %w", err)
 	}
 	if lock.Tampered() {
 		log.Warn("approval lock HMAC verification failed — lock may be tampered or forged; "+
@@ -525,8 +594,12 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 		disarm(id)
 		approvalGate.Forget(id)
 	}
+	return approvalGate, nil
+}
 
-	// 8. Web UI.
+// buildWebUI exports the relay-related env vars and builds the web UI server
+// with its approval / replay wiring (steps 8 + 8.5).
+func buildWebUI(ctx context.Context, cfg *config.Config, configPath, version, dataDir string, database db.DB, reg *registry.Registry, eng *trigger.Engine, localSecrets secrets.Manager, rec *registry.Reconciler, sourceMgr *webui.SourceManager, gateway *ipc.Gateway, logBroadcaster *webui.LogBroadcaster, managedRuntimes []pkgruntime.ManagedRuntime, approvalGate *approval.Gate, replayer *registry.Replayer, log *zap.Logger) (*webui.Server, error) {
 	port := cfg.Server.Port
 	if port == 0 {
 		port = 8080
@@ -537,23 +610,23 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	// These tasks declare the var names in permissions.env; Deno's allow-env
 	// flag exposes them to the task subprocess.
 	if err := os.Setenv("DICODE_DATADIR", dataDir); err != nil {
-		return fmt.Errorf("setenv DICODE_DATADIR: %w", err)
+		return nil, fmt.Errorf("setenv DICODE_DATADIR: %w", err)
 	}
 	if cfg.Defaults.RunInputs.StorageTask != "" {
 		if err := os.Setenv("DICODE_STORAGE_TASK", cfg.Defaults.RunInputs.StorageTask); err != nil {
-			return fmt.Errorf("setenv DICODE_STORAGE_TASK: %w", err)
+			return nil, fmt.Errorf("setenv DICODE_STORAGE_TASK: %w", err)
 		}
 	}
 	if relayConfigured(cfg) {
 		if err := os.Setenv("DICODE_RELAY_SERVER_URL", cfg.Relay.ServerURL); err != nil {
-			return fmt.Errorf("setenv DICODE_RELAY_SERVER_URL: %w", err)
+			return nil, fmt.Errorf("setenv DICODE_RELAY_SERVER_URL: %w", err)
 		}
 		if err := os.Setenv("DICODE_RELAY_LOCAL_PORT", fmt.Sprintf("%d", port)); err != nil {
-			return fmt.Errorf("setenv DICODE_RELAY_LOCAL_PORT: %w", err)
+			return nil, fmt.Errorf("setenv DICODE_RELAY_LOCAL_PORT: %w", err)
 		}
 		if brokerURL := cfg.Relay.ResolvedBrokerURL(); brokerURL != "" {
 			if err := os.Setenv("DICODE_RELAY_BROKER_URL", brokerURL); err != nil {
-				return fmt.Errorf("setenv DICODE_RELAY_BROKER_URL: %w", err)
+				return nil, fmt.Errorf("setenv DICODE_RELAY_BROKER_URL: %w", err)
 			}
 		}
 
@@ -585,7 +658,7 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	webui.Version = version
 	srv, err := webui.New(port, reg, eng, cfg, configPath, localSecrets, rec, sourceMgr, dataDir, logBroadcaster, log, database, gateway)
 	if err != nil {
-		return fmt.Errorf("build webui: %w", err)
+		return nil, fmt.Errorf("build webui: %w", err)
 	}
 	srv.SetManagedRuntimes(managedRuntimes)
 	srv.SetTestGuard(approvalGate.FireGuard)
@@ -626,8 +699,13 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	if replayer != nil {
 		srv.SetReplayer(replayer)
 	}
+	return srv, nil
+}
 
-	// 9. Control socket for CLI clients.
+// buildControlServer builds the control socket for CLI clients and wires its
+// capabilities: API-key minting, the approval-gate test/approve surfaces, AI
+// task authoring, and task deletion (step 9).
+func buildControlServer(cfg *config.Config, dataDir, version string, database db.DB, reg *registry.Registry, eng *trigger.Engine, localSecrets secrets.Manager, srv *webui.Server, sourceMgr *webui.SourceManager, approvalGate *approval.Gate, log *zap.Logger) (*ipc.ControlServer, error) {
 	socketPath := filepath.Join(dataDir, "daemon.sock")
 	tokenPath := filepath.Join(dataDir, "daemon.token")
 	mp := ipc.MetricsProvider{
@@ -643,7 +721,7 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	}
 	ctrlSrv, err := ipc.NewControlServer(socketPath, tokenPath, reg, eng, localSecrets, mp, version, log, database, cfg.AI.Task)
 	if err != nil {
-		return fmt.Errorf("build control server: %w", err)
+		return nil, fmt.Errorf("build control server: %w", err)
 	}
 	// Wire API-key minting so `dicode mcp install` and friends can
 	// auto-generate keys via the control socket. The webui Server holds
@@ -673,32 +751,36 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	// Wire task deletion so `dicode task delete` can remove a task from its
 	// source. The SourceManager owns source state, repo paths, and dev-clones.
 	ctrlSrv.SetTaskDeleter(sourceMgr)
+	return ctrlSrv, nil
+}
 
-	// Wire the generic dicode.crypto.{encrypt, decrypt} IPC verb so buildin
-	// tasks (relay-client, auth-start, auth-relay) can encrypt/decrypt blobs
-	// via DeriveSubKey-derived sub-keys. Sub-keys never cross IPC; only the
-	// encrypt/decrypt operations are exposed.
-	{
-		var cryptoDeriver secrets.SubKeyDeriver
-		for _, p := range secretsChain {
-			if d, ok := p.(secrets.SubKeyDeriver); ok {
-				cryptoDeriver = d
-				break
-			}
-		}
-		if cryptoDeriver == nil {
-			log.Warn("crypto IPC handler: no SubKeyDeriver available in secrets chain — dicode.crypto.{encrypt,decrypt} disabled")
-		} else {
-			denoRT.SetCryptoHandler(cryptoDeriver)
+// wireCryptoIPC wires the generic dicode.crypto.{encrypt, decrypt} IPC verb
+// so buildin tasks (relay-client, auth-start, auth-relay) can encrypt/decrypt
+// blobs via DeriveSubKey-derived sub-keys. Sub-keys never cross IPC; only the
+// encrypt/decrypt operations are exposed.
+func wireCryptoIPC(secretsChain secrets.Chain, denoRT *denoruntime.Runtime, log *zap.Logger) {
+	var cryptoDeriver secrets.SubKeyDeriver
+	for _, p := range secretsChain {
+		if d, ok := p.(secrets.SubKeyDeriver); ok {
+			cryptoDeriver = d
+			break
 		}
 	}
+	if cryptoDeriver == nil {
+		log.Warn("crypto IPC handler: no SubKeyDeriver available in secrets chain — dicode.crypto.{encrypt,decrypt} disabled")
+	} else {
+		denoRT.SetCryptoHandler(cryptoDeriver)
+	}
+}
 
-	// 9.5. Audit-log retention (#45). Event emission is wired implicitly —
-	// the trigger engine (SetDB), per-run IPC servers, and webui all build
-	// their own audit.Store over the shared database handle. The daemon
-	// only owns pruning: once at startup, then periodically. retention 0
-	// (explicit opt-out) disables pruning entirely; Prune itself also
-	// refuses to run with a non-positive window.
+// initAuditPruning builds the audit store and runs the startup prune pass
+// (step 9.5, #45). Event emission is wired implicitly — the trigger engine
+// (SetDB), per-run IPC servers, and webui all build their own audit.Store
+// over the shared database handle. The daemon only owns pruning: once at
+// startup here, then periodically in runServices. retention 0 (explicit
+// opt-out) disables pruning entirely; Prune itself also refuses to run with
+// a non-positive window.
+func initAuditPruning(ctx context.Context, cfg *config.Config, database db.DB, log *zap.Logger) (*audit.Store, int) {
 	auditStore := audit.NewStore(database)
 	auditRetentionDays := cfg.AuditLog.EffectiveRetentionDays()
 	if auditRetentionDays > 0 {
@@ -709,8 +791,14 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	} else {
 		log.Info("audit log pruning disabled (audit_log.retention_days: 0)")
 	}
+	return auditStore, auditRetentionDays
+}
 
-	// 10. Run everything concurrently.
+// runServices runs every daemon loop concurrently until the context is
+// cancelled or one loop fails (step 10): periodic audit pruning, the
+// reconciler, the trigger engine, the web UI, the control server, and the
+// container image GC.
+func runServices(ctx context.Context, rec *registry.Reconciler, eng *trigger.Engine, srv *webui.Server, ctrlSrv *ipc.ControlServer, reg *registry.Registry, auditStore *audit.Store, auditRetentionDays int, log *zap.Logger) error {
 	g, ctx := errgroup.WithContext(ctx)
 	if auditRetentionDays > 0 {
 		g.Go(func() error {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -207,7 +207,7 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	}
 
 	// 9. Control socket for CLI clients.
-	ctrlSrv, err := buildControlServer(cfg, dataDir, version, database, reg, eng, localSecrets, srv, sourceMgr, approvalGate, log)
+	ctrlSrv, err := buildControlServer(cfg, dataDir, version, database, reg, rec, eng, localSecrets, srv, sourceMgr, approvalGate, log)
 	if err != nil {
 		return err
 	}
@@ -705,7 +705,7 @@ func buildWebUI(ctx context.Context, cfg *config.Config, configPath, version, da
 // buildControlServer builds the control socket for CLI clients and wires its
 // capabilities: API-key minting, the approval-gate test/approve surfaces, AI
 // task authoring, and task deletion (step 9).
-func buildControlServer(cfg *config.Config, dataDir, version string, database db.DB, reg *registry.Registry, eng *trigger.Engine, localSecrets secrets.Manager, srv *webui.Server, sourceMgr *webui.SourceManager, approvalGate *approval.Gate, log *zap.Logger) (*ipc.ControlServer, error) {
+func buildControlServer(cfg *config.Config, dataDir, version string, database db.DB, reg *registry.Registry, rec *registry.Reconciler, eng *trigger.Engine, localSecrets secrets.Manager, srv *webui.Server, sourceMgr *webui.SourceManager, approvalGate *approval.Gate, log *zap.Logger) (*ipc.ControlServer, error) {
 	socketPath := filepath.Join(dataDir, "daemon.sock")
 	tokenPath := filepath.Join(dataDir, "daemon.token")
 	mp := ipc.MetricsProvider{

--- a/pkg/trigger/chain.go
+++ b/pkg/trigger/chain.go
@@ -101,14 +101,52 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 	// requires map).
 	upstreamCtx := task.InputContext{Output: output, Params: upstreamParams}
 
-	// Declared chain triggers.
+	e.fireSuccessChains(ctx, completedTaskID, runID, runStatus, output, upstreamCtx)
+	e.firePipelineChains(ctx, completedTaskID, runID, runStatus, output, upstreamCtx)
+	e.fireFailureChain(ctx, completedTaskID, runID, runStatus, output, upstreamCtx)
+}
+
+// chainEdgeMatches reports whether a declared trigger.chain edge fires for
+// the completion of completedTaskID with runStatus: the edge must point at
+// the completed task (chain.From) and its ChainOn() value must be "always"
+// or equal to the run status. Returns the resolved on-value for logging.
+// Shared preamble of the kind: Task and kind: PipelineTask chain loops.
+func chainEdgeMatches(chain *task.ChainTrigger, completedTaskID, runStatus string) (string, bool) {
+	if chain == nil || chain.From != completedTaskID {
+		return "", false
+	}
+	on := chain.ChainOn()
+	if on != chainOnAlways && on != runStatus {
+		return "", false
+	}
+	return on, true
+}
+
+// resolveChainEdge performs the dispatch-time `${input.…}` interpolation for
+// one chain edge against the upstream context, logging and reporting
+// ok=false on failure so the caller skips the edge rather than passing a
+// literal token downstream. skipMsg distinguishes the kind: Task and kind:
+// PipelineTask log lines, which predate this helper.
+func (e *Engine) resolveChainEdge(params map[string]any, upstreamCtx task.InputContext, skipMsg, from, to string) (map[string]any, bool) {
+	resolved, rerr := task.ResolveInputOutputMap(params, upstreamCtx)
+	if rerr != nil {
+		e.log.Error(skipMsg,
+			zap.String("from", from),
+			zap.String("to", to),
+			zap.Error(rerr),
+		)
+		return nil, false
+	}
+	return resolved, true
+}
+
+// fireSuccessChains dispatches every kind: Task whose trigger.chain edge
+// matches the completed run (declared chain triggers).
+func (e *Engine) fireSuccessChains(ctx context.Context, completedTaskID, runID, runStatus string, output interface{}, upstreamCtx task.InputContext) {
 	for _, spec := range e.registry.All() {
 		chain := spec.Trigger.Chain
-		if chain == nil || chain.From != completedTaskID {
-			continue
-		}
-		on := chain.ChainOn()
-		if on != chainOnAlways && on != runStatus {
+		on, matched := chainEdgeMatches(chain, completedTaskID, runStatus)
+		if !matched {
 			continue
 		}
 		// Per-edge overrides (#NNN): when the downstream's trigger.chain
@@ -138,13 +176,9 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 		// requires a non-nil Params map with the named entry. Any
 		// resolution failure skips the chain dispatch (logged) rather
 		// than silently passing a literal token to the downstream.
-		resolvedParams, rerr := task.ResolveInputOutputMap(chain.Params, upstreamCtx)
-		if rerr != nil {
-			e.log.Error("chain trigger skipped — failed to resolve ${input.…} reference",
-				zap.String("from", completedTaskID),
-				zap.String("to", spec.ID),
-				zap.Error(rerr),
-			)
+		resolvedParams, resolved := e.resolveChainEdge(chain.Params, upstreamCtx,
+			"chain trigger skipped — failed to resolve ${input.…} reference", completedTaskID, spec.ID)
+		if !resolved {
 			continue
 		}
 
@@ -190,29 +224,28 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 			Input:       chainInput,
 		}, "chain")
 	}
+}
 
-	// Pipeline chain subscribers: a kind: PipelineTask may chain from an
-	// upstream task's outcome. chain.params (if set) are resolved against the
-	// upstream context and forwarded as the trigger payload for stage 0 (#350),
-	// mirroring the kind: Task chain dispatch path above.
+// firePipelineChains dispatches every pipeline chain subscriber: a kind:
+// PipelineTask may chain from an upstream task's outcome. chain.params (if
+// set) are resolved against the upstream context and forwarded as the
+// trigger payload for stage 0 (#350), mirroring the kind: Task chain
+// dispatch path (fireSuccessChains).
+func (e *Engine) firePipelineChains(ctx context.Context, completedTaskID, runID, runStatus string, output interface{}, upstreamCtx task.InputContext) {
 	for _, k := range e.registry.AllKinded() {
 		p, ok := k.(*task.PipelineTask)
-		if !ok || p.Trigger.Chain == nil || p.Trigger.Chain.From != completedTaskID {
+		if !ok {
 			continue
 		}
-		on := p.Trigger.Chain.ChainOn()
-		if on != chainOnAlways && on != runStatus {
+		on, matched := chainEdgeMatches(p.Trigger.Chain, completedTaskID, runStatus)
+		if !matched {
 			continue
 		}
 		// Resolve any ${input.*} references in chain.params against the upstream
 		// return value + params, exactly like the kind: Task chain path does.
-		resolvedParams, rerr := task.ResolveInputOutputMap(p.Trigger.Chain.Params, upstreamCtx)
-		if rerr != nil {
-			e.log.Error("pipeline chain trigger skipped — failed to resolve ${input.…} reference",
-				zap.String("from", completedTaskID),
-				zap.String("to", p.ID),
-				zap.Error(rerr),
-			)
+		resolvedParams, resolved := e.resolveChainEdge(p.Trigger.Chain.Params, upstreamCtx,
+			"pipeline chain trigger skipped — failed to resolve ${input.…} reference", completedTaskID, p.ID)
+		if !resolved {
 			continue
 		}
 		// Build the trigger payload for stage 0: mirror the kind: Task chain
@@ -237,7 +270,12 @@ func (e *Engine) FireChain(ctx context.Context, completedTaskID, runID, runStatu
 			}
 		}(p, triggerInput, triggerParams)
 	}
+}
 
+// fireFailureChain dispatches the config-level default on_failure_chain (or
+// the failed task's per-task override) when the completed run failed,
+// applying the replay-source, depth, storm, cooldown, and concurrency guards.
+func (e *Engine) fireFailureChain(ctx context.Context, completedTaskID, runID, runStatus string, output interface{}, upstreamCtx task.InputContext) {
 	// Config-level default on_failure_chain.
 	if runStatus == registry.StatusFailure {
 		chainSpec := e.defaultsOnFailureChain

--- a/pkg/trigger/pipeline_runner.go
+++ b/pkg/trigger/pipeline_runner.go
@@ -767,205 +767,211 @@ func (e *Engine) propagatePipelineStageRerun(runner *PipelineRunner, reranTaskID
 		e.log.Debug("pipeline stage re-fire coalesced", zap.String("pipeline", pipelineID))
 		return
 	}
-	go func() {
-		defer e.restartGates.release(gateKey)
+	go e.runPipelineStageRerun(runner, reranTaskID, reranReturn, pipelineID, gateKey)
+}
 
-		// Find the re-fired stage's index in the pipeline's stages.
-		startIdx := -1
-		for i, st := range runner.spec.Stages {
-			if st.Task == reranTaskID {
-				startIdx = i
-				break
-			}
+// pipelineReplayAborted reports whether a mid-stage replay must stop: either
+// the engine is shutting down or the runner is no longer the live
+// registration for the pipeline. what distinguishes the log lines of the
+// guard sites ("skipped" / "aborted" / "restart skipped", preserved from the
+// pre-extraction inline checks); extra fields (e.g. the stage index inside
+// the descendant loop) are appended after the pipeline field.
+func (e *Engine) pipelineReplayAborted(pipelineID string, r *PipelineRunner, what string, fields ...zap.Field) bool {
+	if e.isShuttingDown() {
+		e.log.Debug("pipeline stage re-fire "+what+": engine shutting down",
+			append([]zap.Field{zap.String("pipeline", pipelineID)}, fields...)...)
+		return true
+	}
+	if !e.pipelineStillLive(pipelineID, r) {
+		e.log.Debug("pipeline stage re-fire "+what+": pipeline no longer live",
+			append([]zap.Field{zap.String("pipeline", pipelineID)}, fields...)...)
+		return true
+	}
+	return false
+}
+
+// runPipelineStageRerun is the goroutine body of propagatePipelineStageRerun:
+// replay the non-terminal descendants of the re-fired stage with fresh
+// ${input}, then kill+wait the old terminal daemon run and re-fire the
+// terminal stage via the restart handshake. The caller has already acquired
+// the restartGates slot for gateKey; it is released when this returns.
+func (e *Engine) runPipelineStageRerun(runner *PipelineRunner, reranTaskID string, reranReturn interface{}, pipelineID, gateKey string) {
+	defer e.restartGates.release(gateKey)
+
+	// Find the re-fired stage's index in the pipeline's stages.
+	startIdx := -1
+	for i, st := range runner.spec.Stages {
+		if st.Task == reranTaskID {
+			startIdx = i
+			break
 		}
-		if startIdx < 0 {
-			// Defensive: handlePipelineStageRerun already verified membership.
+	}
+	if startIdx < 0 {
+		// Defensive: handlePipelineStageRerun already verified membership.
+		return
+	}
+
+	// Bail if the engine is shutting down or the pipeline is no longer
+	// live (its terminal daemon already exited / the pipeline finished)
+	// between the liveness check and this goroutine being scheduled.
+	if e.pipelineReplayAborted(pipelineID, runner, "skipped") {
+		return
+	}
+
+	runner.mu.Lock()
+	terminalIdx := runner.terminalIdx
+	terminalStage := runner.terminalStage
+	oldDaemonRunID := runner.daemonRunID
+	storedUpstream := runner.terminalUpstream
+	runner.mu.Unlock()
+
+	e.log.Info("pipeline mid-stage re-fire: propagating to descendants",
+		zap.String("pipeline", pipelineID),
+		zap.String("rerun", reranTaskID),
+		zap.Int("stage", startIdx),
+		// Non-terminal descendants replayed below [startIdx+1 .. terminalIdx-1];
+		// the terminal daemon stage is restarted separately.
+		zap.Int("replayed_descendants", terminalIdx-startIdx-1),
+	)
+
+	// Replay the NON-terminal descendants [startIdx+1 .. terminalIdx-1]
+	// with fresh ${input}, seeded from the re-fired stage's return value.
+	// The terminal stage itself is restarted separately below (it's the
+	// daemon). Use the engine's shutdown-cancellable context so an
+	// in-flight stage bails on Shutdown; the between-iteration guards only
+	// catch the gaps, not a stage already inside Execute.
+	stageCtx := e.getShutdownCtx()
+	if stageCtx == nil {
+		stageCtx = context.Background()
+	}
+	// upstream is what feeds the FIRST replayed descendant. When the
+	// re-fired stage is the terminal daemon stage itself (startIdx ==
+	// terminalIdx — an operator restarting the daemon's own task), there
+	// are no descendants to replay and the terminal stage keeps its
+	// stored upstream; re-seeding it with the daemon's own return would
+	// be wrong. Otherwise the first descendant is fed by the re-fired
+	// stage's fresh return value.
+	upstream := task.InputContext{Output: reranReturn}
+	if startIdx >= terminalIdx {
+		upstream = storedUpstream
+	}
+	for i := startIdx + 1; i < terminalIdx; i++ {
+		if e.pipelineReplayAborted(pipelineID, runner, "aborted", zap.Int("stage", i)) {
 			return
 		}
-
-		// Bail if the engine is shutting down or the pipeline is no longer
-		// live (its terminal daemon already exited / the pipeline finished)
-		// between the liveness check and this goroutine being scheduled.
-		if e.isShuttingDown() {
-			e.log.Debug("pipeline stage re-fire skipped: engine shutting down",
-				zap.String("pipeline", pipelineID))
+		out, err := e.dispatchStage(stageCtx, runner.spec.Stages[i], upstream, runner.runID)
+		if err != nil {
+			e.log.Warn("pipeline mid-stage re-fire: descendant stage failed; pipeline left on old daemon",
+				zap.String("pipeline", pipelineID), zap.Int("stage", i), zap.Error(err))
 			return
 		}
-		if !e.pipelineStillLive(pipelineID, runner) {
-			e.log.Debug("pipeline stage re-fire skipped: pipeline no longer live",
-				zap.String("pipeline", pipelineID))
-			return
-		}
+		upstream = out
+	}
 
-		runner.mu.Lock()
-		terminalIdx := runner.terminalIdx
-		terminalStage := runner.terminalStage
-		oldDaemonRunID := runner.daemonRunID
-		storedUpstream := runner.terminalUpstream
-		runner.mu.Unlock()
+	// Last guard before restarting the daemon: the pipeline could have
+	// finished (terminal daemon exited) or the engine started shutting
+	// down while we replayed descendants.
+	if e.pipelineReplayAborted(pipelineID, runner, "restart skipped") {
+		return
+	}
 
-		e.log.Info("pipeline mid-stage re-fire: propagating to descendants",
-			zap.String("pipeline", pipelineID),
-			zap.String("rerun", reranTaskID),
-			zap.Int("stage", startIdx),
-			// Non-terminal descendants replayed below [startIdx+1 .. terminalIdx-1];
-			// the terminal daemon stage is restarted separately.
-			zap.Int("replayed_descendants", terminalIdx-startIdx-1),
-		)
+	// Enter the restart handshake. Setting restarting=true + a fresh
+	// restartDone BEFORE killing the old run tells the runner's wait loop
+	// that the imminent terminal of oldDaemonRunID is a deliberate restart,
+	// not a real exit — so it blocks on restartDone instead of finishing
+	// the pipeline. We MUST resolve the handshake (publish the new run or
+	// clear restarting) on every exit path from here, or the wait loop
+	// blocks forever; the deferred cleanup below guarantees that.
+	restartDone := make(chan struct{})
+	runner.mu.Lock()
+	runner.restarting = true
+	runner.restartDone = restartDone
+	runner.mu.Unlock()
 
-		// Replay the NON-terminal descendants [startIdx+1 .. terminalIdx-1]
-		// with fresh ${input}, seeded from the re-fired stage's return value.
-		// The terminal stage itself is restarted separately below (it's the
-		// daemon). Use the engine's shutdown-cancellable context so an
-		// in-flight stage bails on Shutdown; the between-iteration guards only
-		// catch the gaps, not a stage already inside Execute.
-		stageCtx := e.getShutdownCtx()
-		if stageCtx == nil {
-			stageCtx = context.Background()
-		}
-		// upstream is what feeds the FIRST replayed descendant. When the
-		// re-fired stage is the terminal daemon stage itself (startIdx ==
-		// terminalIdx — an operator restarting the daemon's own task), there
-		// are no descendants to replay and the terminal stage keeps its
-		// stored upstream; re-seeding it with the daemon's own return would
-		// be wrong. Otherwise the first descendant is fed by the re-fired
-		// stage's fresh return value.
-		upstream := task.InputContext{Output: reranReturn}
-		if startIdx >= terminalIdx {
-			upstream = storedUpstream
-		}
-		for i := startIdx + 1; i < terminalIdx; i++ {
-			if e.isShuttingDown() {
-				e.log.Debug("pipeline stage re-fire aborted: engine shutting down",
-					zap.String("pipeline", pipelineID), zap.Int("stage", i))
-				return
-			}
-			if !e.pipelineStillLive(pipelineID, runner) {
-				e.log.Debug("pipeline stage re-fire aborted: pipeline no longer live",
-					zap.String("pipeline", pipelineID), zap.Int("stage", i))
-				return
-			}
-			out, err := e.dispatchStage(stageCtx, runner.spec.Stages[i], upstream, runner.runID)
-			if err != nil {
-				e.log.Warn("pipeline mid-stage re-fire: descendant stage failed; pipeline left on old daemon",
-					zap.String("pipeline", pipelineID), zap.Int("stage", i), zap.Error(err))
-				return
-			}
-			upstream = out
-		}
-
-		// Last guard before restarting the daemon: the pipeline could have
-		// finished (terminal daemon exited) or the engine started shutting
-		// down while we replayed descendants.
-		if e.isShuttingDown() {
-			e.log.Debug("pipeline stage re-fire restart skipped: engine shutting down",
-				zap.String("pipeline", pipelineID))
-			return
-		}
-		if !e.pipelineStillLive(pipelineID, runner) {
-			e.log.Debug("pipeline stage re-fire restart skipped: pipeline no longer live",
-				zap.String("pipeline", pipelineID))
-			return
-		}
-
-		// Enter the restart handshake. Setting restarting=true + a fresh
-		// restartDone BEFORE killing the old run tells the runner's wait loop
-		// that the imminent terminal of oldDaemonRunID is a deliberate restart,
-		// not a real exit — so it blocks on restartDone instead of finishing
-		// the pipeline. We MUST resolve the handshake (publish the new run or
-		// clear restarting) on every exit path from here, or the wait loop
-		// blocks forever; the deferred cleanup below guarantees that.
-		restartDone := make(chan struct{})
-		runner.mu.Lock()
-		runner.restarting = true
-		runner.restartDone = restartDone
-		runner.mu.Unlock()
-
-		published := false
-		defer func() {
-			// If we exit before publishing the new run (descendant of the
-			// restart phase failed), leave daemonRunID pointing at the old
-			// (now-killed) run and clear restarting; the wait loop detects the
-			// unchanged run ID and finishes the pipeline with the killed
-			// daemon's status. Closing restartDone unblocks it.
-			if !published {
-				runner.mu.Lock()
-				runner.restarting = false
-				runner.mu.Unlock()
-			}
-			close(restartDone)
-		}()
-
-		// Kill the current terminal daemon run and wait for it to drain:
-		// KillRun(old) + bounded WaitRun(old).
-		if oldDaemonRunID != "" {
-			e.KillRun(oldDaemonRunID)
-			waitCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			_, _ = e.WaitRun(waitCtx, oldDaemonRunID)
-			cancel()
-		}
-
-		// Re-fire the terminal daemon stage with the freshly-replayed upstream.
-		newRunID, isDaemon, ferr := e.fireStageRaw(stageCtx, terminalStage, upstream, runner.runID)
-		if ferr != nil {
-			e.log.Error("pipeline mid-stage re-fire: terminal daemon restart failed",
-				zap.String("pipeline", pipelineID), zap.Error(ferr))
-			return
-		}
-		if !isDaemon {
-			// Defensive: the terminal stage was a daemon when we registered as
-			// live; a registry mutation could in principle flip it. Stop the
-			// stray run rather than leaving it untracked, and let the wait loop
-			// finish the pipeline on the old (killed) daemon's status.
-			e.log.Warn("pipeline mid-stage re-fire: terminal stage no longer a daemon after restart; stopping stray run",
-				zap.String("pipeline", pipelineID))
-			e.KillRun(newRunID)
-			return
-		}
-
-		// Publish the new daemon run + upstream so the runner's wait loop
-		// re-waits on it. Clear restarting under the same lock so the loop sees
-		// a consistent snapshot.
-		//
-		// Two abort conditions, checked under the SAME mutex as the publish so
-		// there's no TOCTOU between "is the pipeline still alive?" and "adopt the
-		// fresh run":
-		//
-		//   - runner.finished: the pipeline already finished (its terminal-daemon
-		//     wait loop ran finish()) while we were restarting.
-		//   - runner.runCtx.Err() != nil: the pipeline parent was KillRun'd /
-		//     cancelled while we were restarting. The single-shot runCtx watcher
-		//     in runTerminalDaemon may have already fired on the now-dead OLD run
-		//     (it's spent), so adopting the fresh run here would leave it with
-		//     nothing to kill it → leaked daemon subprocess + pipeline wedged
-		//     'running' (#344, HIGH). Refuse to adopt: kill the fresh daemon and
-		//     leave daemonRunID pointing at the killed old run so the wait loop's
-		//     "restart aborted" branch finishes the pipeline with the old run's
-		//     terminal status (cancelled).
-		//
-		// The deferred cleanup (published==false) clears restarting + closes
-		// restartDone on either abort, unblocking the wait loop.
-		runner.mu.Lock()
-		if runner.finished {
+	published := false
+	defer func() {
+		// If we exit before publishing the new run (descendant of the
+		// restart phase failed), leave daemonRunID pointing at the old
+		// (now-killed) run and clear restarting; the wait loop detects the
+		// unchanged run ID and finishes the pipeline with the killed
+		// daemon's status. Closing restartDone unblocks it.
+		if !published {
+			runner.mu.Lock()
+			runner.restarting = false
 			runner.mu.Unlock()
-			e.log.Debug("pipeline stage re-fire: pipeline finished during restart; stopping fresh daemon run",
-				zap.String("pipeline", pipelineID))
-			e.KillRun(newRunID)
-			return
 		}
-		if runner.runCtx.Err() != nil {
-			runner.mu.Unlock()
-			e.log.Debug("pipeline stage re-fire: pipeline cancelled during restart; stopping fresh daemon run",
-				zap.String("pipeline", pipelineID))
-			e.KillRun(newRunID)
-			return
-		}
-		runner.daemonRunID = newRunID
-		runner.terminalUpstream = upstream
-		runner.restarting = false
-		runner.mu.Unlock()
-		published = true
+		close(restartDone)
 	}()
+
+	// Kill the current terminal daemon run and wait for it to drain:
+	// KillRun(old) + bounded WaitRun(old).
+	if oldDaemonRunID != "" {
+		e.KillRun(oldDaemonRunID)
+		waitCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_, _ = e.WaitRun(waitCtx, oldDaemonRunID)
+		cancel()
+	}
+
+	// Re-fire the terminal daemon stage with the freshly-replayed upstream.
+	newRunID, isDaemon, ferr := e.fireStageRaw(stageCtx, terminalStage, upstream, runner.runID)
+	if ferr != nil {
+		e.log.Error("pipeline mid-stage re-fire: terminal daemon restart failed",
+			zap.String("pipeline", pipelineID), zap.Error(ferr))
+		return
+	}
+	if !isDaemon {
+		// Defensive: the terminal stage was a daemon when we registered as
+		// live; a registry mutation could in principle flip it. Stop the
+		// stray run rather than leaving it untracked, and let the wait loop
+		// finish the pipeline on the old (killed) daemon's status.
+		e.log.Warn("pipeline mid-stage re-fire: terminal stage no longer a daemon after restart; stopping stray run",
+			zap.String("pipeline", pipelineID))
+		e.KillRun(newRunID)
+		return
+	}
+
+	// Publish the new daemon run + upstream so the runner's wait loop
+	// re-waits on it. Clear restarting under the same lock so the loop sees
+	// a consistent snapshot.
+	//
+	// Two abort conditions, checked under the SAME mutex as the publish so
+	// there's no TOCTOU between "is the pipeline still alive?" and "adopt the
+	// fresh run":
+	//
+	//   - runner.finished: the pipeline already finished (its terminal-daemon
+	//     wait loop ran finish()) while we were restarting.
+	//   - runner.runCtx.Err() != nil: the pipeline parent was KillRun'd /
+	//     cancelled while we were restarting. The single-shot runCtx watcher
+	//     in runTerminalDaemon may have already fired on the now-dead OLD run
+	//     (it's spent), so adopting the fresh run here would leave it with
+	//     nothing to kill it → leaked daemon subprocess + pipeline wedged
+	//     'running' (#344, HIGH). Refuse to adopt: kill the fresh daemon and
+	//     leave daemonRunID pointing at the killed old run so the wait loop's
+	//     "restart aborted" branch finishes the pipeline with the old run's
+	//     terminal status (cancelled).
+	//
+	// The deferred cleanup (published==false) clears restarting + closes
+	// restartDone on either abort, unblocking the wait loop.
+	runner.mu.Lock()
+	if runner.finished {
+		runner.mu.Unlock()
+		e.log.Debug("pipeline stage re-fire: pipeline finished during restart; stopping fresh daemon run",
+			zap.String("pipeline", pipelineID))
+		e.KillRun(newRunID)
+		return
+	}
+	if runner.runCtx.Err() != nil {
+		runner.mu.Unlock()
+		e.log.Debug("pipeline stage re-fire: pipeline cancelled during restart; stopping fresh daemon run",
+			zap.String("pipeline", pipelineID))
+		e.KillRun(newRunID)
+		return
+	}
+	runner.daemonRunID = newRunID
+	runner.terminalUpstream = upstream
+	runner.restarting = false
+	runner.mu.Unlock()
+	published = true
 }
 
 // pipelineStillLive reports whether the given runner is still the live

--- a/pkg/trigger/webhook.go
+++ b/pkg/trigger/webhook.go
@@ -392,38 +392,7 @@ func (e *Engine) WebhookHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 
-		// Exact match — normal webhook execution path.
-		e.mu.Lock()
-		taskID, ok := e.webhooks[path]
-		var assetPath, matchedHook string
-		if !ok {
-			// No exact match — the request is for a static asset under some
-			// webhook UI. Walk up one path segment at a time doing exact
-			// map lookups, so the most-specific parent hook wins. This
-			// matters when both `/hooks/ai` and `/hooks/ai/openai` are
-			// registered: `/hooks/ai/openai/chat.js` must bind to the
-			// preset, not to the buildin. Exact map lookups (rather than
-			// iterating e.webhooks with strings.HasPrefix) are also
-			// immune to Go's randomised map iteration order.
-			for candidate := path; ; {
-				idx := strings.LastIndex(candidate, "/")
-				if idx <= 0 {
-					break
-				}
-				candidate = candidate[:idx]
-				if tid, found := e.webhooks[candidate]; found {
-					taskID = tid
-					matchedHook = candidate
-					assetPath = path[len(candidate)+1:]
-					ok = true
-					break
-				}
-			}
-		} else {
-			matchedHook = path
-		}
-		e.mu.Unlock()
-
+		taskID, matchedHook, assetPath, ok := e.resolveWebhookPath(path)
 		if !ok {
 			http.NotFound(w, r)
 			return
@@ -459,181 +428,231 @@ func (e *Engine) WebhookHandler() http.Handler {
 				return
 			}
 			if r.Method == http.MethodGet &&
-				filepath.Ext(assetPath) == "" {
-				indexFile := filepath.Join(spec.TaskDir, "index.html")
-				if data, err := os.ReadFile(indexFile); err == nil {
-					html := injectDicodeSDK(string(data), matchedHook, taskID, r)
-					w.Header().Set("Content-Type", "text/html; charset=utf-8")
-					_, _ = w.Write([]byte(html))
-					return
-				}
+				filepath.Ext(assetPath) == "" &&
+				e.serveTaskUI(w, r, spec, matchedHook, taskID, false) {
+				return
 			}
 			e.serveTaskAsset(w, r, spec.TaskDir, assetPath)
 			return
 		}
 
 		// On GET, serve the task's index.html UI when one is present.
-		if r.Method == http.MethodGet {
-			indexFile := filepath.Join(spec.TaskDir, "index.html")
-			if data, err := os.ReadFile(indexFile); err == nil {
-				e.log.Info("webhook UI served", zap.String("path", path), zap.String("task", taskID))
-				html := injectDicodeSDK(string(data), matchedHook, taskID, r)
-				w.Header().Set("Content-Type", "text/html; charset=utf-8")
-				_, _ = w.Write([]byte(html))
-				return
-			}
-		}
-
-		e.log.Info("webhook trigger", zap.String("path", path), zap.String("task", taskID))
-
-		// Read the raw body first so HMAC verification always covers the
-		// actual request bytes, regardless of content-type.
-		body := readWebhookBody(r)
-		input, isFormSubmit := decodeWebhookPayload(r, body)
-
-		// Verify HMAC signature when a secret is configured on the task.
-		if err := verifyWebhookSignature(spec, r, body); err != nil {
-			e.log.Warn("webhook signature verification failed",
-				zap.String("path", path),
-				zap.String("task", taskID),
-				zap.Error(err),
-			)
-			http.Error(w, "forbidden: "+err.Error(), http.StatusForbidden)
+		if r.Method == http.MethodGet && e.serveTaskUI(w, r, spec, matchedHook, taskID, true) {
 			return
 		}
 
-		// Replay protection: reject duplicate bodies within the nonce cache TTL.
-		if err := e.checkWebhookReplay(spec.Trigger.WebhookSecret, spec.Trigger.ReplayProtection, body); err != nil {
-			e.log.Warn("webhook replay rejected",
-				zap.String("path", path),
-				zap.String("task", taskID),
-			)
-			writeWebhookReplayRejected(w)
-			return
+		e.fireWebhookTask(w, r, spec, path, taskID)
+	})
+}
+
+// resolveWebhookPath routes an incoming request path to a registered webhook:
+// either an exact match (normal webhook execution path) or, for static assets
+// under some webhook UI, the most-specific parent hook plus the remaining
+// asset sub-path. ok=false means no registered webhook claims the path.
+func (e *Engine) resolveWebhookPath(path string) (taskID, matchedHook, assetPath string, ok bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	// Exact match — normal webhook execution path.
+	if tid, found := e.webhooks[path]; found {
+		return tid, path, "", true
+	}
+	// No exact match — the request is for a static asset under some
+	// webhook UI. Walk up one path segment at a time doing exact
+	// map lookups, so the most-specific parent hook wins. This
+	// matters when both `/hooks/ai` and `/hooks/ai/openai` are
+	// registered: `/hooks/ai/openai/chat.js` must bind to the
+	// preset, not to the buildin. Exact map lookups (rather than
+	// iterating e.webhooks with strings.HasPrefix) are also
+	// immune to Go's randomised map iteration order.
+	for candidate := path; ; {
+		idx := strings.LastIndex(candidate, "/")
+		if idx <= 0 {
+			break
 		}
-
-		// Extract a flat string map from the input so it is accessible via
-		// params.get() in task scripts (RunOptions.Params), in addition to the
-		// raw input being available as the `input` global (RunOptions.Input).
-		params := flatStringMap(input)
-
-		// Build the WebhookContext so the persistence layer can apply
-		// content-type-aware redaction to the raw body and populate
-		// Method/Path/Headers/Query on the stored PersistedInput.
-		// For GET requests body is nil; body was already read above for
-		// POST/PUT/etc. and is safe to reference here.
-		webhookCtx := newWebhookContext(r, body)
-
-		// Default: wait for the run to finish and return the result inline.
-		// Pass ?wait=false to fire-and-forget (returns runId immediately).
-		async := r.URL.Query().Get("wait") == "false"
-
-		if async {
-			runID, err := e.fireAsync(r.Context(), spec, pkgruntime.RunOptions{Input: input, Params: params, WebhookCtx: webhookCtx}, registry.TriggerWebhook)
-			if err != nil {
-				http.Error(w, "task failed to start", http.StatusInternalServerError)
-				return
-			}
-			w.Header().Set("X-Run-Id", runID)
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]string{"runId": runID})
-			return
+		candidate = candidate[:idx]
+		if tid, found := e.webhooks[candidate]; found {
+			return tid, candidate, path[len(candidate)+1:], true
 		}
+	}
+	return "", "", "", false
+}
 
-		// Enforce the concurrency cap at the webhook entry point, not inside
-		// fireSync. fireSync is reentrant: if_missing prereqs and input-storage
-		// delegation both call fireSync from within runTask, so placing the gate
-		// inside fireSync causes a parent holding a slot to self-block when it
-		// spawns a nested sub-run. Gate only the top-level webhook-triggered call.
-		if e.taskSem != nil && !spec.Trigger.Daemon {
-			select {
-			case e.taskSem <- struct{}{}:
-				defer func() { <-e.taskSem }()
-			default:
-				http.Error(w, "too many concurrent tasks; retry later", http.StatusServiceUnavailable)
-				return
-			}
-		}
+// serveTaskUI serves the task directory's index.html with the dicode client
+// SDK injected, when one is present. Returns false — without writing to w —
+// when the task has no readable index.html, so callers fall through to their
+// asset-serving / execution path. logServe controls the "webhook UI served"
+// info line: the top-level GET site logs it, the SPA-fallback asset site does
+// not (both preserved from the pre-extraction handler).
+func (e *Engine) serveTaskUI(w http.ResponseWriter, r *http.Request, spec *task.Spec, matchedHook, taskID string, logServe bool) bool {
+	indexFile := filepath.Join(spec.TaskDir, "index.html")
+	data, err := os.ReadFile(indexFile)
+	if err != nil {
+		return false
+	}
+	if logServe {
+		e.log.Info("webhook UI served", zap.String("path", r.URL.Path), zap.String("task", taskID))
+	}
+	html := injectDicodeSDK(string(data), matchedHook, taskID, r)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write([]byte(html))
+	return true
+}
 
-		runID, result, err := e.fireSync(context.Background(), spec, pkgruntime.RunOptions{Input: input, Params: params, WebhookCtx: webhookCtx}, registry.TriggerWebhook)
+// fireWebhookTask executes a kind: Task webhook request end-to-end: decode
+// the payload, verify HMAC signature + replay protection, fire the task
+// (async when ?wait=false, otherwise synchronously under the concurrency
+// cap), and shape the HTTP response (redirect for browser form submissions,
+// structured output, or the JSON/error-page envelopes).
+func (e *Engine) fireWebhookTask(w http.ResponseWriter, r *http.Request, spec *task.Spec, path, taskID string) {
+	e.log.Info("webhook trigger", zap.String("path", path), zap.String("task", taskID))
+
+	// Read the raw body first so HMAC verification always covers the
+	// actual request bytes, regardless of content-type.
+	body := readWebhookBody(r)
+	input, isFormSubmit := decodeWebhookPayload(r, body)
+
+	// Verify HMAC signature when a secret is configured on the task.
+	if err := verifyWebhookSignature(spec, r, body); err != nil {
+		e.log.Warn("webhook signature verification failed",
+			zap.String("path", path),
+			zap.String("task", taskID),
+			zap.Error(err),
+		)
+		http.Error(w, "forbidden: "+err.Error(), http.StatusForbidden)
+		return
+	}
+
+	// Replay protection: reject duplicate bodies within the nonce cache TTL.
+	if err := e.checkWebhookReplay(spec.Trigger.WebhookSecret, spec.Trigger.ReplayProtection, body); err != nil {
+		e.log.Warn("webhook replay rejected",
+			zap.String("path", path),
+			zap.String("task", taskID),
+		)
+		writeWebhookReplayRejected(w)
+		return
+	}
+
+	// Extract a flat string map from the input so it is accessible via
+	// params.get() in task scripts (RunOptions.Params), in addition to the
+	// raw input being available as the `input` global (RunOptions.Input).
+	params := flatStringMap(input)
+
+	// Build the WebhookContext so the persistence layer can apply
+	// content-type-aware redaction to the raw body and populate
+	// Method/Path/Headers/Query on the stored PersistedInput.
+	// For GET requests body is nil; body was already read above for
+	// POST/PUT/etc. and is safe to reference here.
+	webhookCtx := newWebhookContext(r, body)
+
+	// Default: wait for the run to finish and return the result inline.
+	// Pass ?wait=false to fire-and-forget (returns runId immediately).
+	async := r.URL.Query().Get("wait") == "false"
+
+	if async {
+		runID, err := e.fireAsync(r.Context(), spec, pkgruntime.RunOptions{Input: input, Params: params, WebhookCtx: webhookCtx}, registry.TriggerWebhook)
 		if err != nil {
 			http.Error(w, "task failed to start", http.StatusInternalServerError)
 			return
 		}
+		w.Header().Set("X-Run-Id", runID)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"runId": runID})
+		return
+	}
 
-		// Browser form submissions redirect to the run result page.
-		if isFormSubmit {
-			http.Redirect(w, r, "/runs/"+runID+"/result", http.StatusSeeOther)
+	// Enforce the concurrency cap at the webhook entry point, not inside
+	// fireSync. fireSync is reentrant: if_missing prereqs and input-storage
+	// delegation both call fireSync from within runTask, so placing the gate
+	// inside fireSync causes a parent holding a slot to self-block when it
+	// spawns a nested sub-run. Gate only the top-level webhook-triggered call.
+	if e.taskSem != nil && !spec.Trigger.Daemon {
+		select {
+		case e.taskSem <- struct{}{}:
+			defer func() { <-e.taskSem }()
+		default:
+			http.Error(w, "too many concurrent tasks; retry later", http.StatusServiceUnavailable)
 			return
 		}
+	}
 
-		// Return structured output or return value directly when available.
-		if result.OutputContent != "" {
-			ct := result.OutputContentType
-			if ct == "" {
-				ct = "text/plain"
-			}
-			w.Header().Set("Content-Type", ct+"; charset=utf-8")
-			w.Header().Set("X-Run-Id", runID)
-			if result.Error != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-			}
-			_, _ = w.Write([]byte(result.OutputContent))
-			return
-		}
-		if result.ReturnValue != nil {
-			w.Header().Set("Content-Type", "application/json")
-			w.Header().Set("X-Run-Id", runID)
-			if result.Error != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-			}
-			_ = json.NewEncoder(w).Encode(result.ReturnValue)
-			return
-		}
+	runID, result, err := e.fireSync(context.Background(), spec, pkgruntime.RunOptions{Input: input, Params: params, WebhookCtx: webhookCtx}, registry.TriggerWebhook)
+	if err != nil {
+		http.Error(w, "task failed to start", http.StatusInternalServerError)
+		return
+	}
 
-		// No output produced — the task either succeeded silently or threw before
-		// calling output.*. Collect logs so we can surface them to the caller.
-		var logLines []string
-		if logEntries, logErr := e.registry.GetRunLogs(context.Background(), runID); logErr == nil {
-			for _, le := range logEntries {
-				logLines = append(logLines, le.Message)
-			}
-		}
+	// Browser form submissions redirect to the run result page.
+	if isFormSubmit {
+		http.Redirect(w, r, "/runs/"+runID+"/result", http.StatusSeeOther)
+		return
+	}
 
+	// Return structured output or return value directly when available.
+	if result.OutputContent != "" {
+		ct := result.OutputContentType
+		if ct == "" {
+			ct = "text/plain"
+		}
+		w.Header().Set("Content-Type", ct+"; charset=utf-8")
+		w.Header().Set("X-Run-Id", runID)
 		if result.Error != nil {
-			errMsg := result.Error.Error()
-			// Browser: render an error page using the same log style as the webui.
-			if strings.Contains(r.Header.Get("Accept"), "text/html") {
-				w.Header().Set("Content-Type", "text/html; charset=utf-8")
-				w.Header().Set("X-Run-Id", runID)
-				w.WriteHeader(http.StatusInternalServerError)
-				logsJSON, _ := json.Marshal(logLines)
-				var safeJSON bytes.Buffer
-				json.HTMLEscape(&safeJSON, logsJSON)
-				_, _ = fmt.Fprintf(w, taskErrorPage, html.EscapeString(runID), html.EscapeString(errMsg), safeJSON.String())
-				return
-			}
-			// API: JSON envelope with error message.
-			w.Header().Set("Content-Type", "application/json")
-			w.Header().Set("X-Run-Id", runID)
 			w.WriteHeader(http.StatusInternalServerError)
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"runId":  runID,
-				"status": "failure",
-				"error":  errMsg,
-				"logs":   logLines,
-			})
-			return
 		}
-
-		// Successful run with no output.
+		_, _ = w.Write([]byte(result.OutputContent))
+		return
+	}
+	if result.ReturnValue != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("X-Run-Id", runID)
+		if result.Error != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+		_ = json.NewEncoder(w).Encode(result.ReturnValue)
+		return
+	}
+
+	// No output produced — the task either succeeded silently or threw before
+	// calling output.*. Collect logs so we can surface them to the caller.
+	var logLines []string
+	if logEntries, logErr := e.registry.GetRunLogs(context.Background(), runID); logErr == nil {
+		for _, le := range logEntries {
+			logLines = append(logLines, le.Message)
+		}
+	}
+
+	if result.Error != nil {
+		errMsg := result.Error.Error()
+		// Browser: render an error page using the same log style as the webui.
+		if strings.Contains(r.Header.Get("Accept"), "text/html") {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.Header().Set("X-Run-Id", runID)
+			w.WriteHeader(http.StatusInternalServerError)
+			logsJSON, _ := json.Marshal(logLines)
+			var safeJSON bytes.Buffer
+			json.HTMLEscape(&safeJSON, logsJSON)
+			_, _ = fmt.Fprintf(w, taskErrorPage, html.EscapeString(runID), html.EscapeString(errMsg), safeJSON.String())
+			return
+		}
+		// API: JSON envelope with error message.
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Run-Id", runID)
+		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"runId":  runID,
-			"status": "success",
+			"status": "failure",
+			"error":  errMsg,
 			"logs":   logLines,
 		})
+		return
+	}
+
+	// Successful run with no output.
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Run-Id", runID)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"runId":  runID,
+		"status": "success",
+		"logs":   logLines,
 	})
 }
 

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -808,6 +808,34 @@ func redactServerSecret(b []byte) []byte {
 	return out
 }
 
+// decodeBody populates v from a JSON request body when the Content-Type is
+// application/json; for any other content type it invokes fromForm, which
+// reads the equivalent form values into the same destination. The JSON
+// decode error is returned for the caller to surface — call sites use
+// different 400 bodies, preserved verbatim from before this helper existed.
+func decodeBody(r *http.Request, v any, fromForm func()) error {
+	ct := r.Header.Get("Content-Type")
+	if strings.Contains(ct, "application/json") {
+		return json.NewDecoder(r.Body).Decode(v)
+	}
+	fromForm()
+	return nil
+}
+
+// readContentField extracts the editor payload from either a JSON body
+// ({"content": …}) or the "content" form value. ok=false means a JSON decode
+// error was already written as a 400 response.
+func readContentField(w http.ResponseWriter, r *http.Request) (string, bool) {
+	var body struct {
+		Content string `json:"content"`
+	}
+	if err := decodeBody(r, &body, func() { body.Content = r.FormValue("content") }); err != nil {
+		jsonErr(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return "", false
+	}
+	return body.Content, true
+}
+
 // apiSaveConfigRaw validates and writes the raw config back to dicode.yaml.
 // Protected by the main session via requireAuth.
 func (s *Server) apiSaveConfigRaw(w http.ResponseWriter, r *http.Request) {
@@ -817,19 +845,9 @@ func (s *Server) apiSaveConfigRaw(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Support both JSON body and form value.
-	var content string
-	ct := r.Header.Get("Content-Type")
-	if strings.Contains(ct, "application/json") {
-		var body struct {
-			Content string `json:"content"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			jsonErr(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
-			return
-		}
-		content = body.Content
-	} else {
-		content = r.FormValue("content")
+	content, ok := readContentField(w, r)
+	if !ok {
+		return
 	}
 
 	// Validate: must parse as valid YAML mapping.
@@ -921,20 +939,43 @@ func safeTaskFilePath(taskDir, filename string) (string, error) {
 	return joined, nil
 }
 
-func (s *Server) apiGetFile(w http.ResponseWriter, r *http.Request) {
-	id, filename := taskIDParam(r), chi.URLParam(r, "filename")
-	if !allowedFiles[filename] {
-		jsonErr(w, "file not allowed", http.StatusBadRequest)
-		return
-	}
+// taskOr404 looks up a kind: Task spec by ID, writing the shared
+// "task not found" 404 envelope when the registry has no such task.
+// ok=false means the response was already written.
+func (s *Server) taskOr404(w http.ResponseWriter, id string) (*task.Spec, bool) {
 	spec, ok := s.registry.Get(id)
 	if !ok {
 		jsonErr(w, "task not found", http.StatusNotFound)
-		return
+		return nil, false
+	}
+	return spec, true
+}
+
+// resolveTaskFile is the shared apiGetFile/apiSaveFile preamble: extract the
+// task ID + filename params, enforce the editable-file allowlist, resolve the
+// task, and validate the filename stays inside the task dir. ok=false means
+// an error response was already written.
+func (s *Server) resolveTaskFile(w http.ResponseWriter, r *http.Request) (path, id, filename string, ok bool) {
+	id, filename = taskIDParam(r), chi.URLParam(r, "filename")
+	if !allowedFiles[filename] {
+		jsonErr(w, "file not allowed", http.StatusBadRequest)
+		return "", "", "", false
+	}
+	spec, ok := s.taskOr404(w, id)
+	if !ok {
+		return "", "", "", false
 	}
 	path, err := safeTaskFilePath(spec.TaskDir, filename)
 	if err != nil {
 		jsonErr(w, "invalid filename", http.StatusBadRequest)
+		return "", "", "", false
+	}
+	return path, id, filename, true
+}
+
+func (s *Server) apiGetFile(w http.ResponseWriter, r *http.Request) {
+	path, _, _, ok := s.resolveTaskFile(w, r)
+	if !ok {
 		return
 	}
 	b, err := os.ReadFile(path)
@@ -948,19 +989,8 @@ func (s *Server) apiGetFile(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) apiSaveFile(w http.ResponseWriter, r *http.Request) {
-	id, filename := taskIDParam(r), chi.URLParam(r, "filename")
-	if !allowedFiles[filename] {
-		jsonErr(w, "file not allowed", http.StatusBadRequest)
-		return
-	}
-	spec, ok := s.registry.Get(id)
+	path, id, filename, ok := s.resolveTaskFile(w, r)
 	if !ok {
-		jsonErr(w, "task not found", http.StatusNotFound)
-		return
-	}
-	path, err := safeTaskFilePath(spec.TaskDir, filename)
-	if err != nil {
-		jsonErr(w, "invalid filename", http.StatusBadRequest)
 		return
 	}
 
@@ -988,9 +1018,8 @@ func (s *Server) apiSaveFile(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) apiSaveTrigger(w http.ResponseWriter, r *http.Request) {
 	id := taskIDParam(r)
-	spec, ok := s.registry.Get(id)
+	spec, ok := s.taskOr404(w, id)
 	if !ok {
-		jsonErr(w, "task not found", http.StatusNotFound)
 		return
 	}
 
@@ -1016,13 +1045,7 @@ func (s *Server) apiSaveTrigger(w http.ResponseWriter, r *http.Request) {
 		On      string `json:"on"`
 		Restart string `json:"restart"`
 	}
-	ct := r.Header.Get("Content-Type")
-	if strings.Contains(ct, "application/json") {
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			jsonErr(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
-			return
-		}
-	} else {
+	if err := decodeBody(r, &body, func() {
 		// Fallback: form values
 		body.Type = r.FormValue("type")
 		body.Cron = r.FormValue("cron")
@@ -1030,6 +1053,9 @@ func (s *Server) apiSaveTrigger(w http.ResponseWriter, r *http.Request) {
 		body.From = r.FormValue("chain_from")
 		body.On = r.FormValue("chain_on")
 		body.Restart = r.FormValue("restart")
+	}); err != nil {
+		jsonErr(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	var trigMap map[string]any
@@ -1375,23 +1401,18 @@ func (s *Server) apiSetSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var key, value string
-	ct := r.Header.Get("Content-Type")
-	if strings.Contains(ct, "application/json") {
-		var body struct {
-			Key   string `json:"key"`
-			Value string `json:"value"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			jsonErr(w, "invalid JSON", http.StatusBadRequest)
-			return
-		}
-		key = body.Key
-		value = body.Value
-	} else {
-		key = r.FormValue("key")
-		value = r.FormValue("value")
+	var body struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
 	}
+	if err := decodeBody(r, &body, func() {
+		body.Key = r.FormValue("key")
+		body.Value = r.FormValue("value")
+	}); err != nil {
+		jsonErr(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+	key, value := body.Key, body.Value
 
 	if key == "" {
 		jsonErr(w, "key is required", http.StatusBadRequest)
@@ -1702,8 +1723,7 @@ func (s *Server) apiPatchTaskOverrides(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, ok := s.registry.Get(id); !ok {
-		jsonErr(w, "task not found", http.StatusNotFound)
+	if _, ok := s.taskOr404(w, id); !ok {
 		return
 	}
 
@@ -2238,10 +2258,10 @@ func (s *Server) apiSaveAISettings(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, "task must have a webhook trigger under "+webhookPathPrefix, http.StatusBadRequest)
 		return
 	}
-	s.cfgMu.Lock()
-	s.cfg.AI.Task = task
-	err := s.persistConfigLocked()
-	s.cfgMu.Unlock()
+	err := s.updateConfig(func(cfg *config.Config) error {
+		cfg.AI.Task = task
+		return nil
+	})
 	if err != nil {
 		s.log.Warn("settings persist failed", zap.Error(err))
 		jsonErr(w, "saved in memory but could not write file: "+err.Error(), http.StatusInternalServerError)
@@ -2260,15 +2280,15 @@ func (s *Server) apiSaveServerSettings(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, "bad request", http.StatusBadRequest)
 		return
 	}
-	s.cfgMu.Lock()
-	if body.LogLevel != "" {
-		s.cfg.LogLevel = body.LogLevel
-	}
-	if body.Secret != "" {
-		s.cfg.Server.Secret = body.Secret
-	}
-	err := s.persistConfigLocked()
-	s.cfgMu.Unlock()
+	err := s.updateConfig(func(cfg *config.Config) error {
+		if body.LogLevel != "" {
+			cfg.LogLevel = body.LogLevel
+		}
+		if body.Secret != "" {
+			cfg.Server.Secret = body.Secret
+		}
+		return nil
+	})
 	if err != nil {
 		s.log.Warn("settings persist failed", zap.Error(err))
 		jsonErr(w, "saved in memory but could not write file: "+err.Error(), http.StatusInternalServerError)
@@ -2347,13 +2367,13 @@ func (s *Server) apiAddSource(w http.ResponseWriter, r *http.Request) {
 		s.sourceMgr.Register(name, ts)
 	}
 
-	s.cfgMu.Lock()
-	if s.cfg.Spec.Entries == nil {
-		s.cfg.Spec.Entries = make(map[string]*taskset.Entry)
-	}
-	s.cfg.Spec.Entries[name] = entry
-	persistErr := s.persistConfigLocked()
-	s.cfgMu.Unlock()
+	persistErr := s.updateConfig(func(cfg *config.Config) error {
+		if cfg.Spec.Entries == nil {
+			cfg.Spec.Entries = make(map[string]*taskset.Entry)
+		}
+		cfg.Spec.Entries[name] = entry
+		return nil
+	})
 	if persistErr != nil {
 		s.log.Warn("source persist failed", zap.Error(persistErr))
 	}
@@ -2441,22 +2461,30 @@ func normalizeGitURL(raw string) string {
 	return u
 }
 
+// errSourceNotFound aborts the apiRemoveSource updateConfig mutate so a
+// missing source never triggers a config persist. The handler surfaces it
+// as the 404 via its own entry-nil check.
+var errSourceNotFound = errors.New("source not found")
+
 func (s *Server) apiRemoveSource(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	if name == "" {
 		jsonErr(w, "source name is required", http.StatusBadRequest)
 		return
 	}
-	s.cfgMu.Lock()
-	entry := s.cfg.Spec.Entries[name]
+	var entry *taskset.Entry
+	persistErr := s.updateConfig(func(cfg *config.Config) error {
+		entry = cfg.Spec.Entries[name]
+		if entry == nil {
+			return errSourceNotFound // skip the persist; surfaced as a 404 below
+		}
+		delete(cfg.Spec.Entries, name)
+		return nil
+	})
 	if entry == nil {
-		s.cfgMu.Unlock()
 		jsonErr(w, "source not found", http.StatusNotFound)
 		return
 	}
-	delete(s.cfg.Spec.Entries, name)
-	persistErr := s.persistConfigLocked()
-	s.cfgMu.Unlock()
 
 	if s.reconciler != nil && entry.Ref != nil {
 		id := entry.Ref.URL
@@ -2547,15 +2575,15 @@ func (s *Server) apiInstallRuntime(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.cfgMu.Lock()
-	if s.cfg.Runtimes == nil {
-		s.cfg.Runtimes = make(map[string]config.RuntimeConfig)
-	}
-	rcUpdate := s.cfg.Runtimes[name]
-	rcUpdate.Version = version
-	s.cfg.Runtimes[name] = rcUpdate
-	persistErr := s.persistConfigLocked()
-	s.cfgMu.Unlock()
+	persistErr := s.updateConfig(func(cfg *config.Config) error {
+		if cfg.Runtimes == nil {
+			cfg.Runtimes = make(map[string]config.RuntimeConfig)
+		}
+		rcUpdate := cfg.Runtimes[name]
+		rcUpdate.Version = version
+		cfg.Runtimes[name] = rcUpdate
+		return nil
+	})
 	if persistErr != nil {
 		s.log.Warn("runtime config persist failed", zap.Error(persistErr))
 	}
@@ -2574,16 +2602,31 @@ func (s *Server) apiRemoveRuntime(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, "deno is required and cannot be removed", http.StatusBadRequest)
 		return
 	}
-	s.cfgMu.Lock()
-	if s.cfg.Runtimes != nil {
-		delete(s.cfg.Runtimes, name)
-	}
-	persistErr := s.persistConfigLocked()
-	s.cfgMu.Unlock()
+	persistErr := s.updateConfig(func(cfg *config.Config) error {
+		if cfg.Runtimes != nil {
+			delete(cfg.Runtimes, name)
+		}
+		return nil
+	})
 	if persistErr != nil {
 		s.log.Warn("runtime config persist failed", zap.Error(persistErr))
 	}
 	jsonOK(w, map[string]string{"status": "ok"})
+}
+
+// updateConfig runs mutate on the in-memory config and persists the result
+// to dicode.yaml under a single cfgMu critical section — the same
+// lock-across-mutate+persist scope every call site previously held inline.
+// A non-nil error from mutate skips the persist and is returned as-is;
+// otherwise the persistConfigLocked error is returned for the caller to
+// surface (the sites differ: hard 500 vs warn-and-continue).
+func (s *Server) updateConfig(mutate func(*config.Config) error) error {
+	s.cfgMu.Lock()
+	defer s.cfgMu.Unlock()
+	if err := mutate(s.cfg); err != nil {
+		return err
+	}
+	return s.persistConfigLocked()
 }
 
 // persistConfig writes the current in-memory config back to dicode.yaml.


### PR DESCRIPTION
## Summary

Closes #478. The last slice of the code-quality audit batch (#476–#478): **pure-move** decomposition of four god-functions plus extraction of duplicated webui handler boilerplate. Verbatim extraction — no logic/ordering/error-wrap/lock-scope/concurrency changes. **Zero test files modified**; the existing suites (incl. `-race`) are the behavior oracle and stay green.

> ⛓️ **Stacked PR** — base is `claude/issue-477-cleanup` (itself on `claude/issue-476-fsutil-pathguard`). Its own diff is just the #478 changes. When #476/#477 merge, GitHub retargets the base and I rebase onto main.

## Part A — god-function splits
- **`daemon.run()` (601→readable sequence)** — each `// N.` step extracted to a helper (`openDatabase`, `setupRegistry`, `wireRunInputPersistence`, `initSources`, `newArmDisarm`, `setupApprovalGate`, `buildWebUI`, `buildControlServer`, `wireCryptoIPC`, `initAuditPruning`, `runServices`). `defer database.Close()` stays in `run()`; helpers **return** resources rather than deferring, so cleanup order and every error-wrap string are unchanged.
- **`FireChain` (307, 6-deep)** → `fireSuccessChains` / `firePipelineChains` / `fireFailureChain` + shared `chainEdgeMatches` / `resolveChainEdge`. Kept as two helpers (not one) so the success loop's overrides-validate step stays *between* filter and resolve — avoids reordering which error log fires.
- **`WebhookHandler` (248-line closure)** → `resolveWebhookPath` (routing) + `serveTaskUI` (the verbatim read-index→inject-SDK→write block, deduped from 2 sites) + `fireWebhookTask` (fire/response; holds the `taskSem` acquire+release so semaphore timing is identical). Auth/guard ordering untouched.
- **`propagatePipelineStageRerun` (212-line inline goroutine)** → `runPipelineStageRerun` (goroutine body; `defer restartGates.release` fires at the same point) + `pipelineReplayAborted` guard. Concurrency semantics preserved.

## Part B — webui handler helpers (`server.go`)
- **`updateConfig` ×6** — all six config mutate-and-persist sites. Lock-scope audit: contrary to the issue's warning, all six already held `cfgMu` across mutate+persist; no deadlock/scope change.
- **`decodeBody` / `readContentField`** — JSON-or-form decode at the sites whose 400 body matches; **skipped** apiSaveFile (text/plain-or-form, different content-type semantics).
- **`taskOr404` / `resolveTaskFile`** — task-lookup-404 preamble + getFile/saveFile preamble.

## Intentional skips (dedup vs. behavior-preservation — behavior wins)
- `apiGetTask` (PipelineTask fallback between lookup and 404), `apiSaveAISettings` (404 body `"task not found: <id>"`), `ai_chat.go` (503 + Warn) — each would change response status/body if folded into `taskOr404`.
- `apiSaveFile` content read — text/plain-or-form, not JSON-or-form.

## Test plan
- [x] Tests **unmodified**; `go test ./pkg/daemon/... ./pkg/trigger/... ./pkg/webui/...` green, `-race` green on `pkg/trigger`.
- [x] `make build`, `go vet ./...`, `gofmt -l .` clean. (Sole full-suite failure is the documented offline-only deno npm test.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJMqv1hzZzUZep13oyKrCD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined daemon startup orchestration and improved coordination between audit pruning, persistence, and web/control server initialization.
  * Centralized trigger chain dispatch, webhook path resolution, and webhook task execution flow for more consistent routing.
  * Improved pipeline rerun orchestration and terminal-daemon restart/replay lifecycle handling.
  * Unified web UI request decoding, task file access validation, and config mutation/persistence updates.

* **Bug Fixes**
  * Strengthened validation for task UI/assets, webhook payload processing (including replay/signature protections), and safe file handling.
  * Tightened error handling and cleanup during pipeline reruns to reduce disruption during restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->