### PR TITLE
feat(suspend): dicode resume CLI

### DIFF
--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -138,6 +138,15 @@ func dispatch(c *ipc.ControlClient, args []string) error {
 			return fmt.Errorf("usage: dicode logs <run-id>")
 		}
 		return cmdLogs(c, args[1])
+	case "resume":
+		// Bare `dicode resume` lists suspended runs; with a run id it resumes.
+		if len(args) < 2 {
+			return cmdResumeList(c)
+		}
+		if err := waitDaemonReady(c, readyWaitTimeout); err != nil {
+			return err
+		}
+		return cmdResume(c, args[1], args[2:])
 	case "status":
 		taskID := ""
 		if len(args) >= 2 {
@@ -915,6 +924,78 @@ func cmdStatus(c *ipc.ControlClient, taskID string) error {
 	return nil
 }
 
+// parseResumeInput turns `field=value` CLI args into the JSON object the
+// daemon forwards to the resumed task as ctx.resume_input. An arg without an
+// `=` is a usage error. An empty arg list yields an empty object.
+func parseResumeInput(kvArgs []string) ([]byte, error) {
+	input := map[string]string{}
+	for _, kv := range kvArgs {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid form value %q — expected field=value", kv)
+		}
+		input[parts[0]] = parts[1]
+	}
+	return json.Marshal(input)
+}
+
+// cmdResume submits collected form values as the resume input for a suspended
+// run. It sends only the run id and the key=value pairs — the daemon resolves
+// the run's resume token server-side and calls the engine's resume, returning
+// the continuation run id.
+func cmdResume(c *ipc.ControlClient, runID string, kvArgs []string) error {
+	inputJSON, err := parseResumeInput(kvArgs)
+	if err != nil {
+		return err
+	}
+	resp, err := c.Send(ipc.Request{
+		Method: "cli.resume",
+		RunID:  runID,
+		Params: inputJSON,
+	})
+	if err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	var result ipc.ResumeResult
+	if err := remarshal(resp.Result, &result); err != nil {
+		return err
+	}
+	fmt.Printf("resumed: continuation run %s\n", result.RunID)
+	// The continuation runs asynchronously; point the user at its logs rather
+	// than blocking, since resume returns as soon as the run is spawned.
+	fmt.Printf("follow: dicode logs %s\n", result.RunID)
+	return nil
+}
+
+// cmdResumeList prints the runs currently awaiting resume, with the form fields
+// each expects, so the operator knows what to pass to `dicode resume`.
+func cmdResumeList(c *ipc.ControlClient) error {
+	resp, err := c.Send(ipc.Request{Method: "cli.resume.list"})
+	if err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	var runs []ipc.SuspendedRunSummary
+	if err := remarshal(resp.Result, &runs); err != nil {
+		return err
+	}
+	if len(runs) == 0 {
+		fmt.Println("no suspended runs")
+		return nil
+	}
+	fmt.Printf("%-36s %-24s %-20s %s\n", "RUN ID", "TASK", "SUSPENDED AT", "FIELDS")
+	for _, r := range runs {
+		fmt.Printf("%-36s %-24s %-20s %s\n", r.RunID, r.TaskID, orDash(r.SuspendedAt), strings.Join(r.Fields, ","))
+	}
+	fmt.Println("\nresume with: dicode resume <run-id> [field=value ...]")
+	return nil
+}
+
 func cmdSecrets(c *ipc.ControlClient, args []string) error {
 	switch args[0] {
 	case "list":
@@ -1184,6 +1265,7 @@ Commands:
   list                            list registered tasks
   logs <run-id>                   show logs for a run
   status [task-id]                daemon health or task's latest run
+  resume [run-id] [field=value]   resume a suspended run (no args lists suspended runs)
   ai <prompt> [flags]             run the configured AI task with a prompt
                                   flags: --session-id ID, --task TASK_ID
   task test <task-id> [flags]     run the task's sibling task.test.* through its runtime

--- a/cmd/dicode/resume_test.go
+++ b/cmd/dicode/resume_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseResumeInput_KeyValueToJSON(t *testing.T) {
+	got, err := parseResumeInput([]string{"approve=yes", "note=looks good"})
+	if err != nil {
+		t.Fatalf("parseResumeInput: %v", err)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(got, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["approve"] != "yes" {
+		t.Errorf("approve = %q, want yes", m["approve"])
+	}
+	// Values may contain `=` and spaces — only the first `=` splits.
+	if m["note"] != "looks good" {
+		t.Errorf("note = %q, want 'looks good'", m["note"])
+	}
+}
+
+func TestParseResumeInput_ValueWithEquals(t *testing.T) {
+	got, err := parseResumeInput([]string{"expr=a=b"})
+	if err != nil {
+		t.Fatalf("parseResumeInput: %v", err)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(got, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["expr"] != "a=b" {
+		t.Errorf("expr = %q, want a=b", m["expr"])
+	}
+}
+
+func TestParseResumeInput_EmptyIsEmptyObject(t *testing.T) {
+	got, err := parseResumeInput(nil)
+	if err != nil {
+		t.Fatalf("parseResumeInput: %v", err)
+	}
+	if string(got) != "{}" {
+		t.Errorf("got %s, want {}", got)
+	}
+}
+
+func TestParseResumeInput_MissingEqualsIsError(t *testing.T) {
+	if _, err := parseResumeInput([]string{"approve"}); err == nil {
+		t.Fatal("expected error for arg without '='")
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -5,6 +5,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -764,7 +765,30 @@ func buildControlServer(cfg *config.Config, dataDir, version string, database db
 	// Wire task deletion so `dicode task delete` can remove a task from its
 	// source. The SourceManager owns source state, repo paths, and dev-clones.
 	ctrlSrv.SetTaskDeleter(sourceMgr)
+
+	// Wire suspended-run resume so `dicode resume` reaches Engine.ResumeRun.
+	ctrlSrv.SetResumer(resumerAdapter{eng: eng})
 	return ctrlSrv, nil
+}
+
+// resumerAdapter maps the trigger engine's typed resume errors onto the ipc
+// sentinels so the control handler can classify them — pkg/ipc cannot import
+// pkg/trigger (trigger imports ipc), so the translation lives here.
+type resumerAdapter struct{ eng *trigger.Engine }
+
+func (a resumerAdapter) ResumeRun(ctx context.Context, token string, input []byte) (string, error) {
+	id, err := a.eng.ResumeRun(ctx, token, input)
+	switch {
+	case errors.Is(err, trigger.ErrResumeTokenNotFound):
+		return "", ipc.ErrResumeTokenNotFound
+	case errors.Is(err, trigger.ErrResumeNotSuspended):
+		return "", ipc.ErrResumeNotSuspended
+	case errors.Is(err, trigger.ErrResumeExpired):
+		return "", ipc.ErrResumeExpired
+	case errors.Is(err, trigger.ErrResumePending):
+		return "", ipc.ErrResumePending
+	}
+	return id, err
 }
 
 // wireCryptoIPC wires the generic dicode.crypto.{encrypt, decrypt} IPC verb

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -40,6 +40,7 @@ type ControlServer struct {
 	apiKeys         APIKeyMinter     // nil if webui not wired (tests)
 	authoring       AuthoringService // nil if webui not wired (tests)
 	taskDeleter     TaskDeleter      // nil if webui not wired (tests)
+	resumer         Resumer          // nil if engine not wired (tests)
 	log             *zap.Logger
 
 	// taskApprover is the approval gate's Approve, wired via SetTaskApprover.
@@ -234,6 +235,12 @@ func (cs *ControlServer) dispatch(ctx context.Context, req Request) (any, error)
 
 	case "cli.status":
 		return cs.handleStatus(ctx, req)
+
+	case "cli.resume":
+		return cs.handleResume(ctx, req)
+
+	case "cli.resume.list":
+		return cs.handleResumeList(ctx)
 
 	case "cli.secrets.list":
 		return cs.handleSecretsList(ctx)

--- a/pkg/ipc/control_resume.go
+++ b/pkg/ipc/control_resume.go
@@ -1,0 +1,147 @@
+package ipc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	"go.uber.org/zap"
+)
+
+// Resume errors the control server classifies into CLI messages. pkg/ipc cannot
+// import pkg/trigger (trigger imports ipc), so the daemon's Resumer adapter
+// translates trigger's typed sentinels into these before they reach
+// handleResume.
+var (
+	ErrResumeTokenNotFound = errors.New("resume token not found")
+	ErrResumeNotSuspended  = errors.New("run is not suspended")
+	ErrResumeExpired       = errors.New("resume deadline expired")
+	ErrResumePending       = errors.New("resume blocked: task not admitted")
+)
+
+// Resumer spawns the continuation run for a suspended run given its resume
+// token. *trigger.Engine.ResumeRun satisfies the shape; the daemon wraps it in
+// an adapter that maps trigger's typed errors onto the ErrResume* sentinels
+// above so this package needs no dependency on pkg/trigger.
+type Resumer interface {
+	ResumeRun(ctx context.Context, token string, input []byte) (newRunID string, err error)
+}
+
+// SetResumer wires the resume backend for cli.resume dispatch. Nil leaves the
+// method returning a clear error (tests / configurations without a running
+// engine).
+func (cs *ControlServer) SetResumer(r Resumer) { cs.resumer = r }
+
+// ResumeResult is the cli.resume response — the continuation run's ID.
+type ResumeResult struct {
+	RunID string `json:"runID"`
+}
+
+// SuspendedRunSummary is one row in the cli.resume.list response. Fields is the
+// list of form field names the task declared via dicode.suspend(), so the CLI
+// can hint which key=value pairs to supply.
+type SuspendedRunSummary struct {
+	RunID       string   `json:"runID"`
+	TaskID      string   `json:"taskID"`
+	SuspendedAt string   `json:"suspendedAt"` // RFC3339 or ""
+	Deadline    string   `json:"deadline"`    // RFC3339 or ""
+	Fields      []string `json:"fields"`
+}
+
+// handleResume resolves a suspended run server-side and spawns its continuation.
+// The client supplies only the run id and the collected key=value input — never
+// the token: the token is read from the stored run, mirroring the webui's
+// authorization model where the session (here, the trusted control socket) is
+// the authority and the resume handle stays server-side.
+func (cs *ControlServer) handleResume(ctx context.Context, req Request) (ResumeResult, error) {
+	if cs.resumer == nil {
+		return ResumeResult{}, errors.New("resume not available (engine not wired)")
+	}
+	if req.RunID == "" {
+		return ResumeResult{}, errors.New("runID required")
+	}
+	run, err := cs.reg.GetRun(ctx, req.RunID)
+	if err != nil {
+		return ResumeResult{}, fmt.Errorf("run %q not found", req.RunID)
+	}
+	if run.Status != registry.StatusSuspended || run.ResumeToken == "" {
+		return ResumeResult{}, errors.New("run is not suspended")
+	}
+
+	// The key=value pairs arrive as a JSON object in Params; pass through as the
+	// opaque resume input the task reads as ctx.resume_input.
+	input := []byte(req.Params)
+	if len(input) == 0 {
+		input = []byte("{}")
+	}
+
+	newRunID, err := cs.resumer.ResumeRun(ctx, run.ResumeToken, input)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrResumeTokenNotFound):
+			return ResumeResult{}, errors.New("resume token not found — the suspended run may have been cleaned up")
+		case errors.Is(err, ErrResumeNotSuspended):
+			return ResumeResult{}, errors.New("run is not suspended — it may have already been resumed")
+		case errors.Is(err, ErrResumeExpired):
+			return ResumeResult{}, errors.New("resume deadline expired — this run can no longer be resumed")
+		case errors.Is(err, ErrResumePending):
+			return ResumeResult{}, errors.New("task is awaiting approval — resume once it is approved (dicode task approve <task-id>)")
+		}
+		return ResumeResult{}, err
+	}
+	cs.log.Info("run resumed via control socket",
+		zap.String("suspended_run", req.RunID), zap.String("continuation_run", newRunID))
+	return ResumeResult{RunID: newRunID}, nil
+}
+
+// handleResumeList returns the runs currently awaiting resume so the CLI can
+// show the operator what's resumable without hunting through per-task logs.
+func (cs *ControlServer) handleResumeList(ctx context.Context) ([]SuspendedRunSummary, error) {
+	runs, err := cs.reg.ListSuspendedRuns(ctx, 100)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]SuspendedRunSummary, 0, len(runs))
+	for _, r := range runs {
+		s := SuspendedRunSummary{
+			RunID:  r.ID,
+			TaskID: r.TaskID,
+			Fields: resumeFormFieldNames(r.ResumeForm),
+		}
+		if r.SuspendedAt > 0 {
+			s.SuspendedAt = time.UnixMilli(r.SuspendedAt).UTC().Format(time.RFC3339)
+		}
+		if r.ResumeDeadline > 0 {
+			s.Deadline = time.UnixMilli(r.ResumeDeadline).UTC().Format(time.RFC3339)
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// resumeFormFieldNames extracts the field names from a persisted FormSchema
+// blob. A malformed or empty schema yields no names — the listing degrades to
+// run id + task rather than failing.
+func resumeFormFieldNames(formJSON []byte) []string {
+	if len(formJSON) == 0 {
+		return nil
+	}
+	var schema struct {
+		Fields []struct {
+			Name string `json:"name"`
+		} `json:"fields"`
+	}
+	if err := json.Unmarshal(formJSON, &schema); err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(schema.Fields))
+	for _, f := range schema.Fields {
+		if f.Name != "" {
+			names = append(names, f.Name)
+		}
+	}
+	return names
+}

--- a/pkg/ipc/control_resume_test.go
+++ b/pkg/ipc/control_resume_test.go
@@ -1,0 +1,212 @@
+package ipc
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	"go.uber.org/zap"
+)
+
+// fakeResumer records the token and input it was called with and returns a
+// canned result — standing in for the daemon's engine-backed adapter.
+type fakeResumer struct {
+	gotToken string
+	gotInput []byte
+	newRunID string
+	err      error
+	called   bool
+}
+
+func (f *fakeResumer) ResumeRun(_ context.Context, token string, input []byte) (string, error) {
+	f.called = true
+	f.gotToken = token
+	f.gotInput = input
+	return f.newRunID, f.err
+}
+
+// newResumeReg returns an in-memory registry holding one run, optionally
+// suspended with the given token and form.
+func newResumeReg(t *testing.T) (*registry.Registry, db.DB) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return registry.New(d), d
+}
+
+func suspendRun(t *testing.T, reg *registry.Registry, runID, token string, form []byte) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := reg.StartRunWithID(ctx, runID, "task-x", "", string(registry.TriggerManual), registry.RunKindTask); err != nil {
+		t.Fatalf("StartRunWithID: %v", err)
+	}
+	deadline := time.Now().Add(time.Hour).UnixMilli()
+	if err := reg.SuspendRun(ctx, runID, []byte(`{"step":1}`), form, token, time.Now().UnixMilli(), deadline); err != nil {
+		t.Fatalf("SuspendRun: %v", err)
+	}
+}
+
+func TestResume_Success_CallsResumerWithParsedInput(t *testing.T) {
+	reg, _ := newResumeReg(t)
+	suspendRun(t, reg, "run-1", "tok-abc", []byte(`{"fields":[{"name":"approve"}]}`))
+
+	fr := &fakeResumer{newRunID: "run-2"}
+	cs := &ControlServer{reg: reg, resumer: fr, log: zap.NewNop()}
+
+	res, err := cs.dispatch(context.Background(), Request{
+		ID: "1", Method: "cli.resume", RunID: "run-1",
+		Params: json.RawMessage(`{"approve":"yes"}`),
+	})
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	out, ok := res.(ResumeResult)
+	if !ok {
+		t.Fatalf("result type %T", res)
+	}
+	if out.RunID != "run-2" {
+		t.Fatalf("RunID = %q, want run-2", out.RunID)
+	}
+	if !fr.called {
+		t.Fatal("resumer was not called")
+	}
+	// The token must be resolved server-side from the run, never supplied by
+	// the client.
+	if fr.gotToken != "tok-abc" {
+		t.Fatalf("token = %q, want tok-abc (resolved from run)", fr.gotToken)
+	}
+	if string(fr.gotInput) != `{"approve":"yes"}` {
+		t.Fatalf("input = %s, want the parsed key=value JSON", fr.gotInput)
+	}
+}
+
+func TestResume_EmptyParamsBecomesEmptyObject(t *testing.T) {
+	reg, _ := newResumeReg(t)
+	suspendRun(t, reg, "run-1", "tok-abc", nil)
+
+	fr := &fakeResumer{newRunID: "run-2"}
+	cs := &ControlServer{reg: reg, resumer: fr, log: zap.NewNop()}
+
+	if _, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.resume", RunID: "run-1"}); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if string(fr.gotInput) != `{}` {
+		t.Fatalf("input = %s, want {}", fr.gotInput)
+	}
+}
+
+func TestResume_NotSuspended(t *testing.T) {
+	reg, _ := newResumeReg(t)
+	// A plain (non-suspended) run.
+	if _, err := reg.StartRunWithID(context.Background(), "run-1", "task-x", "", string(registry.TriggerManual), registry.RunKindTask); err != nil {
+		t.Fatalf("StartRunWithID: %v", err)
+	}
+	fr := &fakeResumer{}
+	cs := &ControlServer{reg: reg, resumer: fr, log: zap.NewNop()}
+
+	_, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.resume", RunID: "run-1"})
+	if err == nil {
+		t.Fatal("expected error for a non-suspended run")
+	}
+	if fr.called {
+		t.Fatal("resumer must not be called for a non-suspended run")
+	}
+}
+
+func TestResume_EngineErrorsMapToMessages(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"not found", ErrResumeTokenNotFound, "resume token not found"},
+		{"already resumed", ErrResumeNotSuspended, "already been resumed"},
+		{"expired", ErrResumeExpired, "expired"},
+		{"pending", ErrResumePending, "awaiting approval"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg, _ := newResumeReg(t)
+			suspendRun(t, reg, "run-1", "tok-abc", nil)
+			fr := &fakeResumer{err: tc.err}
+			cs := &ControlServer{reg: reg, resumer: fr, log: zap.NewNop()}
+
+			_, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.resume", RunID: "run-1"})
+			if err == nil {
+				t.Fatalf("expected error for %v", tc.err)
+			}
+			if got := err.Error(); !strings.Contains(got, tc.want) {
+				t.Fatalf("message = %q, want it to contain %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResume_MissingRunID(t *testing.T) {
+	fr := &fakeResumer{}
+	cs := &ControlServer{resumer: fr, log: zap.NewNop()}
+	if _, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.resume"}); err == nil {
+		t.Fatal("expected error without runID")
+	}
+	if fr.called {
+		t.Fatal("resumer must not be called without a run id")
+	}
+}
+
+func TestResume_NotConfigured(t *testing.T) {
+	cs := &ControlServer{log: zap.NewNop()}
+	if _, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.resume", RunID: "run-1"}); err == nil {
+		t.Fatal("expected error when resumer is not wired")
+	}
+}
+
+func TestResumeList_ReportsSuspendedRunsWithFields(t *testing.T) {
+	reg, _ := newResumeReg(t)
+	suspendRun(t, reg, "run-1", "tok-1", []byte(`{"fields":[{"name":"approve"},{"name":"note"}]}`))
+
+	cs := &ControlServer{reg: reg, log: zap.NewNop()}
+	res, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.resume.list"})
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	list, ok := res.([]SuspendedRunSummary)
+	if !ok {
+		t.Fatalf("result type %T", res)
+	}
+	if len(list) != 1 {
+		t.Fatalf("len = %d, want 1", len(list))
+	}
+	got := list[0]
+	if got.RunID != "run-1" || got.TaskID != "task-x" {
+		t.Fatalf("summary = %+v", got)
+	}
+	if len(got.Fields) != 2 || got.Fields[0] != "approve" || got.Fields[1] != "note" {
+		t.Fatalf("fields = %v, want [approve note]", got.Fields)
+	}
+	if got.SuspendedAt == "" {
+		t.Fatal("SuspendedAt should be populated")
+	}
+}
+
+func TestResumeList_Empty(t *testing.T) {
+	reg, _ := newResumeReg(t)
+	cs := &ControlServer{reg: reg, log: zap.NewNop()}
+	res, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.resume.list"})
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	list, ok := res.([]SuspendedRunSummary)
+	if !ok {
+		t.Fatalf("result type %T", res)
+	}
+	if len(list) != 0 {
+		t.Fatalf("len = %d, want 0", len(list))
+	}
+}

--- a/pkg/registry/resume.go
+++ b/pkg/registry/resume.go
@@ -37,6 +37,33 @@ func (r *Registry) GetRunByResumeToken(ctx context.Context, token string) (*Run,
 	return run, nil
 }
 
+// ListSuspendedRuns returns every run currently in the suspended state, newest
+// first (by suspend time). Unlike queryRuns, it selects the resume columns so
+// callers can render each run's pending form — used by `dicode resume` to list
+// what's resumable.
+func (r *Registry) ListSuspendedRuns(ctx context.Context, limit int) ([]*Run, error) {
+	var runs []*Run
+	err := r.db.Query(ctx,
+		`SELECT `+runColumns+runInputColumns+runResumeColumns+`
+		 FROM runs WHERE status = ? ORDER BY suspended_at DESC LIMIT ?`,
+		[]any{StatusSuspended, limit},
+		func(rows db.Scanner) error {
+			for rows.Next() {
+				run, err := scanRun(rows, true, true)
+				if err != nil {
+					return err
+				}
+				runs = append(runs, run)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list suspended runs: %w", err)
+	}
+	return runs, nil
+}
+
 // MarkRunResumed transitions a suspended run to the terminal `resumed` state,
 // consuming its resume token so it can't be replayed. The transition is a
 // single conditional UPDATE gated on the current status; RowsAffected decides


### PR DESCRIPTION
## Summary

Adds `dicode resume`, the terminal path to continue a suspended run — the final
piece of the suspend/resume primitive.

`dicode resume <run-id> [field=value ...]` submits the collected form values as
a suspended run's resume input. The CLI never handles the resume token: it sends
only the run id and the key=value pairs, and the daemon resolves the run's
`resume_token` server-side before calling `Engine.ResumeRun` — the same
authorization model the webui uses, where the token stays on the server and the
trusted channel (here the 0600 control socket) is the authority.

Bare `dicode resume` lists the runs currently awaiting resume together with the
form fields each expects, so an operator can discover what's resumable without
digging through per-task logs. A task whose latest run is suspended already
shows `suspended` in `dicode list`, so no change was needed there.

## Design notes

A control-plane pair (`cli.resume` / `cli.resume.list`) backs both commands.
`pkg/ipc` cannot import `pkg/trigger` (trigger imports ipc), so the engine's
typed resume errors are translated into `ipc.ErrResume*` sentinels by a small
`Resumer` adapter wired in the daemon — the same duplication pattern already
used for `StatusCrashLooping`. The handler classifies those sentinels into clear
CLI messages for the not-found / not-suspended / expired / awaiting-approval
cases.

The continuation runs asynchronously (resume returns as soon as the run is
spawned), so rather than block, the CLI prints the continuation run id and a
`dicode logs <id>` hint.

Part of #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)