### PR TITLE
feat(suspend): run status + resume persistence foundation

### DIFF
--- a/pkg/db/sqlite.go
+++ b/pkg/db/sqlite.go
@@ -186,6 +186,16 @@ func (s *SQLiteDB) migrate() error {
 		// parent run by the engine (upcoming PR). SQLite backfills existing
 		// rows to 'task' at ALTER time.
 		{"kind", "TEXT NOT NULL DEFAULT 'task'"},
+		// Suspend/resume columns (#95). All nullable — set only when a run
+		// suspends awaiting user input. resume_state/resume_form hold opaque
+		// JSON blobs; resume_token is an unguessable resume handle; the two
+		// timestamps are Unix milliseconds (resume_deadline is the TTL after
+		// which a still-suspended run is cancelled).
+		{"resume_state", "BLOB"},
+		{"resume_form", "BLOB"},
+		{"resume_token", "TEXT"},
+		{"suspended_at", "INTEGER"},
+		{"resume_deadline", "INTEGER"},
 	}
 	for _, m := range runsMigrations {
 		if err := addColumnIfMissing(ctx, s.db, "runs", m.name, m.ddl); err != nil {

--- a/pkg/db/sqlite_test.go
+++ b/pkg/db/sqlite_test.go
@@ -122,6 +122,44 @@ func TestSQLiteDB_RunsHasInputColumns(t *testing.T) {
 	}
 }
 
+func TestSQLiteDB_RunsHasResumeColumns(t *testing.T) {
+	d := newTestDB(t).(*SQLiteDB)
+	ctx := context.Background()
+	rows, err := d.db.QueryContext(ctx, `PRAGMA table_info(runs)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	cols := map[string]string{}
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dflt any
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatal(err)
+		}
+		cols[name] = ctype
+	}
+	wantCols := map[string]string{
+		"resume_state":    "BLOB",
+		"resume_form":     "BLOB",
+		"resume_token":    "TEXT",
+		"suspended_at":    "INTEGER",
+		"resume_deadline": "INTEGER",
+	}
+	for name, wantType := range wantCols {
+		got, ok := cols[name]
+		if !ok {
+			t.Errorf("runs missing column %q", name)
+			continue
+		}
+		if got != wantType {
+			t.Errorf("runs.%s type = %q, want %q", name, got, wantType)
+		}
+	}
+}
+
 func TestSQLiteDB_Migrate_Idempotent(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "test.db")

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -18,12 +18,16 @@ import (
 // ErrRunNotFound is returned by GetRun when no run record exists for the given ID.
 var ErrRunNotFound = errors.New("run not found")
 
-// RunStatus values.
+// RunStatus values. success/failure/cancelled are terminal; running and
+// suspended are not. A suspended run has paused awaiting user input — it is
+// neither in-flight (not "running", so CleanupStaleRuns leaves it alone) nor
+// finished (finished_at stays NULL until it resumes or its deadline expires).
 const (
 	StatusRunning   = "running"
 	StatusSuccess   = "success"
 	StatusFailure   = "failure"
 	StatusCancelled = "cancelled"
+	StatusSuspended = "suspended"
 )
 
 // Run kind values for the runs.kind column. These are the lowercase run-row
@@ -68,6 +72,15 @@ type Run struct {
 	InputStoredAt       int64    // unix timestamp the blob was stored (AAD-bound)
 	InputRedactedFields []string // dotted paths of any redacted fields
 	InputPinned         int      // 1 = pinned (excluded from retention cleanup)
+
+	// Suspend/resume persistence fields (#95). Populated by GetRun only; the
+	// list queries omit them (mirrors the input-persistence fields above).
+	// Zero values mean "not suspended".
+	ResumeState    []byte // opaque task-provided state blob; nil when absent
+	ResumeForm     []byte // form schema JSON to render on resume; nil when absent
+	ResumeToken    string // unguessable resume handle; empty when absent
+	SuspendedAt    int64  // Unix ms the run suspended; 0 when absent
+	ResumeDeadline int64  // Unix ms TTL; 0 when no deadline set
 }
 
 // LogEntry is one log line from a run.
@@ -223,6 +236,23 @@ func (r *Registry) FinishRunWithResult(ctx context.Context, runID, status, retur
 	)
 }
 
+// SuspendRun records a run as suspended awaiting user input, persisting the
+// opaque state/form blobs, the resume token, and the suspend timestamp. It
+// deliberately leaves finished_at NULL: suspended is a non-terminal status, so
+// the run is neither running (CleanupStaleRuns skips it) nor finished.
+//
+// A deadline of 0 stores NULL (no TTL). state and form may be nil.
+func (r *Registry) SuspendRun(ctx context.Context, runID string, state, form []byte, token string, suspendedAt, deadline int64) error {
+	var deadlineArg any
+	if deadline > 0 {
+		deadlineArg = deadline
+	}
+	return r.db.Exec(ctx,
+		`UPDATE runs SET status = ?, resume_state = ?, resume_form = ?, resume_token = ?, suspended_at = ?, resume_deadline = ? WHERE id = ?`,
+		StatusSuspended, state, form, token, suspendedAt, deadlineArg, runID,
+	)
+}
+
 // SetLogHook registers a function called after each log entry is written.
 func (r *Registry) SetLogHook(fn func(runID, level, msg string, ts int64)) {
 	r.logMu.Lock()
@@ -313,11 +343,21 @@ const runInputColumns = `,
         COALESCE(input_storage_key, ''), COALESCE(input_size, 0), COALESCE(input_stored_at, 0),
         COALESCE(input_redacted_fields, ''), COALESCE(input_pinned, 0)`
 
+// runResumeColumns are the suspend/resume columns GetRun additionally selects
+// (appended after runInputColumns). Like the input columns, queryRuns omits
+// them: list responses serialize Run directly and don't surface resume state.
+// The BLOB columns are scanned as-is (NULL → nil []byte); the scalars use
+// COALESCE so a NULL reads back as the zero value.
+const runResumeColumns = `,
+        resume_state, resume_form, COALESCE(resume_token, ''),
+        COALESCE(suspended_at, 0), COALESCE(resume_deadline, 0)`
+
 // scanRun decodes one row selected with runColumns (plus runInputColumns when
-// withInput is true) into a Run, including the shared post-processing
-// (trigger source, millisecond timestamps, nullable parent, redacted-fields
-// JSON). rows.Next() must already have returned true.
-func scanRun(rows db.Scanner, withInput bool) (*Run, error) {
+// withInput is true, plus runResumeColumns when withResume is true) into a Run,
+// including the shared post-processing (trigger source, millisecond timestamps,
+// nullable parent, redacted-fields JSON). rows.Next() must already have
+// returned true.
+func scanRun(rows db.Scanner, withInput, withResume bool) (*Run, error) {
 	run := &Run{}
 	var startedMs int64
 	var finishedMs *int64
@@ -332,6 +372,10 @@ func scanRun(rows db.Scanner, withInput bool) (*Run, error) {
 	if withInput {
 		dest = append(dest,
 			&run.InputStorageKey, &run.InputSize, &run.InputStoredAt, &redactedFieldsJSON, &run.InputPinned)
+	}
+	if withResume {
+		dest = append(dest,
+			&run.ResumeState, &run.ResumeForm, &run.ResumeToken, &run.SuspendedAt, &run.ResumeDeadline)
 	}
 	if err := rows.Scan(dest...); err != nil {
 		return nil, err
@@ -360,12 +404,12 @@ func scanRun(rows db.Scanner, withInput bool) (*Run, error) {
 func (r *Registry) GetRun(ctx context.Context, runID string) (*Run, error) {
 	var run *Run
 	err := r.db.Query(ctx,
-		`SELECT `+runColumns+runInputColumns+` FROM runs WHERE id = ?`,
+		`SELECT `+runColumns+runInputColumns+runResumeColumns+` FROM runs WHERE id = ?`,
 		[]any{runID},
 		func(rows db.Scanner) error {
 			if rows.Next() {
 				var scanErr error
-				run, scanErr = scanRun(rows, true)
+				run, scanErr = scanRun(rows, true, true)
 				return scanErr
 			}
 			return nil
@@ -436,7 +480,7 @@ func (r *Registry) queryRuns(ctx context.Context, whereAndLimit string, args []a
 		args,
 		func(rows db.Scanner) error {
 			for rows.Next() {
-				run, err := scanRun(rows, false)
+				run, err := scanRun(rows, false, false)
 				if err != nil {
 					return err
 				}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -471,3 +471,123 @@ func TestFinishRunWithResult(t *testing.T) {
 		t.Error("finished_at should be set")
 	}
 }
+
+func TestSuspendRun_RoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := newTestRegistry(t)
+
+	runID, err := r.StartRun(ctx, "task-suspend", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	state := []byte(`{"step":"ask_name"}`)
+	form := []byte(`{"fields":[{"name":"project_name"}]}`)
+	token := "resume-token-xyz"
+	suspendedAt := time.Now().UnixMilli()
+	deadline := suspendedAt + 86_400_000
+
+	if err := r.SuspendRun(ctx, runID, state, form, token, suspendedAt, deadline); err != nil {
+		t.Fatal(err)
+	}
+
+	run, err := r.GetRun(ctx, runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != StatusSuspended {
+		t.Errorf("status = %q, want %q", run.Status, StatusSuspended)
+	}
+	// Suspended is non-terminal: finished_at must stay unset.
+	if run.FinishedAt != nil {
+		t.Errorf("finished_at = %v, want nil for a suspended run", run.FinishedAt)
+	}
+	if string(run.ResumeState) != string(state) {
+		t.Errorf("resume_state = %q, want %q", run.ResumeState, state)
+	}
+	if string(run.ResumeForm) != string(form) {
+		t.Errorf("resume_form = %q, want %q", run.ResumeForm, form)
+	}
+	if run.ResumeToken != token {
+		t.Errorf("resume_token = %q, want %q", run.ResumeToken, token)
+	}
+	if run.SuspendedAt != suspendedAt {
+		t.Errorf("suspended_at = %d, want %d", run.SuspendedAt, suspendedAt)
+	}
+	if run.ResumeDeadline != deadline {
+		t.Errorf("resume_deadline = %d, want %d", run.ResumeDeadline, deadline)
+	}
+}
+
+// A zero deadline persists as NULL and reads back as 0; nil state/form blobs
+// round-trip as nil rather than a zero-length slice mismatch.
+func TestSuspendRun_NoDeadlineNilBlobs(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := newTestRegistry(t)
+
+	runID, err := r.StartRun(ctx, "task-suspend-2", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.SuspendRun(ctx, runID, nil, nil, "tok", time.Now().UnixMilli(), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	run, err := r.GetRun(ctx, runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != StatusSuspended {
+		t.Errorf("status = %q, want %q", run.Status, StatusSuspended)
+	}
+	if run.ResumeDeadline != 0 {
+		t.Errorf("resume_deadline = %d, want 0", run.ResumeDeadline)
+	}
+	if run.ResumeState != nil {
+		t.Errorf("resume_state = %v, want nil", run.ResumeState)
+	}
+	if run.ResumeForm != nil {
+		t.Errorf("resume_form = %v, want nil", run.ResumeForm)
+	}
+}
+
+// A suspended run is not "running", so the startup stale-run sweep must leave
+// it alone rather than cancelling it.
+func TestCleanupStaleRuns_SkipsSuspended(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := newTestRegistry(t)
+
+	suspended, err := r.StartRun(ctx, "task-a", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.SuspendRun(ctx, suspended, []byte(`{}`), nil, "tok", time.Now().UnixMilli(), 0); err != nil {
+		t.Fatal(err)
+	}
+	running, err := r.StartRun(ctx, "task-b", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := r.CleanupStaleRuns(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	sRun, err := r.GetRun(ctx, suspended)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sRun.Status != StatusSuspended {
+		t.Errorf("suspended run status = %q, want %q (sweep must skip it)", sRun.Status, StatusSuspended)
+	}
+	rRun, err := r.GetRun(ctx, running)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rRun.Status != StatusCancelled {
+		t.Errorf("running run status = %q, want %q", rRun.Status, StatusCancelled)
+	}
+}


### PR DESCRIPTION
## Summary

This is the model/status foundation for suspendable tasks (#95): the framework primitive that lets a task pause, persist its state, wait for user input, and resume later. It touches only the persistence and status layer — no runtime, SDK, or UI behavior.

Today every run is terminal: a run is `running`, then ends `success`/`failure`/`cancelled`. There is no way to express "paused, waiting on the user." This change introduces a non-terminal `suspended` status and the columns a suspended run needs to be rehydrated later:

- `resume_state` / `resume_form` (nullable BLOB) — opaque task state and the form schema to render.
- `resume_token` (nullable TEXT) — unguessable resume handle.
- `suspended_at` / `resume_deadline` (nullable INTEGER, Unix ms) — suspend time and optional TTL.

`suspended` is deliberately neither running nor finished. `SuspendRun` leaves `finished_at` NULL, so the startup stale-run sweep (`CleanupStaleRuns`, which targets only `running`) leaves suspended runs untouched, and `WaitRun` (channel-driven, not status-enumerated) is unaffected. There is no central is-terminal helper or status-validation list keyed on the enum, so adding the member does not require changes elsewhere to avoid silent breakage.

The columns follow the existing incremental `addColumnIfMissing` migration style; `SuspendRun` and the `GetRun` read path mirror the existing input-persistence column pattern (extra columns selected by `GetRun` only, omitted from list queries so list-endpoint output is unchanged).

## What was deliberately left behind

The runtime suspend signal, IPC `dicode.suspend`, the SDK `dicode.suspend()` / `ctx.resume_state`, resume re-spawn/orchestration, the deadline sweeper, and the webui form all land in follow-up PRs per the build plan on the issue. This PR is data-model only.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt -l .` — no drift
- `go test ./... -timeout 180s` — pass (32 packages, exit 0)
- `go test -race ./pkg/registry/... ./pkg/db/...` — pass

New tests: migration adds the five resume columns with the right types; a suspend/load round-trip (state/form/token/timestamps, and `finished_at` stays NULL); zero-deadline persists as NULL and nil blobs round-trip as nil; the stale-run sweep skips a suspended run while still cancelling a running one.

Part of #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)