### PR TITLE
fix(suspend): handle a suspended pipeline stage without wedging the parent

### DIFF
--- a/pkg/registry/resume.go
+++ b/pkg/registry/resume.go
@@ -106,6 +106,25 @@ func (r *Registry) MarkRunResumed(ctx context.Context, runID string) error {
 	return ErrRunNotSuspended
 }
 
+// CancelSuspendedRun transitions a suspended run to cancelled with the given
+// fail_reason and clears its resume token, but ONLY while the run is still
+// suspended. The conditional UPDATE mirrors MarkRunResumed/SweepExpiredSuspensions:
+// an operator resume racing this finalize (which flips suspended→resumed) changes
+// 0 rows here and is not clobbered back to cancelled. Reports whether the row
+// changed. Used to finalize a pipeline stage that suspended, since a pipeline
+// stage cannot pause its parent pipeline.
+func (r *Registry) CancelSuspendedRun(ctx context.Context, runID, reason string) (bool, error) {
+	now := time.Now().UnixMilli()
+	affected, err := r.db.ExecResult(ctx,
+		`UPDATE runs SET status = ?, finished_at = ?, fail_reason = ?, resume_token = NULL WHERE id = ? AND status = ?`,
+		StatusCancelled, now, reason, runID, StatusSuspended,
+	)
+	if err != nil {
+		return false, fmt.Errorf("cancel suspended run: %w", err)
+	}
+	return affected > 0, nil
+}
+
 // SweepExpiredSuspensions cancels every suspended run whose resume_deadline has
 // passed (relative to nowMs), recording ReasonResumeTimeout as the fail_reason
 // and stamping finished_at. Rows with no deadline (resume_deadline NULL/0) are

--- a/pkg/trigger/pipeline_runner.go
+++ b/pkg/trigger/pipeline_runner.go
@@ -537,15 +537,55 @@ func (r *PipelineRunner) runTerminalDaemon(stageIdx int, stage task.Stage, upstr
 			// Restart aborted (descendant failed / shutting down): daemonRunID
 			// still points at the killed run. Finish with its terminal status.
 			r.mu.Unlock()
-			r.finish(status, "", ret)
+			r.finishTerminalDaemon(stageIdx, stage.Task, current, status, ret)
 			return
 		}
 		r.mu.Unlock()
 
-		r.finish(status, "", ret)
+		r.finishTerminalDaemon(stageIdx, stage.Task, current, status, ret)
 		return
 	}
 }
+
+// finishTerminalDaemon finalizes the pipeline from the terminal daemon stage's
+// exit. A daemon stage that called dicode.suspend() exits its subprocess but is
+// non-terminal; adopting that status onto the parent would leave the pipeline
+// `suspended` with no resume token and no deadline — unsweepable, unresumable,
+// and matching no chain edge (a permanently wedged parent). Translate a
+// suspended daemon exit into a coherent pipeline failure and cancel the orphaned
+// suspended run instead.
+func (r *PipelineRunner) finishTerminalDaemon(stageIdx int, stageTask, daemonRunID, status string, ret interface{}) {
+	if status == registry.StatusSuspended {
+		r.engine.finalizeSuspendedStage(daemonRunID)
+		reason := fmt.Sprintf("stage %d (%s): suspended mid-pipeline; a pipeline stage cannot suspend", stageIdx, stageTask)
+		r.engine.log.Warn("pipeline terminal daemon suspended; pipeline failed",
+			zap.String("pipeline", r.spec.ID), zap.Int("stage", stageIdx),
+			zap.String("task", stageTask), zap.String("daemon_run", daemonRunID))
+		r.finish(registry.StatusFailure, reason, nil)
+		return
+	}
+	r.finish(status, "", ret)
+}
+
+// finalizeSuspendedStage cancels a stage run that suspended mid-pipeline. Left
+// `suspended`, the stage would still be resumable — spawning a standalone
+// continuation detached from the (now-failed) pipeline. Transitioning it to
+// cancelled makes it terminal and drops its resume token so no orphan can be
+// spawned. Conditional on the run still being suspended, so an operator resume
+// that raced in first is not clobbered.
+func (e *Engine) finalizeSuspendedStage(runID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := e.registry.CancelSuspendedRun(ctx, runID, reasonPipelineStageSuspended); err != nil {
+		e.log.Warn("pipeline: finalize suspended stage failed",
+			zap.String("run", runID), zap.Error(err))
+	}
+}
+
+// reasonPipelineStageSuspended is the fail_reason stamped on a pipeline stage
+// run finalized because it called dicode.suspend(). A pipeline stage cannot
+// pause the pipeline, so the suspension is closed out as a cancellation.
+const reasonPipelineStageSuspended = "pipeline_stage_suspended"
 
 // fireStageRaw resolves the stage's overrides + ${input.*} references against
 // the upstream stage's output and fires the stage as a kind: Task child of the
@@ -608,6 +648,15 @@ func (e *Engine) awaitStageSuccess(ctx context.Context, runID string) (task.Inpu
 		return task.InputContext{}, fmt.Errorf("wait: %w", werr)
 	}
 	if res.Status != registry.StatusSuccess {
+		if res.Status == registry.StatusSuspended {
+			// A pipeline stage cannot pause the pipeline: the parent run is owned
+			// by the PipelineRunner and is not resumable through the single-run
+			// resume path. Finalize the orphaned suspended run so it can't be
+			// resumed into a continuation detached from the (now-failing) pipeline,
+			// and fail the stage.
+			e.finalizeSuspendedStage(runID)
+			return task.InputContext{}, fmt.Errorf("run %s suspended mid-pipeline; a pipeline stage cannot suspend", runID)
+		}
 		return task.InputContext{}, fmt.Errorf("run %s ended with status %s", runID, res.Status)
 	}
 	// Only Output is threaded between stages in v1: PipelineTask.Validate rejects

--- a/pkg/trigger/pipeline_suspend_test.go
+++ b/pkg/trigger/pipeline_suspend_test.go
@@ -1,0 +1,174 @@
+package trigger
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// A pipeline stage that calls dicode.suspend() cannot pause the pipeline: the
+// parent run is owned by the PipelineRunner and is not resumable through the
+// single-run resume path. The engine must therefore (a) finalize the pipeline
+// parent to a terminal FAILURE (never leave it `suspended` with no token/deadline
+// — a permanently wedged, unsweepable, unresumable parent), and (b) cancel the
+// orphaned suspended stage run so it can't be resumed into a continuation
+// detached from the pipeline. These tests assert both, for the two consumption
+// paths: a non-terminal stage (awaitStageSuccess) and a terminal daemon stage
+// (runTerminalDaemon).
+
+// registerStageSpec registers a spec into the registry only. Stages are resolved
+// from the registry by firePipeline; engine-registering a daemon stage would
+// spawn it standalone, which these tests must avoid.
+func registerStageSpec(t *testing.T, reg *registry.Registry, s *task.Spec) {
+	t.Helper()
+	if err := reg.Register(s); err != nil {
+		t.Fatalf("reg.Register %s: %v", s.ID, err)
+	}
+}
+
+// TestPipelineNonTerminalStageSuspend_FailsParentCancelsStage fires a two-stage
+// sequential pipeline whose FIRST (non-terminal) stage suspends. The parent must
+// end terminal-failure (not wedged `suspended`), the suspended stage run must be
+// cancelled with the pipeline_stage_suspended reason, the downstream stage must
+// never run, and nothing must be left resumable.
+func TestPipelineNonTerminalStageSuspend_FailsParentCancelsStage(t *testing.T) {
+	eng, reg := newSuspendEnv(t, &suspendExec{})
+
+	stageA := &task.Spec{ID: "stage-a", Name: "stage-a", Runtime: task.RuntimeDeno, Enabled: true,
+		Trigger: task.TriggerConfig{Manual: true}}
+	stageB := &task.Spec{ID: "stage-b", Name: "stage-b", Runtime: task.RuntimeDeno, Enabled: true,
+		Trigger: task.TriggerConfig{Manual: true}}
+	registerStageSpec(t, reg, stageA)
+	registerStageSpec(t, reg, stageB)
+
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "p", Name: "P", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Manual: true},
+		Stages:  []task.Stage{{Task: "stage-a"}, {Task: "stage-b"}},
+	}
+	if err := reg.Register(pipe); err != nil {
+		t.Fatalf("reg.Register pipe: %v", err)
+	}
+
+	parentRunID, err := eng.FireManual(context.Background(), "p", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+
+	parent := waitStatus(t, reg, parentRunID, registry.StatusFailure)
+	if parent.ResumeToken != "" {
+		t.Errorf("pipeline parent carries a resume token %q; must not be resumable", parent.ResumeToken)
+	}
+	if parent.FinishedAt == nil {
+		t.Error("pipeline parent has no finished_at; a failed pipeline must be terminal")
+	}
+
+	// The suspended stage run must be finalized to cancelled, not left suspended.
+	kids, err := reg.ListChildren(context.Background(), parentRunID, 10)
+	if err != nil {
+		t.Fatalf("ListChildren: %v", err)
+	}
+	var stageARun *registry.Run
+	for _, c := range kids {
+		if c.TaskID == "stage-a" {
+			stageARun = c
+		}
+		if c.TaskID == "stage-b" {
+			t.Errorf("downstream stage-b ran (%s); it must not run after stage-a suspended", c.ID)
+		}
+	}
+	if stageARun == nil {
+		t.Fatalf("no stage-a child run recorded; children=%+v", kids)
+	}
+	if stageARun.Status != registry.StatusCancelled {
+		t.Errorf("stage-a status = %q, want cancelled", stageARun.Status)
+	}
+	if stageARun.FailureReason != reasonPipelineStageSuspended {
+		t.Errorf("stage-a fail_reason = %q, want %q", stageARun.FailureReason, reasonPipelineStageSuspended)
+	}
+	if stageARun.ResumeToken != "" {
+		t.Errorf("stage-a still carries a resume token %q; it must be dropped", stageARun.ResumeToken)
+	}
+
+	// Nothing may be left in the suspended state — no orphan is resumable.
+	if susp, _ := reg.ListSuspendedRuns(context.Background(), 10); len(susp) != 0 {
+		t.Errorf("suspended runs remain after pipeline failed: %+v", susp)
+	}
+}
+
+// TestPipelineTerminalDaemonStageSuspend_FailsParentNotWedged fires a pipeline
+// whose single (terminal) daemon stage suspends. This is the path the issue
+// flagged as wedging: WaitRun returns `suspended` and finish() previously wrote
+// `suspended` onto the parent with no token/deadline. The parent must instead
+// end terminal-failure and the stage run must be cancelled.
+func TestPipelineTerminalDaemonStageSuspend_FailsParentNotWedged(t *testing.T) {
+	eng, reg := newSuspendEnv(t, &suspendExec{})
+
+	daemonStage := &task.Spec{ID: "daemon-stage", Name: "daemon-stage", Runtime: task.RuntimeDeno, Enabled: true,
+		Trigger: task.TriggerConfig{Daemon: true, Restart: "never"}}
+	// Registered in the registry only: engine-registering a daemon would start it
+	// standalone, competing with the pipeline for the run.
+	registerStageSpec(t, reg, daemonStage)
+
+	pipe := &task.PipelineTask{
+		APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+		ID: "pd", Name: "PD", Subtype: "sequential", Enabled: true,
+		Trigger: task.PipelineTrigger{Manual: true},
+		Stages:  []task.Stage{{Task: "daemon-stage"}},
+	}
+	if err := reg.Register(pipe); err != nil {
+		t.Fatalf("reg.Register pipe: %v", err)
+	}
+
+	parentRunID, err := eng.FireManual(context.Background(), "pd", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+
+	parent := waitStatus(t, reg, parentRunID, registry.StatusFailure)
+	if parent.Status == registry.StatusSuspended {
+		t.Fatal("pipeline parent left suspended — wedged (unsweepable, unresumable)")
+	}
+	if parent.ResumeToken != "" {
+		t.Errorf("pipeline parent carries a resume token %q; must not be resumable", parent.ResumeToken)
+	}
+	if parent.ResumeDeadline != 0 {
+		t.Errorf("pipeline parent carries a resume deadline %d; must not be set", parent.ResumeDeadline)
+	}
+	if parent.FinishedAt == nil {
+		t.Error("pipeline parent has no finished_at; a failed pipeline must be terminal")
+	}
+	if parent.FailureReason == "" {
+		t.Error("pipeline parent failure carries no reason; a suspended stage must surface a clear cause")
+	}
+
+	kids, err := reg.ListChildren(context.Background(), parentRunID, 10)
+	if err != nil {
+		t.Fatalf("ListChildren: %v", err)
+	}
+	if len(kids) != 1 {
+		t.Fatalf("want 1 stage child, got %d: %+v", len(kids), kids)
+	}
+	if kids[0].Status != registry.StatusCancelled {
+		t.Errorf("daemon stage status = %q, want cancelled", kids[0].Status)
+	}
+	if kids[0].FailureReason != reasonPipelineStageSuspended {
+		t.Errorf("daemon stage fail_reason = %q, want %q", kids[0].FailureReason, reasonPipelineStageSuspended)
+	}
+
+	if susp, _ := reg.ListSuspendedRuns(context.Background(), 10); len(susp) != 0 {
+		t.Errorf("suspended runs remain after pipeline failed: %+v", susp)
+	}
+
+	// Give the live-pipeline unregister + lifecycle teardown a moment; the test's
+	// engine has no shutdown, so ensure no late goroutine re-suspends the parent.
+	time.Sleep(50 * time.Millisecond)
+	again, _ := reg.GetRun(context.Background(), parentRunID)
+	if again.Status != registry.StatusFailure {
+		t.Errorf("pipeline parent status drifted to %q after finish; want stable failure", again.Status)
+	}
+}


### PR DESCRIPTION
## Summary

A pipeline (`kind: PipelineTask`) whose stage called `dicode.suspend()` left the pipeline in a broken state. This closes integration seam #2 from the #95 suspendable-tasks audit (#502, MEDIUM).

The suspend/resume primitive is built for standalone `kind: Task` runs. A pipeline stage is dispatched as a child `kind: Task`, so it *can* suspend — but the pipeline parent run is owned by the `PipelineRunner`, not the single-run resume machinery, and it is fundamentally not resumable through that path: `ResumeRun` re-fires a `kind: Task` via `fireAsync`, whereas a pipeline parent's `TaskID` resolves to a `kind: PipelineTask`, which that path rejects.

Two concrete failures resulted:

- **Terminal-daemon stage suspends** → `WaitRun` returned `suspended` and `finish()` stamped that status onto the pipeline **parent** with no resume token and no deadline. `SweepExpiredSuspensions` skips it (needs `resume_deadline > 0`), `ResumeRun`/`apiResumeRun` reject it (empty/absent token, and the pipeline kind isn't resumable anyway), and `FireChain("suspended")` matches no edge. The parent was permanently wedged in a non-terminal-looking state.
- **Non-terminal stage suspends** → the pipeline failed, but the stage run was left `suspended`, so an operator could later resume it into a continuation run orphaned from the (already dead) pipeline.

## Chosen semantics

**A suspended stage is a coherent, terminal pipeline failure.** Rather than propagate a half-usable "suspended parent", the pipeline parent ends `failure` with a clear reason (`stage N (task): suspended mid-pipeline; a pipeline stage cannot suspend`), and the orphaned suspended stage run is finalized to `cancelled` (`fail_reason = pipeline_stage_suspended`) with its resume token dropped.

Why fail-closed rather than "pause the whole pipeline":

- A pipeline parent is inherently unresumable through the existing resume path (see above), so carrying the stage's token/deadline on the parent would still 409 on resume — it would only trade "wedged" for "misleadingly resumable". Full mid-stage pipeline resume (re-spawning a `PipelineRunner`, re-threading upstream `${input}`) is a much larger feature and out of scope for closing this seam.
- Failing the parent makes it genuinely terminal: chains fire on `failure`, the sweep is correctly irrelevant, and the UI shows a real cause instead of a stuck run.
- Cancelling the stage (conditionally — an operator resume that raced in first is not clobbered, mirroring `MarkRunResumed`/the sweep) removes the orphan-continuation hazard.

This is applied at both consumption points: `awaitStageSuccess` (non-terminal, terminal-non-daemon, and parallel stages) and `runTerminalDaemon` (the terminal daemon stage).

## Tests

`pkg/trigger/pipeline_suspend_test.go` covers both paths using the existing fake-executor harness (no Deno subprocess): a non-terminal stage suspend and a terminal-daemon stage suspend each assert the parent ends terminal `failure` (never `suspended`, no token, no deadline), the stage run is `cancelled` with the expected reason and no token, no downstream stage runs, and nothing is left resumable. Both tests were confirmed to fail against the pre-fix code (parent wedged `suspended`; stage left orphaned).

## Scope

Touches only the pipeline×suspend seam; the other #502 items are untouched. Adds one small generic registry primitive (`CancelSuspendedRun`) for the conditional stage finalize.

Part of #95. References #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)