### PR TITLE
fix(suspend): fire finish hooks + chains when a suspension is swept on timeout

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -855,7 +855,9 @@ func runServices(ctx context.Context, rec *registry.Reconciler, eng *trigger.Eng
 	}
 	// Resume-deadline sweep (#95): cancel suspended runs whose resume_deadline
 	// has passed, recording ReasonResumeTimeout. Runs on a ticker so a run that
-	// suspends and is never resumed doesn't linger indefinitely.
+	// suspends and is never resumed doesn't linger indefinitely. Routed through
+	// the engine so each cancellation fires the run:finished hook and its
+	// resume_timeout chain, matching a normal cancellation's finish side-effects.
 	g.Go(func() error {
 		ticker := time.NewTicker(resumeSweepInterval)
 		defer ticker.Stop()
@@ -864,7 +866,7 @@ func runServices(ctx context.Context, rec *registry.Reconciler, eng *trigger.Eng
 			case <-ctx.Done():
 				return nil
 			case <-ticker.C:
-				swept, err := reg.SweepExpiredSuspensions(ctx, time.Now().UnixMilli())
+				swept, err := eng.SweepExpiredSuspensions(ctx, time.Now().UnixMilli())
 				if err != nil {
 					log.Warn("resume-deadline sweep failed", zap.Error(err))
 				} else if len(swept) > 0 {

--- a/pkg/registry/resume.go
+++ b/pkg/registry/resume.go
@@ -128,14 +128,18 @@ func (r *Registry) CancelSuspendedRun(ctx context.Context, runID, reason string)
 // SweepExpiredSuspensions cancels every suspended run whose resume_deadline has
 // passed (relative to nowMs), recording ReasonResumeTimeout as the fail_reason
 // and stamping finished_at. Rows with no deadline (resume_deadline NULL/0) are
-// left untouched. Returns the IDs of the runs it cancelled.
+// left untouched. Returns the IDs of the runs it actually cancelled.
 //
-// The SELECT and UPDATE run in one transaction so a run that resumes between the
-// two statements (flipping to `resumed`) is not erroneously cancelled.
+// Each candidate is transitioned with its own status-guarded UPDATE and only
+// the rows that UPDATE changed are returned. A run that resumes between the
+// candidate SELECT and its UPDATE changes 0 rows and is excluded, so a caller
+// that fires finish side-effects per returned ID cannot double-finish a run
+// that already left `suspended`.
 func (r *Registry) SweepExpiredSuspensions(ctx context.Context, nowMs int64) ([]string, error) {
-	var expired []string
+	var cancelled []string
 	err := r.db.Tx(ctx, func(tx db.DB) error {
-		expired = nil // reset on retry
+		cancelled = nil // reset on retry
+		var candidates []string
 		if err := tx.Query(ctx,
 			`SELECT id FROM runs WHERE status = ? AND resume_deadline IS NOT NULL AND resume_deadline > 0 AND resume_deadline < ?`,
 			[]any{StatusSuspended, nowMs},
@@ -145,24 +149,30 @@ func (r *Registry) SweepExpiredSuspensions(ctx context.Context, nowMs int64) ([]
 					if err := rows.Scan(&id); err != nil {
 						return err
 					}
-					expired = append(expired, id)
+					candidates = append(candidates, id)
 				}
 				return nil
 			},
 		); err != nil {
 			return fmt.Errorf("query expired suspensions: %w", err)
 		}
-		if len(expired) == 0 {
-			return nil
+		for _, id := range candidates {
+			affected, err := tx.ExecResult(ctx,
+				`UPDATE runs SET status = ?, finished_at = ?, fail_reason = ?
+				 WHERE id = ? AND status = ?`,
+				StatusCancelled, nowMs, ReasonResumeTimeout, id, StatusSuspended,
+			)
+			if err != nil {
+				return fmt.Errorf("cancel expired suspension %s: %w", id, err)
+			}
+			if affected > 0 {
+				cancelled = append(cancelled, id)
+			}
 		}
-		return tx.Exec(ctx,
-			`UPDATE runs SET status = ?, finished_at = ?, fail_reason = ?
-			 WHERE status = ? AND resume_deadline IS NOT NULL AND resume_deadline > 0 AND resume_deadline < ?`,
-			StatusCancelled, nowMs, ReasonResumeTimeout, StatusSuspended, nowMs,
-		)
+		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	return expired, nil
+	return cancelled, nil
 }

--- a/pkg/trigger/resume.go
+++ b/pkg/trigger/resume.go
@@ -107,8 +107,9 @@ func (e *Engine) ResumeRun(ctx context.Context, token string, input []byte) (str
 	}
 	if run.ResumeDeadline > 0 && time.Now().UnixMilli() > run.ResumeDeadline {
 		// Expired: sweep it now so its terminal state reflects the timeout even
-		// if the periodic sweep hasn't run yet, then reject.
-		if _, serr := e.registry.SweepExpiredSuspensions(ctx, time.Now().UnixMilli()); serr != nil {
+		// if the periodic sweep hasn't run yet, then reject. Routed through the
+		// engine sweep so the run:finished hook and resume_timeout chain fire.
+		if _, serr := e.SweepExpiredSuspensions(ctx, time.Now().UnixMilli()); serr != nil {
 			e.log.Warn("resume: sweep expired suspension failed",
 				zap.String("run", run.ID), zap.Error(serr))
 		}

--- a/pkg/trigger/sweep.go
+++ b/pkg/trigger/sweep.go
@@ -1,0 +1,42 @@
+package trigger
+
+import (
+	"context"
+
+	"github.com/dicode/dicode/pkg/registry"
+	"go.uber.org/zap"
+)
+
+// SweepExpiredSuspensions cancels suspended runs past their resume deadline via
+// the registry sweep, then drives the finish side-effects a normal cancellation
+// performs for each run the sweep actually transitioned: the run:finished hook
+// (so a live run-detail/form page learns the suspension expired instead of
+// waiting on a stale resume form) and FireChain on the resume_timeout
+// cancellation (so on:always / on:failure chain edges observe the outcome).
+// Returns the IDs of the cancelled runs.
+//
+// The registry sweep returns only runs whose status-guarded UPDATE transitioned
+// suspended→cancelled, so a run that resumed between the sweep's SELECT and its
+// UPDATE is not finished twice here. Side-effects run on context.Background so a
+// cancelled sweep context (daemon shutdown) can't drop the matching finish,
+// mirroring the engine's other finish-hook call sites.
+func (e *Engine) SweepExpiredSuspensions(ctx context.Context, nowMs int64) ([]string, error) {
+	swept, err := e.registry.SweepExpiredSuspensions(ctx, nowMs)
+	if err != nil {
+		return nil, err
+	}
+	for _, runID := range swept {
+		run, gerr := e.registry.GetRun(context.Background(), runID)
+		if gerr != nil {
+			e.log.Warn("sweep: load cancelled suspension for finish hooks failed",
+				zap.String("run", runID), zap.Error(gerr))
+			continue
+		}
+		if h := e.runFinishedHook; h != nil {
+			// Duration 0: the suspended body isn't re-executed on timeout.
+			h(run.TaskID, run.ID, registry.StatusCancelled, string(run.TriggerSource), 0)
+		}
+		e.FireChain(context.Background(), run.TaskID, run.ID, registry.StatusCancelled, nil, nil)
+	}
+	return swept, nil
+}

--- a/pkg/trigger/sweep_test.go
+++ b/pkg/trigger/sweep_test.go
@@ -1,0 +1,158 @@
+package trigger
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// finishHookRecorder captures every runFinishedHook invocation.
+type finishHookRecorder struct {
+	mu     sync.Mutex
+	events []finishEvent
+}
+
+type finishEvent struct {
+	taskID, runID, status, triggerSource string
+}
+
+func (r *finishHookRecorder) hook(taskID, runID, status, triggerSource string, _ int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, finishEvent{taskID, runID, status, triggerSource})
+}
+
+// forRunStatus returns the captured events for runID with the given status.
+// A suspend also fires the finished hook (status=suspended), so callers filter
+// to the terminal status they assert on.
+func (r *finishHookRecorder) forRunStatus(runID, status string) []finishEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []finishEvent
+	for _, e := range r.events {
+		if e.runID == runID && e.status == status {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// waitRunCount polls until task taskID has at least want runs, or fails.
+func waitRunCount(t *testing.T, reg *registry.Registry, taskID string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		runs, err := reg.ListRuns(context.Background(), taskID, 10)
+		if err != nil {
+			t.Fatalf("ListRuns: %v", err)
+		}
+		if len(runs) >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	runs, _ := reg.ListRuns(context.Background(), taskID, 10)
+	t.Fatalf("task %s run count = %d, want >= %d", taskID, len(runs), want)
+}
+
+// A suspended run swept past its deadline fires the run:finished hook with the
+// resume_timeout cancellation and drives an on:always chain — the same finish
+// side-effects a normal cancellation performs.
+func TestEngineSweep_FiresFinishHookAndResumeTimeoutChain(t *testing.T) {
+	exec := &suspendExec{firstDeadline: time.Now().Add(-time.Hour).UnixMilli()}
+	eng, reg := newSuspendEnv(t, exec)
+
+	rec := &finishHookRecorder{}
+	eng.SetRunFinishedHook(rec.hook)
+
+	wiz := &task.Spec{ID: "wiz", Name: "wiz", Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}, Enabled: true}
+	after := &task.Spec{ID: "after", Name: "after", Runtime: task.RuntimeDeno, Enabled: true,
+		Trigger: task.TriggerConfig{Chain: &task.ChainTrigger{From: "wiz", On: chainOnAlways}}}
+	if err := reg.Register(wiz); err != nil {
+		t.Fatalf("register wiz: %v", err)
+	}
+	if err := reg.Register(after); err != nil {
+		t.Fatalf("register after: %v", err)
+	}
+	eng.Register(after) // arm the chain
+
+	origID, err := eng.FireManual(context.Background(), "wiz", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	waitStatus(t, reg, origID, registry.StatusSuspended)
+
+	swept, err := eng.SweepExpiredSuspensions(context.Background(), time.Now().UnixMilli())
+	if err != nil {
+		t.Fatalf("SweepExpiredSuspensions: %v", err)
+	}
+	if len(swept) != 1 || swept[0] != origID {
+		t.Fatalf("swept = %v, want [%s]", swept, origID)
+	}
+
+	// The registry row reflects the timeout cancellation.
+	run, _ := reg.GetRun(context.Background(), origID)
+	if run.Status != registry.StatusCancelled || run.FailureReason != registry.ReasonResumeTimeout {
+		t.Errorf("swept run status/reason = %q/%q, want cancelled/resume_timeout", run.Status, run.FailureReason)
+	}
+
+	// The run:finished hook fired exactly once for the swept run, as cancelled.
+	events := rec.forRunStatus(origID, registry.StatusCancelled)
+	if len(events) != 1 {
+		t.Fatalf("cancelled finish hook fired %d times for swept run, want 1: %+v", len(events), events)
+	}
+	if events[0].taskID != "wiz" {
+		t.Errorf("finish event = %+v, want task wiz", events[0])
+	}
+
+	// The on:always chain observed the resume_timeout cancellation and fired.
+	waitRunCount(t, reg, "after", 1)
+}
+
+// A run that resumed just before the sweep must not be finished a second time:
+// the sweep skips any candidate its status-guarded UPDATE didn't transition, so
+// no run:finished hook fires for it and its terminal state is preserved.
+func TestEngineSweep_ResumedRunNotDoubleFinished(t *testing.T) {
+	exec := &suspendExec{firstDeadline: time.Now().Add(-time.Hour).UnixMilli()}
+	eng, reg := newSuspendEnv(t, exec)
+
+	rec := &finishHookRecorder{}
+	eng.SetRunFinishedHook(rec.hook)
+
+	wiz := &task.Spec{ID: "wiz", Name: "wiz", Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}, Enabled: true}
+	if err := reg.Register(wiz); err != nil {
+		t.Fatalf("register wiz: %v", err)
+	}
+
+	origID, err := eng.FireManual(context.Background(), "wiz", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	orig := waitStatus(t, reg, origID, registry.StatusSuspended)
+
+	// The run resumes (token consumed → terminal `resumed`) just before the sweep.
+	if err := reg.MarkRunResumed(context.Background(), orig.ID); err != nil {
+		t.Fatalf("MarkRunResumed: %v", err)
+	}
+
+	swept, err := eng.SweepExpiredSuspensions(context.Background(), time.Now().UnixMilli())
+	if err != nil {
+		t.Fatalf("SweepExpiredSuspensions: %v", err)
+	}
+	if len(swept) != 0 {
+		t.Fatalf("swept = %v, want empty (run already resumed)", swept)
+	}
+	if events := rec.forRunStatus(origID, registry.StatusCancelled); len(events) != 0 {
+		t.Fatalf("cancelled finish hook fired for an already-resumed run: %+v", events)
+	}
+
+	// The resume outcome is preserved — the sweep did not overwrite it.
+	run, _ := reg.GetRun(context.Background(), origID)
+	if run.Status != registry.StatusResumed {
+		t.Errorf("run status = %q, want resumed (sweep must not clobber it)", run.Status)
+	}
+}


### PR DESCRIPTION
## Summary

When a suspended run's resume deadline lapsed, the deadline sweep only UPDATEd the row to `cancelled`/`resume_timeout` and skipped every finish side-effect a normal cancellation performs. A run-detail page showing the resume form never learned the suspension expired (no `run:finished` websocket event), and an `on: always` / `on: failure` chain never observed the timeout (no `FireChain`). The sweep lives in `pkg/registry` but those hooks live in the trigger engine, so the registry-only sweep had no way to fire them.

## Approach

An engine-level sweep wrapper (`Engine.SweepExpiredSuspensions`) calls the registry sweep and then, for each run the sweep actually cancelled, drives the same finish side-effects a normal cancellation does: the `run:finished` hook (so a live form page learns it expired) and `FireChain` on the `resume_timeout` cancellation (so `on: always` / `on: failure` edges observe it). The two engine-driven call sites — the periodic daemon ticker and the inline resume-expiry check in `ResumeRun` — now route through it.

To keep this idempotent, the registry sweep now transitions each candidate with its own status-guarded UPDATE and returns only the rows it actually changed. A run that resumes between the candidate SELECT and its UPDATE changes 0 rows and is excluded, so the engine never double-finishes a run that already left `suspended`.

## What was deliberately left behind

- The **startup sweep** (`setupRegistry`) stays registry-only: the engine doesn't exist yet and there are no websocket subscribers or armed chains at boot, so firing finish side-effects there would be meaningless (or fire chains for runs that expired while the daemon was down).
- **No audit event.** There is no run-finished/cancelled audit event anywhere in the engine — neither `finalizeCancelled`, the normal finish path, nor an operator-initiated kill emits one (`EventRunTriggered` fires at run *start* only). Emitting one solely from the timeout sweep would be net-new, asymmetric surface beyond this seam, so it is out of scope.

Part of #95. References #502 (the sweep-side-effects item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expired suspended runs now cancel through the normal engine flow, ensuring follow-up actions run consistently.
  * Runs that are resumed just before cleanup are no longer incorrectly cancelled again.
  * Cancellation timing now better preserves the final run status and downstream chaining behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->