### PR TITLE
feat(runtime): pattern-scoped host-env forwarding in permissions.env

### DIFF
--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -930,11 +930,12 @@ permissions:
 
 ### `permissions.env` — environment variables
 
-Four forms, with clear source distinction:
+Five forms, with clear source distinction:
 
 | Form | Key | Source | Effect |
 | --- | --- | --- | --- |
-| Bare name | — | Host OS env | Script reads `$VAR` at runtime via `env.get()`; no injection |
+| Bare name | — | Host OS env | Script reads `$VAR` at runtime via `env.get()`; forwarded from the host if set |
+| Bare pattern (`PREFIX_*`) | — | Host OS env | Forward **every** host var matching the trailing-`*` prefix, and make each matched name readable |
 | `from:` | host OS var name | Host OS env | Read `$GH_TOKEN` from OS, inject subprocess env as `API_KEY` |
 | `secret:` | secrets store key | Secrets store | Resolve encrypted secret, inject as the given name; **fails if not found** |
 | `value:` | — | Literal | Inject a fixed string (used by taskset override layers) |
@@ -950,6 +951,9 @@ Two modifiers apply on top:
 - `from:` reads **only** from the host OS environment (`os.Getenv`). Use it to rename a host env var or make the mapping explicit.
 - `secret:` reads **only** from the dicode secrets store (set via `dicode secrets set`). Run fails immediately if the key is not in the store.
 - A bare name does **neither** — it only allowlists the var so the script can read it from the host env via `env.get()`. No injection, no secrets lookup.
+- A bare **pattern** (`PREFIX_*`) is a bare name with a trailing-`*` prefix glob: at launch it expands against the host environment, forwards every matching host var's value into the subprocess, and makes each matched name readable (Deno `--allow-env`, the Python env-read filter). It pulls in a related family of vars without enumerating each — while still **not** granting blanket read the way `env_read_exposed` does. Distinct from a lone `"*"` (rejected — use `env_read_exposed`).
+
+> **Security:** a pattern never forwards the daemon's own credentials. `DICODE_MASTER_KEY`, `DICODE_API_KEY`, `DICODE_MCP_API_KEY` and the per-run IPC vars (`DICODE_SOCKET`/`DICODE_TOKEN`) are always excluded, even when a pattern like `DICODE_*` prefix-matches them.
 
 #### Example 1 — bare passthrough (name stays the same)
 
@@ -964,6 +968,26 @@ permissions:
 // task.ts
 export default async function main({ env }) {
   const token = await env.get("GITHUB_TOKEN")  // reads $GITHUB_TOKEN from host env at runtime
+}
+```
+
+#### Example 1b — pattern passthrough (forward a family of host vars)
+
+The host OS has `GITHUB_TOKEN`, `GITHUB_SHA`, `GITHUB_REPOSITORY`. Forward all of
+them without listing each:
+
+```yaml
+# task.yaml
+permissions:
+  env:
+    - "GITHUB_*"   # every host var starting with GITHUB_ is forwarded and readable
+```
+
+```typescript
+// task.ts
+export default async function main({ env }) {
+  const token = await env.get("GITHUB_TOKEN")  // forwarded from the host
+  const sha = await env.get("GITHUB_SHA")
 }
 ```
 

--- a/docs/deno-runtime.md
+++ b/docs/deno-runtime.md
@@ -409,7 +409,7 @@ Permissions are derived from `task.yaml`:
 | Permission | Source |
 | --- | --- |
 | `--allow-net` / `--allow-net=host1,...` | `net:` entries — omit or `[]` = denied (no flag), `["*"]` = unrestricted, host list = allowlist |
-| `--allow-env=DICODE_SOCKET,DICODE_TOKEN,VAR1,...` | `DICODE_SOCKET`, `DICODE_TOKEN` (IPC handshake) + cache vars + all `env:` vars. Bare `--allow-env` (read any var) when `env_read_exposed: true` — node-compat / npm escape hatch |
+| `--allow-env=DICODE_SOCKET,DICODE_TOKEN,VAR1,...` | `DICODE_SOCKET`, `DICODE_TOKEN` (IPC handshake) + cache vars + all `env:` vars (a `PREFIX_*` pattern entry expands to its matching host var names, minus the daemon credential denylist). Bare `--allow-env` (read any var) when `env_read_exposed: true` — node-compat / npm escape hatch |
 | `--allow-read=path1,path2` | `fs:` entries with `r` or `rw` |
 | `--allow-write=path1` | `fs:` entries with `w` or `rw` |
 

--- a/pkg/runtime/deno/build_args_test.go
+++ b/pkg/runtime/deno/build_args_test.go
@@ -48,6 +48,33 @@ func TestBuildDenoArgs_Env_List(t *testing.T) {
 	}
 }
 
+// TestBuildDenoArgs_Env_Wildcard: a pattern entry adds its expanded host
+// matches (not the literal "GITHUB_*") to --allow-env, and never a denylisted
+// daemon credential the pattern would prefix-match.
+func TestBuildDenoArgs_Env_Wildcard(t *testing.T) {
+	// Collision-proof prefix so match assertions hold under CI's ambient env.
+	t.Setenv("WILDTEST_TOKEN", "gh")
+	t.Setenv("WILDTEST_SHA", "sha")
+	t.Setenv("DICODE_MASTER_KEY", "root")
+
+	args := buildDenoArgs(specWithEnv([]task.EnvEntry{{Name: "WILDTEST_*"}}), "/run/sock", "/shim.ts", "/runner.ts", nil)
+	got, ok := allowEnvArg(args)
+	if !ok {
+		t.Fatal("no --allow-env arg emitted")
+	}
+	for _, want := range []string{"WILDTEST_TOKEN", "WILDTEST_SHA"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("allow-env %q missing wildcard match %q", got, want)
+		}
+	}
+	if strings.Contains(got, "WILDTEST_*") {
+		t.Errorf("literal pattern name leaked into allow-env: %q", got)
+	}
+	if strings.Contains(got, "DICODE_MASTER_KEY") {
+		t.Errorf("wildcard leaked daemon credential into allow-env: %q", got)
+	}
+}
+
 // TestBuildDenoArgs_Env_Omitted: no declared env still yields the baseline
 // allowlist (never bare --allow-env).
 func TestBuildDenoArgs_Env_Omitted(t *testing.T) {

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -418,8 +418,14 @@ func buildDenoArgs(spec *task.Spec, socketPath, shimPath, runnerPath string, pro
 	} else {
 		envVars := []string{"DICODE_SOCKET", "DICODE_TOKEN", "HOME", "DENO_DIR", "XDG_CACHE_HOME"}
 		for _, e := range spec.Permissions.Env {
+			// A pattern entry's literal name ("GITHUB_*") is not a readable var;
+			// its expanded matches are appended below so they reach the sandbox.
+			if pkgruntime.IsWildcardEnvEntry(e) {
+				continue
+			}
 			envVars = append(envVars, e.Name)
 		}
+		envVars = append(envVars, pkgruntime.WildcardEnvNames(spec)...)
 		args = append(args, "--allow-env="+strings.Join(envVars, ","))
 	}
 

--- a/pkg/runtime/envwildcard.go
+++ b/pkg/runtime/envwildcard.go
@@ -1,0 +1,83 @@
+package runtime
+
+import (
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// envWildcardSuffix marks a pattern env entry. A bare permissions.env name
+// ending in "*" forwards every host var sharing the literal prefix before it
+// (e.g. "GITHUB_*" matches GITHUB_TOKEN, GITHUB_SHA, …).
+const envWildcardSuffix = "*"
+
+// IsWildcardEnvEntry reports whether e is a bare, name-only pattern entry
+// (e.g. "GITHUB_*"). Only bare entries can be patterns: an entry carrying
+// from/secret/value is a concrete binding whose Name is the literal target,
+// not a host-env glob. A lone "*" is not a pattern here — it is rejected at
+// spec validation in favour of env_read_exposed.
+func IsWildcardEnvEntry(e task.EnvEntry) bool {
+	return e.Value == "" && e.Secret == "" && e.From == "" &&
+		len(e.Name) > 1 && strings.HasSuffix(e.Name, envWildcardSuffix)
+}
+
+// wildcardBlocked reports whether name must never be reached by a wildcard
+// match. It covers the daemon-only credential denylist and the per-run IPC
+// handshake vars: a pattern like "DICODE_*" prefix-matches all of them, but
+// none may ever leak into a task.
+func wildcardBlocked(name string) bool {
+	if neverForwardEnv[name] {
+		return true
+	}
+	switch name {
+	case "DICODE_SOCKET", "DICODE_TOKEN":
+		return true
+	}
+	return false
+}
+
+// WildcardEnvNames expands the bare wildcard entries in spec.Permissions.Env
+// against the current host environment and returns the matching host var
+// names, de-duplicated and sorted. Denylisted daemon credentials and the
+// internal IPC vars are always excluded, even when a pattern would match them.
+//
+// All three call sites share this one expansion so the set of vars forwarded
+// (SubprocessEnv) exactly matches the set made readable by the sandbox (Deno
+// --allow-env, the Python env-read guardrail).
+func WildcardEnvNames(spec *task.Spec) []string {
+	if spec == nil {
+		return nil
+	}
+	var prefixes []string
+	for _, e := range spec.Permissions.Env {
+		if IsWildcardEnvEntry(e) {
+			prefixes = append(prefixes, strings.TrimSuffix(e.Name, envWildcardSuffix))
+		}
+	}
+	if len(prefixes) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool)
+	var out []string
+	for _, kv := range os.Environ() {
+		i := strings.IndexByte(kv, '=')
+		if i <= 0 {
+			continue
+		}
+		name := kv[:i]
+		if seen[name] || wildcardBlocked(name) {
+			continue
+		}
+		for _, p := range prefixes {
+			if strings.HasPrefix(name, p) {
+				seen[name] = true
+				out = append(out, name)
+				break
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/pkg/runtime/envwildcard_test.go
+++ b/pkg/runtime/envwildcard_test.go
@@ -1,0 +1,86 @@
+package runtime
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+func TestIsWildcardEnvEntry(t *testing.T) {
+	cases := []struct {
+		name string
+		e    task.EnvEntry
+		want bool
+	}{
+		{"bare prefix glob", task.EnvEntry{Name: "GITHUB_*"}, true},
+		{"bare exact name", task.EnvEntry{Name: "GITHUB_TOKEN"}, false},
+		{"lone star", task.EnvEntry{Name: "*"}, false},
+		{"pattern with from", task.EnvEntry{Name: "GITHUB_*", From: "env:X"}, false},
+		{"pattern with secret", task.EnvEntry{Name: "GITHUB_*", Secret: "k"}, false},
+		{"pattern with value", task.EnvEntry{Name: "GITHUB_*", Value: "v"}, false},
+		{"empty", task.EnvEntry{}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsWildcardEnvEntry(c.e); got != c.want {
+				t.Errorf("IsWildcardEnvEntry(%+v) = %v, want %v", c.e, got, c.want)
+			}
+		})
+	}
+}
+
+func TestWildcardEnvNames_MatchesPrefix(t *testing.T) {
+	// A collision-proof prefix so the exact-equality assertion holds regardless
+	// of ambient env (CI hosts carry many GITHUB_*/DICODE_* vars of their own).
+	t.Setenv("WILDTEST_A", "1")
+	t.Setenv("WILDTEST_B", "2")
+	t.Setenv("WILDOTHER_C", "3") // different prefix → not matched
+
+	spec := &task.Spec{}
+	spec.Permissions.Env = []task.EnvEntry{{Name: "WILDTEST_*"}}
+
+	got := WildcardEnvNames(spec)
+	want := []string{"WILDTEST_A", "WILDTEST_B"} // sorted, de-duplicated
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("WildcardEnvNames = %v, want %v", got, want)
+	}
+}
+
+// A pattern that prefix-matches the daemon credentials / IPC vars must exclude
+// every one of them. Asserted as an absence check (not exact equality) so it
+// holds even when CI sets other DICODE_* vars.
+func TestWildcardEnvNames_ExcludesDenylistAndIPC(t *testing.T) {
+	t.Setenv("DICODE_MASTER_KEY", "root")
+	t.Setenv("DICODE_API_KEY", "admin")
+	t.Setenv("DICODE_MCP_API_KEY", "mcp")
+	t.Setenv("DICODE_SOCKET", "/sock")
+	t.Setenv("DICODE_TOKEN", "tok")
+
+	spec := &task.Spec{}
+	spec.Permissions.Env = []task.EnvEntry{{Name: "DICODE_*"}}
+
+	got := make(map[string]bool)
+	for _, n := range WildcardEnvNames(spec) {
+		got[n] = true
+	}
+	for _, blocked := range []string{
+		"DICODE_MASTER_KEY", "DICODE_API_KEY", "DICODE_MCP_API_KEY",
+		"DICODE_SOCKET", "DICODE_TOKEN",
+	} {
+		if got[blocked] {
+			t.Errorf("DICODE_* leaked denylisted/IPC var %q", blocked)
+		}
+	}
+}
+
+func TestWildcardEnvNames_NoPatternsReturnsNil(t *testing.T) {
+	spec := &task.Spec{}
+	spec.Permissions.Env = []task.EnvEntry{{Name: "GITHUB_TOKEN"}}
+	if got := WildcardEnvNames(spec); got != nil {
+		t.Errorf("WildcardEnvNames with no patterns = %v, want nil", got)
+	}
+	if got := WildcardEnvNames(nil); got != nil {
+		t.Errorf("WildcardEnvNames(nil) = %v, want nil", got)
+	}
+}

--- a/pkg/runtime/python/guard.go
+++ b/pkg/runtime/python/guard.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
 	"github.com/dicode/dicode/pkg/task"
 )
 
@@ -139,11 +140,20 @@ func buildGuardPolicy(spec *task.Spec, socketPath string, protectedPaths []strin
 			}
 		}
 		for _, e := range spec.Permissions.Env {
-			if e.Name == "" || seen[e.Name] {
+			// A pattern entry's literal name ("GITHUB_*") is not a readable var;
+			// its expanded matches are appended below.
+			if e.Name == "" || seen[e.Name] || pkgruntime.IsWildcardEnvEntry(e) {
 				continue
 			}
 			seen[e.Name] = true
 			allowed = append(allowed, e.Name)
+		}
+		for _, name := range pkgruntime.WildcardEnvNames(spec) {
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			allowed = append(allowed, name)
 		}
 		pol.EnvAllowed = allowed
 	}

--- a/pkg/runtime/python/guard_test.go
+++ b/pkg/runtime/python/guard_test.go
@@ -191,6 +191,37 @@ func TestBuildGuardPolicy_EnvAllowed_WithDeclaredVars(t *testing.T) {
 	}
 }
 
+func TestBuildGuardPolicy_EnvAllowed_Wildcard(t *testing.T) {
+	// A pattern entry adds its expanded host matches to EnvAllowed (never the
+	// literal "GITHUB_*"), and never a denylisted daemon credential it would
+	// prefix-match.
+	// Collision-proof prefix so match assertions hold under CI's ambient env.
+	t.Setenv("WILDTEST_TOKEN", "gh")
+	t.Setenv("WILDTEST_SHA", "sha")
+	t.Setenv("DICODE_MASTER_KEY", "root")
+
+	spec := specWithPerms(task.Permissions{
+		Env: []task.EnvEntry{{Name: "WILDTEST_*"}},
+	})
+	pol := buildGuardPolicy(spec, "/tmp/dicode.sock", nil)
+
+	names := make(map[string]bool, len(pol.EnvAllowed))
+	for _, n := range pol.EnvAllowed {
+		names[n] = true
+	}
+	for _, want := range []string{"WILDTEST_TOKEN", "WILDTEST_SHA"} {
+		if !names[want] {
+			t.Errorf("EnvAllowed missing wildcard match %q; got %v", want, pol.EnvAllowed)
+		}
+	}
+	if names["WILDTEST_*"] {
+		t.Errorf("literal pattern name leaked into EnvAllowed; got %v", pol.EnvAllowed)
+	}
+	if names["DICODE_MASTER_KEY"] {
+		t.Errorf("wildcard leaked daemon credential into EnvAllowed; got %v", pol.EnvAllowed)
+	}
+}
+
 func TestBuildGuardPolicy_EnvAllowed_EnvReadExposed(t *testing.T) {
 	// env_read_exposed=true must set EnvAllowed=nil (no filter).
 	spec := specWithPerms(task.Permissions{

--- a/pkg/runtime/subprocenv.go
+++ b/pkg/runtime/subprocenv.go
@@ -60,6 +60,11 @@ func SubprocessEnv(spec *task.Spec, resolved map[string]string, socketPath, toke
 			if e.Name == "" || e.Value != "" || e.Secret != "" || e.From != "" {
 				continue
 			}
+			// Pattern entries (e.g. "GITHUB_*") are expanded against the host
+			// environment below; the literal name is never a real var.
+			if IsWildcardEnvEntry(e) {
+				continue
+			}
 			// Daemon-only credentials must never reach a task, even if a
 			// task.yaml names them: the master key derives every secret, and
 			// the API keys authenticate to the daemon's own admin/MCP control
@@ -72,6 +77,16 @@ func SubprocessEnv(spec *task.Spec, resolved map[string]string, socketPath, toke
 			}
 			if v, ok := os.LookupEnv(e.Name); ok {
 				env = append(env, e.Name+"="+v)
+			}
+		}
+		// Wildcard entries forward every matching host var. WildcardEnvNames
+		// already drops the daemon credential denylist and the IPC vars.
+		for _, name := range WildcardEnvNames(spec) {
+			if _, ok := resolved[name]; ok {
+				continue
+			}
+			if v, ok := os.LookupEnv(name); ok {
+				env = append(env, name+"="+v)
 			}
 		}
 	}

--- a/pkg/runtime/subprocenv_test.go
+++ b/pkg/runtime/subprocenv_test.go
@@ -96,6 +96,68 @@ func TestSubprocessEnv_BareAllowlistEntryForwardsHostValue(t *testing.T) {
 	}
 }
 
+func TestSubprocessEnv_WildcardForwardsMatchingHostVars(t *testing.T) {
+	// Collision-proof prefix: CI hosts carry many GITHUB_*/DICODE_* vars, so a
+	// real-world prefix would make presence/absence assertions env-fragile.
+	t.Setenv("WILDTEST_TOKEN", "gh-tok")
+	t.Setenv("WILDTEST_SHA", "abc123")
+	t.Setenv("WILDOTHER_TOKEN", "gl-tok") // different prefix → not matched
+
+	spec := &task.Spec{}
+	spec.Permissions.Env = []task.EnvEntry{{Name: "WILDTEST_*"}}
+
+	m := envMap(SubprocessEnv(spec, nil, "/tmp/sock", "tok"))
+
+	if m["WILDTEST_TOKEN"] != "gh-tok" || m["WILDTEST_SHA"] != "abc123" {
+		t.Errorf("wildcard did not forward matching host vars: token=%q sha=%q", m["WILDTEST_TOKEN"], m["WILDTEST_SHA"])
+	}
+	if _, ok := m["WILDOTHER_TOKEN"]; ok {
+		t.Error("non-matching-prefix var forwarded by wildcard")
+	}
+	// The literal pattern name must never appear as a var.
+	if _, ok := m["WILDTEST_*"]; ok {
+		t.Error("literal wildcard pattern leaked as a var name")
+	}
+}
+
+func TestSubprocessEnv_WildcardUnsetForwardsNothing(t *testing.T) {
+	spec := &task.Spec{}
+	spec.Permissions.Env = []task.EnvEntry{{Name: "NOMATCH_PREFIX_*"}}
+
+	env := SubprocessEnv(spec, nil, "/tmp/sock", "tok")
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "NOMATCH_PREFIX_") || strings.HasPrefix(kv, "NOMATCH_PREFIX_*=") {
+			t.Errorf("wildcard with no matches forwarded %q", kv)
+		}
+	}
+}
+
+// A wildcard must NEVER forward a denylisted daemon credential or the internal
+// IPC vars, even when the pattern (DICODE_*) prefix-matches all of them.
+func TestSubprocessEnv_WildcardNeverLeaksDaemonCredentials(t *testing.T) {
+	t.Setenv("DICODE_MASTER_KEY", "root-key")
+	t.Setenv("DICODE_API_KEY", "admin-key")
+	t.Setenv("DICODE_MCP_API_KEY", "mcp-key")
+	t.Setenv("DICODE_SOCKET", "/daemon/sock")
+	t.Setenv("DICODE_TOKEN", "daemon-tok")
+
+	spec := &task.Spec{}
+	spec.Permissions.Env = []task.EnvEntry{{Name: "DICODE_*"}}
+
+	m := envMap(SubprocessEnv(spec, nil, "/tmp/sock", "tok"))
+
+	for _, name := range []string{"DICODE_MASTER_KEY", "DICODE_API_KEY", "DICODE_MCP_API_KEY"} {
+		if _, ok := m[name]; ok {
+			t.Errorf("wildcard DICODE_* leaked daemon credential %s", name)
+		}
+	}
+	// IPC vars are always injected by the daemon (per-run coordinates), never
+	// the host daemon-env values a DICODE_* pattern would otherwise match.
+	if m["DICODE_SOCKET"] != "/tmp/sock" || m["DICODE_TOKEN"] != "tok" {
+		t.Errorf("IPC vars overwritten by wildcard match: socket=%q token=%q", m["DICODE_SOCKET"], m["DICODE_TOKEN"])
+	}
+}
+
 func TestSubprocessEnv_ResolvedWinsOverBareHostValue(t *testing.T) {
 	t.Setenv("DUAL_VAR", "host-value")
 	spec := &task.Spec{}


### PR DESCRIPTION
## Summary

`permissions.env` now accepts a bare **pattern** entry — a trailing-`*` prefix glob such as `["GITHUB_*"]`. At launch the daemon expands the pattern against the host environment, forwards every matching host var's value into the task subprocess, and makes each matched name readable by the sandbox. This gives a task a least-privilege lever over env **contents**: it can pull in a related family of vars (`GITHUB_TOKEN`, `GITHUB_SHA`, …) without enumerating each, while still **not** getting the blanket read that `env_read_exposed` grants.

This is deliberately distinct from `env_read_exposed` (a lone `"*"` remains rejected in favour of that flag): a pattern narrows *which contents* are forwarded and readable, rather than widening read permission over the already-curated subprocess env.

The three enforcement sites that previously consumed a bare named entry now share one expansion, `runtime.WildcardEnvNames`:
- `runtime.SubprocessEnv` — forwards the matched host values.
- Deno `buildDenoArgs` — appends the matched names to `--allow-env` (Deno takes exact names only, never a bare wildcard).
- the Python env-read guardrail (`buildGuardPolicy`) — appends the matched names to the readable allowlist.

Sharing one expansion guarantees the set of vars *forwarded* is exactly the set made *readable*.

### Security exclusion

A wildcard must never forward a daemon credential. `WildcardEnvNames` always drops the `neverForwardEnv` denylist (`DICODE_MASTER_KEY`, `DICODE_API_KEY`, `DICODE_MCP_API_KEY`) and the per-run IPC vars (`DICODE_SOCKET`, `DICODE_TOKEN`), even when a pattern like `DICODE_*` prefix-matches them. Tests assert `DICODE_*` forwards none of the credentials, leaves the IPC vars as the daemon's per-run coordinates, and never leaks them into `--allow-env` / the Python allowlist.

### Scope note

Matching is a trailing-`*` prefix glob only (e.g. `GITHUB_*`), chosen for predictability over shell/regex globs. A pattern is only recognised on a *bare* entry — an entry carrying `from:`/`secret:`/`value:` keeps its literal name.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt -l .` — no output
- `go test ./... -timeout 180s` — all packages pass
- `go test -race ./pkg/runtime/ ./pkg/runtime/deno/ ./pkg/runtime/python/` — pass

New/updated tests cover: prefix pattern forwards matching set host vars; non-matching-prefix and unrelated vars are not forwarded; an unset pattern forwards nothing; the denylist/IPC-var exclusion under `DICODE_*`; and the matched names reaching both Deno `--allow-env` and the Python `EnvAllowed` guardrail.

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)