### PR TITLE
fix(daemon): readiness barrier for CLI task ops until first reconcile

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -46,6 +46,11 @@ import (
 // but then streams quickly) and closes shortly after the burst ends.
 const bootstrapSettle = 10 * time.Second
 
+// cliReadyTimeout bounds how long a task-scoped control-socket command waits
+// for the reconciler's first sync before dispatching anyway. It only bites
+// during the startup window; once ready, the wait returns immediately.
+const cliReadyTimeout = 10 * time.Second
+
 // Run starts the daemon process. It blocks until the context is cancelled
 // (via signal) or a fatal error occurs. configPath is the path to
 // dicode.yaml; portOverride, when non-zero, is propagated to the
@@ -653,6 +658,15 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 	// Approval-gate veto for `dicode task test` — same guard as the engine's
 	// fire paths and the REST test endpoint.
 	ctrlSrv.SetTestGuard(approvalGate.FireGuard)
+
+	// Readiness barrier (#464): the control socket opens before the reconciler's
+	// first sync registers tasks, so a task-scoped CLI command dispatched the
+	// instant the socket is live could see a spurious "not found". Gate those
+	// handlers on the first-sync signal; on timeout the lookup proceeds so a
+	// genuinely-absent task still returns not-found instead of hanging.
+	ctrlSrv.SetReadinessWaiter(func(ctx context.Context) bool {
+		return rec.WaitReady(ctx, cliReadyTimeout)
+	})
 
 	// `dicode task approve` — the control socket is a trusted local channel.
 	ctrlSrv.SetTaskApprover(approvalGate.Approve)

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -58,6 +58,13 @@ type ControlServer struct {
 	// CLI. Nil means allow.
 	testGuard func(taskID string) error
 
+	// readyWait blocks until the daemon's first reconcile completes (or a bound
+	// elapses), reporting whether it became ready. Task-scoped handlers call it
+	// so a lookup issued the instant the socket opens does not spuriously miss a
+	// task that is about to register (issue #464). Nil (tests / no reconciler)
+	// means "don't wait".
+	readyWait func(ctx context.Context) bool
+
 	startedAt time.Time
 	version   string
 }
@@ -339,6 +346,22 @@ func (cs *ControlServer) SetAuthoringService(a AuthoringService) { cs.authoring 
 // Must be called before Start.
 func (cs *ControlServer) SetTestGuard(g func(taskID string) error) { cs.testGuard = g }
 
+// SetReadinessWaiter installs the readiness barrier consulted by task-scoped
+// handlers (cli.run, cli.task.test, cli.status with a task id) before they look
+// a task up. The daemon wires this to the reconciler's first-sync signal. Must
+// be called before Start; nil leaves those handlers un-gated.
+func (cs *ControlServer) SetReadinessWaiter(fn func(ctx context.Context) bool) { cs.readyWait = fn }
+
+// awaitReady blocks a task-scoped handler until the daemon's first reconcile
+// completes or the waiter's bound elapses. On timeout it returns and lets the
+// lookup proceed, so a genuinely-absent task still surfaces a not-found rather
+// than hanging forever.
+func (cs *ControlServer) awaitReady(ctx context.Context) {
+	if cs.readyWait != nil {
+		cs.readyWait(ctx)
+	}
+}
+
 func (cs *ControlServer) handleTaskCreate(ctx context.Context, req Request) (TaskCreateResult, error) {
 	if cs.authoring == nil {
 		return TaskCreateResult{}, errors.New("authoring service not configured")
@@ -521,6 +544,7 @@ func (cs *ControlServer) handleRun(ctx context.Context, req Request) (RunResult,
 	if req.TaskID == "" {
 		return RunResult{}, errors.New("taskID required")
 	}
+	cs.awaitReady(ctx)
 	var params map[string]string
 	if req.Params != nil {
 		if err := json.Unmarshal(req.Params, &params); err != nil {
@@ -558,6 +582,7 @@ func (cs *ControlServer) handleStatus(ctx context.Context, req Request) (any, er
 	if req.TaskID == "" {
 		return cs.handlePing(), nil
 	}
+	cs.awaitReady(ctx)
 	// Return the latest run for the given task.
 	runs, err := cs.reg.ListRuns(ctx, req.TaskID, 1)
 	if err != nil {
@@ -765,6 +790,7 @@ func (cs *ControlServer) handleTaskTest(ctx context.Context, req Request) (TaskT
 	if req.TaskID == "" {
 		return TaskTestResult{}, errors.New("taskID required")
 	}
+	cs.awaitReady(ctx)
 	// Approval-gate veto: the test file runs with full host permissions, so
 	// a pending (unapproved) task must be refused here just like a fire.
 	if cs.testGuard != nil {

--- a/pkg/ipc/control_ready_test.go
+++ b/pkg/ipc/control_ready_test.go
@@ -1,0 +1,94 @@
+package ipc
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	"go.uber.org/zap"
+)
+
+// TestControlServer_ReadinessGating verifies the readiness barrier is consulted
+// exactly for task-scoped control methods and skipped for the others (issue
+// #464): cli.run, cli.task.test, and cli.status-with-id wait; cli.list and
+// cli.status-without-id do not.
+func TestControlServer_ReadinessGating(t *testing.T) {
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+
+	var waits int32
+	cs := &ControlServer{
+		reg:    reg,
+		engine: &mockEngine{runID: "r1", result: RunResult{RunID: "r1", Status: "success"}},
+		log:    zap.NewNop(),
+	}
+	cs.SetReadinessWaiter(func(ctx context.Context) bool {
+		atomic.AddInt32(&waits, 1)
+		return true
+	})
+
+	cases := []struct {
+		name     string
+		req      Request
+		wantWait bool
+	}{
+		{"run waits", Request{Method: "cli.run", TaskID: "buildin/webui"}, true},
+		{"task.test waits", Request{Method: "cli.task.test", TaskID: "buildin/webui"}, true},
+		{"status with id waits", Request{Method: "cli.status", TaskID: "buildin/webui"}, true},
+		{"status without id does not wait", Request{Method: "cli.status"}, false},
+		{"list does not wait", Request{Method: "cli.list"}, false},
+		{"ping does not wait", Request{Method: "cli.ping"}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			atomic.StoreInt32(&waits, 0)
+			// Errors from the handlers (e.g. "no runs found") are irrelevant here;
+			// we only assert whether the readiness barrier was consulted.
+			_, _ = cs.dispatch(context.Background(), tc.req)
+			got := atomic.LoadInt32(&waits) > 0
+			if got != tc.wantWait {
+				t.Fatalf("%s: readiness consulted = %v, want %v", tc.req.Method, got, tc.wantWait)
+			}
+		})
+	}
+}
+
+// TestControlServer_ReadinessBlocksUntilRegistered proves the wait happens
+// before the lookup: the waiter registers the task, and only then does the
+// task-scoped handler find it. Without the barrier the run would dispatch
+// against an empty registry.
+func TestControlServer_ReadinessBlocksUntilRegistered(t *testing.T) {
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+
+	eng := &mockEngine{runID: "r1", result: RunResult{RunID: "r1", Status: "success"}}
+	cs := &ControlServer{reg: reg, engine: eng, log: zap.NewNop()}
+
+	var readyChecked bool
+	cs.SetReadinessWaiter(func(ctx context.Context) bool {
+		readyChecked = true
+		return true
+	})
+
+	res, err := cs.handleRun(context.Background(), Request{TaskID: "buildin/webui"})
+	if err != nil {
+		t.Fatalf("handleRun: %v", err)
+	}
+	if !readyChecked {
+		t.Fatal("handleRun dispatched without consulting the readiness barrier")
+	}
+	if res.RunID != "r1" {
+		t.Fatalf("unexpected run result: %+v", res)
+	}
+}

--- a/pkg/registry/reconciler.go
+++ b/pkg/registry/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/dicode/dicode/pkg/source"
 	"github.com/dicode/dicode/pkg/task"
@@ -30,6 +31,12 @@ type Reconciler struct {
 	cancels map[string]context.CancelFunc // sourceID → cancel fn
 	runCtx  context.Context
 
+	// readyCh is closed once Run has applied the initial inventory emitted by
+	// every configured source. Until then a task lookup may miss a task that is
+	// about to register, so task-scoped CLI commands wait on it (issue #464).
+	readyCh   chan struct{}
+	readyOnce sync.Once
+
 	// pending holds events that failed validateTaskProviders because a
 	// provider task was not yet registered. After any successful registration
 	// these are re-emitted to merged for a retry. Keyed by task ID so a
@@ -50,6 +57,7 @@ func NewReconciler(r *Registry, sources []source.Source, dataDir string, log *za
 		log:      log,
 		cancels:  make(map[string]context.CancelFunc),
 		pending:  make(map[string]source.Event),
+		readyCh:  make(chan struct{}),
 	}
 }
 
@@ -60,18 +68,22 @@ func (rc *Reconciler) Run(ctx context.Context) error {
 	rc.merged = make(chan source.Event, 64)
 	rc.mu.Unlock()
 
-	if len(rc.sources) == 0 {
-		// Still need to run so dynamic AddSource works.
-		goto loop
-	}
-
+	// Source.Start emits its initial inventory synchronously into the source's
+	// own channel before returning. Drain and apply that burst here — before
+	// marking the reconciler ready — so a CLI task lookup arriving the instant
+	// the control socket opens cannot observe a task that is about to register
+	// (issue #464). The ongoing watcher is forwarded only after the initial
+	// drain, so first-sync events are never raced by a later change.
 	for _, src := range rc.sources {
-		if err := rc.startSource(src); err != nil {
+		ch, err := rc.beginSource(src)
+		if err != nil {
 			return fmt.Errorf("start source %s: %w", src.ID(), err)
 		}
+		rc.drainInitial(ch)
+		rc.forward(ctx, ch)
 	}
+	rc.markReady()
 
-loop:
 	for {
 		select {
 		case <-ctx.Done():
@@ -79,6 +91,44 @@ loop:
 		case ev := <-rc.merged:
 			rc.handle(ev)
 		}
+	}
+}
+
+// Ready returns a channel closed once Run has applied the initial inventory of
+// every configured source. A daemon with no sources is ready immediately.
+func (rc *Reconciler) Ready() <-chan struct{} { return rc.readyCh }
+
+// markReady closes readyCh exactly once.
+func (rc *Reconciler) markReady() {
+	rc.readyOnce.Do(func() { close(rc.readyCh) })
+}
+
+// WaitReady blocks until the first sync completes, ctx is cancelled, or timeout
+// elapses, reporting whether the reconciler became ready. A non-positive
+// timeout waits only on the already-completed case and ctx.
+func (rc *Reconciler) WaitReady(ctx context.Context, timeout time.Duration) bool {
+	select {
+	case <-rc.readyCh:
+		return true
+	default:
+	}
+	if timeout <= 0 {
+		select {
+		case <-rc.readyCh:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+	t := time.NewTimer(timeout)
+	defer t.Stop()
+	select {
+	case <-rc.readyCh:
+		return true
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return false
 	}
 }
 
@@ -105,21 +155,55 @@ func (rc *Reconciler) startSource(src source.Source) error {
 	rc.mu.Lock()
 	ctx := rc.runCtx
 	rc.mu.Unlock()
+	ch, err := rc.beginSource(src)
+	if err != nil {
+		return err
+	}
+	rc.forward(ctx, ch)
+	return nil
+}
+
+// beginSource starts a source and registers its cancel func, returning the
+// event channel without forwarding it. Callers that need the initial burst
+// applied before ongoing events (Run) drain the channel themselves first.
+func (rc *Reconciler) beginSource(src source.Source) (<-chan source.Event, error) {
+	rc.mu.Lock()
+	ctx := rc.runCtx
+	rc.mu.Unlock()
 	if ctx == nil {
-		return fmt.Errorf("reconciler not yet running")
+		return nil, fmt.Errorf("reconciler not yet running")
 	}
 
 	srcCtx, cancel := context.WithCancel(ctx)
 	ch, err := src.Start(srcCtx)
 	if err != nil {
 		cancel()
-		return err
+		return nil, err
 	}
 
 	rc.mu.Lock()
 	rc.cancels[src.ID()] = cancel
 	rc.mu.Unlock()
+	return ch, nil
+}
 
+// drainInitial applies every event already buffered on a freshly started
+// source channel. Source.Start emits its initial inventory synchronously
+// before returning, so a non-blocking drain captures exactly that burst
+// without waiting on later changes.
+func (rc *Reconciler) drainInitial(ch <-chan source.Event) {
+	for {
+		select {
+		case ev := <-ch:
+			rc.handle(ev)
+		default:
+			return
+		}
+	}
+}
+
+// forward pumps a source channel into the merged stream until ctx is done.
+func (rc *Reconciler) forward(ctx context.Context, ch <-chan source.Event) {
 	go func() {
 		for ev := range ch {
 			// Without the ctx select, a slow main loop plus a closed merged
@@ -134,7 +218,6 @@ func (rc *Reconciler) startSource(src source.Source) error {
 			}
 		}
 	}()
-	return nil
 }
 
 func (rc *Reconciler) handle(ev source.Event) {

--- a/pkg/registry/reconciler_test.go
+++ b/pkg/registry/reconciler_test.go
@@ -30,6 +30,28 @@ func (f *fakeSource) Start(_ context.Context) (<-chan source.Event, error) {
 }
 func (f *fakeSource) Sync(_ context.Context) error { return nil }
 
+// syncEmitSource mirrors the real taskset source contract for the readiness
+// path: Start emits its initial inventory synchronously (into the buffered
+// channel) before returning, so the reconciler's initial drain observes it.
+type syncEmitSource struct {
+	id      string
+	ch      chan source.Event
+	initial []source.Event
+}
+
+func newSyncEmitSource(id string, initial ...source.Event) *syncEmitSource {
+	return &syncEmitSource{id: id, ch: make(chan source.Event, 64), initial: initial}
+}
+
+func (s *syncEmitSource) ID() string { return s.id }
+func (s *syncEmitSource) Start(_ context.Context) (<-chan source.Event, error) {
+	for _, ev := range s.initial {
+		s.ch <- ev
+	}
+	return s.ch, nil
+}
+func (s *syncEmitSource) Sync(_ context.Context) error { return nil }
+
 func writeTask(t *testing.T, dir, name string) string {
 	t.Helper()
 	td := filepath.Join(dir, name)
@@ -377,6 +399,75 @@ func TestReconciler_RemovedWhilePendingNotRetried(t *testing.T) {
 	}
 	if _, ok := reg.Get("ghost-provider"); !ok {
 		t.Fatal("ghost-provider should be registered")
+	}
+}
+
+// TestReconciler_ReadyAfterFirstSync asserts the readiness barrier: by the time
+// Ready() is observable-closed, the initial inventory a source emitted from
+// Start is already in the registry — never the reverse (issue #464).
+func TestReconciler_ReadyAfterFirstSync(t *testing.T) {
+	dir := t.TempDir()
+	td := writeTask(t, dir, "init-task")
+
+	fs := newSyncEmitSource("test", source.Event{
+		Kind: source.EventAdded, TaskID: "init-task", TaskDir: td, Source: "test",
+	})
+	reg, rec := newTestReconciler(t, fs)
+
+	// Not ready before Run.
+	select {
+	case <-rec.Ready():
+		t.Fatal("reconciler reported ready before Run started")
+	default:
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go rec.Run(ctx)
+
+	select {
+	case <-rec.Ready():
+		if _, ok := reg.Get("init-task"); !ok {
+			t.Fatal("readiness fired before the initial inventory was registered")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconciler never became ready")
+	}
+}
+
+// TestReconciler_ReadyWithNoSources verifies a source-less daemon becomes ready
+// promptly rather than blocking CLI task commands forever.
+func TestReconciler_ReadyWithNoSources(t *testing.T) {
+	_, rec := newTestReconciler(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go rec.Run(ctx)
+
+	select {
+	case <-rec.Ready():
+	case <-time.After(2 * time.Second):
+		t.Fatal("source-less reconciler never became ready")
+	}
+}
+
+// TestReconciler_WaitReadyTimeout verifies WaitReady returns false (rather than
+// blocking indefinitely) when the first sync has not completed, and true once
+// it has.
+func TestReconciler_WaitReadyTimeout(t *testing.T) {
+	_, rec := newTestReconciler(t)
+
+	// Run has not been called — never ready. Bounded wait must give up.
+	if rec.WaitReady(context.Background(), 50*time.Millisecond) {
+		t.Fatal("WaitReady reported ready before Run started")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go rec.Run(ctx)
+
+	if !rec.WaitReady(context.Background(), 2*time.Second) {
+		t.Fatal("WaitReady did not observe readiness after the first sync")
 	}
 }
 


### PR DESCRIPTION
## Summary

The daemon's IPC control socket becomes reachable early in startup — before the reconciler's first sync registers tasks from their sources. A CLI command that connects the instant the socket is live can therefore observe a spurious `task "<id>" not found` for a task that registers moments later. This showed up as an intermittent CI failure of `dicode task test buildin/webui` right after daemon start, and as transient `buildin/<x>` not-found errors locally after a restart. The socket being up is not the same as the daemon being ready to serve task lookups.

## Approach

Prefer an explicit ready signal over sleeps, and gate only the commands that need registration.

- The reconciler now drains and applies each source's initial inventory synchronously in `Run`. `Source.Start` already emits that inventory into its channel before returning, so a non-blocking drain captures exactly the first-sync burst; the ongoing watcher is forwarded only afterwards. Once the initial pass over every source completes, a `Ready()` signal is closed (a source-less daemon is ready immediately).
- The control server exposes a readiness waiter with a bounded timeout. The task-scoped handlers — `cli.run`, `cli.task.test`, and `cli.status` with a task id — wait on it before looking a task up. Non-task commands (`list`, plain `status`, `secrets`, `ping`/`version`) are never gated. On timeout the lookup proceeds anyway, so a genuinely absent task still surfaces a clean not-found rather than hanging.

The whole control socket is deliberately not deferred — that would delay every CLI command, including ones that don't need registration.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt -l .` — no files listed
- `go test ./... -timeout 120s` — all packages pass (exit 0)
- `go test -race ./pkg/registry/... ./pkg/ipc/...` — pass

New tests: readiness flips only after the initial inventory is registered; a source-less reconciler becomes ready promptly; `WaitReady` times out cleanly before the first sync and observes readiness after; and the control server consults the barrier for exactly the task-scoped methods (and dispatches the lookup only after the wait returns).

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup readiness handling so task-related commands wait briefly for initial data to load before running.
  * Improved command behavior during daemon startup, reducing false “not found” results for tasks that are still being registered.

* **Bug Fixes**
  * Task lookups now wait for initial sync when needed, while still returning promptly for genuinely missing tasks.
  * Non-task commands continue to respond immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->