### PR TITLE
fix(suspend): probe fire guard before consuming the resume token

### DIFF
--- a/pkg/trigger/resume.go
+++ b/pkg/trigger/resume.go
@@ -29,6 +29,12 @@ var (
 	// ErrResumeExpired is returned when the run's resume_deadline has passed.
 	// The run is swept to cancelled/resume_timeout as a side effect.
 	ErrResumeExpired = errors.New("resume deadline expired")
+	// ErrResumePending is returned when the fire guard vetoes the continuation
+	// — typically the trust-on-change approval gate holding the task pending
+	// after an edit. The token is NOT consumed and the run stays suspended, so
+	// it resumes once the task is re-approved. The underlying guard error
+	// (e.g. approval.ErrPending) is wrapped for callers that inspect it.
+	ErrResumePending = errors.New("resume blocked: task not admitted")
 )
 
 // suspendRun persists a run that called dicode.suspend() as suspended: it mints
@@ -62,8 +68,9 @@ func newResumeToken() (string, error) {
 // ResumeRun consumes a resume token and spawns the continuation run for a
 // suspended task. It looks the run up by token, rejects it if not found, not
 // suspended, or past its deadline (an expired run is swept to
-// cancelled/resume_timeout), marks the original run resumed so the token can't
-// be replayed, then fires a fresh run of the same task seeded with the stored
+// cancelled/resume_timeout), verifies the task is still registered and the
+// fire guard admits it, marks the original run resumed so the token can't be
+// replayed, then fires a fresh run of the same task seeded with the stored
 // resume state and the caller's input. The continuation runs the normal
 // execution path, so a task that suspends again mints its own token — chaining
 // multi-step wizards. Returns the continuation run's ID.
@@ -95,6 +102,16 @@ func (e *Engine) ResumeRun(ctx context.Context, token string, input []byte) (str
 	spec, ok := e.registry.Get(run.TaskID)
 	if !ok {
 		return "", fmt.Errorf("resume: task %q is no longer registered", run.TaskID)
+	}
+
+	// Probe the fire guard WITHOUT spawning or consuming the token. The same
+	// guard runs again inside the spawn path; checking it here first means a
+	// vetoed continuation (e.g. the author edited the task, so the
+	// trust-on-change gate holds it pending) leaves the run suspended with its
+	// token intact — consuming the token before the veto would strand the
+	// resume_state on a terminal `resumed` row forever.
+	if gerr := e.checkFireGuard(spec.ID); gerr != nil {
+		return "", fmt.Errorf("%w: %w", ErrResumePending, gerr)
 	}
 
 	// Consume the token atomically. This is the single-use guard: a second

--- a/pkg/trigger/resume_test.go
+++ b/pkg/trigger/resume_test.go
@@ -3,11 +3,13 @@ package trigger
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/dicode/dicode/pkg/approval"
 	"github.com/dicode/dicode/pkg/db"
 	"github.com/dicode/dicode/pkg/registry"
 	pkgruntime "github.com/dicode/dicode/pkg/runtime"
@@ -260,6 +262,59 @@ func TestResumeRun_DeregisteredTaskKeepsSuspensionResumable(t *testing.T) {
 	newID, err := eng.ResumeRun(context.Background(), orig.ResumeToken, []byte(`{"project_name":"acme"}`))
 	if err != nil {
 		t.Fatalf("ResumeRun after re-register: %v", err)
+	}
+	cont := waitStatus(t, reg, newID, registry.StatusSuccess)
+	if cont.ParentRunID != origID {
+		t.Errorf("continuation parent = %q, want %q", cont.ParentRunID, origID)
+	}
+}
+
+func TestResumeRun_FireGuardPendingKeepsSuspensionResumable(t *testing.T) {
+	exec := &suspendExec{}
+	eng, reg := newSuspendEnv(t, exec)
+	spec := &task.Spec{ID: "wiz", Name: "wiz", Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}, Enabled: true}
+	_ = reg.Register(spec)
+
+	origID, err := eng.FireManual(context.Background(), "wiz", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	orig := waitStatus(t, reg, origID, registry.StatusSuspended)
+
+	// The author edits the task, so the trust-on-change approval gate holds it
+	// pending: the fire guard now vetoes any run of "wiz".
+	pending := true
+	eng.SetFireGuard(func(taskID string) error {
+		if pending && taskID == "wiz" {
+			return fmt.Errorf("%w: %s", approval.ErrPending, taskID)
+		}
+		return nil
+	})
+
+	_, err = eng.ResumeRun(context.Background(), orig.ResumeToken, nil)
+	if !errors.Is(err, ErrResumePending) {
+		t.Fatalf("ResumeRun err = %v, want ErrResumePending", err)
+	}
+	// The underlying guard veto is preserved for callers that inspect it.
+	if !errors.Is(err, approval.ErrPending) {
+		t.Errorf("ResumeRun err = %v, want wrapped approval.ErrPending", err)
+	}
+
+	// The token must NOT have been consumed: the run stays suspended and keeps
+	// its token, so it remains resumable once the task is re-approved.
+	still, _ := reg.GetRun(context.Background(), origID)
+	if still.Status != registry.StatusSuspended {
+		t.Errorf("run status = %q, want suspended (token must not be consumed)", still.Status)
+	}
+	if still.ResumeToken != orig.ResumeToken {
+		t.Errorf("resume token changed/cleared: %q", still.ResumeToken)
+	}
+
+	// Re-approving the task (guard admits again) lets the SAME token resume.
+	pending = false
+	newID, err := eng.ResumeRun(context.Background(), orig.ResumeToken, []byte(`{"project_name":"acme"}`))
+	if err != nil {
+		t.Fatalf("ResumeRun after re-approval: %v", err)
 	}
 	cont := waitStatus(t, reg, newID, registry.StatusSuccess)
 	if cont.ParentRunID != origID {

--- a/pkg/webui/resume.go
+++ b/pkg/webui/resume.go
@@ -97,6 +97,11 @@ func (s *Server) apiResumeRun(w http.ResponseWriter, r *http.Request) {
 			jsonErr(w, "run already resumed", http.StatusConflict)
 		case errors.Is(err, trigger.ErrResumeExpired):
 			jsonErr(w, "resume deadline expired", http.StatusGone)
+		case errors.Is(err, trigger.ErrResumePending):
+			// The task is held pending approval (or otherwise vetoed); the run
+			// stays suspended and resumable once it is approved. 423 Locked
+			// signals a retryable, not-yet-permitted state.
+			jsonErr(w, "task is awaiting approval; resume once it is approved", http.StatusLocked)
 		default:
 			jsonErr(w, err.Error(), http.StatusInternalServerError)
 		}


### PR DESCRIPTION
## Summary

`Engine.ResumeRun` consumed the single-use resume token — `registry.MarkRunResumed` flips the suspended run to the terminal `resumed` status — *before* the continuation was actually admitted. The fire path (`fireAsync` → `startRun` → `checkFireGuard`, plus the `StartRunWithID` record write) ran only *after* the token was already spent.

The failure that motivated this: a task suspends, its author edits it, and the trust-on-change approval gate (#392, default-ON) holds the task **pending**. The user submits the resume form → the token is consumed and the suspended run goes terminal → `checkFireGuard` then returns `ErrPending` → no continuation spawns. The `resume_state` blob is now stranded on a `resumed` row forever and every retry gets `409` (`ErrResumeNotSuspended`). The suspension is permanently destroyed. The same permanent loss happened on any other pre-spawn failure occurring after the token was consumed.

## Approach

Consume the token as late as possible — only once the continuation is known to be admitted. `checkFireGuard` is already a pure, non-destructive probe, so `ResumeRun` now calls it *before* `MarkRunResumed`, extending the same pre-consume defense the code already applied for deregistration. A vetoed continuation leaves the run `suspended` with its token intact and returns a new sentinel `ErrResumePending` (wrapping the underlying guard error, so `approval.ErrPending` still inspects through). Once the task is re-approved the same token resumes normally. The webui maps `ErrResumePending` to `423 Locked` instead of the previous generic `500`.

### Residual window

The common case — the gate is pending at resume time — is fully fixed: the pre-check returns before any token consume. A negligible residual remains: if the task flips to pending in the microsecond *between* the pre-check and the spawn path's own internal guard re-check (or if `StartRunWithID` errors), the token is consumed and the run is stranded. That error still wraps `approval.ErrPending`, so it is surfaced rather than opaque. Closing this window entirely would require restructuring the spawn/record ordering, which touches the broader suspend seams tracked in #502 and is deliberately left out of this focused fix.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l .` — clean
- `go test ./... -timeout 180s` — all pass
- `go test -race ./pkg/trigger/... ./pkg/registry/...` — pass
- New test `TestResumeRun_FireGuardPendingKeepsSuspensionResumable` mirrors the existing deregistration test: a suspended run whose task is gate-pending returns `ErrResumePending`, stays `suspended` with its token unchanged, and resumes with the *same* token once the guard admits again.

Part of #95. See #502 for the remaining suspend seams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)