### PR TITLE
feat(suspend): webui form-render + resume submit for suspended runs

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -710,6 +710,8 @@ func buildWebUI(ctx context.Context, cfg *config.Config, configPath, version, da
 	if replayer != nil {
 		srv.SetReplayer(replayer)
 	}
+	// The engine's ResumeRun backs the suspended-run resume endpoint (#95).
+	srv.SetResumer(eng)
 	return srv, nil
 }
 

--- a/pkg/webui/resume.go
+++ b/pkg/webui/resume.go
@@ -1,0 +1,137 @@
+package webui
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/trigger"
+	"github.com/go-chi/chi/v5"
+)
+
+// Resumer spawns the continuation run for a suspended run. The token is
+// resolved server-side from the run record — never supplied by the client —
+// so the continuation task is determined by stored state, not the request.
+// *trigger.Engine satisfies this via ResumeRun.
+type Resumer interface {
+	ResumeRun(ctx context.Context, token string, input []byte) (newRunID string, err error)
+}
+
+// SetResumer wires a Resumer for the POST /api/runs/{runID}/resume endpoint.
+// Pass nil to disable (the endpoint returns 503).
+func (s *Server) SetResumer(r Resumer) { s.resumer = r }
+
+// resumeFormSchema mirrors the FormSchema the task persisted via
+// dicode.suspend(); only the pieces needed for server-side required-field
+// validation are modelled. Unknown keys are ignored.
+type resumeFormSchema struct {
+	Fields []resumeFormField `json:"fields"`
+}
+
+type resumeFormField struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Required bool   `json:"required"`
+}
+
+// apiResumeRun submits a suspended run's form and spawns its continuation.
+// The session (or API key) is the authorization: the raw resume_token is
+// resolved from the stored run, never trusted from the client.
+//
+// Status codes:
+//   - 200 — resumed; body returns the continuation run_id.
+//   - 400 — malformed body OR a required form field is missing.
+//   - 404 — run not found OR its token no longer resolves.
+//   - 409 — run is not suspended (already resumed / finished — single-use guard).
+//   - 410 — resume deadline expired.
+//   - 500 — internal error.
+//   - 503 — resume not available (Resumer not wired).
+func (s *Server) apiResumeRun(w http.ResponseWriter, r *http.Request) {
+	runID := chi.URLParam(r, "runID")
+
+	if s.resumer == nil {
+		jsonErr(w, "resume not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	run, err := s.registry.GetRun(r.Context(), runID)
+	if err != nil {
+		jsonErr(w, "run not found: "+runID, http.StatusNotFound)
+		return
+	}
+	if run.Status != registry.StatusSuspended || run.ResumeToken == "" {
+		jsonErr(w, "run is not suspended", http.StatusConflict)
+		return
+	}
+
+	values := map[string]any{}
+	if r.Body != nil && r.ContentLength != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&values); err != nil && err != io.EOF {
+			jsonErr(w, "invalid JSON body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
+	if missing := firstMissingRequiredField(run.ResumeForm, values); missing != "" {
+		jsonErr(w, "missing required field: "+missing, http.StatusBadRequest)
+		return
+	}
+
+	// Collected values pass through as opaque JSON — the task reads them as
+	// ctx.resume_input.
+	input, err := json.Marshal(values)
+	if err != nil {
+		jsonErr(w, "encode input: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	newRunID, err := s.resumer.ResumeRun(r.Context(), run.ResumeToken, input)
+	if err != nil {
+		switch {
+		case errors.Is(err, trigger.ErrResumeTokenNotFound):
+			jsonErr(w, "resume token not found", http.StatusNotFound)
+		case errors.Is(err, trigger.ErrResumeNotSuspended):
+			jsonErr(w, "run already resumed", http.StatusConflict)
+		case errors.Is(err, trigger.ErrResumeExpired):
+			jsonErr(w, "resume deadline expired", http.StatusGone)
+		default:
+			jsonErr(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+	jsonOK(w, map[string]any{"run_id": newRunID})
+}
+
+// firstMissingRequiredField returns the name of the first required field in
+// the persisted form schema that has no usable value in the submission, or ""
+// if all required fields are satisfied. A boolean field counts as satisfied
+// once present (false is a valid answer); other types require a non-empty
+// value. A malformed/empty schema imposes no requirements.
+func firstMissingRequiredField(formJSON []byte, values map[string]any) string {
+	if len(formJSON) == 0 {
+		return ""
+	}
+	var schema resumeFormSchema
+	if err := json.Unmarshal(formJSON, &schema); err != nil {
+		return ""
+	}
+	for _, f := range schema.Fields {
+		if !f.Required {
+			continue
+		}
+		v, ok := values[f.Name]
+		if !ok || v == nil {
+			return f.Name
+		}
+		if f.Type == "boolean" {
+			continue
+		}
+		if s, isStr := v.(string); isStr && s == "" {
+			return f.Name
+		}
+	}
+	return ""
+}

--- a/pkg/webui/resume_test.go
+++ b/pkg/webui/resume_test.go
@@ -1,0 +1,228 @@
+package webui
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/config"
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/trigger"
+)
+
+// fakeResumer records the token/input it was called with and returns a
+// canned result — standing in for the real *trigger.Engine so handler tests
+// exercise the endpoint's parsing, validation, and error mapping in isolation.
+type fakeResumer struct {
+	gotToken string
+	gotInput []byte
+	calls    int
+	newRunID string
+	err      error
+}
+
+func (f *fakeResumer) ResumeRun(_ context.Context, token string, input []byte) (string, error) {
+	f.calls++
+	f.gotToken = token
+	f.gotInput = input
+	return f.newRunID, f.err
+}
+
+// seedSuspendedRun inserts a run and marks it suspended with the given form
+// and token, returning its run ID.
+func seedSuspendedRun(t *testing.T, reg *registry.Registry, form []byte, token string) string {
+	t.Helper()
+	ctx := context.Background()
+	id, err := reg.StartRunWithID(ctx, "run-suspended-1", "task-a", "", "manual", registry.RunKindTask)
+	if err != nil {
+		t.Fatalf("StartRunWithID: %v", err)
+	}
+	if err := reg.SuspendRun(ctx, id, []byte(`{"step":"x"}`), form, token, 1, 0); err != nil {
+		t.Fatalf("SuspendRun: %v", err)
+	}
+	return id
+}
+
+var oneRequiredField = []byte(`{"title":"Name?","fields":[{"name":"project_name","type":"string","label":"Name","required":true}]}`)
+
+func TestApiResumeRun_HappyPath(t *testing.T) {
+	srv, reg := newTestServer(t)
+	fr := &fakeResumer{newRunID: "continuation-run"}
+	srv.SetResumer(fr)
+	runID := seedSuspendedRun(t, reg, oneRequiredField, "secret-token")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/runs/"+runID+"/resume",
+		strings.NewReader(`{"project_name":"foo"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+	if fr.calls != 1 {
+		t.Fatalf("resumer called %d times, want 1", fr.calls)
+	}
+	if fr.gotToken != "secret-token" {
+		t.Errorf("token = %q, want server-resolved 'secret-token'", fr.gotToken)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(fr.gotInput, &got); err != nil {
+		t.Fatalf("input not JSON: %v", err)
+	}
+	if got["project_name"] != "foo" {
+		t.Errorf("input project_name = %v, want foo", got["project_name"])
+	}
+	var body map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if body["run_id"] != "continuation-run" {
+		t.Errorf("run_id = %v, want continuation-run", body["run_id"])
+	}
+}
+
+func TestApiResumeRun_MissingRequiredField(t *testing.T) {
+	srv, reg := newTestServer(t)
+	fr := &fakeResumer{newRunID: "x"}
+	srv.SetResumer(fr)
+	runID := seedSuspendedRun(t, reg, oneRequiredField, "tok")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/runs/"+runID+"/resume", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "project_name") {
+		t.Errorf("body should name the missing field; got %s", w.Body.String())
+	}
+	if fr.calls != 0 {
+		t.Errorf("resumer must not be called when validation fails; calls = %d", fr.calls)
+	}
+}
+
+func TestApiResumeRun_NotSuspended(t *testing.T) {
+	srv, reg := newTestServer(t)
+	srv.SetResumer(&fakeResumer{})
+	ctx := context.Background()
+	id, _ := reg.StartRunWithID(ctx, "run-finished", "task-a", "", "manual", registry.RunKindTask)
+	_ = reg.FinishRun(ctx, id, registry.StatusSuccess)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/runs/"+id+"/resume", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestApiResumeRun_RunNotFound(t *testing.T) {
+	srv, _ := newTestServer(t)
+	srv.SetResumer(&fakeResumer{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/runs/nope/resume", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body = %s", w.Code, w.Body.String())
+	}
+}
+
+// The engine's typed errors map to distinct HTTP codes. Double-submit surfaces
+// as ErrResumeNotSuspended (the single-use guard) → 409; an expired deadline →
+// 410; a vanished token → 404.
+func TestApiResumeRun_EngineErrorMapping(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"double-submit", trigger.ErrResumeNotSuspended, http.StatusConflict},
+		{"expired", trigger.ErrResumeExpired, http.StatusGone},
+		{"token-gone", trigger.ErrResumeTokenNotFound, http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, reg := newTestServer(t)
+			srv.SetResumer(&fakeResumer{err: tc.err})
+			runID := seedSuspendedRun(t, reg, nil, "tok")
+
+			req := httptest.NewRequest(http.MethodPost, "/api/runs/"+runID+"/resume", strings.NewReader(`{}`))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(w, req)
+
+			if w.Code != tc.want {
+				t.Fatalf("status = %d, want %d; body = %s", w.Code, tc.want, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestApiResumeRun_503WhenResumerNotConfigured(t *testing.T) {
+	srv, reg := newTestServer(t)
+	// Resumer is nil by default.
+	runID := seedSuspendedRun(t, reg, oneRequiredField, "tok")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/runs/"+runID+"/resume", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body = %s", w.Code, w.Body.String())
+	}
+}
+
+// With server.auth enabled, an unauthenticated resume (no session, no API key)
+// must be rejected before reaching the handler.
+func TestApiResumeRun_RequiresAuth(t *testing.T) {
+	cfg := &config.Config{Server: config.ServerConfig{Port: 8080, Auth: true, BcryptCost: 4}}
+	srv, _ := newTestServerWithSourceMgr(t, cfg, "", nil)
+	srv.SetResumer(&fakeResumer{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/runs/whatever/resume", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401; body = %s", w.Code, w.Body.String())
+	}
+}
+
+// GET /api/runs/{id} must expose the decoded form for rendering but never leak
+// the resume token (the resume endpoint resolves it server-side).
+func TestApiGetRun_SuspendedExposesFormNotToken(t *testing.T) {
+	srv, reg := newTestServer(t)
+	runID := seedSuspendedRun(t, reg, oneRequiredField, "super-secret")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/runs/"+runID, nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+	raw := w.Body.String()
+	if strings.Contains(raw, "super-secret") {
+		t.Errorf("response leaked resume token: %s", raw)
+	}
+	var body struct {
+		ResumeForm json.RawMessage `json:"resume_form"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.Contains(string(body.ResumeForm), "project_name") {
+		t.Errorf("resume_form missing form fields; got %s", body.ResumeForm)
+	}
+}

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -159,6 +159,10 @@ type Server struct {
 	// endpoint returns 503 in that case.
 	replayer *registry.Replayer
 
+	// resumer spawns the continuation run for a suspended run (SetResumer).
+	// Nil when not wired; the /api/runs/{runID}/resume endpoint returns 503.
+	resumer Resumer
+
 	// testGuard vetoes POST /api/tasks/{id}/test for a given task ID. The
 	// approval gate wires its FireGuard here: a pending (unapproved) task's
 	// test file runs with full host permissions, so it must be refused
@@ -577,6 +581,12 @@ func (s *Server) Handler() http.Handler {
 	// or a Bearer API key (CLI / auto-fix scripts). Mounted outside the
 	// session-only group so machine callers without cookies still work.
 	r.With(s.requireSessionOrAPIKey).Post("/api/runs/{runID}/replay", s.apiReplayRun)
+
+	// Resume endpoint (#95) — a suspended run's form submission. Same auth
+	// posture as replay: session cookie (WebUI form) or Bearer API key. The
+	// raw resume_token is resolved server-side from the run, never trusted
+	// from the client.
+	r.With(s.requireSessionOrAPIKey).Post("/api/runs/{runID}/resume", s.apiResumeRun)
 
 	// Approval-gate approve endpoint (#398) — same auth posture as replay:
 	// session cookie (WebUI approve button) or Bearer API key.
@@ -2107,10 +2117,16 @@ func (s *Server) apiListRuns(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, runs)
 }
 
-// RunDetail is the shape returned by GET /api/runs/{runID}.
+// RunDetail is the shape returned by GET /api/runs/{runID}. ResumeForm carries
+// the suspended run's form as decoded JSON (resume_form) so the WebUI renders
+// it directly; the embedded Run's own ResumeToken/ResumeState/ResumeForm are
+// cleared by apiGetRun before embedding — the token is the resume
+// authorization and must never reach the client, and the state blob is
+// task-internal.
 type RunDetail struct {
 	*registry.Run
-	TaskName string `json:"task_name"`
+	TaskName   string          `json:"task_name"`
+	ResumeForm json.RawMessage `json:"resume_form,omitempty"`
 }
 
 func (s *Server) apiGetRun(w http.ResponseWriter, r *http.Request) {
@@ -2124,7 +2140,17 @@ func (s *Server) apiGetRun(w http.ResponseWriter, r *http.Request) {
 	if spec, ok := s.registry.Get(run.TaskID); ok {
 		taskName = spec.Name
 	}
-	jsonOK(w, RunDetail{Run: run, TaskName: taskName})
+	// Surface the form (for rendering) but strip the token and state blob from
+	// the wire — the resume endpoint resolves the token server-side.
+	var form json.RawMessage
+	if run.Status == registry.StatusSuspended && len(run.ResumeForm) > 0 {
+		form = json.RawMessage(run.ResumeForm)
+	}
+	safe := *run
+	safe.ResumeToken = ""
+	safe.ResumeState = nil
+	safe.ResumeForm = nil
+	jsonOK(w, RunDetail{Run: &safe, TaskName: taskName, ResumeForm: form})
 }
 
 // LogEntryJSON is the JSON shape returned by GET /api/runs/{runID}/logs.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
         '**/dev-mode-clone.spec.ts',
         '**/run-input-persistence.spec.ts',
         '**/task-toggle.spec.ts',
+        '**/suspend-resume.spec.ts',
       ],
       use: {
         ...devices['Desktop Chrome'],

--- a/tasks/buildin/webui/app/components/dc-run-detail.js
+++ b/tasks/buildin/webui/app/components/dc-run-detail.js
@@ -18,6 +18,8 @@ class DcRunDetail extends LitElement {
     _duration: { state: true },
     _parent:   { state: true }, // Run record for ParentRunID, or null (#115)
     _children: { state: true }, // child Run[] for the Sub-runs panel (#115)
+    _resuming:     { state: true }, // resume submit in flight (#95)
+    _resumeError:  { state: true }, // last resume submit error, or null (#95)
   };
 
   constructor() {
@@ -25,6 +27,7 @@ class DcRunDetail extends LitElement {
     this._run = null; this._logs = []; this._error = null;
     this._status = null; this._duration = null;
     this._parent = null; this._children = null;
+    this._resuming = false; this._resumeError = null;
     this._offLog = null; this._offFinished = null;
   }
 
@@ -55,6 +58,7 @@ class DcRunDetail extends LitElement {
     this._run = null; this._logs = []; this._error = null;
     this._status = null; this._duration = null;
     this._parent = null; this._children = null;
+    this._resuming = false; this._resumeError = null;
     try {
       // Children fetch is fire-and-forget — failure here shouldn't block the
       // main run/logs load (Sub-runs panel just stays empty).
@@ -134,6 +138,88 @@ class DcRunDetail extends LitElement {
     }
   }
 
+  // #95: submit a suspended run's form. Values are collected from the light-DOM
+  // form and POSTed; the server resolves the resume token itself. On success we
+  // navigate to the continuation run.
+  async _submitResume(e) {
+    e.preventDefault();
+    const schema = this._run?.resume_form;
+    if (!schema) return;
+    const form = e.target;
+    const values = {};
+    for (const f of (schema.fields || [])) {
+      const el = form.elements[f.name];
+      if (!el) continue;
+      let v;
+      if (f.type === 'boolean') v = el.checked;
+      else if (f.type === 'number') v = el.value === '' ? '' : Number(el.value);
+      else v = el.value;
+      if (f.required && (v === '' || v === null || v === undefined)) {
+        this._resumeError = `${f.label || f.name} is required`;
+        return;
+      }
+      // Omit empty optional values so the task sees them as absent.
+      if (v === '' && !f.required) continue;
+      values[f.name] = v;
+    }
+    this._resumeError = null;
+    this._resuming = true;
+    try {
+      const res = await post(`/api/runs/${this.runid}/resume`, values);
+      const newID = res?.run_id;
+      if (newID) navigate(`/runs/${newID}`);
+    } catch (err) {
+      this._resumeError = err.message;
+    } finally {
+      this._resuming = false;
+    }
+  }
+
+  _renderResumeField(f) {
+    const req = f.required ? html`<span style="color:var(--red)"> *</span>` : '';
+    let input;
+    switch (f.type) {
+      case 'text':
+        input = html`<textarea name=${f.name} rows="4" placeholder=${f.placeholder || ''} .value=${f.default ?? ''} style="width:100%"></textarea>`;
+        break;
+      case 'number':
+        input = html`<input type="number" name=${f.name} placeholder=${f.placeholder || ''} .value=${f.default ?? ''} style="width:100%">`;
+        break;
+      case 'boolean':
+        return html`<div style="margin-bottom:var(--space-md)">
+          <label><input type="checkbox" name=${f.name} ?checked=${f.default === true}> ${f.label || f.name}${req}</label>
+        </div>`;
+      case 'select':
+        input = html`<select name=${f.name} style="width:100%">
+          ${(f.options || []).map(o => html`<option value=${o.value} ?selected=${o.value === f.default}>${o.label ?? o.value}</option>`)}
+        </select>`;
+        break;
+      default:
+        input = html`<input type="text" name=${f.name} placeholder=${f.placeholder || ''} .value=${f.default ?? ''} style="width:100%">`;
+    }
+    return html`<div style="margin-bottom:var(--space-md)">
+      <label style="display:block;font-weight:var(--font-semibold);margin-bottom:.25rem">${f.label || f.name}${req}</label>
+      ${input}
+    </div>`;
+  }
+
+  _renderResumeForm() {
+    const schema = this._run?.resume_form;
+    if (!schema) return '';
+    return html`
+      <h2 style="margin-top:var(--space-lg)">${schema.title || 'Waiting on your input'}</h2>
+      <div class="card">
+        ${schema.description ? html`<p class="meta" style="margin-top:0">${schema.description}</p>` : ''}
+        <form @submit=${e => this._submitResume(e)}>
+          ${(schema.fields || []).map(f => this._renderResumeField(f))}
+          ${this._resumeError ? html`<p style="color:var(--red)">${this._resumeError}</p>` : ''}
+          <div style="margin-top:var(--space-md)">
+            <button class="btn" type="submit" ?disabled=${this._resuming}>${this._resuming ? 'Resuming…' : 'Submit'}</button>
+          </div>
+        </form>
+      </div>`;
+  }
+
   render() {
     if (this._error) return html`<p style="color:red">Error: ${this._error}</p>`;
     if (!this._run) return html`<div class="meta">Loading…</div>`;
@@ -188,6 +274,8 @@ class DcRunDetail extends LitElement {
             <button class="btn btn-sm" @click=${() => this._replay()} title="Re-fire this run with its persisted input">Replay</button>` : ''}
         </div>
       </div>
+
+      ${status === 'suspended' ? this._renderResumeForm() : ''}
 
       ${children.length ? html`
         <h2 style="margin-top:var(--space-lg)">Sub-runs <span class="meta">(${children.length})</span></h2>

--- a/tasks/buildin/webui/app/components/dc-task-detail.js
+++ b/tasks/buildin/webui/app/components/dc-task-detail.js
@@ -335,7 +335,9 @@ class DcTaskDetail extends LitElement {
         <td><span class="badge badge-${r.Status}">${r.Status}</span></td>
         <td class="meta">${fmtTime(r.StartedAt)}</td>
         <td class="meta">${fmtDuration(r.StartedAt, r.FinishedAt)}</td>
-        <td>${(r.OutputContentType || r.ReturnValue) ? html`
+        <td>${r.Status === 'suspended' ? html`
+          <a href="/runs/${r.ID}" class="btn btn-sm">Resume ↗</a>`
+          : (r.OutputContentType || r.ReturnValue) ? html`
           <a href="/runs/${r.ID}/result" target="_blank"
              class="btn btn-sm secondary">Result</a>` : ''}</td>
       </tr>

--- a/tasks/buildin/webui/app/global.css
+++ b/tasks/buildin/webui/app/global.css
@@ -135,6 +135,9 @@ tr:last-child td { border-bottom: none; }
 .badge-crashlooping { background: rgba(243, 139, 168, .28); color: var(--red); border-color: rgba(243, 139, 168, .4); }
 .badge-cancelled { background: var(--card-bg); color: var(--muted); border-color: var(--border); }
 .badge-manual    { background: var(--card-bg); color: var(--muted); border-color: var(--border); }
+/* suspended (#95): a run paused waiting on user input — blue "waiting on you". */
+.badge-suspended { background: var(--blue-tint); color: var(--sky); border-color: var(--blue-tint-strong); }
+.badge-resumed   { background: var(--card-bg); color: var(--muted); border-color: var(--border); }
 
 /* ── PILLS & TAGS ─────────────────────────────────────────────────── */
 .pill {

--- a/tests/e2e/fixtures/tasks/suspend-wizard/task.js
+++ b/tests/e2e/fixtures/tasks/suspend-wizard/task.js
@@ -1,0 +1,16 @@
+// First invocation suspends asking for a project name; the resume invocation
+// echoes the submitted value back as the run's result (#95 e2e).
+export default async function main({ dicode, resume_state, resume_input }) {
+  if (!resume_state) {
+    await dicode.suspend({
+      state: { step: 'ask_name' },
+      form: {
+        title: "What's the project name?",
+        fields: [
+          { name: 'project_name', type: 'string', label: 'Name', required: true },
+        ],
+      },
+    });
+  }
+  return { created: resume_input?.project_name };
+}

--- a/tests/e2e/fixtures/tasks/suspend-wizard/task.yaml
+++ b/tests/e2e/fixtures/tasks/suspend-wizard/task.yaml
@@ -1,0 +1,8 @@
+apiVersion: dicode/v1
+kind: Task
+name: Suspend Wizard
+description: A one-step suspend/resume wizard for e2e testing (#95).
+runtime: deno
+trigger:
+  manual: true
+timeout: 10s

--- a/tests/e2e/fixtures/tasks/taskset.yaml
+++ b/tests/e2e/fixtures/tasks/taskset.yaml
@@ -28,6 +28,9 @@ spec:
     persistence-test:
       ref:
         path: FIXTURES_TASKS_DIR/persistence-test/task.yaml
+    suspend-wizard:
+      ref:
+        path: FIXTURES_TASKS_DIR/suspend-wizard/task.yaml
     webui:
       ref:
         path: BUILDIN_WEBUI_TASK_YAML

--- a/tests/e2e/suspend-resume.spec.ts
+++ b/tests/e2e/suspend-resume.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * suspend-resume.spec.ts
+ *
+ * End-to-end coverage for the suspend/resume WebUI surface (#95, PR 4):
+ * fire a task that calls dicode.suspend(), confirm the run lands in
+ * `suspended` with a form, submit the form via POST /api/runs/<id>/resume,
+ * and assert the continuation run succeeds with the submitted value while the
+ * original run transitions to `resumed`.
+ */
+
+import { test, expect } from '@playwright/test';
+import type { APIRequestContext } from '@playwright/test';
+
+const TASK_ID = 'e2e-tests/suspend-wizard';
+
+function runStatus(run: Record<string, unknown>): string {
+  return (run.Status ?? run.status) as string;
+}
+
+async function getRun(
+  request: APIRequestContext,
+  runID: string,
+): Promise<Record<string, unknown>> {
+  const res = await request.get(`/api/runs/${runID}`);
+  expect(res.ok()).toBe(true);
+  return (await res.json()) as Record<string, unknown>;
+}
+
+async function waitForStatus(
+  request: APIRequestContext,
+  runID: string,
+  want: string,
+  timeoutMs = 30_000,
+): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + timeoutMs;
+  let last = '';
+  while (Date.now() < deadline) {
+    const run = await getRun(request, runID);
+    last = runStatus(run);
+    if (last === want) return run;
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  throw new Error(`Run ${runID} did not reach ${want} within ${timeoutMs}ms (last=${last})`);
+}
+
+test.describe('suspend/resume webui', () => {
+  test.setTimeout(60_000);
+
+  test('suspend → fill form → resume spawns the continuation', async ({ request }) => {
+    const taskRes = await request.get(`/api/tasks/${encodeURIComponent(TASK_ID)}`);
+    if (!taskRes.ok()) {
+      test.skip(true, `${TASK_ID} not registered — fixture taskset missing it?`);
+      return;
+    }
+
+    // Fire the wizard — first invocation suspends.
+    const fireRes = await request.post(
+      `/api/tasks/${encodeURIComponent(TASK_ID)}/run`,
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+    expect(fireRes.ok()).toBe(true);
+    const { runId } = (await fireRes.json()) as { runId: string };
+    expect(runId).toBeTruthy();
+
+    // It must land suspended, carrying a decoded form — and NOT leak a token.
+    const suspended = await waitForStatus(request, runId, 'suspended');
+    const form = suspended.resume_form as { fields?: { name: string }[] } | undefined;
+    expect(form?.fields?.some((f) => f.name === 'project_name')).toBe(true);
+    // The token is the resume authorization — it must never reach the client.
+    expect(suspended.ResumeToken ?? '').toBe('');
+    expect(suspended.ResumeState ?? null).toBeNull();
+
+    // Missing required field → 400.
+    const bad = await request.post(`/api/runs/${runId}/resume`, {
+      headers: { 'Content-Type': 'application/json' },
+      data: {},
+    });
+    expect(bad.status()).toBe(400);
+
+    // Submit the form → continuation run id.
+    const ok = await request.post(`/api/runs/${runId}/resume`, {
+      headers: { 'Content-Type': 'application/json' },
+      data: { project_name: 'webui-e2e' },
+    });
+    expect(ok.ok()).toBe(true);
+    const { run_id: continuationId } = (await ok.json()) as { run_id: string };
+    expect(continuationId).toBeTruthy();
+    expect(continuationId).not.toBe(runId);
+
+    // Continuation succeeds with the submitted value echoed back.
+    const done = await waitForStatus(request, continuationId, 'success');
+    expect((done.ReturnValue ?? done.return_value) as string).toContain('webui-e2e');
+    expect((done.ParentRunID ?? done.parent_run_id) as string).toBe(runId);
+
+    // Original run is now resumed; a second submit is rejected (single-use).
+    const original = await getRun(request, runId);
+    expect(runStatus(original)).toBe('resumed');
+
+    const replay = await request.post(`/api/runs/${runId}/resume`, {
+      headers: { 'Content-Type': 'application/json' },
+      data: { project_name: 'again' },
+    });
+    expect(replay.status()).toBe(409);
+  });
+});


### PR DESCRIPTION
## Summary

Delivers the webui surface for suspendable tasks (#95, PR 4 of the stack). An authenticated user can now open a suspended run, fill in the form the task requested via `dicode.suspend()`, and submit it to resume — spawning the continuation run.

The design follows the existing replay wiring: a `Resumer` interface + `SetResumer` (analogous to `Replayer`/`SetReplayer`), backed by `Engine.ResumeRun` and wired in the daemon. The new `POST /api/runs/{runID}/resume` endpoint sits behind `requireSessionOrAPIKey`.

The security posture is that the session (or API key) is the authorization. The endpoint loads the run, confirms it is `suspended`, and resolves the `resume_token` server-side from the stored run — the client never sends a token or task id, so the continuation task is determined by stored state, not the request. `GET /api/runs/{runID}` exposes the form as decoded `resume_form` for rendering but strips the token and state blob from the wire. Double-submit is safe: the engine's single-use guard returns `ErrResumeNotSuspended`, surfaced as 409. Typed engine errors map to HTTP codes (not-suspended/already-resumed → 409, expired → 410, token-gone → 404).

Server-side validation rejects a submission missing a `required` field with a 400 naming the field; otherwise the collected values pass through as opaque JSON input. The run-detail view renders the form (string/text/number/boolean/select, honoring label/required/default/options/placeholder) and navigates to the continuation on success. Run-status badges and the task-detail run list distinguish `suspended`/`resumed` and offer a resume affordance.

### Deliberately left behind

Python runtime parity (PR 5), the `dicode resume` CLI (PR 6), and any AI-chat-specific UI. The form mechanism is generic so the AI chat panel can consume it later.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `gofmt -l pkg/ tests/` — clean
- `go test ./... -timeout 180s` — pass
- `go test -race ./pkg/webui/...` — pass (61s)
- Go handler tests (fake `Resumer`): happy path parses input + resolves token server-side, missing-required → 400, not-suspended → 409, not-found → 404, engine error mapping (409/410/404), 503 when unwired, auth-enabled unauth → 401, and GET exposes form but not token.
- E2E (`tests/e2e/suspend-resume.spec.ts`, real daemon + Deno): fire wizard → `suspended` with form and no leaked token → missing field 400 → resume → continuation `success` echoing the submitted value with `parent_run_id` set → original `resumed` → double-submit 409. Passes. The `webui` browser project (run-detail render) also still passes.

Part of #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)