### PR TITLE
feat(suspend): Deno runtime + SDK suspend mechanism

### DIFF
--- a/pkg/ipc/capability.go
+++ b/pkg/ipc/capability.go
@@ -43,6 +43,13 @@ const (
 	// only so future denial policies can revoke it.
 	CapOutputSecret = "output.secret"
 
+	// CapSuspend allows a task to call dicode.suspend() — pause the run,
+	// hand the runtime an opaque state blob plus a form schema, and exit
+	// cleanly for later resume (#95). A core self-affecting primitive
+	// granted to every task token by default; the cap exists only so future
+	// denial policies can revoke it.
+	CapSuspend = "suspend"
+
 	// Conditionally granted to tasks based on security config.
 	CapTaskTrigger = "tasks.trigger" // dicode.run_task — also checked against allowed_tasks list
 	CapTasksList   = "tasks.list"    // dicode.list_tasks
@@ -118,5 +125,6 @@ func defaultTaskCaps() []string {
 		CapReturn,
 		CapOutputSecret,
 		CapSetGroup,
+		CapSuspend,
 	}
 }

--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -101,6 +101,15 @@ type Request struct {
 	// dicode.set_group — free-text label for the caller's run (#116).
 	Group string `json:"group,omitempty"`
 
+	// dicode.suspend — pause the run and yield a form for the user (#95).
+	// State is the opaque JSON blob to rehydrate on resume; Form is the
+	// FormSchema describing the input to collect; Deadline is an optional
+	// Unix-ms TTL (0 = unset, engine applies its default). Kept as raw JSON
+	// so the runtime threads the blobs through without re-encoding.
+	State    json.RawMessage `json:"state,omitempty"`
+	Form     json.RawMessage `json:"form,omitempty"`
+	Deadline int64           `json:"deadline,omitempty"`
+
 	// dicode.sources.set_dev_mode — toggles dev mode on a configured source (#234)
 	Name      string `json:"name,omitempty"`       // source name
 	Enabled   bool   `json:"enabled,omitempty"`    // true to enable
@@ -172,6 +181,16 @@ type OutputResult struct {
 
 // IsSet reports whether any output was recorded.
 func (o *OutputResult) IsSet() bool { return o != nil && o.ContentType != "" }
+
+// SuspendResult captures a dicode.suspend() request (#95): the opaque state
+// blob to rehydrate on resume, the FormSchema describing the input to
+// collect, and an optional Unix-ms deadline (0 = unset). State and Form are
+// kept as raw JSON so the runtime forwards them to the engine unchanged.
+type SuspendResult struct {
+	State    json.RawMessage `json:"state,omitempty"`
+	Form     json.RawMessage `json:"form,omitempty"`
+	Deadline int64           `json:"deadline,omitempty"`
+}
 
 // EngineRunner allows the IPC server to fire and await task runs, and to
 // query live concurrency state. Implemented by the trigger engine; injected

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -82,9 +82,18 @@ type Server struct {
 	connWG   sync.WaitGroup // tracks in-flight handleConn goroutines
 	acceptMu sync.Mutex     // serialises accept+Add against Stop's Wait
 
-	mu     sync.Mutex
-	output *OutputResult
-	retCh  chan any
+	mu      sync.Mutex
+	output  *OutputResult
+	suspend *SuspendResult // set when the task calls dicode.suspend (#95)
+	retCh   chan any
+
+	// resumeState / resumeInput are the prior-run payload injected when this
+	// run is a resume of a suspended one (#95). Exposed to the task as
+	// ctx.resume_state / ctx.resume_input via the "resume" IPC method. Both
+	// are nil on a first (non-resume) invocation. Set via SetResume before
+	// Start; read-only afterwards, so no mutex is needed.
+	resumeState json.RawMessage
+	resumeInput json.RawMessage
 
 	// secretOut, when non-nil, receives the flat map produced by a
 	// provider task calling dicode.output(map, { secret: true }). The
@@ -392,6 +401,23 @@ func (s *Server) Output() *OutputResult {
 	return s.output
 }
 
+// Suspend returns the payload captured when the task called dicode.suspend,
+// or nil if it did not (#95). The runtime reads it after the subprocess exits
+// to build a suspended RunResult.
+func (s *Server) Suspend() *SuspendResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.suspend
+}
+
+// SetResume injects the prior-run state and user input for a resumed run,
+// exposed to the task as ctx.resume_state / ctx.resume_input (#95). Both are
+// opaque JSON blobs; nil means "not a resume". Must be called before Start.
+func (s *Server) SetResume(state, input json.RawMessage) {
+	s.resumeState = state
+	s.resumeInput = input
+}
+
 func (s *Server) accept() {
 	for {
 		conn, err := s.listener.Accept()
@@ -604,6 +630,20 @@ func (s *Server) handleConn(conn net.Conn) {
 			}
 			reply(req.ID, s.input, "")
 
+		case "resume":
+			// Returns the prior-run state + user input for a resumed run
+			// (#95), exposed to the task as ctx.resume_state / ctx.resume_input.
+			// Gated by the same cap as input — it is contextual run input.
+			// Both fields are nil on a first (non-resume) invocation.
+			if !hasCap(caps, CapInputRead) {
+				reply(req.ID, nil, "ipc: permission denied (input.read)")
+				continue
+			}
+			reply(req.ID, map[string]any{
+				"state": s.resumeState,
+				"input": s.resumeInput,
+			}, "")
+
 		case "kv.get":
 			if !hasCap(caps, CapKVRead) {
 				reply(req.ID, nil, "ipc: permission denied (kv.read)")
@@ -686,6 +726,26 @@ func (s *Server) handleConn(conn net.Conn) {
 			reply(req.ID, true, "")
 
 		// ── dicode.* ──────────────────────────────────────────────────────
+
+		case "dicode.suspend":
+			// The task is pausing: capture the state/form/deadline and ack.
+			// dicode.suspend() is a request/response call so the ack ordering
+			// guarantees the payload is recorded before the shim throws its
+			// SuspendSignal and the subprocess exits — the runtime then reads
+			// Suspend() to build a suspended RunResult. Never resolves in task
+			// code (the shim throws on ack).
+			if !hasCap(caps, CapSuspend) {
+				reply(req.ID, nil, "ipc: permission denied (suspend)")
+				continue
+			}
+			s.mu.Lock()
+			s.suspend = &SuspendResult{
+				State:    req.State,
+				Form:     req.Form,
+				Deadline: req.Deadline,
+			}
+			s.mu.Unlock()
+			reply(req.ID, true, "")
 
 		case "dicode.set_group":
 			if !hasCap(caps, CapSetGroup) {

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -295,7 +295,7 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		zap.String("task_script", taskPath),
 		zap.String("runner", runnerPath),
 	)
-	runner := "import { params, kv, input, output, mcp, dicode, resume_state, resume_input, __setReturn__, __conn__, __flush__, __isSuspend__ } from \"" + shimPath + "\";\n" +
+	runner := "import { params, kv, input, output, mcp, dicode, resume_state, resume_input, __setReturn__, __conn__, __flush__, __isSuspend__, __wasSuspendRequested__ } from \"" + shimPath + "\";\n" +
 		"let __main__;\n" +
 		"try {\n" +
 		"  __main__ = (await import(\"" + taskPath + "\")).default;\n" +
@@ -307,6 +307,17 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		"}\n" +
 		"try {\n" +
 		"  const result = await __main__({ params, kv, input, output, mcp, dicode, resume_state, resume_input });\n" +
+		// If main() returned normally yet a suspend was requested, the task
+		// caught the SuspendSignal in its own try/catch and kept running. The
+		// payload is already recorded server-side, so a normal return would
+		// leave the run in a contradictory suspended-and-returned state. Fail
+		// loudly (exit 1) instead so the author fixes the swallowing catch.
+		"  if (__wasSuspendRequested__()) {\n" +
+		"    console.error(\"[dicode] dicode.suspend() was called but its control-flow signal was caught by task code — do not wrap dicode.suspend() in a try/catch that swallows it\");\n" +
+		"    await __flush__();\n" +
+		"    try { __conn__.close(); } catch {}\n" +
+		"    Deno.exit(1);\n" +
+		"  }\n" +
 		"  await __setReturn__(result);\n" +
 		"} catch (__err__) {\n" +
 		// A dicode.suspend() throws SuspendSignal after the payload is already
@@ -434,14 +445,18 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		return rt.relockDeno(ctx, spec, runID, lockPath)
 	})
 
-	// A dicode.suspend() exits the process cleanly (exit 0), so the run is not
-	// a failure. Translate the captured payload into a suspended result (#95).
-	if sr := srv.Suspend(); sr != nil {
+	// A legitimate dicode.suspend() exits the process cleanly (exit 0), so the
+	// run is not a failure. Only then translate the captured payload into a
+	// suspended result (#95). When result.Error is set the subprocess exited
+	// non-zero — the shim's guard trips this path when a task swallowed the
+	// SuspendSignal and kept running — so keep it a failure rather than a
+	// contradictory suspended-and-returned run, even though a payload was
+	// recorded server-side.
+	if sr := srv.Suspend(); sr != nil && result.Error == nil {
 		result.Suspended = true
 		result.ResumeState = sr.State
 		result.ResumeForm = sr.Form
 		result.ResumeDeadline = sr.Deadline
-		result.Error = nil
 	}
 
 	return result, nil

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -6,6 +6,7 @@ package deno
 import (
 	"context"
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -61,6 +62,13 @@ type RunOptions struct {
 	// values directly instead of constructing its own resolver. Nil falls
 	// back to the inline resolver path.
 	PreResolvedEnv *envresolve.Resolved
+
+	// ResumeState / ResumeInput carry a suspended run's prior state and the
+	// user's form submission when this run is a resume (#95). Both are opaque
+	// JSON blobs surfaced to the task as ctx.resume_state / ctx.resume_input.
+	// Nil on a first (non-resume) invocation.
+	ResumeState json.RawMessage
+	ResumeInput json.RawMessage
 }
 
 // RunResult is returned by Run.
@@ -70,6 +78,15 @@ type RunResult struct {
 	Output      *ipc.OutputResult
 	Logs        []*registry.LogEntry
 	Error       error
+
+	// Suspended is set when the task called dicode.suspend() (#95): the run
+	// paused cleanly rather than completing or failing. ResumeState/ResumeForm
+	// are the opaque state blob and form schema; ResumeDeadline is an optional
+	// Unix-ms TTL (0 = unset).
+	Suspended      bool
+	ResumeState    []byte
+	ResumeForm     []byte
+	ResumeDeadline int64
 }
 
 // Runtime executes task scripts with Deno.
@@ -232,6 +249,8 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	if d := rt.effectiveCryptoDeriver(); d != nil {
 		srv.SetCryptoHandler(d)
 	}
+	// Inject a resumed run's prior state + user input (#95); nil on first run.
+	srv.SetResume(opts.ResumeState, opts.ResumeInput)
 	socketPath, token, err := srv.Start(srvCtx)
 	if err != nil {
 		result.Error = fmt.Errorf("start socket server: %w", err)
@@ -276,7 +295,7 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		zap.String("task_script", taskPath),
 		zap.String("runner", runnerPath),
 	)
-	runner := "import { params, kv, input, output, mcp, dicode, __setReturn__, __conn__, __flush__ } from \"" + shimPath + "\";\n" +
+	runner := "import { params, kv, input, output, mcp, dicode, resume_state, resume_input, __setReturn__, __conn__, __flush__, __isSuspend__ } from \"" + shimPath + "\";\n" +
 		"let __main__;\n" +
 		"try {\n" +
 		"  __main__ = (await import(\"" + taskPath + "\")).default;\n" +
@@ -287,8 +306,17 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		"  Deno.exit(1);\n" +
 		"}\n" +
 		"try {\n" +
-		"  const result = await __main__({ params, kv, input, output, mcp, dicode });\n" +
+		"  const result = await __main__({ params, kv, input, output, mcp, dicode, resume_state, resume_input });\n" +
 		"  await __setReturn__(result);\n" +
+		"} catch (__err__) {\n" +
+		// A dicode.suspend() throws SuspendSignal after the payload is already
+		// delivered over IPC. Treat it as a clean exit (0), not a failure.
+		"  if (__isSuspend__(__err__)) {\n" +
+		"    await __flush__();\n" +
+		"    try { __conn__.close(); } catch {}\n" +
+		"    Deno.exit(0);\n" +
+		"  }\n" +
+		"  throw __err__;\n" +
 		"} finally {\n" +
 		"  await __flush__();\n" +
 		"  try { __conn__.close(); } catch {}\n" +
@@ -405,6 +433,16 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	pkgruntime.RecoverStaleLock(enabled, runOnce, func() error {
 		return rt.relockDeno(ctx, spec, runID, lockPath)
 	})
+
+	// A dicode.suspend() exits the process cleanly (exit 0), so the run is not
+	// a failure. Translate the captured payload into a suspended result (#95).
+	if sr := srv.Suspend(); sr != nil {
+		result.Suspended = true
+		result.ResumeState = sr.State
+		result.ResumeForm = sr.Form
+		result.ResumeDeadline = sr.Deadline
+		result.Error = nil
+	}
 
 	return result, nil
 }
@@ -587,6 +625,8 @@ func (rt *Runtime) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 		Params:         opts.Params,
 		Input:          opts.Input,
 		PreResolvedEnv: opts.PreResolvedEnv,
+		ResumeState:    opts.ResumeState,
+		ResumeInput:    opts.ResumeInput,
 	})
 	if err != nil {
 		return nil, err
@@ -598,6 +638,12 @@ func (rt *Runtime) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 		r.ChainInput = result.Output.Data
 	} else {
 		r.ChainInput = result.ReturnValue
+	}
+	if result.Suspended {
+		r.Suspended = true
+		r.ResumeState = result.ResumeState
+		r.ResumeForm = result.ResumeForm
+		r.ResumeDeadline = result.ResumeDeadline
 	}
 	return r, nil
 }

--- a/pkg/runtime/deno/sdk/sdk.d.ts
+++ b/pkg/runtime/deno/sdk/sdk.d.ts
@@ -75,6 +75,34 @@ declare interface TaskSummary {
   enabled:      boolean;
 }
 
+/** One field in a suspend form (#95). `type` selects the input widget the
+ *  WebUI renders; `options` is required for "select". */
+declare interface FormField {
+  name: string;
+  type: "string" | "text" | "number" | "boolean" | "select";
+  label: string;
+  required?: boolean;
+  default?: string | number | boolean;
+  options?: { value: string; label: string }[];
+  placeholder?: string;
+}
+
+/** The form a suspended task asks the user to fill in before resume (#95). */
+declare interface FormSchema {
+  title?: string;
+  description?: string;
+  fields: FormField[];
+}
+
+/** Argument to dicode.suspend() (#95). `state` is an opaque JSON blob echoed
+ *  back as ctx.resume_state on resume; `form` describes the input to collect;
+ *  `deadline` is an optional Unix-ms TTL. */
+declare interface SuspendRequest {
+  state: unknown;
+  form: FormSchema;
+  deadline?: number;
+}
+
 declare interface Dicode {
   /** Fully-namespaced id of the currently-running task (e.g. "buildin/ai-agent"). */
   task_id:        string;
@@ -83,6 +111,10 @@ declare interface Dicode {
   run_task:       (taskID: string, params?: Record<string, string>) => Promise<unknown>;
   list_tasks:     ()                                                 => Promise<TaskSummary[]>;
   get_runs:       (taskID: string, opts?: { limit?: number })        => Promise<unknown>;
+  /** Pause the run: hand the runtime `state` + `form`, then never resolve —
+   *  the process exits cleanly and the run ends as `suspended`. On resume the
+   *  task re-runs with ctx.resume_state / ctx.resume_input populated (#95). */
+  suspend:        (req: SuspendRequest) => Promise<never>;
   secrets_set:    (key: string, value: string) => Promise<void>;
   secrets_delete: (key: string)                => Promise<void>;
   /** Secrets presence API. Requires permissions.dicode.secrets_has: true. */
@@ -95,6 +127,12 @@ declare interface DicodeSdk {
   params: Params;
   kv:     KV;
   input:  unknown;
+  /** Prior state blob when this run is a resume of a suspended one; the same
+   *  value passed to dicode.suspend({ state }). Undefined on a first run (#95). */
+  resume_state?: unknown;
+  /** The user's form submission that triggered this resume, keyed by field
+   *  name. Undefined on a first run (#95). */
+  resume_input?: Record<string, unknown>;
   output: Output;
   mcp:    MCP;
   dicode: Dicode;

--- a/pkg/runtime/deno/sdk/shim.ts
+++ b/pkg/runtime/deno/sdk/shim.ts
@@ -140,6 +140,34 @@ export interface TaskSummary {
   enabled:      boolean;
 }
 
+// One field in a suspend form (#95). `type` selects the input widget the
+// WebUI renders; `options` is required for "select".
+export interface FormField {
+  name: string;
+  type: "string" | "text" | "number" | "boolean" | "select";
+  label: string;
+  required?: boolean;
+  default?: string | number | boolean;
+  options?: { value: string; label: string }[];
+  placeholder?: string;
+}
+
+// The form a suspended task asks the user to fill in before resume (#95).
+export interface FormSchema {
+  title?: string;
+  description?: string;
+  fields: FormField[];
+}
+
+// Argument to dicode.suspend() (#95). `state` is an opaque JSON blob echoed
+// back as ctx.resume_state on resume; `form` describes the input to collect;
+// `deadline` is an optional Unix-ms TTL (default applied by the engine).
+export interface SuspendRequest {
+  state: unknown;
+  form: FormSchema;
+  deadline?: number;
+}
+
 export interface Dicode {
   // task_id: the fully-namespaced id of the currently-running task (e.g.
   // "buildin/ai-agent"). Populated from the IPC handshake so task code can
@@ -154,6 +182,11 @@ export interface Dicode {
   // WebUI to collapse same-group siblings (#116). Last write wins; only
   // affects the current run.
   set_group:      (label: string)      => Promise<void>;
+  // suspend pauses the run: it hands the runtime the state blob + form, then
+  // never resolves — it throws internally so the process exits cleanly and
+  // the run ends as `suspended`. On resume the task is re-run with
+  // ctx.resume_state / ctx.resume_input populated (#95).
+  suspend:        (req: SuspendRequest) => Promise<never>;
   secrets_set:    (key: string, value: string) => Promise<void>;
   secrets_delete: (key: string)                => Promise<void>;
   secrets:        DicodeSecrets;
@@ -327,6 +360,28 @@ const kv: KV = {
 
 const input = await __call__({ method: "input" });
 
+// ── resume (#95) ────────────────────────────────────────────────────────────────
+// When this run is a resume of a suspended one, the runtime injects the prior
+// state blob and the user's form submission. Both are null on a first run.
+
+const __resume__ = await __call__({ method: "resume" }) as
+  { state?: unknown; input?: unknown } | null;
+const resume_state: unknown = __resume__?.state ?? undefined;
+const resume_input: unknown = __resume__?.input ?? undefined;
+
+// SuspendSignal is thrown by dicode.suspend() after the payload is delivered
+// over IPC. The per-run wrapper catches it (via __isSuspend__) and exits the
+// process cleanly (exit 0) — a suspend is not a failure.
+class SuspendSignal extends Error {
+  constructor() {
+    super("dicode.suspend");
+    this.name = "SuspendSignal";
+  }
+}
+function __isSuspend__(e: unknown): boolean {
+  return e instanceof SuspendSignal;
+}
+
 // ── output ────────────────────────────────────────────────────────────────────
 
 function __outputCallable__(value: Record<string, string>, _opts: SecretOutputOptions): Promise<void> {
@@ -374,6 +429,18 @@ const dicode: Dicode = {
   list_tasks:     (opts)                => __call__({ method: "dicode.list_tasks", mcpContext: opts?.mcpContext ?? false }) as Promise<TaskSummary[]>,
   get_runs:       (taskID, opts)    => __call__({ method: "dicode.get_runs",        taskID, limit: opts?.limit ?? 10 }),
   set_group:      (label)           => __call__({ method: "dicode.set_group",       group: String(label ?? "") }) as Promise<void>,
+  suspend:        async (req) => {
+    // Await the ack so the payload is recorded before we throw — the read
+    // loop resolves this once the daemon captured state/form/deadline. The
+    // call then never resolves normally: it always throws.
+    await __call__({
+      method: "dicode.suspend",
+      state: req.state ?? null,
+      form: req.form,
+      deadline: req.deadline ?? 0,
+    });
+    throw new SuspendSignal();
+  },
   secrets_set:    (key, value)      => __call__({ method: "dicode.secrets_set",     key, stringValue: value }) as Promise<void>,
   secrets_delete: (key)             => __call__({ method: "dicode.secrets_delete",  key }) as Promise<void>,
   secrets: {
@@ -463,4 +530,4 @@ const dicode: Dicode = {
 // The runner awaits this on exit so fire-and-forget log writes are not lost.
 async function __flush__(): Promise<void> { await __wq__; }
 
-export { params, kv, input, output, mcp, dicode, __setReturn__, __conn__, __flush__ };
+export { params, kv, input, resume_state, resume_input, output, mcp, dicode, __setReturn__, __conn__, __flush__, __isSuspend__ };

--- a/pkg/runtime/deno/sdk/shim.ts
+++ b/pkg/runtime/deno/sdk/shim.ts
@@ -382,6 +382,13 @@ function __isSuspend__(e: unknown): boolean {
   return e instanceof SuspendSignal;
 }
 
+// Set the instant before the SuspendSignal is thrown (payload already recorded
+// server-side). If main() returns normally with this set, a user try/catch
+// swallowed the signal and kept executing — the wrapper turns that into a loud
+// failure rather than a contradictory "suspended run that also returned".
+let __suspendRequested__ = false;
+function __wasSuspendRequested__(): boolean { return __suspendRequested__; }
+
 // ── output ────────────────────────────────────────────────────────────────────
 
 function __outputCallable__(value: Record<string, string>, _opts: SecretOutputOptions): Promise<void> {
@@ -439,6 +446,7 @@ const dicode: Dicode = {
       form: req.form,
       deadline: req.deadline ?? 0,
     });
+    __suspendRequested__ = true;
     throw new SuspendSignal();
   },
   secrets_set:    (key, value)      => __call__({ method: "dicode.secrets_set",     key, stringValue: value }) as Promise<void>,
@@ -530,4 +538,4 @@ const dicode: Dicode = {
 // The runner awaits this on exit so fire-and-forget log writes are not lost.
 async function __flush__(): Promise<void> { await __wq__; }
 
-export { params, kv, input, resume_state, resume_input, output, mcp, dicode, __setReturn__, __conn__, __flush__, __isSuspend__ };
+export { params, kv, input, resume_state, resume_input, output, mcp, dicode, __setReturn__, __conn__, __flush__, __isSuspend__, __wasSuspendRequested__ };

--- a/pkg/runtime/deno/suspend_test.go
+++ b/pkg/runtime/deno/suspend_test.go
@@ -3,6 +3,7 @@ package deno
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -80,6 +81,66 @@ export default async function main({ dicode }) {
 	}
 	if form.Title != "Your name?" || len(form.Fields) != 1 || form.Fields[0].Name != "project_name" {
 		t.Errorf("ResumeForm = %+v, want title + one project_name field", form)
+	}
+}
+
+// TestRun_SuspendSwallowedByTaskFails guards the case where a task wraps its
+// body in a broad try/catch that swallows the SuspendSignal thrown by
+// dicode.suspend() and keeps executing (#95). The suspend payload is already
+// recorded server-side, so a normal return would leave the run in a
+// contradictory suspended-and-returned state. The run must instead FAIL
+// loudly and NOT be classified as suspended.
+func TestRun_SuspendSwallowedByTaskFails(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rt, reg, cleanup := newTestRuntime(t)
+	defer cleanup()
+
+	spec := writeProviderTask(t, "swallower", `
+export default async function main({ dicode }) {
+  try {
+    await dicode.suspend({
+      state: { step: "one" },
+      form: { fields: [{ name: "x", type: "string", label: "X" }] },
+    });
+  } catch (_e) {
+    // Swallow the control-flow signal and keep going — the bug we guard against.
+  }
+  return { kept_running: true };
+}
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := rt.Run(ctx, spec, RunOptions{RunID: "run-swallow-1"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Suspended {
+		t.Fatalf("swallowed suspend must not be classified as suspended")
+	}
+	if res.Error == nil {
+		t.Fatalf("swallowed suspend must fail the run, got no error")
+	}
+	if res.ReturnValue != nil {
+		t.Errorf("swallowed suspend must not record a return value, got %#v", res.ReturnValue)
+	}
+
+	logs, _ := reg.GetRunLogs(ctx, "run-swallow-1")
+	found := false
+	for _, l := range logs {
+		if strings.Contains(l.Message, "control-flow signal was caught by task code") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a clear diagnostic in the run log, logs = %+v", logs)
 	}
 }
 

--- a/pkg/runtime/deno/suspend_test.go
+++ b/pkg/runtime/deno/suspend_test.go
@@ -1,0 +1,181 @@
+package deno
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestRun_SuspendYieldsSuspendedResult runs a real Deno task that calls
+// dicode.suspend({ state, form, deadline }) and asserts the run ends as a
+// clean suspend (not a failure) with the state/form/deadline captured on the
+// RunResult (#95). The SuspendSignal thrown by the SDK must exit the process
+// with code 0.
+func TestRun_SuspendYieldsSuspendedResult(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rt, reg, cleanup := newTestRuntime(t)
+	defer cleanup()
+
+	spec := writeProviderTask(t, "wizard", `
+export default async function main({ dicode }) {
+  await dicode.suspend({
+    state: { step: "ask_name", n: 42 },
+    form: {
+      title: "Your name?",
+      fields: [{ name: "project_name", type: "string", label: "Name", required: true }],
+    },
+    deadline: 1893456000000,
+  });
+  // Unreachable: suspend never resolves.
+  return { reached: true };
+}
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := rt.Run(ctx, spec, RunOptions{RunID: "run-suspend-1"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Error != nil {
+		t.Fatalf("suspend must not be a failure, got error: %v", res.Error)
+	}
+	if !res.Suspended {
+		t.Fatalf("expected Suspended = true, got false")
+	}
+	if res.ReturnValue != nil {
+		t.Errorf("suspend must not produce a return value, got %#v", res.ReturnValue)
+	}
+	if res.ResumeDeadline != 1893456000000 {
+		t.Errorf("ResumeDeadline = %d, want 1893456000000", res.ResumeDeadline)
+	}
+
+	var state struct {
+		Step string `json:"step"`
+		N    int    `json:"n"`
+	}
+	if err := json.Unmarshal(res.ResumeState, &state); err != nil {
+		t.Fatalf("ResumeState not valid JSON (%q): %v", res.ResumeState, err)
+	}
+	if state.Step != "ask_name" || state.N != 42 {
+		t.Errorf("ResumeState = %+v, want {ask_name 42}", state)
+	}
+
+	var form struct {
+		Title  string `json:"title"`
+		Fields []struct {
+			Name string `json:"name"`
+			Type string `json:"type"`
+		} `json:"fields"`
+	}
+	if err := json.Unmarshal(res.ResumeForm, &form); err != nil {
+		t.Fatalf("ResumeForm not valid JSON (%q): %v", res.ResumeForm, err)
+	}
+	if form.Title != "Your name?" || len(form.Fields) != 1 || form.Fields[0].Name != "project_name" {
+		t.Errorf("ResumeForm = %+v, want title + one project_name field", form)
+	}
+}
+
+// TestRun_ResumeStateAndInputExposed injects a prior-run state blob and a
+// user form submission via RunOptions and asserts the task sees them on
+// ctx.resume_state / ctx.resume_input (#95). Nothing in PR 2 populates these
+// from a real suspended run yet — this verifies the accept + expose mechanism
+// with an injected value.
+func TestRun_ResumeStateAndInputExposed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rt, reg, cleanup := newTestRuntime(t)
+	defer cleanup()
+
+	spec := writeProviderTask(t, "resumer", `
+export default async function main({ resume_state, resume_input }) {
+  return { st: resume_state, inp: resume_input };
+}
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := rt.Run(ctx, spec, RunOptions{
+		RunID:       "run-resume-1",
+		ResumeState: json.RawMessage(`{"step":"ask_framework","name":"proj"}`),
+		ResumeInput: json.RawMessage(`{"project_name":"acme"}`),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Error != nil {
+		t.Fatalf("run error: %v", res.Error)
+	}
+	if res.Suspended {
+		t.Fatalf("resume run must not be suspended")
+	}
+
+	ret, ok := res.ReturnValue.(map[string]any)
+	if !ok {
+		t.Fatalf("ReturnValue = %#v, want map", res.ReturnValue)
+	}
+	st, ok := ret["st"].(map[string]any)
+	if !ok {
+		t.Fatalf("resume_state not exposed: %#v", ret["st"])
+	}
+	if st["step"] != "ask_framework" || st["name"] != "proj" {
+		t.Errorf("resume_state = %#v, want step=ask_framework name=proj", st)
+	}
+	inp, ok := ret["inp"].(map[string]any)
+	if !ok {
+		t.Fatalf("resume_input not exposed: %#v", ret["inp"])
+	}
+	if inp["project_name"] != "acme" {
+		t.Errorf("resume_input = %#v, want project_name=acme", inp)
+	}
+}
+
+// TestRun_NoResumeIsUndefined verifies that a first (non-resume) invocation
+// sees ctx.resume_state / ctx.resume_input as undefined (#95), so a task can
+// branch on their presence.
+func TestRun_NoResumeIsUndefined(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rt, reg, cleanup := newTestRuntime(t)
+	defer cleanup()
+
+	spec := writeProviderTask(t, "firstrun", `
+export default async function main({ resume_state, resume_input }) {
+  return { hasState: resume_state !== undefined, hasInput: resume_input !== undefined };
+}
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := rt.Run(ctx, spec, RunOptions{RunID: "run-first-1"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Error != nil {
+		t.Fatalf("run error: %v", res.Error)
+	}
+	ret, ok := res.ReturnValue.(map[string]any)
+	if !ok {
+		t.Fatalf("ReturnValue = %#v, want map", res.ReturnValue)
+	}
+	if ret["hasState"] != false || ret["hasInput"] != false {
+		t.Errorf("expected resume_state/resume_input undefined on first run, got %#v", ret)
+	}
+}

--- a/pkg/runtime/executor.go
+++ b/pkg/runtime/executor.go
@@ -55,6 +55,15 @@ type RunOptions struct {
 	// on_failure_chain. Empty for non-chained runs. Used by the trigger
 	// engine to release the chainGuards slot on completion.
 	ChainParentTask string
+
+	// ResumeState / ResumeInput carry a suspended run's prior state and the
+	// user's form submission when the engine re-spawns a task to resume it
+	// (#95). Both are opaque JSON blobs surfaced to the task as
+	// ctx.resume_state / ctx.resume_input. Nil on a first (non-resume) run.
+	// Populated by the resume orchestration (PR 3); the runtime only forwards
+	// them to the subprocess.
+	ResumeState []byte
+	ResumeInput []byte
 }
 
 // RunResult is returned by every Executor.
@@ -68,6 +77,17 @@ type RunResult struct {
 	// Empty string means no structured output was produced.
 	OutputContentType string
 	OutputContent     string
+
+	// Suspended is set when the task called dicode.suspend() (#95): the run
+	// paused cleanly (exit 0, not a failure) and yielded state + a form for
+	// later resume. ResumeState/ResumeForm are opaque JSON blobs; ResumeDeadline
+	// is an optional Unix-ms TTL (0 = unset). The trigger engine consumes these
+	// to persist the suspended run and mint a resume token (PR 3); this runtime
+	// only produces them.
+	Suspended      bool
+	ResumeState    []byte
+	ResumeForm     []byte
+	ResumeDeadline int64
 }
 
 // Executor is the common interface satisfied by every runtime (Deno, Docker,

--- a/tasks/sdk.ts
+++ b/tasks/sdk.ts
@@ -79,6 +79,34 @@ export interface DicodeAudit {
   }): Promise<AuditQueryResult>;
 }
 
+// One field in a suspend form (#95). `type` selects the input widget the
+// WebUI renders; `options` is required for "select".
+export interface FormField {
+  name: string;
+  type: "string" | "text" | "number" | "boolean" | "select";
+  label: string;
+  required?: boolean;
+  default?: string | number | boolean;
+  options?: { value: string; label: string }[];
+  placeholder?: string;
+}
+
+// The form a suspended task asks the user to fill in before resume (#95).
+export interface FormSchema {
+  title?: string;
+  description?: string;
+  fields: FormField[];
+}
+
+// Argument to dicode.suspend() (#95). `state` is an opaque JSON blob echoed
+// back as ctx.resume_state on resume; `form` describes the input to collect;
+// `deadline` is an optional Unix-ms TTL.
+export interface SuspendRequest {
+  state: unknown;
+  form: FormSchema;
+  deadline?: number;
+}
+
 export interface Dicode {
   // Fully-namespaced id of the currently-running task (e.g. "buildin/ai-agent").
   // Populated from the IPC handshake; lets task code self-identify without
@@ -89,6 +117,10 @@ export interface Dicode {
   run_task(taskID: string, params?: Record<string, string>): Promise<unknown>;
   list_tasks(): Promise<unknown[]>;
   get_runs(taskID: string, opts?: { limit?: number }): Promise<unknown[]>;
+  // Pause the run: hand the runtime `state` + `form`, then never resolve — the
+  // process exits cleanly and the run ends as `suspended`. On resume the task
+  // re-runs with ctx.resume_state / ctx.resume_input populated (#95).
+  suspend(req: SuspendRequest): Promise<never>;
   secrets_set(key: string, value: string): Promise<void>;
   secrets_delete(key: string): Promise<void>;
   crypto: DicodeCrypto;
@@ -99,6 +131,12 @@ export interface DicodeSdk {
   params: Params;
   kv:     KV;
   input:  unknown;
+  // Prior state blob when this run is a resume of a suspended one; the same
+  // value passed to dicode.suspend({ state }). Undefined on a first run (#95).
+  resume_state?: unknown;
+  // The user's form submission that triggered this resume, keyed by field name.
+  // Undefined on a first run (#95).
+  resume_input?: Record<string, unknown>;
   output: Output;
   mcp:    MCP;
   dicode: Dicode;


### PR DESCRIPTION
## Summary

This is PR 2 of the suspendable-tasks stack (#95): the **Deno runtime + SDK suspend mechanism**. It gives a task the ability to pause and to be re-entered with prior state — the primitive's runtime half. The engine orchestration that persists the suspended run, mints a resume token, applies a deadline, and re-spawns on submission is intentionally **not** here; it lands in PR 3.

A task calls `dicode.suspend({ state, form, deadline? })`. The SDK signals the per-run IPC bridge (the same socket that serves `dicode.output` / `kv` / `log`) with the opaque `state` blob, the `form` schema, and an optional Unix-ms `deadline`, awaits the ack so the payload is recorded, then throws an internal `SuspendSignal`. The per-run runner catches that signal and exits the process cleanly (exit 0, no return value) — a suspend is deliberately not classified as a failure. After the clean exit the Deno `Run` reads the captured payload and produces `RunResult{ Suspended: true, ResumeState, ResumeForm, ResumeDeadline }`.

Resume is wired symmetrically so PR 3 only has to populate it: `RunOptions.ResumeState` / `ResumeInput` are injected over a new `resume` IPC method and surfaced to the task as `ctx.resume_state` / `ctx.resume_input` (both `undefined` on a first, non-resume run). Nothing populates these from a real suspended run yet.

`suspend` is granted to every task token by default (`CapSuspend`), matching the other self-affecting primitives (`output`, `return`, `set_group`). Gating it behind a `task.yaml` permission — the open question in the issue — is deferred rather than guessed.

### Deferred to PR 3 (how the engine consumes this)

The trigger engine already receives a `runtime.RunResult`; this PR adds `Suspended` / `ResumeState` / `ResumeForm` / `ResumeDeadline` to it. PR 3 should, when `RunResult.Suspended` is true: call `registry.SuspendRun` with the state/form, mint the `resume_token`, apply `ResumeDeadline` (or the default TTL), persist the run as `suspended` instead of finishing it success/failure, and on form submission re-spawn the task with `RunOptions.ResumeState` / `ResumeInput` set from the stored state + user input.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt -l .` — no Go files unformatted
- `go test ./... -timeout 180s` — all packages pass
- `go test -race ./pkg/runtime/... ./pkg/ipc/...` — pass (deno 9.4s, ipc 17.3s, all ok)

New Deno integration tests (real subprocess) in `pkg/runtime/deno/suspend_test.go`:
- `TestRun_SuspendYieldsSuspendedResult` — `dicode.suspend()` yields `Suspended: true` with state/form/deadline captured, no return value, and `Error == nil` (clean exit, not a failure).
- `TestRun_ResumeStateAndInputExposed` — injected `ResumeState`/`ResumeInput` reach the task as `ctx.resume_state` / `ctx.resume_input`.
- `TestRun_NoResumeIsUndefined` — a first run sees both as `undefined`.

Part of #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pausing and later resuming task runs.
  * Introduced a new suspend flow with optional form data and deadline handling.
  * Exposed resume data to tasks when a run continues after suspension.
  * Updated runtime results to report when a task was suspended and include resume details.

* **Tests**
  * Added coverage for suspend behavior, resume data exposure, and first-run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->