### PR TITLE
fix(runtime): fresh retry deadline + serialize deno relock for stale-lock recovery

### DIFF
--- a/pkg/runtime/deno/lock.go
+++ b/pkg/runtime/deno/lock.go
@@ -8,10 +8,19 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"sync"
 
 	"github.com/dicode/dicode/internal/fsutil"
 	denopkg "github.com/dicode/dicode/pkg/deno"
 )
+
+// denoLockMu serializes regeneration of the shared tasks/deno.lock. Every deno
+// task shares one lock, so a dependency drift after a push stale-fails several
+// concurrently running tasks at once; each would call Relock in parallel and
+// race writing the same file. Serializing them means later relocks observe the
+// freshly written lock instead of clobbering it. Check mode (frozen) does not
+// write and is not held.
+var denoLockMu sync.Mutex
 
 // staleLockSignature is the substring Deno prints to stderr when a `--frozen`
 // run is rejected because the dependency graph drifted from the lockfile:
@@ -35,6 +44,12 @@ func Relock(ctx context.Context, dir string, frozen bool, out io.Writer) (int, e
 	}
 	if len(entrypoints) == 0 {
 		return 0, fmt.Errorf("no task.ts entrypoints found under %s", dir)
+	}
+
+	// Serialize writers against the shared lock; verifiers are read-only.
+	if !frozen {
+		denoLockMu.Lock()
+		defer denoLockMu.Unlock()
 	}
 
 	denoPath, err := denopkg.EnsureDeno(denopkg.DefaultVersion)

--- a/pkg/runtime/deno/lock_recovery_test.go
+++ b/pkg/runtime/deno/lock_recovery_test.go
@@ -1,0 +1,97 @@
+//go:build !windows
+
+package deno
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// TestRuntime_StaleLockRetryFreshDeadline proves the retry after a stale-lock
+// relock runs under a fresh per-attempt timeout budget, not the initial
+// attempt's already-spent one. A fake deno stale-fails the first run, the relock
+// is stubbed to consume most of the task timeout, and the retry then sleeps long
+// enough that it would be killed under a shared budget but completes under a
+// fresh one. Uses a fake deno binary + stubbed relock, so it needs no toolchain
+// or network.
+func TestRuntime_StaleLockRetryFreshDeadline(t *testing.T) {
+	e := newTestEnv(t)
+	dir := t.TempDir()
+
+	// Fake deno: first invocation emits the stale-lock signature and fails;
+	// every later invocation sleeps (the retry) and exits 0. A state file
+	// distinguishes the two.
+	statePath := filepath.Join(dir, "attempt.state")
+	fake := filepath.Join(dir, "fake-deno.sh")
+	script := "#!/bin/sh\n" +
+		"if [ ! -f '" + statePath + "' ]; then\n" +
+		"  : > '" + statePath + "'\n" +
+		"  echo 'error: The lockfile is out of date. rerun with --frozen=false' 1>&2\n" +
+		"  exit 1\n" +
+		"fi\n" +
+		"sleep 0.4\n" +
+		"exit 0\n"
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	e.rt.denoPath = fake
+
+	// deno.lock present + no deno.json ⇒ recovery is enabled for this task.
+	if err := os.WriteFile(filepath.Join(dir, "deno.lock"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "task.ts"),
+		[]byte("export default async function main(){ return 1 }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "task.yaml"),
+		[]byte("name: fresh-deadline\nruntime: deno\ntrigger:\n  manual: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Relock consumes most of the 1s budget. Under a shared budget the retry
+	// would be born with ~0.2s left and its 0.4s subprocess would be killed;
+	// a fresh per-attempt budget lets it finish.
+	restore := denoRelock
+	denoRelock = func(_ context.Context, _ string, _ bool, _ io.Writer) (int, error) {
+		time.Sleep(800 * time.Millisecond)
+		return 1, nil
+	}
+	t.Cleanup(func() { denoRelock = restore })
+
+	spec := &task.Spec{
+		ID: "fresh-deadline", Name: "fresh-deadline", Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true}, Timeout: 1000 * time.Millisecond,
+		TaskDir: dir,
+	}
+	if err := e.reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := e.rt.Run(context.Background(), spec, RunOptions{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if r.Error != nil {
+		t.Fatalf("retry should run under a fresh deadline and succeed, got: %v", r.Error)
+	}
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("first attempt did not run (no state file): %v", err)
+	}
+	var sawAudit bool
+	for _, l := range r.Logs {
+		if strings.Contains(l.Message, "auto-recovery: deno.lock was stale") {
+			sawAudit = true
+		}
+	}
+	if !sawAudit {
+		t.Errorf("expected auto-recovery audit line, logs: %+v", r.Logs)
+	}
+}

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -216,8 +216,14 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		return result, nil
 	}
 
-	execCtx, cancel := pkgruntime.ExecContext(ctx, spec.Timeout)
-	defer cancel()
+	// The IPC server spans the whole run — both the initial attempt and any
+	// stale-lock retry — so it is scoped to a run-lifetime context, not a
+	// per-attempt timeout. Each subprocess attempt gets its own fresh
+	// ExecContext (see runOnce) so the retry, which follows a possibly slow
+	// relock, is born with a full timeout budget rather than the initial
+	// attempt's already-spent one.
+	srvCtx, srvCancel := context.WithCancel(ctx)
+	defer srvCancel()
 
 	mergedParams := pkgruntime.MergeParams(spec.Params, opts.Params)
 
@@ -226,7 +232,7 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	if d := rt.effectiveCryptoDeriver(); d != nil {
 		srv.SetCryptoHandler(d)
 	}
-	socketPath, token, err := srv.Start(execCtx)
+	socketPath, token, err := srv.Start(srvCtx)
 	if err != nil {
 		result.Error = fmt.Errorf("start socket server: %w", err)
 		return result, nil
@@ -305,11 +311,20 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		result.Output = nil
 		result.ReturnValue = nil
 
+		// Fresh per-attempt timeout budget: the retry's deadline is measured
+		// from here (after any relock), so a slow relock cannot starve it.
+		execCtx, cancel := pkgruntime.ExecContext(ctx, spec.Timeout)
+		defer cancel()
+
 		cmd := exec.CommandContext(execCtx, rt.denoPath, args...) //nolint:gosec
 		cmd.Env = pkgruntime.SubprocessEnv(spec, resolved, socketPath, token)
 		sniffer := pkgruntime.NewLockErrSniffer(staleLockSignature)
 
 		var wg sync.WaitGroup
+		// stderrW, when non-nil, is closed by the cmd.Wait goroutine once the
+		// process has exited and every stderr byte has been copied to the
+		// sniffer — this is what lets the log streamer drain to EOF.
+		var stderrW *io.PipeWriter
 		if spec.Silent {
 			// Discard stdout — no AppendLog calls — but still sniff stderr for the
 			// stale-lock signature so recovery works for silent tasks too.
@@ -325,23 +340,23 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 				result.Error = err
 				return false
 			}
-			stderr, err := cmd.StderrPipe()
-			if err != nil {
-				result.Error = err
-				return false
-			}
+			// Route stderr through cmd.Stderr (a writer), not StderrPipe: this
+			// makes cmd.Wait block until every stderr byte has been copied to the
+			// sniffer, so the stale-lock decision never races the process exit
+			// closing a pipe. The bytes are teed to a pipe that feeds the log
+			// streamer, so they still reach the run log ("error" level).
+			pr, pw := io.Pipe()
+			stderrW = pw
+			cmd.Stderr = io.MultiWriter(sniffer, pw)
 			if err := cmd.Start(); err != nil {
 				result.Error = fmt.Errorf("start deno: %w", err)
 				return false
 			}
-			// Stream stdout (console.log/info) as "info" and stderr (console.error +
-			// Deno runtime errors) as "error" in the run log; tee stderr through the
-			// sniffer so the same bytes still reach the log.
 			// wg ensures all log lines are flushed before Run returns, avoiding the race
 			// where the caller fetches logs immediately after exit and sees an empty list.
 			wg.Add(2)
 			go rt.StreamRunLog(&wg, stdout, runID, "stdout", "info", redactor)
-			go rt.StreamRunLog(&wg, io.TeeReader(stderr, sniffer), runID, "stderr", "error", redactor)
+			go rt.StreamRunLog(&wg, pr, runID, "stderr", "error", redactor)
 		}
 
 		// Register PID so metrics can aggregate child process resource usage.
@@ -349,7 +364,16 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		activePIDs.Store(pid, struct{}{})
 
 		doneCh := make(chan error, 1)
-		go func() { doneCh <- cmd.Wait() }()
+		go func() {
+			err := cmd.Wait()
+			// The process has exited and (for the non-silent path) the stderr
+			// copier has flushed to the sniffer; close the pipe so the log
+			// streamer sees EOF and wg can complete.
+			if stderrW != nil {
+				_ = stderrW.Close()
+			}
+			doneCh <- err
+		}()
 
 		exitErr, exitedFirst := pkgruntime.AwaitBridgeCompletion(srv.ReturnCh(), doneCh, pkgruntime.BridgeShutdownGrace,
 			func(retVal any) {
@@ -396,6 +420,10 @@ func denoLockForRecovery(spec *task.Spec) string {
 	return findDenoLockFile(spec.TaskDir, 2)
 }
 
+// denoRelock is the relock entry the runtime invokes; a package var so tests
+// can simulate a slow or failing relock without the Deno toolchain.
+var denoRelock = Relock
+
 // relockDeno regenerates the shared deno.lock covering spec's task tree after a
 // stale-lock run failure and records an audit line with the lock's hash delta.
 // Regenerating re-pins the dependencies the (already-approved) task declares,
@@ -404,7 +432,7 @@ func (rt *Runtime) relockDeno(ctx context.Context, spec *task.Spec, runID, lockP
 	before, _ := os.ReadFile(lockPath) //nolint:gosec
 	dir := filepath.Dir(lockPath)
 	var out strings.Builder
-	if _, err := Relock(ctx, dir, false, &out); err != nil {
+	if _, err := denoRelock(ctx, dir, false, &out); err != nil {
 		rt.Log.Warn("stale-lock auto-recovery: deno relock failed",
 			zap.String("task", spec.ID), zap.String("lock", lockPath), zap.Error(err))
 		_ = rt.Registry.AppendLog(context.Background(), runID, "error",

--- a/pkg/runtime/python/lock_recovery_test.go
+++ b/pkg/runtime/python/lock_recovery_test.go
@@ -1,0 +1,98 @@
+//go:build !windows
+
+package python
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// TestExecute_StaleLockRetryFreshDeadline is the Python analogue of the Deno
+// fresh-deadline regression test: after a stale-lock relock, the retry must run
+// under a fresh per-attempt timeout budget, not the initial attempt's spent one.
+// A fake uv stale-fails the first run, the relock is stubbed to consume most of
+// the timeout, and the retry then sleeps long enough that it would be killed
+// under a shared budget but completes under a fresh one.
+func TestExecute_StaleLockRetryFreshDeadline(t *testing.T) {
+	rt, reg := newTestRuntime(t)
+	dir := t.TempDir()
+
+	// Fake uv: first invocation emits uv's --locked staleness signature and
+	// fails; every later invocation sleeps (the retry) and exits 0.
+	statePath := filepath.Join(dir, "attempt.state")
+	fake := filepath.Join(dir, "fake-uv.sh")
+	script := "#!/bin/sh\n" +
+		"if [ ! -f '" + statePath + "' ]; then\n" +
+		"  : > '" + statePath + "'\n" +
+		"  echo 'error: The lockfile needs to be updated, but `--locked` was provided.' 1>&2\n" +
+		"  exit 1\n" +
+		"fi\n" +
+		"sleep 0.4\n" +
+		"exit 0\n"
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	scriptPath := filepath.Join(dir, "task.py")
+	if err := os.WriteFile(scriptPath, []byte("result = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A sidecar makes the run --locked so the stale path is realistic.
+	if err := os.WriteFile(LockSidecarPath(scriptPath), []byte("version = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	restore := pythonRelock
+	pythonRelock = func(_ context.Context, _, _ string, _ bool, _ io.Writer) error {
+		time.Sleep(800 * time.Millisecond)
+		return nil
+	}
+	t.Cleanup(func() { pythonRelock = restore })
+
+	ex := rt.NewExecutor(fake)
+	spec := &task.Spec{
+		ID: "fresh-deadline", Name: "fresh-deadline", Runtime: task.Runtime("python"),
+		Trigger: task.TriggerConfig{Manual: true}, Timeout: 1000 * time.Millisecond,
+		TaskDir: dir,
+	}
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	runID, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{RunID: runID})
+	if err != nil {
+		t.Fatalf("Execute transport error: %v", err)
+	}
+	if res.Error != nil {
+		t.Fatalf("retry should run under a fresh deadline and succeed, got: %v", res.Error)
+	}
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("first attempt did not run (no state file): %v", err)
+	}
+	logs, err := reg.GetRunLogs(ctx, runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawAudit bool
+	for _, l := range logs {
+		if strings.Contains(l.Message, "was stale, regenerated") {
+			sawAudit = true
+		}
+	}
+	if !sawAudit {
+		t.Errorf("expected auto-recovery audit line, logs: %+v", logs)
+	}
+}

--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -209,13 +209,19 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 		return result, nil
 	}
 
-	execCtx, cancel := pkgruntime.ExecContext(ctx, spec.Timeout)
-	defer cancel()
+	// The IPC server spans the whole run — both the initial attempt and any
+	// stale-lock retry — so it is scoped to a run-lifetime context, not a
+	// per-attempt timeout. Each subprocess attempt gets its own fresh
+	// ExecContext (see runOnce) so the retry, which follows a possibly slow
+	// relock, is born with a full timeout budget rather than the initial
+	// attempt's already-spent one.
+	srvCtx, srvCancel := context.WithCancel(ctx)
+	defer srvCancel()
 
 	mergedParams := pkgruntime.MergeParams(spec.Params, opts.Params)
 
 	srv := e.BridgeDeps.NewIPCServer(runID, spec, mergedParams, opts.Input, redactor, &e.parent.BridgeDeps)
-	socketPath, token, err := srv.Start(execCtx)
+	socketPath, token, err := srv.Start(srvCtx)
 	if err != nil {
 		result.Error = fmt.Errorf("start socket server: %w", err)
 		return result, nil
@@ -270,31 +276,42 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 			return false
 		}
 
+		// Fresh per-attempt timeout budget: the retry's deadline is measured
+		// from here (after any relock), so a slow relock cannot starve it.
+		execCtx, cancel := pkgruntime.ExecContext(ctx, spec.Timeout)
+		defer cancel()
+
 		cmd := exec.CommandContext(execCtx, e.uvPath, buildUvRunArgs(tmpFile.Name(), locked)...) //nolint:gosec
 		cmd.Env = pkgruntime.SubprocessEnv(spec, resolved, socketPath, token)
 		sniffer := pkgruntime.NewLockErrSniffer(staleLockSignature)
 
-		stderr, err := cmd.StderrPipe()
-		if err != nil {
-			result.Error = err
-			return false
-		}
+		// Route stderr through cmd.Stderr (a writer), not StderrPipe: this makes
+		// cmd.Wait block until every stderr byte has been copied to the sniffer,
+		// so the stale-lock decision never races the process exit closing a
+		// pipe. The bytes are teed to a pipe that feeds the log streamer, so they
+		// still reach the run log. Stream at "warn": the stream mixes uv's own
+		// progress chatter with Python tracebacks, unlike Deno's, whose stderr is
+		// logged as "error". Stdout is not streamed (Python tasks log via the
+		// SDK's log global over IPC).
+		pr, pw := io.Pipe()
+		cmd.Stderr = io.MultiWriter(sniffer, pw)
 		if err := cmd.Start(); err != nil {
 			result.Error = fmt.Errorf("start uv: %w", err)
 			return false
 		}
 
-		// Stream uv/Python stderr to registry logs in real-time, at "warn": the
-		// stream mixes uv's own progress chatter with Python tracebacks, unlike
-		// Deno's, whose stderr is logged as "error". Tee it through the sniffer so
-		// the same bytes still reach the log. Stdout is not streamed (Python tasks
-		// log via the SDK's log global over IPC).
 		var wg sync.WaitGroup
 		wg.Add(1)
-		go e.StreamRunLog(&wg, io.TeeReader(stderr, sniffer), runID, "stderr", "warn", redactor)
+		go e.StreamRunLog(&wg, pr, runID, "stderr", "warn", redactor)
 
 		doneCh := make(chan error, 1)
-		go func() { doneCh <- cmd.Wait() }()
+		go func() {
+			err := cmd.Wait()
+			// The process has exited and the stderr copier has flushed to the
+			// sniffer; close the pipe so the log streamer sees EOF.
+			_ = pw.Close()
+			doneCh <- err
+		}()
 
 		exitErr, exitedFirst := pkgruntime.AwaitBridgeCompletion(srv.ReturnCh(), doneCh, pkgruntime.BridgeShutdownGrace,
 			func(retVal any) {
@@ -325,6 +342,10 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	return result, nil
 }
 
+// pythonRelock is the relock entry the runtime invokes; a package var so tests
+// can simulate a slow or failing relock without the uv toolchain.
+var pythonRelock = RelockScript
+
 // relockScript regenerates the task.py.lock sidecar for the failing script
 // after a stale-lock run failure and records an audit line with the sidecar's
 // hash delta. Regenerating re-pins the dependencies the (already-approved) task
@@ -333,7 +354,7 @@ func (e *executor) relockScript(ctx context.Context, spec *task.Spec, runID, scr
 	sidecar := LockSidecarPath(scriptPath)
 	before, _ := os.ReadFile(sidecar) //nolint:gosec
 	var out strings.Builder
-	if err := RelockScript(ctx, e.uvPath, scriptPath, false, &out); err != nil {
+	if err := pythonRelock(ctx, e.uvPath, scriptPath, false, &out); err != nil {
 		e.Log.Warn("stale-lock auto-recovery: uv relock failed",
 			zap.String("task", spec.ID), zap.String("lock", sidecar), zap.Error(err))
 		_ = e.Registry.AppendLog(context.Background(), runID, "error",


### PR DESCRIPTION
## Summary

Follow-up to #494 (merged) addressing two issues found in review of the stale-lock auto-recovery retry wiring.

**Retry reused an already-spent timeout budget.** `ExecContext(ctx, spec.Timeout)` was created once at `Run` entry and reused by the retry subprocess (and the IPC server). But the relock runs under the parent context and is the slow path — it re-downloads the drifted dependencies, exactly why the lock went stale. For a short-timeout / heavy-dependency task the relock could burn the wall-clock budget, so the retry was born under an already-expired `execCtx`: the subprocess was killed immediately and its IPC/SDK (`dicode.*`) calls failed context-cancelled — the recovery fixed the lock on disk but the retry it exists to perform misfired. Each subprocess attempt now gets a fresh `ExecContext` measured from after the relock; the IPC server is scoped to a run-lifetime context so it spans both attempts. Both contexts are cancelled (no leak). Same fix in the Python runtime.

**Concurrent relocks raced the shared `deno.lock`.** `tasks/deno.lock` is shared across all deno tasks, which run concurrently; a push that drifts it stale-fails several at once, each calling `Relock` in parallel on the same file. A package-level mutex now serializes deno lock regeneration (write mode only — verifies are read-only). Python's per-script sidecar isn't shared, so it's left alone.

**(found while fixing) The stale-lock decision raced the pipe close.** Detection read stderr via `StderrPipe`, which races `cmd.Wait` closing the pipe — the documented "don't call Wait before reads complete" hazard. Tolerable when stderr is only logged, but not when it drives control flow: under load the signature line could be dropped and recovery would misfire (observed as a flaky `-race` failure). Stderr now flows through `cmd.Stderr = io.MultiWriter(sniffer, pipe)` so `cmd.Wait` blocks until every byte has reached the sniffer, with the pipe closed from the wait goroutine to drain the log streamer.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l .` — all clean.
- `go test ./... -timeout 180s` — pass (32 packages ok).
- `go test -race ./pkg/runtime/...` — pass, run 5× consecutively with zero failures/races (the flake fix above).
- New tests, both proven to fail against the pre-fix shared-context code (retry killed with `signal: killed`): `TestRuntime_StaleLockRetryFreshDeadline` (deno) and `TestExecute_StaleLockRetryFreshDeadline` (python) — each stubs a relock that consumes most of the task timeout and asserts the retry, given a fresh budget, still completes. Both use a fake deno/uv binary + stubbed relock, so no toolchain or network.

Relates to #455. Follow-up to #494.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lockfile recovery for Deno and Python tasks so retries get a fresh timeout and are less likely to fail after a slow relock.
  * Prevented concurrent relock attempts from racing when updating shared lockfiles.
  * Fixed stderr handling so stale-lock detection and log output are processed more reliably before a run completes.
  * Added regression coverage for stale-lock retry behavior and recovery logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->