### PR TITLE
feat(suspend): Python runtime parity for the suspend mechanism

### DIFF
--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -221,6 +221,8 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	mergedParams := pkgruntime.MergeParams(spec.Params, opts.Params)
 
 	srv := e.BridgeDeps.NewIPCServer(runID, spec, mergedParams, opts.Input, redactor, &e.parent.BridgeDeps)
+	// Inject a resumed run's prior state + user input (#95); nil on first run.
+	srv.SetResume(opts.ResumeState, opts.ResumeInput)
 	socketPath, token, err := srv.Start(srvCtx)
 	if err != nil {
 		result.Error = fmt.Errorf("start socket server: %w", err)
@@ -339,6 +341,20 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 		return e.relockScript(ctx, spec, runID, scriptPath)
 	})
 
+	// A legitimate dicode.suspend() exits the process cleanly (exit 0), so the
+	// run is not a failure. Only then translate the captured payload into a
+	// suspended result (#95). When result.Error is set the subprocess exited
+	// non-zero — the wrapper's swallow-guard trips this when a task caught the
+	// SuspendSignal and kept running — so keep it a failure rather than a
+	// contradictory suspended-and-returned run, even though a payload was
+	// recorded server-side. Mirrors the Deno runtime.
+	if sr := srv.Suspend(); sr != nil && result.Error == nil {
+		result.Suspended = true
+		result.ResumeState = sr.State
+		result.ResumeForm = sr.Form
+		result.ResumeDeadline = sr.Deadline
+	}
+
 	return result, nil
 }
 
@@ -404,20 +420,28 @@ func buildWrapper(scriptBytes []byte, pol guardPolicy) (string, error) {
 	w.WriteString("\n# === return capture ===\n")
 	w.WriteString("import sys as _sys\n")
 	w.WriteString("_asyncio_mod = _sys.modules['asyncio']\n")
-	w.WriteString("_main = globals().get('main')\n")
-	w.WriteString("if _main is not None and _asyncio_mod.iscoroutinefunction(_main):\n")
-	w.WriteString("    result = _asyncio_mod.run(_main())\n")
-	w.WriteString("_set_return(globals().get('result', None))\n")
-	// Schedule close on _loop so it runs *after* any pending _fire coroutines
-	// (the event loop is FIFO — tasks submitted before this will drain first).
-	// Wrap in try/except so a timeout never marks a successful run as failed.
-	w.WriteString("async def _dicode_close():\n")
-	w.WriteString("    _writer.close()\n")
-	w.WriteString("    await _writer.wait_closed()\n")
+	// A clean dicode.suspend() from inside main() raises SuspendSignal after the
+	// payload is recorded — exit 0 without a return value (a suspend is not a
+	// failure). If task code instead swallowed the signal and returned, the
+	// suspend flag is still set: fail loudly rather than record a contradictory
+	// suspended-and-returned run (#95). A suspend at task top level (sync tasks)
+	// unwinds past this block and is handled by the SDK's sys.excepthook.
 	w.WriteString("try:\n")
-	w.WriteString("    _asyncio_mod.run_coroutine_threadsafe(_dicode_close(), _loop).result(timeout=5)\n")
-	w.WriteString("except Exception:\n")
-	w.WriteString("    pass\n")
+	w.WriteString("    _main = globals().get('main')\n")
+	w.WriteString("    if _main is not None and _asyncio_mod.iscoroutinefunction(_main):\n")
+	w.WriteString("        result = _asyncio_mod.run(_main())\n")
+	w.WriteString("    if _was_suspend_requested():\n")
+	w.WriteString("        _sys.stderr.write(\"[dicode] dicode.suspend() was called but its control-flow signal was caught by task code — do not wrap dicode.suspend() in a try/except that swallows it\\n\")\n")
+	w.WriteString("        _sys.stderr.flush()\n")
+	w.WriteString("        _flush_and_close()\n")
+	w.WriteString("        _sys.exit(1)\n")
+	w.WriteString("    _set_return(globals().get('result', None))\n")
+	w.WriteString("except SuspendSignal:\n")
+	w.WriteString("    _flush_and_close()\n")
+	w.WriteString("    _sys.exit(0)\n")
+	// _flush_and_close drains pending _fire writes and closes the socket on the
+	// FIFO IO loop; it swallows errors so a slow close never fails a good run.
+	w.WriteString("_flush_and_close()\n")
 	return w.String(), nil
 }
 

--- a/pkg/runtime/python/sdk/dicode_sdk.py
+++ b/pkg/runtime/python/sdk/dicode_sdk.py
@@ -254,6 +254,84 @@ kv = _KV()
 input = _call({"method": "input"})
 
 
+# ── suspend / resume (#95) ────────────────────────────────────────────────────
+# dicode.suspend() pauses the run: it hands the daemon a state blob + form, then
+# raises SuspendSignal so the process exits cleanly (exit 0) and the run ends as
+# `suspended`. On resume the task is re-run with ctx.resume_state /
+# ctx.resume_input populated. See runtime.go for how the wrapper turns a clean
+# suspend into a suspended RunResult.
+
+
+class SuspendSignal(Exception):
+    """Control-flow signal raised by dicode.suspend() after the payload is
+    recorded over IPC. The wrapper catches it and exits the process cleanly —
+    a suspend is not a failure. It subclasses Exception (not BaseException) to
+    mirror the Deno SDK, whose signal is a plain Error; the wrapper's
+    swallow-guard fails the run loudly if task code catches it and returns."""
+
+    def __init__(self):
+        super().__init__("dicode.suspend")
+
+
+# Set the instant before SuspendSignal is raised (payload already recorded
+# server-side). If task code returns normally with this set, a try/except
+# swallowed the signal and kept executing — the wrapper turns that into a loud
+# failure rather than a contradictory "suspended run that also returned".
+_suspend_requested = False
+
+
+def _was_suspend_requested():
+    return _suspend_requested
+
+
+def _flush_and_close():
+    """Drain pending fire-and-forget writes and close the socket on _loop.
+    Scheduling on _loop makes the close run *after* any queued _fire coroutines
+    (the loop is FIFO). Swallows errors so a slow/broken close never masks the
+    run outcome."""
+    async def _do():
+        try:
+            _writer.close()
+            await _writer.wait_closed()
+        except Exception:
+            pass
+    try:
+        asyncio.run_coroutine_threadsafe(_do(), _loop).result(timeout=5)
+    except Exception:
+        pass
+
+
+class _Context:
+    """Resume context (#95). resume_state is the prior suspended run's opaque
+    state blob; resume_input is the user's form submission. Both are None on a
+    first (non-resume) invocation. Fetched once at import time."""
+
+    def __init__(self):
+        r = _call({"method": "resume"}) or {}
+        self.resume_state = r.get("state")
+        self.resume_input = r.get("input")
+
+
+ctx = _Context()
+
+
+# A dicode.suspend() at task top level (a synchronous task) raises SuspendSignal
+# that unwinds past the wrapper's return-capture epilogue. Intercept it here so
+# the process still exits cleanly; real errors fall through to the default hook
+# (which prints the traceback) and the non-zero exit that marks a failed run.
+_orig_excepthook = sys.excepthook
+
+
+def _suspend_excepthook(exc_type, exc, tb):
+    if isinstance(exc, SuspendSignal):
+        _flush_and_close()
+        os._exit(0)
+    _orig_excepthook(exc_type, exc, tb)
+
+
+sys.excepthook = _suspend_excepthook
+
+
 # ── output ────────────────────────────────────────────────────────────────────
 
 
@@ -441,6 +519,21 @@ class _Dicode:
         # Label the current run with a free-text group string (#116). Used
         # by the WebUI to collapse same-group siblings. Last write wins.
         _call({"method": "dicode.set_group", "group": str(label or "")})
+
+    def suspend(self, state=None, form=None, deadline=None):
+        """Pause the run and wait for user input (#95). Records the state blob +
+        form over IPC, then raises SuspendSignal — it never returns. The wrapper
+        exits the process cleanly and the run ends as `suspended`; on resume the
+        task is re-run with ctx.resume_state / ctx.resume_input populated. Do not
+        wrap this call in a try/except that swallows the signal."""
+        global _suspend_requested
+        # Await the ack so the payload is recorded before we raise: the daemon
+        # captures state/form/deadline synchronously in response to this call.
+        _call({"method": "dicode.suspend",
+               "state": state, "form": form,
+               "deadline": deadline or 0})
+        _suspend_requested = True
+        raise SuspendSignal()
 
     async def run_task_async(self, task_id, params=None, mcp_context=False):
         return await _call_async({"method": "dicode.run_task", "taskID": task_id,

--- a/pkg/runtime/python/sdk/test_dicode_sdk.py
+++ b/pkg/runtime/python/sdk/test_dicode_sdk.py
@@ -345,6 +345,58 @@ class MCPTests(SDKTestBase):
         self.assertEqual(result, {"output": "result"})
 
 
+class SuspendTests(SDKTestBase):
+    def test_suspend_records_payload_and_raises(self):
+        captured = {}
+
+        def on_suspend(msg):
+            captured["state"] = msg.get("state")
+            captured["form"] = msg.get("form")
+            captured["deadline"] = msg.get("deadline")
+            return True  # ack
+        self.server.handlers["dicode.suspend"] = on_suspend
+
+        sdk = self.load_sdk()
+        self.assertFalse(sdk._was_suspend_requested())
+        with self.assertRaises(sdk.SuspendSignal):
+            sdk.dicode.suspend(
+                state={"step": "one", "n": 42},
+                form={"title": "Name?", "fields": [
+                    {"name": "project_name", "type": "string", "label": "Name"}]},
+                deadline=1893456000000,
+            )
+        # The signal was raised only after the payload was acked, and the
+        # module-level flag is set so the wrapper's swallow-guard can fire.
+        self.assertTrue(sdk._was_suspend_requested())
+        self.assertEqual(captured["state"], {"step": "one", "n": 42})
+        self.assertEqual(captured["form"]["title"], "Name?")
+        self.assertEqual(captured["deadline"], 1893456000000)
+
+    def test_suspend_signal_is_exception_subclass(self):
+        # Mirrors the Deno SDK: the signal is a plain Error/Exception so a broad
+        # `except Exception` swallows it — exactly the footgun the wrapper's
+        # swallow-guard protects against.
+        sdk = self.load_sdk()
+        self.assertTrue(issubclass(sdk.SuspendSignal, Exception))
+
+
+class ResumeContextTests(SDKTestBase):
+    def test_ctx_none_on_first_run(self):
+        sdk = self.load_sdk()
+        self.assertIsNone(sdk.ctx.resume_state)
+        self.assertIsNone(sdk.ctx.resume_input)
+
+    def test_ctx_exposes_injected_state_and_input(self):
+        self.server.handlers["resume"] = lambda _: {
+            "state": {"step": "ask_framework", "name": "proj"},
+            "input": {"project_name": "acme"},
+        }
+        sdk = self.load_sdk()
+        self.assertEqual(sdk.ctx.resume_state,
+                         {"step": "ask_framework", "name": "proj"})
+        self.assertEqual(sdk.ctx.resume_input, {"project_name": "acme"})
+
+
 class ReturnTests(SDKTestBase):
     def test_set_return(self):
         captured = {}

--- a/pkg/runtime/python/suspend_test.go
+++ b/pkg/runtime/python/suspend_test.go
@@ -1,0 +1,342 @@
+//go:build !windows
+
+package python
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+	"github.com/dicode/dicode/pkg/task"
+	uvpkg "github.com/dicode/dicode/pkg/uv"
+)
+
+// writePythonTask writes body to task.py in a fresh temp dir and returns a
+// manual-trigger spec pointed at it.
+func writePythonTask(t *testing.T, id, body string) *task.Spec {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "task.py"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return &task.Spec{
+		ID:      id,
+		Name:    id,
+		Runtime: task.Runtime("python"),
+		TaskDir: dir,
+		Trigger: task.TriggerConfig{Manual: true},
+		Timeout: 120 * time.Second,
+	}
+}
+
+// newSuspendExecutor provisions uv the way the runtime does and returns a
+// registry + executor, skipping when uv cannot be provisioned (offline CI).
+func newSuspendExecutor(t *testing.T) (*registry.Registry, pkgruntime.Executor) {
+	t.Helper()
+	uv, err := uvpkg.EnsureUv("")
+	if err != nil {
+		t.Skipf("uv provisioning failed (offline?): %v", err)
+	}
+	rt, reg := newTestRuntime(t)
+	return reg, rt.NewExecutor(uv)
+}
+
+// TestExecute_SuspendYieldsSuspendedResult runs a real Python task that calls
+// dicode.suspend(state=..., form=..., deadline=...) and asserts the run ends as
+// a clean suspend (not a failure) with the state/form/deadline captured on the
+// RunResult (#95). The SuspendSignal must exit the process with code 0.
+func TestExecute_SuspendYieldsSuspendedResult(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires uv subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	reg, ex := newSuspendExecutor(t)
+
+	spec := writePythonTask(t, "examples/wizard", `
+async def main():
+    dicode.suspend(
+        state={"step": "ask_name", "n": 42},
+        form={
+            "title": "Your name?",
+            "fields": [{"name": "project_name", "type": "string", "label": "Name", "required": True}],
+        },
+        deadline=1893456000000,
+    )
+    # Unreachable: suspend never returns.
+    return {"reached": True}
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+	runID, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{RunID: runID})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	logs, _ := reg.GetRunLogs(ctx, runID)
+	if res.Error != nil {
+		t.Fatalf("suspend must not be a failure, got error: %v\nlogs:\n%s", res.Error, joinLogs(logs))
+	}
+	if !res.Suspended {
+		t.Fatalf("expected Suspended = true, got false\nlogs:\n%s", joinLogs(logs))
+	}
+	if res.ChainInput != nil {
+		t.Errorf("suspend must not produce a return value, got %#v", res.ChainInput)
+	}
+	if res.ResumeDeadline != 1893456000000 {
+		t.Errorf("ResumeDeadline = %d, want 1893456000000", res.ResumeDeadline)
+	}
+
+	var state struct {
+		Step string `json:"step"`
+		N    int    `json:"n"`
+	}
+	if err := json.Unmarshal(res.ResumeState, &state); err != nil {
+		t.Fatalf("ResumeState not valid JSON (%q): %v", res.ResumeState, err)
+	}
+	if state.Step != "ask_name" || state.N != 42 {
+		t.Errorf("ResumeState = %+v, want {ask_name 42}", state)
+	}
+
+	var form struct {
+		Title  string `json:"title"`
+		Fields []struct {
+			Name string `json:"name"`
+			Type string `json:"type"`
+		} `json:"fields"`
+	}
+	if err := json.Unmarshal(res.ResumeForm, &form); err != nil {
+		t.Fatalf("ResumeForm not valid JSON (%q): %v", res.ResumeForm, err)
+	}
+	if form.Title != "Your name?" || len(form.Fields) != 1 || form.Fields[0].Name != "project_name" {
+		t.Errorf("ResumeForm = %+v, want title + one project_name field", form)
+	}
+}
+
+// TestExecute_SuspendAtTopLevelYieldsSuspendedResult covers a synchronous task
+// that calls dicode.suspend() at module top level (no async main). The
+// SuspendSignal unwinds past the return-capture epilogue and is caught by the
+// SDK's sys.excepthook, which still exits the process cleanly (#95).
+func TestExecute_SuspendAtTopLevelYieldsSuspendedResult(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires uv subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	reg, ex := newSuspendExecutor(t)
+
+	spec := writePythonTask(t, "examples/sync-wizard", `
+if ctx.resume_state is None:
+    dicode.suspend(
+        state={"step": "sync"},
+        form={"fields": [{"name": "x", "type": "string", "label": "X"}]},
+    )
+result = {"reached": True}
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+	runID, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{RunID: runID})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	logs, _ := reg.GetRunLogs(ctx, runID)
+	if res.Error != nil {
+		t.Fatalf("top-level suspend must not be a failure, got: %v\nlogs:\n%s", res.Error, joinLogs(logs))
+	}
+	if !res.Suspended {
+		t.Fatalf("expected Suspended = true\nlogs:\n%s", joinLogs(logs))
+	}
+	if res.ChainInput != nil {
+		t.Errorf("suspend must not produce a return value, got %#v", res.ChainInput)
+	}
+	var state struct {
+		Step string `json:"step"`
+	}
+	if err := json.Unmarshal(res.ResumeState, &state); err != nil {
+		t.Fatalf("ResumeState not valid JSON (%q): %v", res.ResumeState, err)
+	}
+	if state.Step != "sync" {
+		t.Errorf("ResumeState = %+v, want step=sync", state)
+	}
+}
+
+// TestExecute_SuspendSwallowedByTaskFails guards the case where task code wraps
+// dicode.suspend() in a broad try/except that swallows the SuspendSignal and
+// keeps executing (#95). The payload is already recorded server-side, so a
+// normal return would leave the run suspended-and-returned. The run must FAIL
+// loudly and NOT be classified as suspended. Mirrors the Deno test.
+func TestExecute_SuspendSwallowedByTaskFails(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires uv subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	reg, ex := newSuspendExecutor(t)
+
+	spec := writePythonTask(t, "examples/swallower", `
+async def main():
+    try:
+        dicode.suspend(
+            state={"step": "one"},
+            form={"fields": [{"name": "x", "type": "string", "label": "X"}]},
+        )
+    except Exception:
+        # Swallow the control-flow signal and keep going — the bug we guard against.
+        pass
+    return {"kept_running": True}
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+	runID, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{RunID: runID})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Suspended {
+		t.Fatal("swallowed suspend must not be classified as suspended")
+	}
+	if res.Error == nil {
+		t.Fatal("swallowed suspend must fail the run, got no error")
+	}
+	if res.ChainInput != nil {
+		t.Errorf("swallowed suspend must not record a return value, got %#v", res.ChainInput)
+	}
+
+	logs, _ := reg.GetRunLogs(ctx, runID)
+	found := false
+	for _, l := range logs {
+		if strings.Contains(l.Message, "control-flow signal was caught by task code") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a clear diagnostic in the run log, logs:\n%s", joinLogs(logs))
+	}
+}
+
+// TestExecute_ResumeStateAndInputExposed injects a prior-run state blob and a
+// user form submission via RunOptions and asserts the task sees them on
+// ctx.resume_state / ctx.resume_input (#95).
+func TestExecute_ResumeStateAndInputExposed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires uv subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	reg, ex := newSuspendExecutor(t)
+
+	spec := writePythonTask(t, "examples/resumer", `
+async def main():
+    return {"st": ctx.resume_state, "inp": ctx.resume_input}
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+	runID, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{
+		RunID:       runID,
+		ResumeState: json.RawMessage(`{"step":"ask_framework","name":"proj"}`),
+		ResumeInput: json.RawMessage(`{"project_name":"acme"}`),
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	logs, _ := reg.GetRunLogs(ctx, runID)
+	if res.Error != nil {
+		t.Fatalf("run error: %v\nlogs:\n%s", res.Error, joinLogs(logs))
+	}
+	if res.Suspended {
+		t.Fatal("resume run must not be suspended")
+	}
+
+	ret, ok := res.ChainInput.(map[string]any)
+	if !ok {
+		t.Fatalf("ChainInput = %#v, want map", res.ChainInput)
+	}
+	st, ok := ret["st"].(map[string]any)
+	if !ok {
+		t.Fatalf("resume_state not exposed: %#v", ret["st"])
+	}
+	if st["step"] != "ask_framework" || st["name"] != "proj" {
+		t.Errorf("resume_state = %#v, want step=ask_framework name=proj", st)
+	}
+	inp, ok := ret["inp"].(map[string]any)
+	if !ok {
+		t.Fatalf("resume_input not exposed: %#v", ret["inp"])
+	}
+	if inp["project_name"] != "acme" {
+		t.Errorf("resume_input = %#v, want project_name=acme", inp)
+	}
+}
+
+// TestExecute_NoResumeIsNone verifies that a first (non-resume) invocation sees
+// ctx.resume_state / ctx.resume_input as None (#95), so a task can branch on
+// their presence.
+func TestExecute_NoResumeIsNone(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires uv subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	reg, ex := newSuspendExecutor(t)
+
+	spec := writePythonTask(t, "examples/firstrun", `
+async def main():
+    return {"has_state": ctx.resume_state is not None, "has_input": ctx.resume_input is not None}
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+	runID, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{RunID: runID})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	logs, _ := reg.GetRunLogs(ctx, runID)
+	if res.Error != nil {
+		t.Fatalf("run error: %v\nlogs:\n%s", res.Error, joinLogs(logs))
+	}
+	ret, ok := res.ChainInput.(map[string]any)
+	if !ok {
+		t.Fatalf("ChainInput = %#v, want map", res.ChainInput)
+	}
+	if ret["has_state"] != false || ret["has_input"] != false {
+		t.Errorf("expected resume_state/resume_input None on first run, got %#v", ret)
+	}
+}


### PR DESCRIPTION
## Summary

Brings the Deno suspend primitive (PR 2) to the uv-managed Python runtime so a task authored in either language can pause, persist state, wait for user input, and resume later (#95). This is a straight parity port: the shared IPC `suspend`/`resume` methods and the runtime-agnostic engine orchestration already landed, so this PR only teaches the Python SDK and runtime to speak the same protocol. No CLI changes — `dicode resume` is PR 6.

The Python SDK gains `dicode.suspend(state=..., form=..., deadline=None)`: it records the state blob + form over the shared per-run `suspend` IPC method, awaits the ack, sets a module-level `_suspend_requested` flag, then raises `SuspendSignal`. The signal subclasses `Exception` (not `BaseException`) to mirror the Deno signal being a plain `Error` — which is exactly why the swallow-guard exists. `ctx.resume_state` / `ctx.resume_input` expose a resumed run's prior state and the user's form submission (fetched via the shared `resume` method; `None` on a first run).

The wrapper's return-capture epilogue catches `SuspendSignal` raised from `main()` and exits cleanly (exit 0, no return value). A synchronous task that suspends at module top level unwinds past the epilogue and is caught by the SDK's `sys.excepthook`, which produces the same clean exit. The swallow-guard matches Deno exactly: if task code caught the signal in a `try/except` and returned normally, `_was_suspend_requested()` is still set, so the wrapper writes the same specific diagnostic to stderr and exits non-zero rather than recording a contradictory suspended-and-returned run.

On the Go side the runtime injects `srv.SetResume(...)` before start and reads `srv.Suspend()` after the run, classifying `Suspended` only on a clean exit (`result.Error == nil`) so a swallowed-and-continued run (non-zero exit) stays a plain failure. The existing stale-lock retry closure and lock-staging paths are untouched.

The FIFO socket-close logic that used to be inlined in the wrapper string is now a small `_flush_and_close()` helper in the SDK, shared by the epilogue, the swallow-guard path, and the excepthook.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l .` — all clean.
- `go test ./... -timeout 180s` — exit 0, 32 packages ok, no failures.
- `go test -race ./pkg/runtime/python/... ./pkg/ipc/...` — ok.
- Python SDK unit tests (`python3 -m unittest test_dicode_sdk`) — 19 pass, including new suspend + resume-context cases.
- New real-uv integration tests (`pkg/runtime/python/suspend_test.go`) mirror the Deno suite and pass: suspend yields `Suspended:true` with state/form/deadline and no return value; a top-level (sync) suspend takes the excepthook path to the same result; a `try/except` that swallows the signal and returns is a clear FAILURE with the diagnostic in the run log; `ctx.resume_state`/`ctx.resume_input` are exposed when injected and `None` on a first run.

Part of #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)