### PR TITLE
fix(suspend): keep the daemon body-in-flight invariant across suspend/resume

### DIFF
--- a/pkg/trigger/daemon.go
+++ b/pkg/trigger/daemon.go
@@ -7,6 +7,7 @@ package trigger
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/dicode/dicode/pkg/registry"
@@ -107,7 +108,89 @@ func (e *Engine) startDaemon(spec *task.Spec) {
 	}
 }
 
+// resumeDaemonBody spawns the continuation of a suspended daemon body while
+// keeping the #470 "slot present == one body in flight" invariant honest across
+// the suspend→resume hop. onDaemonRunFinished parked the slot on the suspended
+// run; this adopts it for the continuation BEFORE the body fires (mirroring
+// startDaemon's pre-reservation, which fireAsync honors via opts.RunID) so a
+// reconciler reload during the continuation observes alreadyRunning and won't
+// start a second body, and the continuation's onDaemonRunFinished slot-match
+// frees the slot correctly. The compare-and-swap is the safety interlock: if
+// the slot is no longer parked on the suspended run (the task was unregistered,
+// or another start took over), coalesce rather than double-start.
+func (e *Engine) resumeDaemonBody(spec *task.Spec, suspendedRunID string, opts pkgruntime.RunOptions) (string, error) {
+	runID := uuid.New().String()
+	opts.RunID = runID
+
+	e.daemonMu.Lock()
+	if e.daemonRuns[spec.ID] != suspendedRunID {
+		e.daemonMu.Unlock()
+		return "", fmt.Errorf("resume: daemon %q slot no longer parked on suspended run %q", spec.ID, suspendedRunID)
+	}
+	e.daemonRuns[spec.ID] = runID
+	e.daemonMu.Unlock()
+
+	// Record the spawn before fireAsync for the same reason startDaemon does:
+	// an instant exit could otherwise run noteExit before a late noteSpawn,
+	// stamping a spawn time onto a dead run (#458).
+	e.crashloops.noteSpawn(spec.ID)
+	e.setDaemonState(spec.ID, DaemonRunning)
+
+	newRunID, err := e.fireAsync(context.Background(), spec, opts, registry.TriggerResume)
+	if err != nil {
+		// No body is live: roll back the adoption. The slot-match guard mirrors
+		// onDaemonRunFinished so a concurrent starter's reservation is never
+		// clobbered.
+		e.daemonMu.Lock()
+		if e.daemonRuns[spec.ID] == runID {
+			delete(e.daemonRuns, spec.ID)
+		}
+		e.daemonMu.Unlock()
+		e.crashloops.clearSpawn(spec.ID)
+		e.setDaemonState(spec.ID, DaemonFailedAfterPreflight)
+		return "", err
+	}
+	return newRunID, nil
+}
+
 func (e *Engine) onDaemonRunFinished(spec *task.Spec, runID string) {
+	// Resolve the run status BEFORE releasing the slot: a suspended body must
+	// keep its #470 reservation (see below), so the slot decision depends on
+	// the outcome.
+	run, err := e.registry.GetRun(context.Background(), runID)
+	if err != nil {
+		// Free the slot even on a lookup failure so a dead body can't pin the
+		// "body in flight" reservation forever.
+		e.daemonMu.Lock()
+		if e.daemonRuns[spec.ID] == runID {
+			delete(e.daemonRuns, spec.ID)
+		}
+		e.daemonMu.Unlock()
+		e.log.Error("daemon: failed to get run status", zap.String("run", runID), zap.Error(err))
+		return
+	}
+
+	// A suspended run is non-terminal (#95): the subprocess exited to await
+	// user input, not because the daemon crashed or stopped. Keep the run slot
+	// reserved so the #470 "one body in flight" invariant holds across the
+	// suspended gap — a reconciler reload must not start a second body while
+	// this one is parked — and publish DaemonSuspended instead of leaving a
+	// stale "running". The resume continuation (resumeDaemonBody) adopts the
+	// slot and drives the next transition. Crash-loop tracking and the restart
+	// policy are deliberately untouched. The slot-ownership check guards the
+	// unregister race: if Unregister already freed the slot (and killed the
+	// body), there is nothing to park and no state to publish for a task the
+	// engine no longer tracks.
+	if run.Status == registry.StatusSuspended {
+		e.daemonMu.Lock()
+		slotOwned := e.daemonRuns[spec.ID] == runID
+		e.daemonMu.Unlock()
+		if slotOwned {
+			e.setDaemonState(spec.ID, DaemonSuspended)
+		}
+		return
+	}
+
 	e.daemonMu.Lock()
 	if e.daemonRuns[spec.ID] == runID {
 		delete(e.daemonRuns, spec.ID)
@@ -116,20 +199,6 @@ func (e *Engine) onDaemonRunFinished(spec *task.Spec, runID string) {
 	e.daemonMu.Unlock()
 
 	if !stillRegistered || e.isShuttingDown() {
-		return
-	}
-
-	run, err := e.registry.GetRun(context.Background(), runID)
-	if err != nil {
-		e.log.Error("daemon: failed to get run status", zap.String("run", runID), zap.Error(err))
-		return
-	}
-	// A suspended run is non-terminal (#95): the subprocess exited to await
-	// user input, not because the daemon crashed or stopped. Treat it as a
-	// neutral outcome — don't count it as a crash-loop exit, don't reset the
-	// counter, and don't schedule a restart. The daemon state is unchanged;
-	// the continuation run drives the next lifecycle transition on resume.
-	if run.Status == registry.StatusSuspended {
 		return
 	}
 

--- a/pkg/trigger/daemon_state.go
+++ b/pkg/trigger/daemon_state.go
@@ -61,6 +61,15 @@ const (
 	// engine does not automatically transition out of this state.
 	DaemonCrashed DaemonState = "crashed"
 
+	// DaemonSuspended indicates the daemon body exited to await user input
+	// via dicode.suspend() (#95) — non-terminal, distinct from a crash or a
+	// stop. The daemon run slot stays reserved while suspended so the #470
+	// "one body in flight" invariant holds across the suspended gap (a
+	// reconciler reload must not start a second body), and the resume
+	// continuation drives the next transition. Reported instead of the stale
+	// "running" a parked-awaiting-input body would otherwise show.
+	DaemonSuspended DaemonState = "suspended"
+
 	// DaemonCrashLooping indicates the daemon's body has failed
 	// crashloopThreshold consecutive starts, each dying within
 	// crashloopSustainWindow (issue #458). Unlike DaemonCrashed the engine IS

--- a/pkg/trigger/resume.go
+++ b/pkg/trigger/resume.go
@@ -163,7 +163,17 @@ func (e *Engine) ResumeRun(ctx context.Context, token string, input []byte) (str
 		}
 	}
 
-	newRunID, err := e.fireAsync(context.Background(), spec, opts, registry.TriggerResume)
+	// A daemon body's continuation must re-enter the #470 slot accounting: it
+	// adopts the slot the suspended body kept reserved so a reconciler reload
+	// can't start a second body alongside the continuation, and its
+	// onDaemonRunFinished frees the slot correctly. Plain (non-daemon) tasks
+	// have no slot to manage and fire directly.
+	var newRunID string
+	if spec.Trigger.Daemon {
+		newRunID, err = e.resumeDaemonBody(spec, run.ID, opts)
+	} else {
+		newRunID, err = e.fireAsync(context.Background(), spec, opts, registry.TriggerResume)
+	}
 	if err != nil {
 		return "", fmt.Errorf("resume: spawn continuation run: %w", err)
 	}

--- a/pkg/trigger/resume_test.go
+++ b/pkg/trigger/resume_test.go
@@ -406,10 +406,12 @@ func TestResumeRun_MultiStepWizardChains(t *testing.T) {
 	}
 }
 
-// TestSuspendedDaemonRun_NeutralForCrashloop verifies a daemon body that
-// suspends is a neutral outcome: it does not flip the daemon to crashed/stopped
-// and does not count as a crash-loop exit.
-func TestSuspendedDaemonRun_NeutralForCrashloop(t *testing.T) {
+// TestSuspendedDaemonRun_KeepsSlotAndReportsSuspended verifies that a daemon
+// body which suspends (a) does not count as a crash-loop exit, (b) reports the
+// distinct DaemonSuspended state instead of a stale "running", and (c) keeps
+// its #470 run slot reserved so the "one body in flight" invariant holds across
+// the suspended gap.
+func TestSuspendedDaemonRun_KeepsSlotAndReportsSuspended(t *testing.T) {
 	eng, reg := newSuspendEnv(t, &suspendExec{})
 	spec := &task.Spec{ID: "wiz-daemon", Name: "wiz-daemon", Runtime: task.RuntimeDeno,
 		Trigger: task.TriggerConfig{Daemon: true, Restart: "never"}, Enabled: true}
@@ -432,10 +434,19 @@ func TestSuspendedDaemonRun_NeutralForCrashloop(t *testing.T) {
 
 	eng.onDaemonRunFinished(spec, runID)
 
-	// With restart=never, a non-suspended non-success exit would flip state to
-	// DaemonCrashed. A suspended run must leave the state untouched.
-	if got := eng.daemonStates.get(spec.ID); got != DaemonRunning {
-		t.Errorf("daemon state = %q, want running (suspended is neutral)", got)
+	// State reflects reality: awaiting input, not the stale "running" (and not
+	// DaemonCrashed, which a non-suspended non-success exit under restart=never
+	// would produce).
+	if got := eng.daemonStates.get(spec.ID); got != DaemonSuspended {
+		t.Errorf("daemon state = %q, want suspended", got)
+	}
+	// The slot stays reserved: a reconciler reload's registerDaemon must see the
+	// daemon as still in flight, and a resume must find the slot parked here.
+	eng.daemonMu.Lock()
+	slot, ok := eng.daemonRuns[spec.ID]
+	eng.daemonMu.Unlock()
+	if !ok || slot != runID {
+		t.Errorf("daemon slot = %q (present=%v), want it kept at %q across the suspended gap", slot, ok, runID)
 	}
 	if eng.IsCrashLooping(spec.ID) {
 		t.Error("suspended daemon run must not count toward crash-loop")
@@ -522,4 +533,159 @@ func decodeCarryDepth(t *testing.T, blob []byte) int {
 		t.Fatalf("decode resume_params: %v", err)
 	}
 	return c.ChainDepth
+}
+
+// TestSuspendedDaemon_ReloadFencesStaleResume is the double-start regression
+// (#502 item 2 / #470). A daemon body suspends; a reconciler content reload
+// (eng.Register) tears the daemon down and restarts a fresh body, re-pointing
+// the run slot. Resuming the now-stale pre-reload suspension must be fenced off
+// — otherwise its continuation would run as a SECOND concurrent body next to
+// the reloaded one. The interlock is resumeDaemonBody's slot compare-and-swap:
+// the slot no longer points at the suspended run, so no continuation spawns.
+func TestSuspendedDaemon_ReloadFencesStaleResume(t *testing.T) {
+	eng, reg := newSuspendEnv(t, &suspendExec{})
+	spec := &task.Spec{ID: "wiz-daemon", Name: "wiz-daemon", Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Daemon: true, Restart: "never"}, Enabled: true}
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("reg.Register: %v", err)
+	}
+
+	// Bring the daemon up; its body suspends immediately.
+	if err := eng.Register(spec); err != nil {
+		t.Fatalf("eng.Register: %v", err)
+	}
+	waitUntil(t, 5*time.Second, func() bool {
+		return eng.DaemonState(spec.ID) == DaemonSuspended
+	}, "daemon never parked in DaemonSuspended")
+
+	eng.daemonMu.Lock()
+	firstRun, ok := eng.daemonRuns[spec.ID]
+	eng.daemonMu.Unlock()
+	if !ok {
+		t.Fatal("suspended daemon dropped its run slot")
+	}
+	orig, err := reg.GetRun(context.Background(), firstRun)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	staleToken := orig.ResumeToken
+
+	// Reconciler content reload: eng.Register tears down + restarts. The fresh
+	// body re-points the slot (reserved before the body fires, #470 race 1), so
+	// the pre-reload suspension is now stale.
+	if err := eng.Register(spec); err != nil {
+		t.Fatalf("reload eng.Register: %v", err)
+	}
+	eng.daemonMu.Lock()
+	freshRun, ok := eng.daemonRuns[spec.ID]
+	eng.daemonMu.Unlock()
+	if !ok || freshRun == firstRun {
+		t.Fatalf("reload did not start a fresh body: slot=%q present=%v (pre-reload %q)", freshRun, ok, firstRun)
+	}
+
+	// Resuming the STALE suspension must fail — it must not start a second body.
+	if _, err := eng.ResumeRun(context.Background(), staleToken, nil); err == nil {
+		t.Fatal("stale daemon resume after reload must fail — it would start a second concurrent body")
+	}
+
+	// The slot still belongs to the fresh body; no continuation adopted it.
+	eng.daemonMu.Lock()
+	slot := eng.daemonRuns[spec.ID]
+	eng.daemonMu.Unlock()
+	if slot != freshRun {
+		t.Fatalf("slot = %q after the fenced resume, want the fresh body %q left untouched", slot, freshRun)
+	}
+}
+
+// blockingResumeDaemonExec suspends the first (non-resume) run and blocks the
+// resume continuation inside Execute until release is closed, so a test can
+// observe engine state while the continuation is provably in flight.
+type blockingResumeDaemonExec struct {
+	started    chan string // continuation run ID, sent once its body starts
+	release    chan struct{}
+	firstRuns  atomic.Int32
+	resumeRuns atomic.Int32
+}
+
+func (b *blockingResumeDaemonExec) Execute(_ context.Context, _ *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
+	if opts.ResumeState == nil {
+		b.firstRuns.Add(1)
+		return &pkgruntime.RunResult{
+			RunID:       opts.RunID,
+			Suspended:   true,
+			ResumeState: []byte(`{"step":"one"}`),
+			ResumeForm:  []byte(`{}`),
+		}, nil
+	}
+	b.resumeRuns.Add(1)
+	b.started <- opts.RunID
+	<-b.release
+	return &pkgruntime.RunResult{RunID: opts.RunID, ReturnValue: "done"}, nil
+}
+
+// TestResumeRun_DaemonContinuation_KeepsOneBodyInFlight verifies the resume half
+// of the #470 invariant: a suspended daemon body's continuation adopts the run
+// slot (so it participates in "one body in flight") and the state reflects a
+// live body again — asserted while the continuation is deterministically parked
+// mid-execution.
+func TestResumeRun_DaemonContinuation_KeepsOneBodyInFlight(t *testing.T) {
+	exec := &blockingResumeDaemonExec{started: make(chan string, 1), release: make(chan struct{})}
+	eng, reg := newSuspendEnv(t, exec)
+	spec := &task.Spec{ID: "wiz-daemon", Name: "wiz-daemon", Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Daemon: true, Restart: "never"}, Enabled: true}
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("reg.Register: %v", err)
+	}
+
+	if err := eng.Register(spec); err != nil {
+		t.Fatalf("eng.Register: %v", err)
+	}
+	waitUntil(t, 5*time.Second, func() bool {
+		return eng.DaemonState(spec.ID) == DaemonSuspended
+	}, "daemon never parked in DaemonSuspended")
+
+	eng.daemonMu.Lock()
+	firstRun := eng.daemonRuns[spec.ID]
+	eng.daemonMu.Unlock()
+	orig, err := reg.GetRun(context.Background(), firstRun)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+
+	contID, err := eng.ResumeRun(context.Background(), orig.ResumeToken, nil)
+	if err != nil {
+		t.Fatalf("ResumeRun: %v", err)
+	}
+	if contID == firstRun {
+		t.Fatal("continuation must have a fresh run ID")
+	}
+
+	// The continuation body is now in flight (blocked in Execute).
+	if started := <-exec.started; started != contID {
+		t.Fatalf("continuation body run %q != returned continuation ID %q", started, contID)
+	}
+
+	// It adopted the daemon slot, and the state reflects a live body again.
+	eng.daemonMu.Lock()
+	slot := eng.daemonRuns[spec.ID]
+	eng.daemonMu.Unlock()
+	if slot != contID {
+		t.Fatalf("continuation did not adopt the slot: slot=%q, want %q", slot, contID)
+	}
+	if got := eng.DaemonState(spec.ID); got != DaemonRunning {
+		t.Fatalf("state = %q while continuation in flight, want running", got)
+	}
+
+	// Release; the continuation completes and frees the slot.
+	close(exec.release)
+	waitStatus(t, reg, contID, registry.StatusSuccess)
+	waitUntil(t, 5*time.Second, func() bool {
+		eng.daemonMu.Lock()
+		defer eng.daemonMu.Unlock()
+		_, reserved := eng.daemonRuns[spec.ID]
+		return !reserved
+	}, "continuation finished but the daemon slot leaked")
+	if got := exec.resumeRuns.Load(); got != 1 {
+		t.Fatalf("continuation bodies = %d, want exactly 1", got)
+	}
 }

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -1581,12 +1581,13 @@ type TaskDetail struct {
 
 	// DaemonState surfaces the engine's lifecycle phase for daemon tasks.
 	// Empty for non-daemon tasks so the WebUI can hide the row entirely.
-	// Six-value enum — see pkg/trigger.DaemonState for the canonical list.
+	// See pkg/trigger.DaemonState for the canonical enum.
 	// The "failed_after_preflight" and "crashed" values are distinct from
 	// "stopped" so operators can tell "fireAsync broke" (#318) and "body
 	// crashed without auto-restart" (#325) apart from "deliberately stopped";
 	// "crashlooping" (#458) marks a daemon stuck in a spawn/crash/backoff
-	// loop that would otherwise sample as "running".
+	// loop that would otherwise sample as "running"; "suspended" (#95) marks a
+	// body parked awaiting user input.
 	DaemonState string `json:"daemon_state,omitempty"`
 
 	// PendingApproval flags a task held by the trust-on-change approval gate.


### PR DESCRIPTION
## Summary

A `trigger.daemon` task that calls `dicode.suspend()` broke the #470 daemon invariant that "a `daemonRuns` slot present == exactly one body in flight."

`onDaemonRunFinished` deleted the slot at the top, before the `suspended` early-return, and the resume continuation (fired via `ResumeRun`) never re-entered slot accounting. So while a daemon body was parked awaiting input — and while its continuation ran — `registerDaemon` saw `alreadyRunning=false`. A reconciler content reload (`eng.Register` = teardown + restart) would start a fresh body while the pre-reload suspension stayed resumable; resuming it then spawned a **second concurrent daemon body**. The daemon also stayed pinned to `DaemonRunning` while its body had actually exited awaiting input.

## Approach

Keep the run slot reserved while suspended (parked on the suspended run) and publish a distinct `DaemonSuspended` state so the reported phase reflects reality. The resume continuation of a daemon body now adopts that slot **before** it fires, mirroring `startDaemon`'s pre-reservation, so it participates in the "one body in flight" invariant and its own `onDaemonRunFinished` frees the slot correctly.

The adoption is a compare-and-swap on the slot, which is also the safety interlock:
- a **clean resume** (no reload) finds the slot still parked on the suspended run → adopts it → one body;
- a **resume after a reload** finds the slot re-pointed at the fresh body → is fenced off → no second body starts.

`suspendedRunID` no longer being the slot owner is exactly the "the world moved on" signal, so a stale wizard can't resurrect a duplicate daemon. Crash-loop tracking and the restart policy are deliberately untouched on the suspend path.

## Scope

Only the daemon×suspend seam: `pkg/trigger/daemon.go` (slot/state accounting + `resumeDaemonBody`), the new `DaemonSuspended` value in `daemon_state.go`, the daemon-branch wiring in `resume.go`, and a stale enum-count comment in `pkg/webui/server.go`. Other #502 items are left to their own PRs.

Part of #95
References #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)