### PR TITLE
fix(suspend): preserve run params and chain depth across resume

### DIFF
--- a/pkg/db/sqlite.go
+++ b/pkg/db/sqlite.go
@@ -196,6 +196,11 @@ func (s *SQLiteDB) migrate() error {
 		{"resume_token", "TEXT"},
 		{"suspended_at", "INTEGER"},
 		{"resume_deadline", "INTEGER"},
+		// resume_params carries the ORIGINAL run's fire-time param overrides and
+		// chain depth as a JSON envelope so the continuation resumes with the same
+		// ctx.params and honors the same chain-depth ceiling. NULL when the
+		// suspended run carried neither.
+		{"resume_params", "BLOB"},
 	}
 	for _, m := range runsMigrations {
 		if err := addColumnIfMissing(ctx, s.db, "runs", m.name, m.ddl); err != nil {

--- a/pkg/db/sqlite_test.go
+++ b/pkg/db/sqlite_test.go
@@ -147,6 +147,7 @@ func TestSQLiteDB_RunsHasResumeColumns(t *testing.T) {
 		"resume_token":    "TEXT",
 		"suspended_at":    "INTEGER",
 		"resume_deadline": "INTEGER",
+		"resume_params":   "BLOB",
 	}
 	for name, wantType := range wantCols {
 		got, ok := cols[name]

--- a/pkg/ipc/control_resume_test.go
+++ b/pkg/ipc/control_resume_test.go
@@ -48,7 +48,7 @@ func suspendRun(t *testing.T, reg *registry.Registry, runID, token string, form 
 		t.Fatalf("StartRunWithID: %v", err)
 	}
 	deadline := time.Now().Add(time.Hour).UnixMilli()
-	if err := reg.SuspendRun(ctx, runID, []byte(`{"step":1}`), form, token, time.Now().UnixMilli(), deadline); err != nil {
+	if err := reg.SuspendRun(ctx, runID, []byte(`{"step":1}`), form, token, time.Now().UnixMilli(), deadline, nil); err != nil {
 		t.Fatalf("SuspendRun: %v", err)
 	}
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -94,6 +94,10 @@ type Run struct {
 	ResumeToken    string // unguessable resume handle; empty when absent
 	SuspendedAt    int64  // Unix ms the run suspended; 0 when absent
 	ResumeDeadline int64  // Unix ms TTL; 0 when no deadline set
+	// ResumeParams is a JSON envelope of the original run's fire-time param
+	// overrides and chain depth, preserved so the continuation resumes with the
+	// same ctx.params and honors the same chain-depth ceiling. nil when absent.
+	ResumeParams []byte
 }
 
 // LogEntry is one log line from a run.
@@ -254,15 +258,15 @@ func (r *Registry) FinishRunWithResult(ctx context.Context, runID, status, retur
 // deliberately leaves finished_at NULL: suspended is a non-terminal status, so
 // the run is neither running (CleanupStaleRuns skips it) nor finished.
 //
-// A deadline of 0 stores NULL (no TTL). state and form may be nil.
-func (r *Registry) SuspendRun(ctx context.Context, runID string, state, form []byte, token string, suspendedAt, deadline int64) error {
+// A deadline of 0 stores NULL (no TTL). state, form, and resumeParams may be nil.
+func (r *Registry) SuspendRun(ctx context.Context, runID string, state, form []byte, token string, suspendedAt, deadline int64, resumeParams []byte) error {
 	var deadlineArg any
 	if deadline > 0 {
 		deadlineArg = deadline
 	}
 	return r.db.Exec(ctx,
-		`UPDATE runs SET status = ?, resume_state = ?, resume_form = ?, resume_token = ?, suspended_at = ?, resume_deadline = ? WHERE id = ?`,
-		StatusSuspended, state, form, token, suspendedAt, deadlineArg, runID,
+		`UPDATE runs SET status = ?, resume_state = ?, resume_form = ?, resume_token = ?, suspended_at = ?, resume_deadline = ?, resume_params = ? WHERE id = ?`,
+		StatusSuspended, state, form, token, suspendedAt, deadlineArg, resumeParams, runID,
 	)
 }
 
@@ -363,7 +367,7 @@ const runInputColumns = `,
 // COALESCE so a NULL reads back as the zero value.
 const runResumeColumns = `,
         resume_state, resume_form, COALESCE(resume_token, ''),
-        COALESCE(suspended_at, 0), COALESCE(resume_deadline, 0)`
+        COALESCE(suspended_at, 0), COALESCE(resume_deadline, 0), resume_params`
 
 // scanRun decodes one row selected with runColumns (plus runInputColumns when
 // withInput is true, plus runResumeColumns when withResume is true) into a Run,
@@ -388,7 +392,8 @@ func scanRun(rows db.Scanner, withInput, withResume bool) (*Run, error) {
 	}
 	if withResume {
 		dest = append(dest,
-			&run.ResumeState, &run.ResumeForm, &run.ResumeToken, &run.SuspendedAt, &run.ResumeDeadline)
+			&run.ResumeState, &run.ResumeForm, &run.ResumeToken, &run.SuspendedAt, &run.ResumeDeadline,
+			&run.ResumeParams)
 	}
 	if err := rows.Scan(dest...); err != nil {
 		return nil, err

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -488,7 +488,7 @@ func TestSuspendRun_RoundTrip(t *testing.T) {
 	suspendedAt := time.Now().UnixMilli()
 	deadline := suspendedAt + 86_400_000
 
-	if err := r.SuspendRun(ctx, runID, state, form, token, suspendedAt, deadline); err != nil {
+	if err := r.SuspendRun(ctx, runID, state, form, token, suspendedAt, deadline, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -531,7 +531,7 @@ func TestSuspendRun_NoDeadlineNilBlobs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := r.SuspendRun(ctx, runID, nil, nil, "tok", time.Now().UnixMilli(), 0); err != nil {
+	if err := r.SuspendRun(ctx, runID, nil, nil, "tok", time.Now().UnixMilli(), 0, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -564,7 +564,7 @@ func TestCleanupStaleRuns_SkipsSuspended(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := r.SuspendRun(ctx, suspended, []byte(`{}`), nil, "tok", time.Now().UnixMilli(), 0); err != nil {
+	if err := r.SuspendRun(ctx, suspended, []byte(`{}`), nil, "tok", time.Now().UnixMilli(), 0, nil); err != nil {
 		t.Fatal(err)
 	}
 	running, err := r.StartRun(ctx, "task-b", "")

--- a/pkg/registry/resume_test.go
+++ b/pkg/registry/resume_test.go
@@ -26,7 +26,7 @@ func seedSuspendedRun(t *testing.T, r *Registry, runID, token string, deadline i
 	if _, err := r.StartRunWithID(ctx, runID, "task-x", "", string(TriggerManual), RunKindTask); err != nil {
 		t.Fatalf("StartRunWithID: %v", err)
 	}
-	if err := r.SuspendRun(ctx, runID, []byte(`{"step":1}`), []byte(`{"fields":[]}`), token, time.Now().UnixMilli(), deadline); err != nil {
+	if err := r.SuspendRun(ctx, runID, []byte(`{"step":1}`), []byte(`{"fields":[]}`), token, time.Now().UnixMilli(), deadline, nil); err != nil {
 		t.Fatalf("SuspendRun: %v", err)
 	}
 }

--- a/pkg/trigger/resume.go
+++ b/pkg/trigger/resume.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -12,6 +13,16 @@ import (
 	pkgruntime "github.com/dicode/dicode/pkg/runtime"
 	"go.uber.org/zap"
 )
+
+// resumeCarry is the fire-time context of a suspended run that must survive the
+// suspend→resume hop: the param overrides the run was fired with (so the
+// continuation sees the same ctx.params instead of reverting to spec defaults)
+// and the chain depth (so the chain-depth ceiling is not reset by a suspend).
+// Persisted as JSON in runs.resume_params at suspend, restored in ResumeRun.
+type resumeCarry struct {
+	Params     map[string]string `json:"params,omitempty"`
+	ChainDepth int               `json:"chain_depth,omitempty"`
+}
 
 // defaultResumeTTL is how long a suspended run stays resumable when the task
 // did not specify its own deadline. After it, the sweep cancels the run with
@@ -41,7 +52,7 @@ var (
 // an unguessable single-use resume token and records the state/form blobs plus
 // the deadline. The deadline comes from the task (result.ResumeDeadline) or
 // defaults to defaultResumeTTL from now.
-func (e *Engine) suspendRun(runID string, result *pkgruntime.RunResult) error {
+func (e *Engine) suspendRun(opts *pkgruntime.RunOptions, result *pkgruntime.RunResult) error {
 	token, err := newResumeToken()
 	if err != nil {
 		return fmt.Errorf("mint resume token: %w", err)
@@ -51,8 +62,17 @@ func (e *Engine) suspendRun(runID string, result *pkgruntime.RunResult) error {
 	if deadlineMs <= 0 {
 		deadlineMs = time.Now().Add(defaultResumeTTL).UnixMilli()
 	}
-	return e.registry.SuspendRun(context.Background(), runID,
-		result.ResumeState, result.ResumeForm, token, nowMs, deadlineMs)
+	// Persist the run's fire-time params and chain depth so the continuation
+	// resumes with the same ctx.params and the same chain-depth ceiling.
+	var carryJSON []byte
+	carry := resumeCarry{Params: opts.Params, ChainDepth: e.chainDepth(opts.RunID)}
+	if len(carry.Params) > 0 || carry.ChainDepth > 0 {
+		if carryJSON, err = json.Marshal(carry); err != nil {
+			return fmt.Errorf("marshal resume params: %w", err)
+		}
+	}
+	return e.registry.SuspendRun(context.Background(), opts.RunID,
+		result.ResumeState, result.ResumeForm, token, nowMs, deadlineMs, carryJSON)
 }
 
 // newResumeToken returns a 32-byte crypto/rand token, hex-encoded. Long and
@@ -123,11 +143,27 @@ func (e *Engine) ResumeRun(ctx context.Context, token string, input []byte) (str
 		return "", fmt.Errorf("mark run resumed: %w", err)
 	}
 
-	newRunID, err := e.fireAsync(context.Background(), spec, pkgruntime.RunOptions{
+	opts := pkgruntime.RunOptions{
 		ParentRunID: run.ID,
 		ResumeState: run.ResumeState,
 		ResumeInput: input,
-	}, registry.TriggerResume)
+	}
+	// Restore the original run's fire-time params and chain depth so the
+	// continuation sees the same ctx.params (not spec defaults) and stays under
+	// the chain-depth ceiling. Chain depth rides in Input because fireAsync reads
+	// _chain_depth from there to seed runChainDepth.
+	if len(run.ResumeParams) > 0 {
+		var carry resumeCarry
+		if err := json.Unmarshal(run.ResumeParams, &carry); err != nil {
+			return "", fmt.Errorf("resume: decode carried run params: %w", err)
+		}
+		opts.Params = carry.Params
+		if carry.ChainDepth > 0 {
+			opts.Input = map[string]any{"_chain_depth": carry.ChainDepth}
+		}
+	}
+
+	newRunID, err := e.fireAsync(context.Background(), spec, opts, registry.TriggerResume)
 	if err != nil {
 		return "", fmt.Errorf("resume: spawn continuation run: %w", err)
 	}

--- a/pkg/trigger/resume_test.go
+++ b/pkg/trigger/resume_test.go
@@ -2,6 +2,7 @@ package trigger
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -28,9 +29,11 @@ type suspendExec struct {
 	firstDeadline int64
 	suspendAgain  bool
 
-	resumeCalls     int
-	seenResumeState []byte
-	seenResumeInput []byte
+	resumeCalls      int
+	seenResumeState  []byte
+	seenResumeInput  []byte
+	seenResumeParams map[string]string
+	seenInput        any
 }
 
 func (s *suspendExec) Execute(_ context.Context, _ *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
@@ -48,6 +51,8 @@ func (s *suspendExec) Execute(_ context.Context, _ *task.Spec, opts pkgruntime.R
 	s.resumeCalls++
 	s.seenResumeState = append([]byte(nil), opts.ResumeState...)
 	s.seenResumeInput = append([]byte(nil), opts.ResumeInput...)
+	s.seenResumeParams = opts.Params
+	s.seenInput = opts.Input
 	if s.suspendAgain {
 		return &pkgruntime.RunResult{
 			RunID:       opts.RunID,
@@ -415,7 +420,7 @@ func TestSuspendedDaemonRun_NeutralForCrashloop(t *testing.T) {
 	if _, err := reg.StartRunWithID(ctx, runID, spec.ID, "", string(registry.TriggerDaemon), registry.RunKindTask); err != nil {
 		t.Fatalf("StartRunWithID: %v", err)
 	}
-	if err := reg.SuspendRun(ctx, runID, []byte(`{}`), nil, "tok-daemon", time.Now().UnixMilli(), 0); err != nil {
+	if err := reg.SuspendRun(ctx, runID, []byte(`{}`), nil, "tok-daemon", time.Now().UnixMilli(), 0, nil); err != nil {
 		t.Fatalf("SuspendRun: %v", err)
 	}
 
@@ -435,4 +440,86 @@ func TestSuspendedDaemonRun_NeutralForCrashloop(t *testing.T) {
 	if eng.IsCrashLooping(spec.ID) {
 		t.Error("suspended daemon run must not count toward crash-loop")
 	}
+}
+
+// TestResumeRun_PreservesFireTimeParams pins #502: a run fired with a param
+// override that suspends must resume with the SAME override, not the spec
+// defaults. Without preservation the continuation's opts.Params is nil and
+// MergeParams(spec.Params, nil) silently reverts ctx.params mid-wizard.
+func TestResumeRun_PreservesFireTimeParams(t *testing.T) {
+	exec := &suspendExec{}
+	eng, reg := newSuspendEnv(t, exec)
+	spec := &task.Spec{ID: "wiz", Name: "wiz", Runtime: task.RuntimeDeno,
+		Params:  []task.Param{{Name: "project_name", Default: "spec-default"}},
+		Trigger: task.TriggerConfig{Manual: true}, Enabled: true}
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	override := map[string]string{"project_name": "user-choice"}
+	origID, err := eng.FireManual(context.Background(), "wiz", override)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	orig := waitStatus(t, reg, origID, registry.StatusSuspended)
+	if len(orig.ResumeParams) == 0 {
+		t.Fatal("suspended run did not persist fire-time params")
+	}
+
+	newID, err := eng.ResumeRun(context.Background(), orig.ResumeToken, []byte(`{}`))
+	if err != nil {
+		t.Fatalf("ResumeRun: %v", err)
+	}
+	waitStatus(t, reg, newID, registry.StatusSuccess)
+
+	exec.mu.Lock()
+	defer exec.mu.Unlock()
+	if got := exec.seenResumeParams["project_name"]; got != "user-choice" {
+		t.Errorf("continuation param project_name = %q, want %q (reverted to spec default?)", got, "user-choice")
+	}
+}
+
+// TestResumeRun_PreservesChainDepth pins #502: the chain-depth ceiling must
+// survive a suspend hop. A run fired at depth 3 that suspends and resumes into
+// a continuation which suspends again must carry depth 3 forward — if the hop
+// reset it, the persisted depth of the second suspension would be 0.
+func TestResumeRun_PreservesChainDepth(t *testing.T) {
+	exec := &suspendExec{suspendAgain: true}
+	eng, reg := newSuspendEnv(t, exec)
+	spec := &task.Spec{ID: "wiz", Name: "wiz", Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true}, Enabled: true}
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	origID, err := eng.fireAsync(context.Background(), spec,
+		pkgruntime.RunOptions{Input: map[string]any{"_chain_depth": 3}}, registry.TriggerChain)
+	if err != nil {
+		t.Fatalf("fireAsync: %v", err)
+	}
+	orig := waitStatus(t, reg, origID, registry.StatusSuspended)
+	if got := decodeCarryDepth(t, orig.ResumeParams); got != 3 {
+		t.Fatalf("original suspension chain depth = %d, want 3", got)
+	}
+
+	newID, err := eng.ResumeRun(context.Background(), orig.ResumeToken, []byte(`{"project_name":"acme"}`))
+	if err != nil {
+		t.Fatalf("ResumeRun: %v", err)
+	}
+	step2 := waitStatus(t, reg, newID, registry.StatusSuspended)
+	if got := decodeCarryDepth(t, step2.ResumeParams); got != 3 {
+		t.Errorf("chain depth after suspend hop = %d, want 3 (ceiling reset?)", got)
+	}
+}
+
+func decodeCarryDepth(t *testing.T, blob []byte) int {
+	t.Helper()
+	if len(blob) == 0 {
+		t.Fatal("resume_params blob is empty")
+	}
+	var c resumeCarry
+	if err := json.Unmarshal(blob, &c); err != nil {
+		t.Fatalf("decode resume_params: %v", err)
+	}
+	return c.ChainDepth
 }

--- a/pkg/trigger/run.go
+++ b/pkg/trigger/run.go
@@ -694,7 +694,7 @@ func (e *Engine) dispatch(ctx context.Context, spec *task.Spec, opts pkgruntime.
 	// chain — suspended is non-terminal, so success/failure chains must not
 	// fire until the continuation run reaches a real terminal state.
 	if result.Suspended {
-		if serr := e.suspendRun(opts.RunID, result); serr != nil {
+		if serr := e.suspendRun(&opts, result); serr != nil {
 			e.log.Warn("suspend run persist failed", zap.String("run", opts.RunID), zap.Error(serr))
 			if ferr := e.registry.FinishRun(context.Background(), opts.RunID, registry.StatusFailure); ferr != nil {
 				e.log.Warn("FinishRun: suspend fallback", zap.String("run", opts.RunID), zap.Error(ferr))

--- a/pkg/webui/resume_test.go
+++ b/pkg/webui/resume_test.go
@@ -40,7 +40,7 @@ func seedSuspendedRun(t *testing.T, reg *registry.Registry, form []byte, token s
 	if err != nil {
 		t.Fatalf("StartRunWithID: %v", err)
 	}
-	if err := reg.SuspendRun(ctx, id, []byte(`{"step":"x"}`), form, token, 1, 0); err != nil {
+	if err := reg.SuspendRun(ctx, id, []byte(`{"step":"x"}`), form, token, 1, 0, nil); err != nil {
 		t.Fatalf("SuspendRun: %v", err)
 	}
 	return id


### PR DESCRIPTION
## Summary

A run fired with param overrides (manual/webhook/chain `params:`) that suspends resumed with spec-default params. `ResumeRun` rebuilt the continuation's `RunOptions` with only `ParentRunID`/`ResumeState`/`ResumeInput`, dropping the original run's `opts.Params` and its `_chain_depth`. The effect: `ctx.params` silently reverted to `MergeParams(spec.Params, nil)` mid-wizard unless the task manually stashed the params in its own state, and the chain-depth ceiling reset to 0 on every suspend hop (a suspending task could escape `on_failure_chain` depth caps).

## Approach

Persist the original run's fire-time params and chain depth as a small JSON envelope (`resumeCarry{params, chain_depth}`) when the run suspends, and restore both into the continuation's `RunOptions` on resume. Params flow straight back into `opts.Params` (so `MergeParams` reproduces the same `ctx.params`); the chain depth rides in `opts.Input._chain_depth`, the existing seam `fireAsync` reads to seed `runChainDepth`, so the ceiling is honored by any chain the continuation fires.

Storage rides in a new nullable `runs.resume_params` BLOB column. The existing run-input persistence was unsuitable as a source because it redacts param values (lossy), and `resume_state` is the task's opaque blob and must not be polluted — so a dedicated carrier is the reliable minimal mechanism. The column is only written when the suspended run actually carried params or a non-zero depth.

## Tests

- A run fired with a param override that suspends → its continuation observes the SAME override, not the spec default.
- A run fired at chain depth 3 that suspends → the depth survives the resume hop into the continuation (verified via the persisted carrier of a second suspension). Both tests were confirmed to fail without the restore.

Part of #95. Closes one of the integration seams tracked in #502 (param/chain-depth drop across resume).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resuming paused runs now preserves the original run parameters and chain-depth setting, so continued runs behave consistently after a suspend/resume cycle.
  * Improved handling of suspended runs to keep stored resume details available when a run is restarted.
* **New Features**
  * Added support for carrying resume-specific run context through the suspension process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->