### PR TITLE
fix(suspend): don't grant CapSuspend to runtimes that can't suspend (docker/podman)

### DIFF
--- a/pkg/ipc/capability.go
+++ b/pkg/ipc/capability.go
@@ -21,6 +21,8 @@
 //	Response (error):       {"id":"1","error":"something went wrong"}
 package ipc
 
+import "github.com/dicode/dicode/pkg/task"
+
 // Capability constants — used in token claims and capability checks.
 const (
 	// Task-shim capabilities (all task tokens include these by default).
@@ -45,9 +47,11 @@ const (
 
 	// CapSuspend allows a task to call dicode.suspend() — pause the run,
 	// hand the runtime an opaque state blob plus a form schema, and exit
-	// cleanly for later resume (#95). A core self-affecting primitive
-	// granted to every task token by default; the cap exists only so future
-	// denial policies can revoke it.
+	// cleanly for later resume (#95). Granted only to runtimes that read
+	// srv.Suspend() to build a suspended result (deno, python); withheld from
+	// container runtimes (docker/podman) so a suspend attempt fails with a
+	// clear permission-denied error instead of being acked then dropped.
+	// See runtimeSupportsSuspend.
 	CapSuspend = "suspend"
 
 	// Conditionally granted to tasks based on security config.
@@ -125,6 +129,20 @@ func defaultTaskCaps() []string {
 		CapReturn,
 		CapOutputSecret,
 		CapSetGroup,
-		CapSuspend,
+	}
+}
+
+// runtimeSupportsSuspend reports whether a runtime implements the suspend
+// mechanism — reading srv.Suspend() after the task exits to turn a
+// dicode.suspend() into a suspended RunResult. Only the managed subprocess
+// runtimes do. Container runtimes (docker/podman) run an opaque image and
+// never read the payload, so granting CapSuspend there would let a suspend be
+// acked then silently dropped; withholding it yields a clear cap-denied error.
+func runtimeSupportsSuspend(rt task.Runtime) bool {
+	switch rt {
+	case task.RuntimeDocker, task.RuntimePodman:
+		return false
+	default:
+		return true
 	}
 }

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -228,6 +228,9 @@ func (s *Server) Start(ctx context.Context) (socketPath, token string, err error
 	// Core I/O caps are always granted; dicode.* API caps require explicit
 	// opt-in via permissions.dicode in task.yaml.
 	caps := defaultTaskCaps()
+	if s.spec != nil && runtimeSupportsSuspend(s.spec.Runtime) {
+		caps = append(caps, CapSuspend)
+	}
 	if dp := dicodePerms(s.spec); dp != nil {
 		if len(dp.Tasks) > 0 {
 			caps = append(caps, CapTaskTrigger)

--- a/pkg/ipc/server_test.go
+++ b/pkg/ipc/server_test.go
@@ -2486,3 +2486,76 @@ func TestServer_SocketDirCleanedUpOnStartFailure(t *testing.T) {
 		t.Errorf("fresh socket dir missing: %v", err)
 	}
 }
+
+// ── suspend capability gating (#502) ────────────────────────────────────────
+
+// CapSuspend must be granted only to runtimes that read srv.Suspend(): deno
+// and python. Container runtimes (docker/podman) never read the payload, so
+// granting the cap would let a dicode.suspend be acked then silently dropped.
+func TestServer_SuspendCap_GrantedByRuntime(t *testing.T) {
+	cases := []struct {
+		runtime task.Runtime
+		want    bool
+	}{
+		{task.RuntimeDeno, true},
+		{task.Runtime("python"), true},
+		{task.RuntimeDocker, false},
+		{task.RuntimePodman, false},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.runtime), func(t *testing.T) {
+			e := newTestEnv(t)
+			runID := fmt.Sprintf("test-%d", time.Now().UnixNano())
+			srv := New(runID, "test-task", e.secret, e.reg, e.db, nil, nil, zap.NewNop(), &task.Spec{Runtime: tc.runtime}, nil)
+			_, token, err := srv.Start(context.Background())
+			if err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+			t.Cleanup(srv.Stop)
+			claims, err := VerifyToken(e.secret, token)
+			if err != nil {
+				t.Fatalf("VerifyToken: %v", err)
+			}
+			if got := hasCap(claims.Caps, CapSuspend); got != tc.want {
+				t.Errorf("runtime %s: CapSuspend granted=%v, want %v (caps=%v)", tc.runtime, got, tc.want, claims.Caps)
+			}
+		})
+	}
+}
+
+// A docker task's dicode.suspend must be rejected with a clear cap-denied
+// error rather than acked-then-dropped.
+func TestServer_Suspend_DeniedForDocker(t *testing.T) {
+	e := newTestEnv(t)
+	conn, srv := e.startWithSpec(t, nil, nil, &task.Spec{Runtime: task.RuntimeDocker}, nil)
+	sendMsg(t, conn, map[string]any{
+		"id":     "1",
+		"method": "dicode.suspend",
+		"state":  json.RawMessage(`{"step":1}`),
+	})
+	resp := recvMsg(t, conn)
+	if errMsg, _ := resp["error"].(string); !strings.Contains(errMsg, "permission denied") {
+		t.Fatalf("expected permission denied for docker suspend; got error=%v result=%v", resp["error"], resp["result"])
+	}
+	if srv.Suspend() != nil {
+		t.Fatal("docker suspend must not record a payload")
+	}
+}
+
+// A deno task's dicode.suspend is accepted and records the payload.
+func TestServer_Suspend_GrantedForDeno(t *testing.T) {
+	e := newTestEnv(t)
+	conn, srv := e.startWithSpec(t, nil, nil, &task.Spec{Runtime: task.RuntimeDeno}, nil)
+	sendMsg(t, conn, map[string]any{
+		"id":     "1",
+		"method": "dicode.suspend",
+		"state":  json.RawMessage(`{"step":1}`),
+	})
+	resp := recvMsg(t, conn)
+	if resp["error"] != nil {
+		t.Fatalf("deno suspend rejected: %v", resp["error"])
+	}
+	if srv.Suspend() == nil {
+		t.Fatal("expected suspend payload recorded for deno")
+	}
+}


### PR DESCRIPTION
## Summary

`CapSuspend` was in `defaultTaskCaps()`, so it was part of the capability set for every task. But only the deno and python runtimes read `srv.Suspend()` after the task exits to turn a `dicode.suspend()` into a suspended `RunResult`. The docker and podman runtimes run an opaque container image and never read that payload, so a suspend from such a task would be acked over IPC and then silently dropped — the run just finishes normally, losing the suspend intent with no error.

## Approach

Gate `CapSuspend` on the runtime rather than granting it unconditionally. It is now added to the token's capability set only for suspend-capable runtimes (anything that is not docker/podman); a small `runtimeSupportsSuspend` predicate encodes the rule. The existing `hasCap` guard on the `dicode.suspend` IPC handler then rejects the call with a clear `permission denied` error instead of a silent no-op.

This makes the failure mode explicit and keeps the capability model honest: were docker/podman ever wired to the IPC server, they still would not receive a cap they cannot honor. The alternative — implementing suspend for container runtimes — is out of scope for this seam; the intent is only ever silently lost today.

Scope: only the suspend capability-gating is touched; the other #502 integration items are left alone.

Part of #95. References #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)