### PR TITLE
feat(suspend): resume orchestration + deadline sweep

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -46,6 +46,10 @@ import (
 // but then streams quickly) and closes shortly after the burst ends.
 const bootstrapSettle = 10 * time.Second
 
+// resumeSweepInterval is how often runServices sweeps suspended runs whose
+// resume_deadline has passed and cancels them with ReasonResumeTimeout (#95).
+const resumeSweepInterval = 1 * time.Minute
+
 // Run starts the daemon process. It blocks until the context is cancelled
 // (via signal) or a fatal error occurs. configPath is the path to
 // dicode.yaml; portOverride, when non-zero, is propagated to the
@@ -251,6 +255,13 @@ func setupRegistry(ctx context.Context, database db.DB, log *zap.Logger) *regist
 		}
 	} else {
 		log.Warn("sweep stale input pins failed", zap.Error(err))
+	}
+	// Cancel suspended runs whose resume deadline lapsed while the daemon was
+	// down (#95); the periodic sweep in runServices handles the steady state.
+	if swept, err := reg.SweepExpiredSuspensions(ctx, time.Now().UnixMilli()); err != nil {
+		log.Warn("resume-deadline sweep failed at startup", zap.Error(err))
+	} else if len(swept) > 0 {
+		log.Info("cancelled suspended runs past resume deadline at startup", zap.Strings("runs", swept))
 	}
 	return reg
 }
@@ -816,6 +827,26 @@ func runServices(ctx context.Context, rec *registry.Reconciler, eng *trigger.Eng
 			}
 		})
 	}
+	// Resume-deadline sweep (#95): cancel suspended runs whose resume_deadline
+	// has passed, recording ReasonResumeTimeout. Runs on a ticker so a run that
+	// suspends and is never resumed doesn't linger indefinitely.
+	g.Go(func() error {
+		ticker := time.NewTicker(resumeSweepInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-ticker.C:
+				swept, err := reg.SweepExpiredSuspensions(ctx, time.Now().UnixMilli())
+				if err != nil {
+					log.Warn("resume-deadline sweep failed", zap.Error(err))
+				} else if len(swept) > 0 {
+					log.Info("cancelled suspended runs past resume deadline", zap.Strings("runs", swept))
+				}
+			}
+		}
+	})
 	g.Go(func() error { return rec.Run(ctx) })
 	g.Go(func() error { return eng.Start(ctx) })
 	g.Go(func() error { return srv.Start(ctx) })

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -25,6 +25,12 @@ type DB interface {
 	// Exec executes a statement that returns no rows.
 	Exec(ctx context.Context, query string, args ...any) error
 
+	// ExecResult executes a statement and reports the number of rows it
+	// affected. Use it when a conditional write's row count is load-bearing
+	// (e.g. a single-shot guarded UPDATE whose success must not depend on the
+	// connection-pool size).
+	ExecResult(ctx context.Context, query string, args ...any) (int64, error)
+
 	// Query executes a query and returns rows via the callback.
 	Query(ctx context.Context, query string, args []any, scan func(rows Scanner) error) error
 

--- a/pkg/db/sqlite.go
+++ b/pkg/db/sqlite.go
@@ -325,6 +325,14 @@ func (s *SQLiteDB) Exec(ctx context.Context, query string, args ...any) error {
 	return err
 }
 
+func (s *SQLiteDB) ExecResult(ctx context.Context, query string, args ...any) (int64, error) {
+	res, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
 func (s *SQLiteDB) Query(ctx context.Context, query string, args []any, scan func(rows Scanner) error) error {
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -363,6 +371,14 @@ func (t *sqliteTx) Close() error                 { return nil }
 func (t *sqliteTx) Exec(ctx context.Context, query string, args ...any) error {
 	_, err := t.tx.ExecContext(ctx, query, args...)
 	return err
+}
+
+func (t *sqliteTx) ExecResult(ctx context.Context, query string, args ...any) (int64, error) {
+	res, err := t.tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
 }
 
 func (t *sqliteTx) Query(ctx context.Context, query string, args []any, scan func(rows Scanner) error) error {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -18,17 +18,30 @@ import (
 // ErrRunNotFound is returned by GetRun when no run record exists for the given ID.
 var ErrRunNotFound = errors.New("run not found")
 
-// RunStatus values. success/failure/cancelled are terminal; running and
+// ErrRunNotSuspended is returned by MarkRunResumed when the target run is not
+// in the suspended state — the single-use guard that makes a resume token
+// non-replayable (a second resume of the same run finds it already resumed).
+var ErrRunNotSuspended = errors.New("run not suspended")
+
+// RunStatus values. success/failure/cancelled/resumed are terminal; running and
 // suspended are not. A suspended run has paused awaiting user input — it is
 // neither in-flight (not "running", so CleanupStaleRuns leaves it alone) nor
 // finished (finished_at stays NULL until it resumes or its deadline expires).
+// A suspended run transitions to resumed exactly once, when its token is
+// consumed to spawn the continuation run — after which the token can't be
+// replayed.
 const (
 	StatusRunning   = "running"
 	StatusSuccess   = "success"
 	StatusFailure   = "failure"
 	StatusCancelled = "cancelled"
 	StatusSuspended = "suspended"
+	StatusResumed   = "resumed"
 )
+
+// ReasonResumeTimeout is the fail_reason recorded when the deadline sweep
+// cancels a suspended run whose resume_deadline has passed.
+const ReasonResumeTimeout = "resume_timeout"
 
 // Run kind values for the runs.kind column. These are the lowercase run-row
 // discriminators — distinct from pkg/task's task-kind strings ("Task" /

--- a/pkg/registry/resume.go
+++ b/pkg/registry/resume.go
@@ -38,41 +38,45 @@ func (r *Registry) GetRunByResumeToken(ctx context.Context, token string) (*Run,
 }
 
 // MarkRunResumed transitions a suspended run to the terminal `resumed` state,
-// consuming its resume token so it can't be replayed. The suspended→resumed
-// UPDATE and the current-status check run in one transaction, so two concurrent
-// resumes of the same token race to a single winner: the loser sees the row
-// already resumed and gets ErrRunNotSuspended. Returns ErrRunNotSuspended when
-// the run isn't currently suspended (already resumed, cancelled, or never
-// suspended).
+// consuming its resume token so it can't be replayed. The transition is a
+// single conditional UPDATE gated on the current status; RowsAffected decides
+// the outcome, so exactly one of two concurrent resumes of the same token wins
+// (the loser changes 0 rows and gets ErrRunNotSuspended). This is atomic and
+// correct regardless of the connection-pool size — no SELECT-then-UPDATE window.
+// Returns ErrRunNotSuspended when the run isn't currently suspended (already
+// resumed, cancelled, or never suspended) and ErrRunNotFound when no such run
+// exists.
 func (r *Registry) MarkRunResumed(ctx context.Context, runID string) error {
 	now := time.Now().UnixMilli()
-	return r.db.Tx(ctx, func(tx db.DB) error {
-		var status string
-		var found bool
-		if err := tx.Query(ctx,
-			`SELECT status FROM runs WHERE id = ?`,
-			[]any{runID},
-			func(rows db.Scanner) error {
-				if rows.Next() {
-					found = true
-					return rows.Scan(&status)
-				}
-				return nil
-			},
-		); err != nil {
-			return fmt.Errorf("read run status: %w", err)
-		}
-		if !found {
-			return ErrRunNotFound
-		}
-		if status != StatusSuspended {
-			return ErrRunNotSuspended
-		}
-		return tx.Exec(ctx,
-			`UPDATE runs SET status = ?, finished_at = ? WHERE id = ?`,
-			StatusResumed, now, runID,
-		)
-	})
+	affected, err := r.db.ExecResult(ctx,
+		`UPDATE runs SET status = ?, finished_at = ? WHERE id = ? AND status = ?`,
+		StatusResumed, now, runID, StatusSuspended,
+	)
+	if err != nil {
+		return fmt.Errorf("mark run resumed: %w", err)
+	}
+	if affected > 0 {
+		return nil
+	}
+	// The guarded UPDATE changed nothing: the run isn't suspended. Distinguish
+	// "no such run" from "present but not suspended" for a precise error — this
+	// is diagnostic only; the single-use guard was already enforced atomically
+	// by the conditional UPDATE above.
+	var exists bool
+	if err := r.db.Query(ctx,
+		`SELECT 1 FROM runs WHERE id = ?`,
+		[]any{runID},
+		func(rows db.Scanner) error {
+			exists = rows.Next()
+			return nil
+		},
+	); err != nil {
+		return fmt.Errorf("check run exists: %w", err)
+	}
+	if !exists {
+		return ErrRunNotFound
+	}
+	return ErrRunNotSuspended
 }
 
 // SweepExpiredSuspensions cancels every suspended run whose resume_deadline has

--- a/pkg/registry/resume.go
+++ b/pkg/registry/resume.go
@@ -1,0 +1,118 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+)
+
+// GetRunByResumeToken fetches the run holding the given resume token. Returns
+// ErrRunNotFound when no run carries the token. A token is unique per suspend
+// (minted from crypto/rand by the engine), so at most one row matches.
+func (r *Registry) GetRunByResumeToken(ctx context.Context, token string) (*Run, error) {
+	if token == "" {
+		return nil, ErrRunNotFound
+	}
+	var run *Run
+	err := r.db.Query(ctx,
+		`SELECT `+runColumns+runInputColumns+runResumeColumns+` FROM runs WHERE resume_token = ?`,
+		[]any{token},
+		func(rows db.Scanner) error {
+			if rows.Next() {
+				var scanErr error
+				run, scanErr = scanRun(rows, true, true)
+				return scanErr
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get run by resume token: %w", err)
+	}
+	if run == nil {
+		return nil, ErrRunNotFound
+	}
+	return run, nil
+}
+
+// MarkRunResumed transitions a suspended run to the terminal `resumed` state,
+// consuming its resume token so it can't be replayed. The suspended→resumed
+// UPDATE and the current-status check run in one transaction, so two concurrent
+// resumes of the same token race to a single winner: the loser sees the row
+// already resumed and gets ErrRunNotSuspended. Returns ErrRunNotSuspended when
+// the run isn't currently suspended (already resumed, cancelled, or never
+// suspended).
+func (r *Registry) MarkRunResumed(ctx context.Context, runID string) error {
+	now := time.Now().UnixMilli()
+	return r.db.Tx(ctx, func(tx db.DB) error {
+		var status string
+		var found bool
+		if err := tx.Query(ctx,
+			`SELECT status FROM runs WHERE id = ?`,
+			[]any{runID},
+			func(rows db.Scanner) error {
+				if rows.Next() {
+					found = true
+					return rows.Scan(&status)
+				}
+				return nil
+			},
+		); err != nil {
+			return fmt.Errorf("read run status: %w", err)
+		}
+		if !found {
+			return ErrRunNotFound
+		}
+		if status != StatusSuspended {
+			return ErrRunNotSuspended
+		}
+		return tx.Exec(ctx,
+			`UPDATE runs SET status = ?, finished_at = ? WHERE id = ?`,
+			StatusResumed, now, runID,
+		)
+	})
+}
+
+// SweepExpiredSuspensions cancels every suspended run whose resume_deadline has
+// passed (relative to nowMs), recording ReasonResumeTimeout as the fail_reason
+// and stamping finished_at. Rows with no deadline (resume_deadline NULL/0) are
+// left untouched. Returns the IDs of the runs it cancelled.
+//
+// The SELECT and UPDATE run in one transaction so a run that resumes between the
+// two statements (flipping to `resumed`) is not erroneously cancelled.
+func (r *Registry) SweepExpiredSuspensions(ctx context.Context, nowMs int64) ([]string, error) {
+	var expired []string
+	err := r.db.Tx(ctx, func(tx db.DB) error {
+		expired = nil // reset on retry
+		if err := tx.Query(ctx,
+			`SELECT id FROM runs WHERE status = ? AND resume_deadline IS NOT NULL AND resume_deadline > 0 AND resume_deadline < ?`,
+			[]any{StatusSuspended, nowMs},
+			func(rows db.Scanner) error {
+				for rows.Next() {
+					var id string
+					if err := rows.Scan(&id); err != nil {
+						return err
+					}
+					expired = append(expired, id)
+				}
+				return nil
+			},
+		); err != nil {
+			return fmt.Errorf("query expired suspensions: %w", err)
+		}
+		if len(expired) == 0 {
+			return nil
+		}
+		return tx.Exec(ctx,
+			`UPDATE runs SET status = ?, finished_at = ?, fail_reason = ?
+			 WHERE status = ? AND resume_deadline IS NOT NULL AND resume_deadline > 0 AND resume_deadline < ?`,
+			StatusCancelled, nowMs, ReasonResumeTimeout, StatusSuspended, nowMs,
+		)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return expired, nil
+}

--- a/pkg/registry/resume_test.go
+++ b/pkg/registry/resume_test.go
@@ -1,0 +1,128 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+)
+
+func newResumeTestReg(t *testing.T) *Registry {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return New(d)
+}
+
+// seedSuspendedRun creates a run and suspends it with the given token/deadline.
+func seedSuspendedRun(t *testing.T, r *Registry, runID, token string, deadline int64) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := r.StartRunWithID(ctx, runID, "task-x", "", string(TriggerManual), RunKindTask); err != nil {
+		t.Fatalf("StartRunWithID: %v", err)
+	}
+	if err := r.SuspendRun(ctx, runID, []byte(`{"step":1}`), []byte(`{"fields":[]}`), token, time.Now().UnixMilli(), deadline); err != nil {
+		t.Fatalf("SuspendRun: %v", err)
+	}
+}
+
+func TestGetRunByResumeToken(t *testing.T) {
+	r := newResumeTestReg(t)
+	ctx := context.Background()
+	seedSuspendedRun(t, r, "run-1", "tok-abc", 0)
+
+	run, err := r.GetRunByResumeToken(ctx, "tok-abc")
+	if err != nil {
+		t.Fatalf("GetRunByResumeToken: %v", err)
+	}
+	if run.ID != "run-1" {
+		t.Errorf("run ID = %q, want run-1", run.ID)
+	}
+	if run.Status != StatusSuspended {
+		t.Errorf("status = %q, want suspended", run.Status)
+	}
+	if string(run.ResumeState) != `{"step":1}` {
+		t.Errorf("resume state = %q", run.ResumeState)
+	}
+
+	if _, err := r.GetRunByResumeToken(ctx, "nope"); !errors.Is(err, ErrRunNotFound) {
+		t.Errorf("unknown token err = %v, want ErrRunNotFound", err)
+	}
+	if _, err := r.GetRunByResumeToken(ctx, ""); !errors.Is(err, ErrRunNotFound) {
+		t.Errorf("empty token err = %v, want ErrRunNotFound", err)
+	}
+}
+
+func TestMarkRunResumed_SingleUse(t *testing.T) {
+	r := newResumeTestReg(t)
+	ctx := context.Background()
+	seedSuspendedRun(t, r, "run-2", "tok-2", 0)
+
+	if err := r.MarkRunResumed(ctx, "run-2"); err != nil {
+		t.Fatalf("MarkRunResumed: %v", err)
+	}
+	run, err := r.GetRun(ctx, "run-2")
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if run.Status != StatusResumed {
+		t.Errorf("status = %q, want resumed", run.Status)
+	}
+	if run.FinishedAt == nil {
+		t.Error("resumed run should have finished_at set")
+	}
+
+	// Second attempt must fail — the token is single-use.
+	if err := r.MarkRunResumed(ctx, "run-2"); !errors.Is(err, ErrRunNotSuspended) {
+		t.Errorf("second MarkRunResumed err = %v, want ErrRunNotSuspended", err)
+	}
+}
+
+func TestMarkRunResumed_NotFound(t *testing.T) {
+	r := newResumeTestReg(t)
+	if err := r.MarkRunResumed(context.Background(), "ghost"); !errors.Is(err, ErrRunNotFound) {
+		t.Errorf("err = %v, want ErrRunNotFound", err)
+	}
+}
+
+func TestSweepExpiredSuspensions(t *testing.T) {
+	r := newResumeTestReg(t)
+	ctx := context.Background()
+	now := time.Now().UnixMilli()
+
+	seedSuspendedRun(t, r, "expired", "tok-e", now-1000)     // deadline in the past
+	seedSuspendedRun(t, r, "future", "tok-f", now+1_000_000) // deadline in the future
+	seedSuspendedRun(t, r, "nodeadline", "tok-n", 0)         // no deadline
+
+	swept, err := r.SweepExpiredSuspensions(ctx, now)
+	if err != nil {
+		t.Fatalf("SweepExpiredSuspensions: %v", err)
+	}
+	if len(swept) != 1 || swept[0] != "expired" {
+		t.Fatalf("swept = %v, want [expired]", swept)
+	}
+
+	expired, _ := r.GetRun(ctx, "expired")
+	if expired.Status != StatusCancelled {
+		t.Errorf("expired status = %q, want cancelled", expired.Status)
+	}
+	if expired.FailureReason != ReasonResumeTimeout {
+		t.Errorf("expired fail_reason = %q, want %q", expired.FailureReason, ReasonResumeTimeout)
+	}
+	if expired.FinishedAt == nil {
+		t.Error("swept run should have finished_at set")
+	}
+
+	// Untouched rows stay suspended.
+	for _, id := range []string{"future", "nodeadline"} {
+		run, _ := r.GetRun(ctx, id)
+		if run.Status != StatusSuspended {
+			t.Errorf("%s status = %q, want suspended", id, run.Status)
+		}
+	}
+}

--- a/pkg/registry/trigger_source.go
+++ b/pkg/registry/trigger_source.go
@@ -18,6 +18,9 @@ const (
 	TriggerCronCatchup TriggerSource = "cron-catchup"
 	TriggerProvider    TriggerSource = "provider"
 	TriggerIfMissing   TriggerSource = "if_missing"
+	// TriggerResume marks the continuation run spawned when a suspended run is
+	// resumed (#95). Its parent_run_id points at the original suspended run.
+	TriggerResume TriggerSource = "resume"
 	// TriggerPipelineStage marks a run fired as a stage of a kind: PipelineTask.
 	// The WebUI groups pipeline stage runs under their parent pipeline run.
 	TriggerPipelineStage TriggerSource = "pipeline-stage"

--- a/pkg/trigger/daemon.go
+++ b/pkg/trigger/daemon.go
@@ -124,6 +124,15 @@ func (e *Engine) onDaemonRunFinished(spec *task.Spec, runID string) {
 		e.log.Error("daemon: failed to get run status", zap.String("run", runID), zap.Error(err))
 		return
 	}
+	// A suspended run is non-terminal (#95): the subprocess exited to await
+	// user input, not because the daemon crashed or stopped. Treat it as a
+	// neutral outcome — don't count it as a crash-loop exit, don't reset the
+	// counter, and don't schedule a restart. The daemon state is unchanged;
+	// the continuation run drives the next lifecycle transition on resume.
+	if run.Status == registry.StatusSuspended {
+		return
+	}
+
 	// Elapsed run time, shared by the crash-loop tracker and the restart
 	// backoff below. run.StartedAt is always set by startRun; run.FinishedAt
 	// may be nil on abnormal exit — treat that as an instant crash so the

--- a/pkg/trigger/resume.go
+++ b/pkg/trigger/resume.go
@@ -1,0 +1,119 @@
+package trigger
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+	"go.uber.org/zap"
+)
+
+// defaultResumeTTL is how long a suspended run stays resumable when the task
+// did not specify its own deadline. After it, the sweep cancels the run with
+// ReasonResumeTimeout.
+const defaultResumeTTL = 24 * time.Hour
+
+// Resume errors surfaced to callers (webui/CLI in later PRs).
+var (
+	// ErrResumeTokenNotFound is returned when no suspended run carries the token.
+	ErrResumeTokenNotFound = errors.New("resume token not found")
+	// ErrResumeNotSuspended is returned when the token's run is no longer
+	// suspended — already resumed (single-use token replayed), cancelled, or
+	// finished.
+	ErrResumeNotSuspended = errors.New("run is not suspended")
+	// ErrResumeExpired is returned when the run's resume_deadline has passed.
+	// The run is swept to cancelled/resume_timeout as a side effect.
+	ErrResumeExpired = errors.New("resume deadline expired")
+)
+
+// suspendRun persists a run that called dicode.suspend() as suspended: it mints
+// an unguessable single-use resume token and records the state/form blobs plus
+// the deadline. The deadline comes from the task (result.ResumeDeadline) or
+// defaults to defaultResumeTTL from now.
+func (e *Engine) suspendRun(runID string, result *pkgruntime.RunResult) error {
+	token, err := newResumeToken()
+	if err != nil {
+		return fmt.Errorf("mint resume token: %w", err)
+	}
+	nowMs := time.Now().UnixMilli()
+	deadlineMs := result.ResumeDeadline
+	if deadlineMs <= 0 {
+		deadlineMs = time.Now().Add(defaultResumeTTL).UnixMilli()
+	}
+	return e.registry.SuspendRun(context.Background(), runID,
+		result.ResumeState, result.ResumeForm, token, nowMs, deadlineMs)
+}
+
+// newResumeToken returns a 32-byte crypto/rand token, hex-encoded. Long and
+// unpredictable enough to serve as the resume authorization handle.
+func newResumeToken() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// ResumeRun consumes a resume token and spawns the continuation run for a
+// suspended task. It looks the run up by token, rejects it if not found, not
+// suspended, or past its deadline (an expired run is swept to
+// cancelled/resume_timeout), marks the original run resumed so the token can't
+// be replayed, then fires a fresh run of the same task seeded with the stored
+// resume state and the caller's input. The continuation runs the normal
+// execution path, so a task that suspends again mints its own token — chaining
+// multi-step wizards. Returns the continuation run's ID.
+func (e *Engine) ResumeRun(ctx context.Context, token string, input []byte) (string, error) {
+	run, err := e.registry.GetRunByResumeToken(ctx, token)
+	if err != nil {
+		if errors.Is(err, registry.ErrRunNotFound) {
+			return "", ErrResumeTokenNotFound
+		}
+		return "", err
+	}
+	if run.Status != registry.StatusSuspended {
+		return "", ErrResumeNotSuspended
+	}
+	if run.ResumeDeadline > 0 && time.Now().UnixMilli() > run.ResumeDeadline {
+		// Expired: sweep it now so its terminal state reflects the timeout even
+		// if the periodic sweep hasn't run yet, then reject.
+		if _, serr := e.registry.SweepExpiredSuspensions(ctx, time.Now().UnixMilli()); serr != nil {
+			e.log.Warn("resume: sweep expired suspension failed",
+				zap.String("run", run.ID), zap.Error(serr))
+		}
+		return "", ErrResumeExpired
+	}
+
+	// Consume the token atomically. This is the single-use guard: a second
+	// ResumeRun for the same token finds the run already resumed and fails.
+	if err := e.registry.MarkRunResumed(ctx, run.ID); err != nil {
+		if errors.Is(err, registry.ErrRunNotSuspended) {
+			return "", ErrResumeNotSuspended
+		}
+		return "", fmt.Errorf("mark run resumed: %w", err)
+	}
+
+	spec, ok := e.registry.Get(run.TaskID)
+	if !ok {
+		return "", fmt.Errorf("resume: task %q is no longer registered", run.TaskID)
+	}
+
+	newRunID, err := e.fireAsync(context.Background(), spec, pkgruntime.RunOptions{
+		ParentRunID: run.ID,
+		ResumeState: run.ResumeState,
+		ResumeInput: input,
+	}, registry.TriggerResume)
+	if err != nil {
+		return "", fmt.Errorf("resume: spawn continuation run: %w", err)
+	}
+	e.log.Info("run resumed",
+		zap.String("task", run.TaskID),
+		zap.String("suspended_run", run.ID),
+		zap.String("continuation_run", newRunID),
+	)
+	return newRunID, nil
+}

--- a/pkg/trigger/resume.go
+++ b/pkg/trigger/resume.go
@@ -88,6 +88,15 @@ func (e *Engine) ResumeRun(ctx context.Context, token string, input []byte) (str
 		return "", ErrResumeExpired
 	}
 
+	// Resolve the task BEFORE consuming the token. If it was deregistered or
+	// reloaded away between suspend and resume, fail without spending the
+	// single-use token or flipping the run out of `suspended` — the suspension
+	// stays resumable once the task is back.
+	spec, ok := e.registry.Get(run.TaskID)
+	if !ok {
+		return "", fmt.Errorf("resume: task %q is no longer registered", run.TaskID)
+	}
+
 	// Consume the token atomically. This is the single-use guard: a second
 	// ResumeRun for the same token finds the run already resumed and fails.
 	if err := e.registry.MarkRunResumed(ctx, run.ID); err != nil {
@@ -95,11 +104,6 @@ func (e *Engine) ResumeRun(ctx context.Context, token string, input []byte) (str
 			return "", ErrResumeNotSuspended
 		}
 		return "", fmt.Errorf("mark run resumed: %w", err)
-	}
-
-	spec, ok := e.registry.Get(run.TaskID)
-	if !ok {
-		return "", fmt.Errorf("resume: task %q is no longer registered", run.TaskID)
 	}
 
 	newRunID, err := e.fireAsync(context.Background(), spec, pkgruntime.RunOptions{

--- a/pkg/trigger/resume_test.go
+++ b/pkg/trigger/resume_test.go
@@ -1,0 +1,289 @@
+package trigger
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
+)
+
+// suspendExec is a fake Executor that suspends on a first (non-resume) run and,
+// on a resume run, records the seeded state/input and either succeeds or (when
+// suspendAgain is set) suspends again to model a multi-step wizard.
+type suspendExec struct {
+	mu sync.Mutex
+
+	// firstDeadline is the ResumeDeadline stamped on the initial suspend result
+	// (0 = let the engine apply its 24h default).
+	firstDeadline int64
+	suspendAgain  bool
+
+	resumeCalls     int
+	seenResumeState []byte
+	seenResumeInput []byte
+}
+
+func (s *suspendExec) Execute(_ context.Context, _ *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if opts.ResumeState == nil {
+		return &pkgruntime.RunResult{
+			RunID:          opts.RunID,
+			Suspended:      true,
+			ResumeState:    []byte(`{"step":"ask_name"}`),
+			ResumeForm:     []byte(`{"fields":[{"name":"project_name"}]}`),
+			ResumeDeadline: s.firstDeadline,
+		}, nil
+	}
+	s.resumeCalls++
+	s.seenResumeState = append([]byte(nil), opts.ResumeState...)
+	s.seenResumeInput = append([]byte(nil), opts.ResumeInput...)
+	if s.suspendAgain {
+		return &pkgruntime.RunResult{
+			RunID:       opts.RunID,
+			Suspended:   true,
+			ResumeState: []byte(`{"step":"ask_framework"}`),
+			ResumeForm:  []byte(`{"fields":[{"name":"framework"}]}`),
+		}, nil
+	}
+	return &pkgruntime.RunResult{RunID: opts.RunID, ReturnValue: "wizard-done"}, nil
+}
+
+func newSuspendEnv(t *testing.T, exec pkgruntime.Executor) (*Engine, *registry.Registry) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+	eng := New(reg, exec, zap.NewNop())
+	return eng, reg
+}
+
+func waitStatus(t *testing.T, reg *registry.Registry, runID, want string) *registry.Run {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		run, err := reg.GetRun(context.Background(), runID)
+		if err != nil {
+			t.Fatalf("GetRun: %v", err)
+		}
+		if run.Status == want {
+			return run
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	run, _ := reg.GetRun(context.Background(), runID)
+	t.Fatalf("run %s status = %q, want %q", runID, run.Status, want)
+	return nil
+}
+
+func TestSuspend_PersistsRunWithTokenAndDeadline_NoChain(t *testing.T) {
+	eng, reg := newSuspendEnv(t, &suspendExec{})
+
+	specA := &task.Spec{ID: "wiz", Name: "wiz", Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}, Enabled: true}
+	specB := &task.Spec{ID: "after", Name: "after", Runtime: task.RuntimeDeno, Enabled: true,
+		Trigger: task.TriggerConfig{Chain: &task.ChainTrigger{From: "wiz", On: "success"}}}
+	if err := reg.Register(specA); err != nil {
+		t.Fatalf("register A: %v", err)
+	}
+	if err := reg.Register(specB); err != nil {
+		t.Fatalf("register B: %v", err)
+	}
+	eng.Register(specB) // arm the chain
+
+	before := time.Now().Add(23 * time.Hour).UnixMilli()
+	runID, err := eng.FireManual(context.Background(), "wiz", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+
+	run := waitStatus(t, reg, runID, registry.StatusSuspended)
+	if run.ResumeToken == "" {
+		t.Error("suspended run has no resume token")
+	}
+	if len(run.ResumeToken) != 64 {
+		t.Errorf("resume token length = %d, want 64 hex chars", len(run.ResumeToken))
+	}
+	if run.ResumeDeadline < before {
+		t.Errorf("resume deadline %d not defaulted to ~24h from now", run.ResumeDeadline)
+	}
+	if string(run.ResumeState) != `{"step":"ask_name"}` {
+		t.Errorf("resume state = %q", run.ResumeState)
+	}
+	if run.FinishedAt != nil {
+		t.Error("suspended run must not have finished_at set")
+	}
+
+	// The success chain must NOT fire for a suspended (non-terminal) run.
+	time.Sleep(200 * time.Millisecond)
+	if runs, _ := reg.ListRuns(context.Background(), "after", 5); len(runs) != 0 {
+		t.Errorf("success chain fired for suspended run: %d runs", len(runs))
+	}
+}
+
+func TestResumeRun_SeedsContinuationAndConsumesToken(t *testing.T) {
+	exec := &suspendExec{}
+	eng, reg := newSuspendEnv(t, exec)
+
+	spec := &task.Spec{ID: "wiz", Name: "wiz", Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}, Enabled: true}
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	origID, err := eng.FireManual(context.Background(), "wiz", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	orig := waitStatus(t, reg, origID, registry.StatusSuspended)
+
+	input := []byte(`{"project_name":"acme"}`)
+	newID, err := eng.ResumeRun(context.Background(), orig.ResumeToken, input)
+	if err != nil {
+		t.Fatalf("ResumeRun: %v", err)
+	}
+	if newID == origID {
+		t.Fatal("continuation run must have a fresh ID")
+	}
+
+	cont := waitStatus(t, reg, newID, registry.StatusSuccess)
+	if cont.ParentRunID != origID {
+		t.Errorf("continuation parent = %q, want %q", cont.ParentRunID, origID)
+	}
+	if cont.TriggerSource != registry.TriggerResume {
+		t.Errorf("continuation trigger = %q, want resume", cont.TriggerSource)
+	}
+
+	// Original run consumed → resumed (terminal).
+	after, _ := reg.GetRun(context.Background(), origID)
+	if after.Status != registry.StatusResumed {
+		t.Errorf("original status = %q, want resumed", after.Status)
+	}
+
+	// Continuation was seeded with the stored state and the caller's input.
+	exec.mu.Lock()
+	defer exec.mu.Unlock()
+	if string(exec.seenResumeState) != `{"step":"ask_name"}` {
+		t.Errorf("continuation resume_state = %q", exec.seenResumeState)
+	}
+	if string(exec.seenResumeInput) != string(input) {
+		t.Errorf("continuation resume_input = %q, want %q", exec.seenResumeInput, input)
+	}
+}
+
+func TestResumeRun_TokenIsSingleUse(t *testing.T) {
+	eng, reg := newSuspendEnv(t, &suspendExec{})
+	spec := &task.Spec{ID: "wiz", Name: "wiz", Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}, Enabled: true}
+	_ = reg.Register(spec)
+
+	origID, err := eng.FireManual(context.Background(), "wiz", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	orig := waitStatus(t, reg, origID, registry.StatusSuspended)
+
+	if _, err := eng.ResumeRun(context.Background(), orig.ResumeToken, nil); err != nil {
+		t.Fatalf("first ResumeRun: %v", err)
+	}
+	// Replay of the same token must be rejected.
+	if _, err := eng.ResumeRun(context.Background(), orig.ResumeToken, nil); !errors.Is(err, ErrResumeNotSuspended) {
+		t.Errorf("second ResumeRun err = %v, want ErrResumeNotSuspended", err)
+	}
+}
+
+func TestResumeRun_ExpiredTokenRejectedAndSwept(t *testing.T) {
+	// Suspend with a deadline already in the past.
+	eng, reg := newSuspendEnv(t, &suspendExec{firstDeadline: time.Now().Add(-time.Hour).UnixMilli()})
+	spec := &task.Spec{ID: "wiz", Name: "wiz", Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}, Enabled: true}
+	_ = reg.Register(spec)
+
+	origID, err := eng.FireManual(context.Background(), "wiz", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	orig := waitStatus(t, reg, origID, registry.StatusSuspended)
+
+	if _, err := eng.ResumeRun(context.Background(), orig.ResumeToken, nil); !errors.Is(err, ErrResumeExpired) {
+		t.Errorf("ResumeRun err = %v, want ErrResumeExpired", err)
+	}
+	// The expired run is swept to cancelled/resume_timeout as a side effect.
+	after, _ := reg.GetRun(context.Background(), origID)
+	if after.Status != registry.StatusCancelled {
+		t.Errorf("expired run status = %q, want cancelled", after.Status)
+	}
+	if after.FailureReason != registry.ReasonResumeTimeout {
+		t.Errorf("expired run reason = %q, want %q", after.FailureReason, registry.ReasonResumeTimeout)
+	}
+}
+
+func TestResumeRun_UnknownToken(t *testing.T) {
+	eng, _ := newSuspendEnv(t, &suspendExec{})
+	if _, err := eng.ResumeRun(context.Background(), "does-not-exist", nil); !errors.Is(err, ErrResumeTokenNotFound) {
+		t.Errorf("err = %v, want ErrResumeTokenNotFound", err)
+	}
+}
+
+func TestResumeRun_MultiStepWizardChains(t *testing.T) {
+	// The continuation suspends again, minting its own fresh token.
+	exec := &suspendExec{suspendAgain: true}
+	eng, reg := newSuspendEnv(t, exec)
+	spec := &task.Spec{ID: "wiz", Name: "wiz", Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}, Enabled: true}
+	_ = reg.Register(spec)
+
+	origID, _ := eng.FireManual(context.Background(), "wiz", nil)
+	orig := waitStatus(t, reg, origID, registry.StatusSuspended)
+
+	newID, err := eng.ResumeRun(context.Background(), orig.ResumeToken, []byte(`{"project_name":"acme"}`))
+	if err != nil {
+		t.Fatalf("ResumeRun: %v", err)
+	}
+	// Step 2 run suspends again with a distinct token.
+	step2 := waitStatus(t, reg, newID, registry.StatusSuspended)
+	if step2.ResumeToken == "" || step2.ResumeToken == orig.ResumeToken {
+		t.Errorf("step2 token %q must be fresh (orig %q)", step2.ResumeToken, orig.ResumeToken)
+	}
+}
+
+// TestSuspendedDaemonRun_NeutralForCrashloop verifies a daemon body that
+// suspends is a neutral outcome: it does not flip the daemon to crashed/stopped
+// and does not count as a crash-loop exit.
+func TestSuspendedDaemonRun_NeutralForCrashloop(t *testing.T) {
+	eng, reg := newSuspendEnv(t, &suspendExec{})
+	spec := &task.Spec{ID: "wiz-daemon", Name: "wiz-daemon", Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Daemon: true, Restart: "never"}, Enabled: true}
+
+	// Seed a suspended run row for the daemon.
+	ctx := context.Background()
+	runID := "daemon-run-1"
+	if _, err := reg.StartRunWithID(ctx, runID, spec.ID, "", string(registry.TriggerDaemon), registry.RunKindTask); err != nil {
+		t.Fatalf("StartRunWithID: %v", err)
+	}
+	if err := reg.SuspendRun(ctx, runID, []byte(`{}`), nil, "tok-daemon", time.Now().UnixMilli(), 0); err != nil {
+		t.Fatalf("SuspendRun: %v", err)
+	}
+
+	eng.daemonMu.Lock()
+	eng.daemonSpecs[spec.ID] = spec
+	eng.daemonRuns[spec.ID] = runID
+	eng.daemonMu.Unlock()
+	eng.setDaemonState(spec.ID, DaemonRunning)
+
+	eng.onDaemonRunFinished(spec, runID)
+
+	// With restart=never, a non-suspended non-success exit would flip state to
+	// DaemonCrashed. A suspended run must leave the state untouched.
+	if got := eng.daemonStates.get(spec.ID); got != DaemonRunning {
+		t.Errorf("daemon state = %q, want running (suspended is neutral)", got)
+	}
+	if eng.IsCrashLooping(spec.ID) {
+		t.Error("suspended daemon run must not count toward crash-loop")
+	}
+}

--- a/pkg/trigger/resume_test.go
+++ b/pkg/trigger/resume_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -221,6 +222,99 @@ func TestResumeRun_ExpiredTokenRejectedAndSwept(t *testing.T) {
 	}
 	if after.FailureReason != registry.ReasonResumeTimeout {
 		t.Errorf("expired run reason = %q, want %q", after.FailureReason, registry.ReasonResumeTimeout)
+	}
+}
+
+func TestResumeRun_DeregisteredTaskKeepsSuspensionResumable(t *testing.T) {
+	exec := &suspendExec{}
+	eng, reg := newSuspendEnv(t, exec)
+	spec := &task.Spec{ID: "wiz", Name: "wiz", Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}, Enabled: true}
+	_ = reg.Register(spec)
+
+	origID, err := eng.FireManual(context.Background(), "wiz", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	orig := waitStatus(t, reg, origID, registry.StatusSuspended)
+
+	// Task disappears (deregistered / reloaded away) before the user resumes.
+	reg.Unregister("wiz")
+
+	if _, err := eng.ResumeRun(context.Background(), orig.ResumeToken, nil); err == nil {
+		t.Fatal("expected error resuming a run whose task is gone")
+	}
+	// The token must NOT have been consumed: the run is still suspended and
+	// keeps its token, so it stays resumable once the task is back.
+	still, _ := reg.GetRun(context.Background(), origID)
+	if still.Status != registry.StatusSuspended {
+		t.Errorf("run status = %q, want suspended (token must not be consumed)", still.Status)
+	}
+	if still.ResumeToken != orig.ResumeToken {
+		t.Errorf("resume token changed/cleared: %q", still.ResumeToken)
+	}
+
+	// Once the task is re-registered, the same token still resumes.
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("re-register: %v", err)
+	}
+	newID, err := eng.ResumeRun(context.Background(), orig.ResumeToken, []byte(`{"project_name":"acme"}`))
+	if err != nil {
+		t.Fatalf("ResumeRun after re-register: %v", err)
+	}
+	cont := waitStatus(t, reg, newID, registry.StatusSuccess)
+	if cont.ParentRunID != origID {
+		t.Errorf("continuation parent = %q, want %q", cont.ParentRunID, origID)
+	}
+}
+
+func TestResumeRun_ConcurrentSingleWinner(t *testing.T) {
+	eng, reg := newSuspendEnv(t, &suspendExec{})
+	spec := &task.Spec{ID: "wiz", Name: "wiz", Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}, Enabled: true}
+	_ = reg.Register(spec)
+
+	origID, err := eng.FireManual(context.Background(), "wiz", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	orig := waitStatus(t, reg, origID, registry.StatusSuspended)
+
+	const racers = 8
+	var wg sync.WaitGroup
+	var winners, notSuspended int32
+	results := make(chan error, racers)
+	wg.Add(racers)
+	start := make(chan struct{})
+	for i := 0; i < racers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			_, rerr := eng.ResumeRun(context.Background(), orig.ResumeToken, nil)
+			results <- rerr
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	for rerr := range results {
+		switch {
+		case rerr == nil:
+			atomic.AddInt32(&winners, 1)
+		case errors.Is(rerr, ErrResumeNotSuspended):
+			atomic.AddInt32(&notSuspended, 1)
+		default:
+			t.Errorf("unexpected ResumeRun error: %v", rerr)
+		}
+	}
+	if winners != 1 {
+		t.Errorf("winners = %d, want exactly 1 continuation spawned", winners)
+	}
+	if notSuspended != racers-1 {
+		t.Errorf("ErrResumeNotSuspended count = %d, want %d", notSuspended, racers-1)
+	}
+
+	after, _ := reg.GetRun(context.Background(), origID)
+	if after.Status != registry.StatusResumed {
+		t.Errorf("original status = %q, want resumed", after.Status)
 	}
 }
 

--- a/pkg/trigger/run.go
+++ b/pkg/trigger/run.go
@@ -689,6 +689,21 @@ func (e *Engine) dispatch(ctx context.Context, spec *task.Spec, opts pkgruntime.
 		return registry.StatusFailure, &pkgruntime.RunResult{Error: err}
 	}
 
+	// dicode.suspend() paused the task (#95): persist the run as suspended with
+	// a fresh resume token and deadline instead of finishing it, and skip the
+	// chain — suspended is non-terminal, so success/failure chains must not
+	// fire until the continuation run reaches a real terminal state.
+	if result.Suspended {
+		if serr := e.suspendRun(opts.RunID, result); serr != nil {
+			e.log.Warn("suspend run persist failed", zap.String("run", opts.RunID), zap.Error(serr))
+			if ferr := e.registry.FinishRun(context.Background(), opts.RunID, registry.StatusFailure); ferr != nil {
+				e.log.Warn("FinishRun: suspend fallback", zap.String("run", opts.RunID), zap.Error(ferr))
+			}
+			return registry.StatusFailure, &pkgruntime.RunResult{Error: serr}
+		}
+		return registry.StatusSuspended, result
+	}
+
 	// Compute final status from the result.
 	status := registry.StatusSuccess
 	if result.Error != nil {


### PR DESCRIPTION
## Summary

Third PR in the suspendable-tasks stack (#95). PRs 1 and 2 gave the registry a `suspended` status with resume columns and made the Deno runtime return `RunResult{Suspended, ResumeState, ResumeForm, ResumeDeadline}`. This PR is the engine-side orchestration that turns a suspended result into a persisted, resumable run and drives the resume back into a fresh execution.

When `runtime.Execute` returns `Suspended`, the engine branches before the normal finish/chain path: it mints an unguessable resume token, computes a deadline, persists the run as `suspended`, and returns without firing success/failure chains. `ResumeRun` looks a run up by its token, rejects it if unknown, no longer suspended, or past its deadline, marks the original run terminal, and spawns a continuation run seeded with the stored state and the caller's input. Because the continuation runs the ordinary execution path, a task that suspends again simply mints its own token — which is how multi-step wizards chain.

### Design choices
- **Single-use token.** The token is 32 bytes of `crypto/rand`, hex-encoded — not a UUID. It is consumed by an atomic suspended→`resumed` transition in the registry (status-check and update in one transaction), so a replayed token and two concurrent resumes both resolve to a single winner; the loser gets a typed `ErrResumeNotSuspended`.
- **New terminal status `resumed`.** A suspended run moves to `resumed` exactly once, when its token is consumed. This keeps the token non-replayable and gives resume history a clean terminal marker distinct from success/failure/cancelled.
- **Continuation run, not in-place restart.** The resumed task runs as a fresh run linked to the original via `parent_run_id` (trigger source `resume`), preserving the one-shot execution model and giving each wizard step isolated run history.
- **Suspended is non-terminal / neutral.** A suspended run does not fire chains and — when the suspending body is a daemon — is treated as a neutral outcome: it does not count as a crash-loop exit and does not flip daemon state.
- **Deadline sweep.** A periodic sweep (plus a startup pass, mirroring `CleanupStaleRuns`) cancels suspended runs past `resume_deadline` with reason `resume_timeout`. An expired token encountered by `ResumeRun` is swept on the spot.

Resume entry point PR 4 (webui) will call: `Engine.ResumeRun(ctx context.Context, token string, input []byte) (newRunID string, err error)`, returning typed `ErrResumeTokenNotFound` / `ErrResumeNotSuspended` / `ErrResumeExpired`.

WebUI form rendering/submit (PR 4), Python parity (PR 5), and the `dicode resume` CLI (PR 6) are deliberately left to follow-ups; this PR adds only the internal engine/registry surface they will consume.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `gofmt -l .` — clean (no repo files listed)
- `go test ./... -timeout 180s` — pass
- `go test -race ./pkg/trigger/... ./pkg/registry/...` — pass (trigger 57.7s, registry 6.7s)

New tests cover: suspended result persists as `suspended` with a 64-hex token and defaulted 24h deadline while firing no success chain; `ResumeRun` seeds the continuation with stored state + input, links it via `parent_run_id`, and marks the original `resumed`; a replayed token is rejected (single-use); an expired token is rejected and swept to `cancelled`/`resume_timeout`; an unknown token is rejected; a multi-step wizard mints a fresh token on the second suspend; a suspended daemon body is neutral for crash-loop/daemon-state; and registry-level coverage of `GetRunByResumeToken`, single-use `MarkRunResumed`, and `SweepExpiredSuspensions`.

Part of #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pausing and later resuming runs with resume tokens.
  * Resumed runs now continue as a new follow-up run, preserving prior state and input.
  * Suspended runs can now expire automatically and be canceled after their resume window passes.

* **Bug Fixes**
  * Improved handling so suspended runs no longer trigger crash-loop or restart behavior.
  * Expired suspended runs are cleaned up both at startup and during normal operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->