### PR TITLE
feat(runtime): deterministic stale-lock auto-recovery for deno + python

### DIFF
--- a/cmd/dicode/deno.go
+++ b/cmd/dicode/deno.go
@@ -1,13 +1,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 
-	"github.com/dicode/dicode/internal/fsutil"
-	denopkg "github.com/dicode/dicode/pkg/deno"
+	denort "github.com/dicode/dicode/pkg/runtime/deno"
 )
 
 // cmdDeno implements `dicode deno <subcommand>` — local, daemon-free helpers
@@ -44,8 +43,9 @@ func cmdDenoRelock(args []string) error {
 	return runDenoRelock(check, dir)
 }
 
-// runDenoRelock is the parse-free core of `dicode deno relock`, shared with
-// the runtime-spanning `dicode relock` frontend.
+// runDenoRelock is the parse-free frontend of `dicode deno relock`, shared with
+// the runtime-spanning `dicode relock`. It delegates the deno-cache pass to
+// denort.Relock — the same core the runtime uses for stale-lock auto-recovery.
 func runDenoRelock(check bool, dir string) error {
 	lockPath := filepath.Join(dir, "deno.lock")
 	if check {
@@ -54,57 +54,24 @@ func runDenoRelock(check bool, dir string) error {
 		}
 	}
 
-	entrypoints, err := findTaskEntrypoints(dir)
-	if err != nil {
-		return err
-	}
-	if len(entrypoints) == 0 {
-		return fmt.Errorf("no task.ts entrypoints found under %s", dir)
-	}
-
-	denoPath, err := denopkg.EnsureDeno(denopkg.DefaultVersion)
-	if err != nil {
-		return fmt.Errorf("provision deno %s: %w", denopkg.DefaultVersion, err)
-	}
-
-	cacheArgs := []string{"cache"}
-	if check {
-		cacheArgs = append(cacheArgs, "--frozen")
-	} else {
-		cacheArgs = append(cacheArgs, "--frozen=false")
-	}
-	cacheArgs = append(cacheArgs, "--lock="+lockPath)
-	if cfg := filepath.Join(dir, "deno.json"); fsutil.Exists(cfg) {
-		cacheArgs = append(cacheArgs, "--config="+cfg)
-	}
-	cacheArgs = append(cacheArgs, entrypoints...)
-
-	cmd := exec.Command(denoPath, cacheArgs...)
 	// Deno's Check/Download/lockfile-diff chatter goes to the operator terminal;
 	// stdout is kept clean for scripting.
-	cmd.Stdout = os.Stderr
-	cmd.Stderr = os.Stderr
-	if runErr := cmd.Run(); runErr != nil {
+	n, err := denort.Relock(context.Background(), dir, check, os.Stderr)
+	if err != nil {
 		if check {
 			// deno prints the cause above — a lockfile diff if the lock is
 			// stale, otherwise a dependency/config/type error. Don't assert
 			// staleness; surface both so a non-lock failure isn't mistaken for
 			// drift.
-			return fmt.Errorf("deno cache --frozen failed (see output above); if %s is stale, run `dicode deno relock %s`: %w", lockPath, dir, runErr)
+			return fmt.Errorf("deno cache --frozen failed (see output above); if %s is stale, run `dicode deno relock %s`: %w", lockPath, dir, err)
 		}
-		return fmt.Errorf("deno cache: %w", runErr)
+		return fmt.Errorf("deno cache: %w", err)
 	}
 
 	if check {
-		fmt.Fprintf(os.Stderr, "dicode: %s is up to date (%d entrypoints)\n", lockPath, len(entrypoints))
+		fmt.Fprintf(os.Stderr, "dicode: %s is up to date (%d entrypoints)\n", lockPath, n)
 	} else {
-		fmt.Fprintf(os.Stderr, "dicode: regenerated %s (%d entrypoints)\n", lockPath, len(entrypoints))
+		fmt.Fprintf(os.Stderr, "dicode: regenerated %s (%d entrypoints)\n", lockPath, n)
 	}
 	return nil
-}
-
-// findTaskEntrypoints returns every task.ts under dir, sorted for a stable
-// command line (deterministic lock ordering).
-func findTaskEntrypoints(dir string) ([]string, error) {
-	return findTaskFiles(dir, "task.ts")
 }

--- a/cmd/dicode/deno_test.go
+++ b/cmd/dicode/deno_test.go
@@ -7,32 +7,6 @@ import (
 	"testing"
 )
 
-func TestFindTaskEntrypoints(t *testing.T) {
-	root := t.TempDir()
-	// Two task.ts (one nested), plus decoys that must be ignored.
-	mustWrite(t, filepath.Join(root, "a", "task.ts"), "")
-	mustWrite(t, filepath.Join(root, "b", "nested", "task.ts"), "")
-	mustWrite(t, filepath.Join(root, "b", "task.test.ts"), "") // not an entrypoint
-	mustWrite(t, filepath.Join(root, "c", "task.py"), "")      // other runtime
-
-	got, err := findTaskEntrypoints(root)
-	if err != nil {
-		t.Fatalf("findTaskEntrypoints: %v", err)
-	}
-	want := []string{
-		filepath.Join(root, "a", "task.ts"),
-		filepath.Join(root, "b", "nested", "task.ts"),
-	}
-	if len(got) != len(want) {
-		t.Fatalf("got %v, want %v", got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] { // also asserts sorted order
-			t.Errorf("entry %d = %q, want %q", i, got[i], want[i])
-		}
-	}
-}
-
 // The early validation paths must fail before provisioning Deno, so they are
 // testable without the toolchain or network.
 func TestCmdDenoRelock_EarlyErrors(t *testing.T) {

--- a/cmd/dicode/python.go
+++ b/cmd/dicode/python.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
-	"os/exec"
 
 	"github.com/dicode/dicode/internal/fsutil"
 	pythonpkg "github.com/dicode/dicode/pkg/runtime/python"
@@ -109,16 +109,9 @@ func runPythonRelock(check bool, dir string) error {
 	}
 
 	for _, p := range lockable {
-		lockArgs := []string{"lock", "--script", p}
-		if check {
-			lockArgs = append(lockArgs, "--check")
-		}
-		cmd := exec.Command(uvPath, lockArgs...) // #nosec G204 — argv is the provisioned uv plus discovered task.py paths, no user shell injection.
 		// uv's resolution chatter goes to the operator terminal; stdout is
 		// kept clean for scripting (same contract as cmdDenoRelock).
-		cmd.Stdout = os.Stderr
-		cmd.Stderr = os.Stderr
-		if runErr := cmd.Run(); runErr != nil {
+		if runErr := pythonpkg.RelockScript(context.Background(), uvPath, p, check, os.Stderr); runErr != nil {
 			sidecar := pythonpkg.LockSidecarPath(p)
 			if check {
 				// uv prints the cause above — a lockfile diff if the sidecar

--- a/pkg/runtime/deno/lock.go
+++ b/pkg/runtime/deno/lock.go
@@ -1,0 +1,85 @@
+package deno
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os/exec"
+	"path/filepath"
+	"sort"
+
+	"github.com/dicode/dicode/internal/fsutil"
+	denopkg "github.com/dicode/dicode/pkg/deno"
+)
+
+// staleLockSignature is the substring Deno prints to stderr when a `--frozen`
+// run is rejected because the dependency graph drifted from the lockfile:
+//
+//	error: The lockfile is out of date. Run `deno install --frozen=false`, ...
+//
+// Matching it lets the runtime tell a stale lock (mechanically recoverable by
+// regenerating the lock) apart from an ordinary dependency/type error.
+const staleLockSignature = "lockfile is out of date"
+
+// Relock regenerates (frozen=false) or verifies (frozen=true) the shared
+// deno.lock covering every task.ts entrypoint under dir, using the exact Deno
+// version dicode runs tasks with (provisioned on demand). A single entrypoint
+// would prune the shared lock, so all are passed together. Deno's diff/download
+// chatter is written to out. Returns the entrypoint count. This is the core
+// behind both `dicode deno relock` and the runtime's stale-lock auto-recovery.
+func Relock(ctx context.Context, dir string, frozen bool, out io.Writer) (int, error) {
+	entrypoints, err := findEntrypoints(dir)
+	if err != nil {
+		return 0, err
+	}
+	if len(entrypoints) == 0 {
+		return 0, fmt.Errorf("no task.ts entrypoints found under %s", dir)
+	}
+
+	denoPath, err := denopkg.EnsureDeno(denopkg.DefaultVersion)
+	if err != nil {
+		return 0, fmt.Errorf("provision deno %s: %w", denopkg.DefaultVersion, err)
+	}
+
+	lockPath := filepath.Join(dir, "deno.lock")
+	args := []string{"cache"}
+	if frozen {
+		args = append(args, "--frozen")
+	} else {
+		args = append(args, "--frozen=false")
+	}
+	args = append(args, "--lock="+lockPath)
+	if cfg := filepath.Join(dir, "deno.json"); fsutil.Exists(cfg) {
+		args = append(args, "--config="+cfg)
+	}
+	args = append(args, entrypoints...)
+
+	cmd := exec.CommandContext(ctx, denoPath, args...) //nolint:gosec
+	cmd.Stdout = out
+	cmd.Stderr = out
+	if err := cmd.Run(); err != nil {
+		return 0, err
+	}
+	return len(entrypoints), nil
+}
+
+// findEntrypoints returns every task.ts under dir, sorted for a stable command
+// line so the regenerated lock is deterministic.
+func findEntrypoints(dir string) ([]string, error) {
+	var out []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && d.Name() == "task.ts" {
+			out = append(out, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scan %s for task.ts: %w", dir, err)
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/pkg/runtime/deno/lock_test.go
+++ b/pkg/runtime/deno/lock_test.go
@@ -1,0 +1,63 @@
+package deno
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+)
+
+// The exact stderr Deno 2.x writes when a `--frozen` run is rejected for lock
+// drift. Pins that staleLockSignature keeps matching the real message.
+const denoFrozenStaleErr = "error: The lockfile is out of date. Run `deno install --frozen=false`, or rerun with `--frozen=false` to update it.\nchanges:\n"
+
+func TestStaleLockSignature_MatchesDenoFrozenError(t *testing.T) {
+	s := pkgruntime.NewLockErrSniffer(staleLockSignature)
+	s.Write([]byte(denoFrozenStaleErr)) //nolint:errcheck
+	if !s.StaleLock() {
+		t.Errorf("staleLockSignature %q did not match Deno's frozen error", staleLockSignature)
+	}
+}
+
+func TestStaleLockSignature_IgnoresOrdinaryError(t *testing.T) {
+	s := pkgruntime.NewLockErrSniffer(staleLockSignature)
+	s.Write([]byte("error: Uncaught (in promise) TypeError: fetch failed\n")) //nolint:errcheck
+	if s.StaleLock() {
+		t.Error("ordinary Deno error must not be treated as a stale lock")
+	}
+}
+
+func TestFindEntrypoints(t *testing.T) {
+	root := t.TempDir()
+	write := func(rel string) {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(""), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("a/task.ts")
+	write("b/nested/task.ts")
+	write("b/task.test.ts") // not an entrypoint
+	write("c/task.py")      // other runtime
+
+	got, err := findEntrypoints(root)
+	if err != nil {
+		t.Fatalf("findEntrypoints: %v", err)
+	}
+	want := []string{
+		filepath.Join(root, "a", "task.ts"),
+		filepath.Join(root, "b", "nested", "task.ts"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] { // also asserts sorted order
+			t.Errorf("entry %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -295,71 +295,130 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	runnerFile.Close()
 
 	args := buildDenoArgs(spec, socketPath, shimPath, runnerPath, rt.effectiveProtectedPaths())
-	cmd := exec.CommandContext(execCtx, rt.denoPath, args...) //nolint:gosec
-	cmd.Env = pkgruntime.SubprocessEnv(spec, resolved, socketPath, token)
 
-	var wg sync.WaitGroup
-	if spec.Silent {
-		// Discard stdout/stderr entirely — no AppendLog calls. Use io.Discard
-		// so the task process doesn't block on a full pipe buffer either.
-		cmd.Stdout = io.Discard
-		cmd.Stderr = io.Discard
-		if err := cmd.Start(); err != nil {
-			result.Error = fmt.Errorf("start deno: %w", err)
-			return result, nil
-		}
-	} else {
-		stdout, err := cmd.StdoutPipe()
-		if err != nil {
-			result.Error = err
-			return result, nil
-		}
-		stderr, err := cmd.StderrPipe()
-		if err != nil {
-			result.Error = err
-			return result, nil
-		}
-		if err := cmd.Start(); err != nil {
-			result.Error = fmt.Errorf("start deno: %w", err)
-			return result, nil
-		}
-		// Stream stdout (console.log/info) as "info" and stderr (console.error +
-		// Deno runtime errors) as "error" in the run log.
-		// wg ensures all log lines are flushed before Run returns, avoiding the race
-		// where the caller fetches logs immediately after exit and sees an empty list.
-		wg.Add(2)
-		go rt.StreamRunLog(&wg, stdout, runID, "stdout", "info", redactor)
-		go rt.StreamRunLog(&wg, stderr, runID, "stderr", "error", redactor)
-	}
+	// runOnce spawns the Deno subprocess, streams its output, and records the
+	// outcome on result. It reports whether the run failed with the stale-lock
+	// signature so a single deterministic relock+retry can recover a drifted
+	// deno.lock without invoking the AI auto-fix loop (issue #455).
+	runOnce := func() (staleLock bool) {
+		result.Error = nil
+		result.Output = nil
+		result.ReturnValue = nil
 
-	// Register PID so metrics can aggregate child process resource usage.
-	pid := cmd.Process.Pid
-	activePIDs.Store(pid, struct{}{})
-	defer activePIDs.Delete(pid)
+		cmd := exec.CommandContext(execCtx, rt.denoPath, args...) //nolint:gosec
+		cmd.Env = pkgruntime.SubprocessEnv(spec, resolved, socketPath, token)
+		sniffer := pkgruntime.NewLockErrSniffer(staleLockSignature)
 
-	doneCh := make(chan error, 1)
-	go func() { doneCh <- cmd.Wait() }()
+		var wg sync.WaitGroup
+		if spec.Silent {
+			// Discard stdout — no AppendLog calls — but still sniff stderr for the
+			// stale-lock signature so recovery works for silent tasks too.
+			cmd.Stdout = io.Discard
+			cmd.Stderr = sniffer
+			if err := cmd.Start(); err != nil {
+				result.Error = fmt.Errorf("start deno: %w", err)
+				return false
+			}
+		} else {
+			stdout, err := cmd.StdoutPipe()
+			if err != nil {
+				result.Error = err
+				return false
+			}
+			stderr, err := cmd.StderrPipe()
+			if err != nil {
+				result.Error = err
+				return false
+			}
+			if err := cmd.Start(); err != nil {
+				result.Error = fmt.Errorf("start deno: %w", err)
+				return false
+			}
+			// Stream stdout (console.log/info) as "info" and stderr (console.error +
+			// Deno runtime errors) as "error" in the run log; tee stderr through the
+			// sniffer so the same bytes still reach the log.
+			// wg ensures all log lines are flushed before Run returns, avoiding the race
+			// where the caller fetches logs immediately after exit and sees an empty list.
+			wg.Add(2)
+			go rt.StreamRunLog(&wg, stdout, runID, "stdout", "info", redactor)
+			go rt.StreamRunLog(&wg, io.TeeReader(stderr, sniffer), runID, "stderr", "error", redactor)
+		}
 
-	exitErr, exitedFirst := pkgruntime.AwaitBridgeCompletion(srv.ReturnCh(), doneCh, pkgruntime.BridgeShutdownGrace,
-		func(retVal any) {
-			result.ReturnValue = retVal
+		// Register PID so metrics can aggregate child process resource usage.
+		pid := cmd.Process.Pid
+		activePIDs.Store(pid, struct{}{})
+
+		doneCh := make(chan error, 1)
+		go func() { doneCh <- cmd.Wait() }()
+
+		exitErr, exitedFirst := pkgruntime.AwaitBridgeCompletion(srv.ReturnCh(), doneCh, pkgruntime.BridgeShutdownGrace,
+			func(retVal any) {
+				result.ReturnValue = retVal
+				result.Output = srv.Output()
+			},
+			func() { _ = cmd.Process.Signal(syscall.SIGTERM) },
+		)
+		if exitedFirst {
 			result.Output = srv.Output()
-		},
-		func() { _ = cmd.Process.Signal(syscall.SIGTERM) },
-	)
-	if exitedFirst {
-		result.Output = srv.Output()
-		if exitErr != nil {
-			result.Error = exitErr
+			if exitErr != nil {
+				result.Error = exitErr
+			}
 		}
+
+		activePIDs.Delete(pid)
+		// Wait for stdout/stderr scanners to flush all log lines before returning.
+		// Without this, callers that fetch logs immediately after Run returns may see
+		// an empty list because the goroutines haven't written to the DB yet.
+		wg.Wait()
+
+		return result.Error != nil && sniffer.StaleLock()
 	}
 
-	// Wait for stdout/stderr scanners to flush all log lines before returning.
-	// Without this, callers that fetch logs immediately after Run returns may see
-	// an empty list because the goroutines haven't written to the DB yet.
-	wg.Wait()
+	// A deno.lock is only enforced (and only stale-fails) when one is present at
+	// or near the task dir; recover only then, and only when not opted out.
+	lockPath := denoLockForRecovery(spec)
+	enabled := lockPath != "" && pkgruntime.StaleLockRecoveryEnabled()
+	pkgruntime.RecoverStaleLock(enabled, runOnce, func() error {
+		return rt.relockDeno(ctx, spec, runID, lockPath)
+	})
 
 	return result, nil
+}
+
+// denoLockForRecovery returns the deno.lock path enforced for spec (the one a
+// stale-lock failure would come from), or "" when the task opts out via its own
+// deno.json or has no lock nearby. Mirrors the enforcement decision in
+// buildDenoArgs.
+func denoLockForRecovery(spec *task.Spec) string {
+	if _, err := os.Stat(filepath.Join(spec.TaskDir, "deno.json")); !os.IsNotExist(err) {
+		return ""
+	}
+	return findDenoLockFile(spec.TaskDir, 2)
+}
+
+// relockDeno regenerates the shared deno.lock covering spec's task tree after a
+// stale-lock run failure and records an audit line with the lock's hash delta.
+// Regenerating re-pins the dependencies the (already-approved) task declares,
+// so it does not bypass the approval gate, which governs task content.
+func (rt *Runtime) relockDeno(ctx context.Context, spec *task.Spec, runID, lockPath string) error {
+	before, _ := os.ReadFile(lockPath) //nolint:gosec
+	dir := filepath.Dir(lockPath)
+	var out strings.Builder
+	if _, err := Relock(ctx, dir, false, &out); err != nil {
+		rt.Log.Warn("stale-lock auto-recovery: deno relock failed",
+			zap.String("task", spec.ID), zap.String("lock", lockPath), zap.Error(err))
+		_ = rt.Registry.AppendLog(context.Background(), runID, "error",
+			fmt.Sprintf("auto-recovery: deno.lock regeneration failed: %v", err))
+		return err
+	}
+	after, _ := os.ReadFile(lockPath) //nolint:gosec
+	hb, ha := pkgruntime.ShortHash(before), pkgruntime.ShortHash(after)
+	rt.Log.Info("stale-lock auto-recovery: regenerated deno.lock, retrying run",
+		zap.String("task", spec.ID), zap.String("lock", lockPath),
+		zap.String("hash_before", hb), zap.String("hash_after", ha))
+	_ = rt.Registry.AppendLog(context.Background(), runID, "info",
+		fmt.Sprintf("auto-recovery: deno.lock was stale, regenerated (%s→%s), retrying run", hb, ha))
+	return nil
 }
 
 func expandHome(p string) string {

--- a/pkg/runtime/lockrecover.go
+++ b/pkg/runtime/lockrecover.go
@@ -1,0 +1,100 @@
+package runtime
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+)
+
+// StaleLockRecoveryEnabled reports whether a runtime should deterministically
+// regenerate a stale lockfile and retry the run once. Recovery is on by
+// default: regenerating a lock for an already-approved task re-pins the
+// dependencies the task already declares, so the approval gate (which governs
+// task *content*, not lock resolution) is not bypassed. Set
+// DICODE_DISABLE_LOCK_AUTORECOVERY=1 to keep a stale lock a hard failure — the
+// escape hatch for deployments that treat any lock drift as a supply-chain
+// signal to investigate rather than heal.
+func StaleLockRecoveryEnabled() bool {
+	return os.Getenv("DICODE_DISABLE_LOCK_AUTORECOVERY") != "1"
+}
+
+// staleLockSniffCap bounds how much subprocess stderr a LockErrSniffer retains
+// while looking for the stale-lock signature. The runtime emits the lockfile
+// diagnostic as its first output, so a small window catches it without
+// buffering an unbounded error stream.
+const staleLockSniffCap = 64 << 10
+
+// LockErrSniffer is an io.Writer that watches a subprocess's output for a
+// runtime's stale-lock signature (Deno's "lockfile is out of date", uv's
+// "--locked was provided"). It is teed off the log-streaming pipe so the same
+// bytes still reach the run log; it only records whether the signature
+// appeared, capping retained bytes so a chatty task cannot grow it without
+// bound. A signature may straddle two writes, so it re-scans the retained
+// buffer on each write until matched.
+type LockErrSniffer struct {
+	sigs [][]byte
+	buf  []byte
+	hit  bool
+}
+
+// NewLockErrSniffer returns a sniffer that matches any of sigs.
+func NewLockErrSniffer(sigs ...string) *LockErrSniffer {
+	s := &LockErrSniffer{}
+	for _, sig := range sigs {
+		s.sigs = append(s.sigs, []byte(sig))
+	}
+	return s
+}
+
+func (s *LockErrSniffer) Write(p []byte) (int, error) {
+	if !s.hit && len(s.buf) < staleLockSniffCap {
+		if room := staleLockSniffCap - len(s.buf); len(p) > room {
+			s.buf = append(s.buf, p[:room]...)
+		} else {
+			s.buf = append(s.buf, p...)
+		}
+		for _, sig := range s.sigs {
+			if bytes.Contains(s.buf, sig) {
+				s.hit = true
+				s.buf = nil // matched; stop retaining
+				break
+			}
+		}
+	}
+	return len(p), nil
+}
+
+// StaleLock reports whether a stale-lock signature was seen.
+func (s *LockErrSniffer) StaleLock() bool { return s.hit }
+
+// RecoverStaleLock runs a subprocess attempt and, when it fails with a
+// stale-lock signature and recovery is enabled, regenerates the lock once and
+// retries the attempt exactly one more time. attempt performs the run and
+// reports whether it failed with the stale-lock signature; relock regenerates
+// the lock. Recovery is bounded to a single relock+retry — a second stale
+// result is left as the run's outcome, so a genuinely broken lock cannot
+// thrash. Returns whether a relock+retry happened and any error from relock
+// (in which case the original failure stands and no retry is attempted).
+func RecoverStaleLock(enabled bool, attempt func() (staleLock bool), relock func() error) (retried bool, relockErr error) {
+	stale := attempt()
+	if !stale || !enabled {
+		return false, nil
+	}
+	if err := relock(); err != nil {
+		return false, err
+	}
+	attempt()
+	return true, nil
+}
+
+// ShortHash returns a short hex digest of b for audit lines, or "absent" when
+// b is nil (the lockfile did not exist). Used to record the before/after lock
+// content delta when a stale lock is auto-regenerated.
+func ShortHash(b []byte) string {
+	if b == nil {
+		return "absent"
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:6])
+}

--- a/pkg/runtime/lockrecover_test.go
+++ b/pkg/runtime/lockrecover_test.go
@@ -1,0 +1,186 @@
+package runtime
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestRecoverStaleLock_SucceedsAfterOneRelock: a stale-lock failure triggers a
+// single relock and a single retry that then succeeds.
+func TestRecoverStaleLock_SucceedsAfterOneRelock(t *testing.T) {
+	var attempts, relocks int
+	attempt := func() bool {
+		attempts++
+		return attempts == 1 // first run stale, retry succeeds
+	}
+	relock := func() error { relocks++; return nil }
+
+	retried, err := RecoverStaleLock(true, attempt, relock)
+	if err != nil {
+		t.Fatalf("unexpected relock error: %v", err)
+	}
+	if !retried {
+		t.Error("expected retried=true")
+	}
+	if attempts != 2 {
+		t.Errorf("attempts = %d, want 2", attempts)
+	}
+	if relocks != 1 {
+		t.Errorf("relocks = %d, want 1", relocks)
+	}
+}
+
+// TestRecoverStaleLock_NonLockFailureNotRetried: a failure that is not the
+// stale-lock signature must not relock or retry.
+func TestRecoverStaleLock_NonLockFailureNotRetried(t *testing.T) {
+	var attempts, relocks int
+	attempt := func() bool { attempts++; return false } // not a stale-lock failure
+	relock := func() error { relocks++; return nil }
+
+	retried, err := RecoverStaleLock(true, attempt, relock)
+	if err != nil || retried {
+		t.Fatalf("retried=%v err=%v, want false/nil", retried, err)
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1", attempts)
+	}
+	if relocks != 0 {
+		t.Errorf("relocks = %d, want 0", relocks)
+	}
+}
+
+// TestRecoverStaleLock_BoundedToOne: even when every attempt reports stale, the
+// relock+retry happens exactly once — no thrashing on a genuinely broken lock.
+func TestRecoverStaleLock_BoundedToOne(t *testing.T) {
+	var attempts, relocks int
+	attempt := func() bool { attempts++; return true } // always stale
+	relock := func() error { relocks++; return nil }
+
+	retried, err := RecoverStaleLock(true, attempt, relock)
+	if err != nil {
+		t.Fatalf("unexpected relock error: %v", err)
+	}
+	if !retried {
+		t.Error("expected retried=true")
+	}
+	if attempts != 2 {
+		t.Errorf("attempts = %d, want 2 (bounded to one retry)", attempts)
+	}
+	if relocks != 1 {
+		t.Errorf("relocks = %d, want 1", relocks)
+	}
+}
+
+// TestRecoverStaleLock_Disabled: with recovery disabled, a stale-lock failure
+// is left as-is — attempt runs once, no relock.
+func TestRecoverStaleLock_Disabled(t *testing.T) {
+	var attempts, relocks int
+	attempt := func() bool { attempts++; return true }
+	relock := func() error { relocks++; return nil }
+
+	retried, _ := RecoverStaleLock(false, attempt, relock)
+	if retried {
+		t.Error("expected retried=false when disabled")
+	}
+	if attempts != 1 || relocks != 0 {
+		t.Errorf("attempts=%d relocks=%d, want 1/0", attempts, relocks)
+	}
+}
+
+// TestRecoverStaleLock_RelockErrorSurfacesOriginal: when relock itself fails,
+// there is no retry and the relock error is returned so the caller can leave
+// the original run failure in place.
+func TestRecoverStaleLock_RelockErrorSurfacesOriginal(t *testing.T) {
+	var attempts int
+	relockErr := errors.New("relock boom")
+	attempt := func() bool { attempts++; return true }
+	relock := func() error { return relockErr }
+
+	retried, err := RecoverStaleLock(true, attempt, relock)
+	if retried {
+		t.Error("expected retried=false when relock fails")
+	}
+	if !errors.Is(err, relockErr) {
+		t.Errorf("err = %v, want relock error", err)
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1 (no retry after relock failure)", attempts)
+	}
+}
+
+func TestLockErrSniffer_MatchAndSplit(t *testing.T) {
+	t.Run("single write", func(t *testing.T) {
+		s := NewLockErrSniffer("lockfile is out of date")
+		n, err := s.Write([]byte("error: The lockfile is out of date. Rerun ...\n"))
+		if err != nil || n == 0 {
+			t.Fatalf("Write = %d, %v", n, err)
+		}
+		if !s.StaleLock() {
+			t.Error("expected match")
+		}
+	})
+
+	t.Run("split across writes", func(t *testing.T) {
+		s := NewLockErrSniffer("`--locked` was provided")
+		s.Write([]byte("error: The lockfile needs to be updated, but `--loc")) //nolint:errcheck
+		if s.StaleLock() {
+			t.Fatal("matched too early")
+		}
+		s.Write([]byte("ked` was provided. To update ...")) //nolint:errcheck
+		if !s.StaleLock() {
+			t.Error("expected match across split writes")
+		}
+	})
+
+	t.Run("no match on ordinary error", func(t *testing.T) {
+		s := NewLockErrSniffer("lockfile is out of date")
+		s.Write([]byte("TypeError: undefined is not a function\n    at main\n")) //nolint:errcheck
+		if s.StaleLock() {
+			t.Error("ordinary error must not match")
+		}
+	})
+}
+
+// TestLockErrSniffer_WriteContract: Write must always report the full length as
+// consumed (it is teed off the log pipe and must never short-write).
+func TestLockErrSniffer_WriteContract(t *testing.T) {
+	s := NewLockErrSniffer("x")
+	big := strings.Repeat("y", staleLockSniffCap*2)
+	n, err := s.Write([]byte(big))
+	if err != nil {
+		t.Fatalf("Write err: %v", err)
+	}
+	if n != len(big) {
+		t.Errorf("n = %d, want %d", n, len(big))
+	}
+}
+
+// TestStaleLockRecoveryEnabled_OptOut: recovery is on by default and the env
+// opt-out turns it off.
+func TestStaleLockRecoveryEnabled_OptOut(t *testing.T) {
+	if !StaleLockRecoveryEnabled() {
+		t.Error("recovery should be enabled by default")
+	}
+	t.Setenv("DICODE_DISABLE_LOCK_AUTORECOVERY", "1")
+	if StaleLockRecoveryEnabled() {
+		t.Error("DICODE_DISABLE_LOCK_AUTORECOVERY=1 should disable recovery")
+	}
+}
+
+func TestShortHash(t *testing.T) {
+	if got := ShortHash(nil); got != "absent" {
+		t.Errorf("nil hash = %q, want absent", got)
+	}
+	a := ShortHash([]byte("one"))
+	b := ShortHash([]byte("two"))
+	if a == "" || a == "absent" {
+		t.Errorf("unexpected hash %q", a)
+	}
+	if a == b {
+		t.Error("distinct inputs hashed equal")
+	}
+	if a != ShortHash([]byte("one")) {
+		t.Error("hash not deterministic")
+	}
+}

--- a/pkg/runtime/python/lock.go
+++ b/pkg/runtime/python/lock.go
@@ -1,10 +1,40 @@
 package python
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
 	"strings"
 )
+
+// staleLockSignature is the substring uv prints to stderr when a `--locked`
+// run is rejected because the script's inline metadata drifted from its lock
+// sidecar:
+//
+//	error: The lockfile at `...` needs to be updated, but `--locked` was provided. ...
+//
+// Matching it lets the runtime tell a stale sidecar (mechanically recoverable
+// by regenerating it) apart from an ordinary resolution/metadata error.
+const staleLockSignature = "`--locked` was provided"
+
+// RelockScript regenerates (check=false) or verifies (check=true) the lock
+// sidecar for a single PEP 723 script via `uv lock --script`, using uv at
+// uvPath. uv's resolution chatter is written to out. This is the per-script
+// core behind both `dicode python relock` and the runtime's stale-lock
+// auto-recovery; the runtime relocks only the one script that failed, since uv
+// locks inline scripts individually (unlike Deno's shared lock).
+func RelockScript(ctx context.Context, uvPath, scriptPath string, check bool, out io.Writer) error {
+	args := []string{"lock", "--script", scriptPath}
+	if check {
+		args = append(args, "--check")
+	}
+	cmd := exec.CommandContext(ctx, uvPath, args...) // #nosec G204 — argv is the provisioned uv plus a discovered task.py path, no user shell injection.
+	cmd.Stdout = out
+	cmd.Stderr = out
+	return cmd.Run()
+}
 
 // LockSidecarPath returns the path of the per-script uv lock sidecar for a
 // PEP 723 inline script, as written by `uv lock --script <script>`:

--- a/pkg/runtime/python/lock_test.go
+++ b/pkg/runtime/python/lock_test.go
@@ -5,11 +5,34 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
 )
 
 func TestLockSidecarPath(t *testing.T) {
 	if got := LockSidecarPath("/x/tasks/t/task.py"); got != "/x/tasks/t/task.py.lock" {
 		t.Fatalf("LockSidecarPath = %q", got)
+	}
+}
+
+// The exact stderr uv writes when a `--locked` run is rejected because the
+// script's inline metadata drifted from its lock sidecar. Pins that
+// staleLockSignature keeps matching the real message.
+const uvLockedStaleErr = "error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.\n"
+
+func TestStaleLockSignature_MatchesUvLockedError(t *testing.T) {
+	s := pkgruntime.NewLockErrSniffer(staleLockSignature)
+	s.Write([]byte(uvLockedStaleErr)) //nolint:errcheck
+	if !s.StaleLock() {
+		t.Errorf("staleLockSignature %q did not match uv's --locked error", staleLockSignature)
+	}
+}
+
+func TestStaleLockSignature_IgnoresOrdinaryError(t *testing.T) {
+	s := pkgruntime.NewLockErrSniffer(staleLockSignature)
+	s.Write([]byte("Traceback (most recent call last):\n  File task.py, line 1\nValueError: boom\n")) //nolint:errcheck
+	if s.StaleLock() {
+		t.Error("ordinary Python traceback must not be treated as a stale lock")
 	}
 }
 

--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -44,6 +44,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -248,60 +249,105 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	// loudly instead of silently resolving new versions. Tasks without a
 	// sidecar run exactly as before — mirrors the Deno runtime, which only
 	// enforces --frozen when a deno.lock is present.
-	stagedLock, locked, err := stageLockSidecar(scriptPath, tmpFile.Name())
-	if err != nil {
-		result.Error = err
-		return result, nil
-	}
-	if locked {
-		defer os.Remove(stagedLock)
-	}
+	//
+	// Staging happens per attempt so a stale-lock auto-recovery relock (issue
+	// #455) is picked up on retry: uv discovers the lock strictly by the
+	// <wrapper>.lock filename, so the regenerated sidecar must be re-copied.
+	stagedPath := LockSidecarPath(tmpFile.Name())
+	defer os.Remove(stagedPath)
 
-	cmd := exec.CommandContext(execCtx, e.uvPath, buildUvRunArgs(tmpFile.Name(), locked)...) //nolint:gosec
-	cmd.Env = pkgruntime.SubprocessEnv(spec, resolved, socketPath, token)
+	// runOnce stages the lock, spawns the uv subprocess, streams its output, and
+	// records the outcome on result. It reports whether the run failed with the
+	// stale-lock signature so a single deterministic relock+retry can recover a
+	// drifted sidecar without invoking the AI auto-fix loop.
+	runOnce := func() (staleLock bool) {
+		result.Error = nil
+		result.ChainInput = nil
 
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		result.Error = err
-		return result, nil
-	}
+		_, locked, err := stageLockSidecar(scriptPath, tmpFile.Name())
+		if err != nil {
+			result.Error = err
+			return false
+		}
 
-	if err := cmd.Start(); err != nil {
-		result.Error = fmt.Errorf("start uv: %w", err)
-		return result, nil
-	}
+		cmd := exec.CommandContext(execCtx, e.uvPath, buildUvRunArgs(tmpFile.Name(), locked)...) //nolint:gosec
+		cmd.Env = pkgruntime.SubprocessEnv(spec, resolved, socketPath, token)
+		sniffer := pkgruntime.NewLockErrSniffer(staleLockSignature)
 
-	// Stream uv/Python stderr to registry logs in real-time, at "warn": the
-	// stream mixes uv's own progress chatter with Python tracebacks, unlike
-	// Deno's, whose stderr is logged as "error". Stdout is not streamed
-	// (Python tasks log via the SDK's log global over IPC).
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go e.StreamRunLog(&wg, stderr, runID, "stderr", "warn", redactor)
+		stderr, err := cmd.StderrPipe()
+		if err != nil {
+			result.Error = err
+			return false
+		}
+		if err := cmd.Start(); err != nil {
+			result.Error = fmt.Errorf("start uv: %w", err)
+			return false
+		}
 
-	doneCh := make(chan error, 1)
-	go func() { doneCh <- cmd.Wait() }()
+		// Stream uv/Python stderr to registry logs in real-time, at "warn": the
+		// stream mixes uv's own progress chatter with Python tracebacks, unlike
+		// Deno's, whose stderr is logged as "error". Tee it through the sniffer so
+		// the same bytes still reach the log. Stdout is not streamed (Python tasks
+		// log via the SDK's log global over IPC).
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go e.StreamRunLog(&wg, io.TeeReader(stderr, sniffer), runID, "stderr", "warn", redactor)
 
-	exitErr, exitedFirst := pkgruntime.AwaitBridgeCompletion(srv.ReturnCh(), doneCh, pkgruntime.BridgeShutdownGrace,
-		func(retVal any) {
-			result.ChainInput = retVal
+		doneCh := make(chan error, 1)
+		go func() { doneCh <- cmd.Wait() }()
+
+		exitErr, exitedFirst := pkgruntime.AwaitBridgeCompletion(srv.ReturnCh(), doneCh, pkgruntime.BridgeShutdownGrace,
+			func(retVal any) {
+				result.ChainInput = retVal
+				if out := srv.Output(); out != nil {
+					result.ChainInput = out.Data
+				}
+			},
+			func() { _ = cmd.Process.Signal(syscall.SIGTERM) },
+		)
+		if exitedFirst {
 			if out := srv.Output(); out != nil {
 				result.ChainInput = out.Data
 			}
-		},
-		func() { _ = cmd.Process.Signal(syscall.SIGTERM) },
-	)
-	if exitedFirst {
-		if out := srv.Output(); out != nil {
-			result.ChainInput = out.Data
+			if exitErr != nil {
+				result.Error = exitErr
+			}
 		}
-		if exitErr != nil {
-			result.Error = exitErr
-		}
+
+		wg.Wait()
+		return result.Error != nil && sniffer.StaleLock()
 	}
 
-	wg.Wait()
+	pkgruntime.RecoverStaleLock(pkgruntime.StaleLockRecoveryEnabled(), runOnce, func() error {
+		return e.relockScript(ctx, spec, runID, scriptPath)
+	})
+
 	return result, nil
+}
+
+// relockScript regenerates the task.py.lock sidecar for the failing script
+// after a stale-lock run failure and records an audit line with the sidecar's
+// hash delta. Regenerating re-pins the dependencies the (already-approved) task
+// declares, so it does not bypass the approval gate, which governs task content.
+func (e *executor) relockScript(ctx context.Context, spec *task.Spec, runID, scriptPath string) error {
+	sidecar := LockSidecarPath(scriptPath)
+	before, _ := os.ReadFile(sidecar) //nolint:gosec
+	var out strings.Builder
+	if err := RelockScript(ctx, e.uvPath, scriptPath, false, &out); err != nil {
+		e.Log.Warn("stale-lock auto-recovery: uv relock failed",
+			zap.String("task", spec.ID), zap.String("lock", sidecar), zap.Error(err))
+		_ = e.Registry.AppendLog(context.Background(), runID, "error",
+			fmt.Sprintf("auto-recovery: %s regeneration failed: %v", sidecar, err))
+		return err
+	}
+	after, _ := os.ReadFile(sidecar) //nolint:gosec
+	hb, ha := pkgruntime.ShortHash(before), pkgruntime.ShortHash(after)
+	e.Log.Info("stale-lock auto-recovery: regenerated uv lock, retrying run",
+		zap.String("task", spec.ID), zap.String("lock", sidecar),
+		zap.String("hash_before", hb), zap.String("hash_after", ha))
+	_ = e.Registry.AppendLog(context.Background(), runID, "info",
+		fmt.Sprintf("auto-recovery: %s was stale, regenerated (%s→%s), retrying run", sidecar, hb, ha))
+	return nil
 }
 
 // buildWrapper assembles the final Python file that uv will execute:


### PR DESCRIPTION
## Summary

When a task fails at run time because its lockfile has drifted from the script's dependency graph, the failure is fully mechanical to fix — regenerate the lock and run again — yet it previously surfaced as a hard error (or, at best, would route through the AI auto-fix loop, which is overkill for a deterministic remediation). This adds deterministic, no-AI auto-recovery for that specific failure across both runtimes:

- **Deno**: a `--frozen` "lockfile is out of date" rejection against the shared `tasks/deno.lock`.
- **Python**: a `uv --locked` out-of-date rejection against a per-script `task.py.lock` sidecar.

On detecting that exact exit signature, the runtime regenerates the lock with the existing relock primitive and retries the run **once**. If the relock fails, or the retry still fails, the original error stands.

## Approach

Detection sniffs the subprocess's stderr — teed off the existing log-stream pipe, so the same bytes still reach the run log — for the runtime's stale-lock message (`lockfile is out of date` for Deno, `` `--locked` was provided `` for uv). Matching the structured message, not just a non-zero exit, means an ordinary dependency/type/traceback error is never mistaken for lock drift and is never retried. The orchestration (`RecoverStaleLock`) is bounded to a single relock+retry so a genuinely broken lock cannot thrash.

The relock cores are reused, not shelled out to: the Deno relock logic moves from `cmd/dicode` into `pkg/runtime/deno` (`denort.Relock`) and the per-script uv relock into `pkg/runtime/python` (`RelockScript`), with the CLI `relock` frontends delegating to those same cores. Because Deno shares one `tasks/deno.lock`, its relock regenerates across every `task.ts` entrypoint; uv locks scripts individually, so Python relocks only the failing script and re-stages the sidecar before the retry (uv discovers the lock strictly by the `<wrapper>.lock` filename).

## Trust / supply-chain choice

Regenerating a lock re-pins the dependencies an **already-approved** task already declares in its source, so recovery does not bypass the approval gate — that gate governs task *content*, not lock resolution, and the task content is unchanged. Every relock emits an audit line (structured logger + run log) recording the task, the lockfile, and the before/after content-hash delta.

Recovery defaults **on**: the stale lock came from an approved task, the fix is mechanical, and the alternative is a hard failure on every run until an operator intervenes. For deployments that treat any lock drift as a supply-chain signal to investigate rather than silently heal, `DICODE_DISABLE_LOCK_AUTORECOVERY=1` keeps a stale lock a hard failure (following the existing `DICODE_DISABLE_*` toggle pattern). No `dicode.yaml` surface was added — an env opt-out is the minimal escape hatch; per-source config can follow if demand appears.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l .` — all clean.
- `go test ./... -timeout 180s` — pass (32 packages ok).
- `go test -race ./pkg/runtime/ ./pkg/runtime/deno/ ./pkg/runtime/python/ ./cmd/dicode/` — pass.
- New tests: the relock+retry-once orchestration (succeeds after one relock; non-lock failure not retried; bounded to one; disabled opt-out; relock-error surfaces the original), the stderr sniffer (match, split-across-writes, no-match, write contract), and each runtime's stale-lock signature matched against the real captured Deno/uv error text.
- End-to-end, the Deno runtime was manually driven against a real drifted `deno.lock`: detection fired, the audit line was emitted, the relock ran, and the retry recovered — confirming the full wiring. (A committed integration test was dropped because Deno auto-discovers the repo's own `package.json` into the lock when `go test` runs from the repo CWD, making it environment-sensitive; the deterministic tests cover the behavior without that flakiness.)
- Refactored CLI confirmed intact: `dicode deno relock --check tasks` and `dicode python relock --check tasks` both report the repo's locks up to date.

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)
