### PR TITLE
fix(suspend): release the daemon slot + restart when a suspended daemon is swept on timeout

### DIFF
--- a/pkg/trigger/daemon.go
+++ b/pkg/trigger/daemon.go
@@ -216,10 +216,9 @@ func (e *Engine) onDaemonRunFinished(spec *task.Spec, runID string) {
 		// The daemon was running; treat the deliberate stop as a clean
 		// transition to DaemonStopped so the WebUI doesn't pin a stale
 		// "Running" pill on a daemon whose body has been killed (issue
-		// #332). This sits ahead of the noRestartTransition switch
-		// below because cancellation short-circuits the restart-policy
-		// decision entirely — a killed daemon stays stopped regardless
-		// of restart=always/on-failure/never.
+		// #332). This sits ahead of the restart-policy decision because
+		// cancellation short-circuits it entirely — a killed daemon
+		// stays stopped regardless of restart=always/on-failure/never.
 		//
 		// Cancellation also clears crash-loop tracking (#458): a kill is
 		// deliberate operator intent, not another crashed start, and the
@@ -229,12 +228,26 @@ func (e *Engine) onDaemonRunFinished(spec *task.Spec, runID string) {
 		return
 	}
 
+	e.restartDaemonAfterExit(spec, run.Status, elapsed)
+}
+
+// restartDaemonAfterExit applies crash-loop accounting and the restart policy
+// for a daemon body that has left the running state with a non-cancelled exit,
+// re-launching it (through the shared restart gate, after backoff) when the
+// policy calls for it. The caller must have already released the run slot and
+// confirmed the task is still registered and the engine is not shutting down.
+//
+// Reused by two entry points: the run goroutine's onDaemonRunFinished (in-line,
+// where blocking on the backoff is fine) and the timeout sweep of a suspended
+// daemon (out-of-band, where the run goroutine is already gone) — so both take
+// the identical restart decision.
+func (e *Engine) restartDaemonAfterExit(spec *task.Spec, status string, elapsed time.Duration) {
 	// Crash-loop accounting (#458): a quick non-success exit bumps the
 	// consecutive-failure counter; a clean or sustained exit resets it.
 	// Tracked for every non-cancelled exit regardless of restart policy so
 	// the rule stays a single invariant; in practice only auto-restarting
 	// daemons accumulate enough consecutive starts to trip the threshold.
-	if fails := e.crashloops.noteExit(spec.ID, elapsed, run.Status == registry.StatusSuccess); fails == crashloopThreshold {
+	if fails := e.crashloops.noteExit(spec.ID, elapsed, status == registry.StatusSuccess); fails == crashloopThreshold {
 		e.log.Warn("daemon is crash-looping — status reports 'crashlooping' until a run sustains",
 			zap.String("task", spec.ID),
 			zap.Int("consecutive_quick_failures", fails),
@@ -256,7 +269,7 @@ func (e *Engine) onDaemonRunFinished(spec *task.Spec, runID string) {
 	// daemonStates, leaving the WebUI showing a stale "Running" pill
 	// for a daemon that's no longer running.
 	noRestartTransition := func() {
-		if run.Status == registry.StatusSuccess {
+		if status == registry.StatusSuccess {
 			e.setDaemonState(spec.ID, DaemonStopped)
 		} else {
 			e.setDaemonState(spec.ID, DaemonCrashed)
@@ -265,13 +278,13 @@ func (e *Engine) onDaemonRunFinished(spec *task.Spec, runID string) {
 	switch restart {
 	case "never":
 		e.log.Info("daemon exited — restart=never, not restarting",
-			zap.String("task", spec.ID), zap.String("status", run.Status))
+			zap.String("task", spec.ID), zap.String("status", status))
 		noRestartTransition()
 		return
 	case "on-failure":
-		if run.Status != registry.StatusFailure {
+		if status != registry.StatusFailure {
 			e.log.Info("daemon exited — restart=on-failure, not restarting (no failure)",
-				zap.String("task", spec.ID), zap.String("status", run.Status))
+				zap.String("task", spec.ID), zap.String("status", status))
 			noRestartTransition()
 			return
 		}
@@ -279,7 +292,7 @@ func (e *Engine) onDaemonRunFinished(spec *task.Spec, runID string) {
 
 	e.log.Info("daemon exited, scheduling restart",
 		zap.String("task", spec.ID),
-		zap.String("status", run.Status),
+		zap.String("status", status),
 		zap.String("restart", restart),
 	)
 
@@ -347,15 +360,15 @@ func (e *Engine) onDaemonRunFinished(spec *task.Spec, runID string) {
 	// Re-check under the gate: the backoff sleep is up to daemonBackoffMax,
 	// plenty of time for the world to have moved on.
 	//   - An Unregister during the sleep must not resurrect the daemon (the
-	//     stillRegistered check at the top of this function predates the
-	//     sleep, so it cannot cover this).
+	//     caller's stillRegistered check predates the sleep, so it cannot
+	//     cover this).
 	//   - A re-register that already completed (gate released) has a live
 	//     run slot; starting again would double-start the body. With the
 	//     slot now reserved before the body fires (race 1 fix above), slot
 	//     presence is a reliable "body in flight" signal — the same check
 	//     registerDaemon uses.
 	e.daemonMu.Lock()
-	_, stillRegistered = e.daemonSpecs[spec.ID]
+	_, stillRegistered := e.daemonSpecs[spec.ID]
 	_, alreadyRunning := e.daemonRuns[spec.ID]
 	e.daemonMu.Unlock()
 	if !stillRegistered {
@@ -371,4 +384,50 @@ func (e *Engine) onDaemonRunFinished(spec *task.Spec, runID string) {
 
 	e.log.Info("restarting daemon task", zap.String("task", spec.ID))
 	e.startDaemon(spec)
+}
+
+// onDaemonSuspensionSwept routes a standalone daemon body whose suspension
+// timed out — swept suspended→cancelled by SweepExpiredSuspensions — back
+// through the daemon lifecycle. onDaemonRunFinished parked the #470 run slot on
+// the suspended run and published DaemonSuspended, expecting a resume to adopt
+// the slot; but the body goroutine exited cleanly on suspend, so
+// onDaemonRunFinished will never run again for this run. Without this the slot
+// stays pinned to a now-cancelled run — registerDaemon reads alreadyRunning and
+// a reconciler reload refuses to restart, wedging the daemon and bypassing its
+// restart policy until a full process restart.
+//
+// This does the slot release + restart decision onDaemonRunFinished would have
+// done, but out-of-band from the (already gone) run goroutine. It must run in
+// its own goroutine: restartDaemonAfterExit blocks on the restart backoff.
+func (e *Engine) onDaemonSuspensionSwept(spec *task.Spec, run *registry.Run) {
+	// Slot-match guard, identical to onDaemonRunFinished/resumeDaemonBody: only
+	// release the slot if it still parks the swept run. The status-guarded sweep
+	// UPDATE already ensures the sweep and a resume can't both transition the
+	// same run (a resumed run is excluded from the swept set), so a resume that
+	// adopted the slot is not in play here — but the guard keeps slot ownership
+	// consistent with that outcome regardless.
+	e.daemonMu.Lock()
+	if e.daemonRuns[spec.ID] != run.ID {
+		e.daemonMu.Unlock()
+		return
+	}
+	delete(e.daemonRuns, spec.ID)
+	_, stillRegistered := e.daemonSpecs[spec.ID]
+	e.daemonMu.Unlock()
+
+	if !stillRegistered || e.isShuttingDown() {
+		// Nothing will restart; clear the parked DaemonSuspended so the WebUI
+		// doesn't pin a stale "suspended" pill on a daemon that is gone.
+		e.setDaemonState(spec.ID, DaemonStopped)
+		return
+	}
+
+	// elapsed spans the whole suspended gap (StartedAt → the sweep's
+	// finished_at). A real suspension outlives daemonStableThreshold, so the
+	// restart backoff resets to init — a timeout is not a crash loop.
+	var elapsed time.Duration
+	if run.FinishedAt != nil {
+		elapsed = run.FinishedAt.Sub(run.StartedAt)
+	}
+	e.restartDaemonAfterExit(spec, run.Status, elapsed)
 }

--- a/pkg/trigger/daemon_sweep_test.go
+++ b/pkg/trigger/daemon_sweep_test.go
@@ -1,0 +1,204 @@
+package trigger
+
+// Regression tests for issue #502: a standalone daemon that suspends via
+// dicode.suspend() and is never resumed used to wedge permanently once its
+// resume deadline lapsed. onDaemonRunFinished parked the #470 run slot and set
+// DaemonSuspended for a resume that never came; the body goroutine had already
+// exited, so when the #509 sweep flipped the run suspended→cancelled it left
+// the slot pinned to a now-cancelled run. registerDaemon then read
+// alreadyRunning=true and a reconciler reload refused to restart — the restart
+// policy bypassed until a full process restart cleared the fresh map.
+//
+// The fix routes a swept standalone-daemon suspension back through the daemon
+// lifecycle (SweepExpiredSuspensions → onDaemonSuspensionSwept): release the
+// slot under the same slot-match guard, clear DaemonSuspended, and let the
+// restart policy decide.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// suspendDaemonEnv wires a suspendExec-backed engine with a standalone daemon
+// registered in both the registry and daemonSpecs (so the sweep's daemon-ness
+// lookup and onDaemonRunFinished's stillRegistered guard see it), then brings
+// the daemon up and waits for it to park in DaemonSuspended. Returns the engine,
+// registry, spec, and the suspended run ID holding the parked slot.
+func suspendDaemonEnv(t *testing.T, restart string) (*Engine, *registry.Registry, *task.Spec, string) {
+	t.Helper()
+	exec := &suspendExec{firstDeadline: time.Now().Add(-time.Hour).UnixMilli()}
+	eng, reg := newSuspendEnv(t, exec)
+
+	spec := &task.Spec{
+		ID:      "d-suspend",
+		Name:    "d-suspend",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Daemon: true, Restart: restart},
+		Enabled: true,
+	}
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("reg.Register: %v", err)
+	}
+	eng.daemonMu.Lock()
+	eng.daemonSpecs[spec.ID] = spec
+	eng.daemonMu.Unlock()
+
+	eng.startDaemon(spec)
+
+	var suspendedRunID string
+	waitUntil(t, 5*time.Second, func() bool {
+		eng.daemonMu.Lock()
+		suspendedRunID = eng.daemonRuns[spec.ID]
+		eng.daemonMu.Unlock()
+		return suspendedRunID != "" && eng.DaemonState(spec.ID) == DaemonSuspended
+	}, "daemon never parked in DaemonSuspended with a reserved slot")
+	return eng, reg, spec, suspendedRunID
+}
+
+func daemonSlot(eng *Engine, id string) string {
+	eng.daemonMu.Lock()
+	defer eng.daemonMu.Unlock()
+	return eng.daemonRuns[id]
+}
+
+// TestSweep_SuspendedDaemonTimeout_ReleasesSlotAndRestarts is the #502 wedge
+// regression: a restart:always standalone daemon that suspended and timed out
+// must have its slot released and restart per policy — not stay pinned to the
+// cancelled run.
+func TestSweep_SuspendedDaemonTimeout_ReleasesSlotAndRestarts(t *testing.T) {
+	eng, reg, spec, suspendedRunID := suspendDaemonEnv(t, "always")
+
+	swept, err := eng.SweepExpiredSuspensions(context.Background(), time.Now().UnixMilli())
+	if err != nil {
+		t.Fatalf("SweepExpiredSuspensions: %v", err)
+	}
+	if len(swept) != 1 || swept[0] != suspendedRunID {
+		t.Fatalf("swept = %v, want [%s]", swept, suspendedRunID)
+	}
+
+	// The restart fires a fresh body (which suspends again), so the slot must end
+	// up parked on a DIFFERENT run than the swept, now-cancelled one.
+	waitUntil(t, 5*time.Second, func() bool {
+		slot := daemonSlot(eng, spec.ID)
+		return slot != "" && slot != suspendedRunID
+	}, "daemon slot never re-parked on a restarted body — it wedged on the cancelled run")
+
+	// A second run exists for the daemon: proof the restart actually ran a body,
+	// not just cleared the slot.
+	waitRunCount(t, reg, spec.ID, 2)
+
+	// The swept run is terminal cancelled with the resume-timeout reason.
+	run, _ := reg.GetRun(context.Background(), suspendedRunID)
+	if run.Status != registry.StatusCancelled || run.FailureReason != registry.ReasonResumeTimeout {
+		t.Errorf("swept run status/reason = %q/%q, want cancelled/resume_timeout", run.Status, run.FailureReason)
+	}
+}
+
+// TestSweep_SuspendedDaemonTimeout_RestartNever_NoRestart confirms the sweep
+// honors the restart policy: a restart:never daemon whose suspension timed out
+// releases its slot (so it is no longer wedged) but is NOT restarted, and lands
+// in the terminal DaemonCrashed state rather than a stale DaemonSuspended.
+func TestSweep_SuspendedDaemonTimeout_RestartNever_NoRestart(t *testing.T) {
+	eng, reg, spec, suspendedRunID := suspendDaemonEnv(t, "never")
+
+	if _, err := eng.SweepExpiredSuspensions(context.Background(), time.Now().UnixMilli()); err != nil {
+		t.Fatalf("SweepExpiredSuspensions: %v", err)
+	}
+
+	waitUntil(t, 5*time.Second, func() bool {
+		return daemonSlot(eng, spec.ID) == "" && eng.DaemonState(spec.ID) == DaemonCrashed
+	}, "restart:never daemon did not release its slot / reach DaemonCrashed")
+
+	// No restart: only the original suspended body ever ran.
+	time.Sleep(50 * time.Millisecond)
+	runs, err := reg.ListRuns(context.Background(), spec.ID, 10)
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) != 1 || runs[0].ID != suspendedRunID {
+		t.Fatalf("restart:never spawned a new run: got %d runs %v, want only the swept one", len(runs), runs)
+	}
+}
+
+// TestOnDaemonSuspensionSwept_ConcurrentResumeSlotNotClobbered pins the
+// slot-match guard: if a resume continuation has already adopted the slot
+// (daemonRuns points at a different run than the swept one), the sweep's slot
+// handling must leave it alone rather than delete the continuation's slot.
+func TestOnDaemonSuspensionSwept_ConcurrentResumeSlotNotClobbered(t *testing.T) {
+	eng, reg, spec, suspendedRunID := suspendDaemonEnv(t, "always")
+
+	run, err := reg.GetRun(context.Background(), suspendedRunID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+
+	// Model a resume continuation that adopted the slot before the sweep's
+	// out-of-band slot handling ran.
+	const continuationRunID = "continuation-run"
+	eng.daemonMu.Lock()
+	eng.daemonRuns[spec.ID] = continuationRunID
+	eng.daemonMu.Unlock()
+
+	// Drive the sweep's daemon handler directly with the swept (old) run.
+	eng.onDaemonSuspensionSwept(spec, run)
+
+	if slot := daemonSlot(eng, spec.ID); slot != continuationRunID {
+		t.Fatalf("daemon slot = %q, want the continuation's %q left untouched", slot, continuationRunID)
+	}
+}
+
+// TestSweep_SuspendedPipelineStageDaemon_DoesNotTouchDaemonRuns confirms a
+// pipeline-stage daemon run (TriggerPipelineStage) that suspends and is swept is
+// NOT treated as a standalone daemon: the standalone daemon's parked slot for
+// the SAME task must be left untouched, since a pipeline stage is owned by the
+// PipelineRunner, not the standalone-daemon machinery.
+func TestSweep_SuspendedPipelineStageDaemon_DoesNotTouchDaemonRuns(t *testing.T) {
+	exec := &suspendExec{firstDeadline: time.Now().Add(-time.Hour).UnixMilli()}
+	eng, reg := newSuspendEnv(t, exec)
+
+	spec := &task.Spec{
+		ID:      "d-both",
+		Name:    "d-both",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Daemon: true, Restart: "always"},
+		Enabled: true,
+	}
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("reg.Register: %v", err)
+	}
+	// A live standalone daemon body of this task holds the slot.
+	const standaloneRunID = "standalone-body"
+	eng.daemonMu.Lock()
+	eng.daemonSpecs[spec.ID] = spec
+	eng.daemonRuns[spec.ID] = standaloneRunID
+	eng.daemonMu.Unlock()
+
+	// Fire the SAME task as a pipeline stage; it suspends with a past deadline.
+	// The run.go finish gate skips onDaemonRunFinished for pipeline-stage runs,
+	// so the standalone slot is untouched by the suspend.
+	stageRunID, err := eng.fireAsync(context.Background(), spec, pkgruntime.RunOptions{}, registry.TriggerPipelineStage)
+	if err != nil {
+		t.Fatalf("fireAsync pipeline stage: %v", err)
+	}
+	waitStatus(t, reg, stageRunID, registry.StatusSuspended)
+
+	swept, err := eng.SweepExpiredSuspensions(context.Background(), time.Now().UnixMilli())
+	if err != nil {
+		t.Fatalf("SweepExpiredSuspensions: %v", err)
+	}
+	if len(swept) != 1 || swept[0] != stageRunID {
+		t.Fatalf("swept = %v, want [%s]", swept, stageRunID)
+	}
+
+	// The standalone daemon's slot must be exactly as it was — the pipeline-stage
+	// sweep must not release or restart it.
+	time.Sleep(50 * time.Millisecond)
+	if slot := daemonSlot(eng, spec.ID); slot != standaloneRunID {
+		t.Fatalf("standalone daemon slot = %q, want %q untouched by pipeline-stage sweep", slot, standaloneRunID)
+	}
+}

--- a/pkg/trigger/sweep.go
+++ b/pkg/trigger/sweep.go
@@ -37,6 +37,24 @@ func (e *Engine) SweepExpiredSuspensions(ctx context.Context, nowMs int64) ([]st
 			h(run.TaskID, run.ID, registry.StatusCancelled, string(run.TriggerSource), 0)
 		}
 		e.FireChain(context.Background(), run.TaskID, run.ID, registry.StatusCancelled, nil, nil)
+
+		// A standalone daemon body that suspended kept its #470 run slot parked
+		// (DaemonSuspended) for a resume that never came; the sweep just made the
+		// run terminal but its goroutine is long gone, so onDaemonRunFinished
+		// won't release the slot or apply the restart policy. Route it back
+		// through the daemon lifecycle so the slot frees and restart=always
+		// restarts instead of the daemon wedging. Pipeline-stage daemon runs
+		// (TriggerPipelineStage) are owned by the PipelineRunner, not the
+		// standalone-daemon machinery — mirror run.go's onDaemonRunFinished gate
+		// and leave them alone.
+		if run.TriggerSource != registry.TriggerPipelineStage {
+			e.daemonMu.Lock()
+			spec, isDaemon := e.daemonSpecs[run.TaskID]
+			e.daemonMu.Unlock()
+			if isDaemon && spec.Trigger.Daemon {
+				go e.onDaemonSuspensionSwept(spec, run)
+			}
+		}
 	}
 	return swept, nil
 }


### PR DESCRIPTION
## Summary

A standalone `restart: always` (or any) daemon task that calls `dicode.suspend()` and is never resumed wedged permanently once its resume deadline lapsed.

When a daemon body suspends, `onDaemonRunFinished` intentionally keeps the `daemonRuns[spec.ID]` slot reserved and publishes `DaemonSuspended` (the #508 invariant), expecting a resume to adopt the slot via `resumeDaemonBody`. But suspend is a clean goroutine exit, so `onDaemonRunFinished` never runs again for that run. When the deadline lapsed, the #509 sweep flipped the run `suspended→cancelled` and fired `run:finished` + `FireChain`, but never touched `daemonRuns`, `daemonStates`, or the restart policy. The slot stayed pinned to a now-`cancelled` run, so `registerDaemon` read `alreadyRunning=true` and a reconciler reload silently coalesced and refused to restart. The daemon stayed dead, `restart: always` was bypassed, and the UI reported "suspended" for a gone daemon — recoverable only by a full process restart (whose startup sweep clears the fresh map).

## The fix

The engine-level `SweepExpiredSuspensions` wrapper now routes each swept run that is a standalone daemon body back through the daemon lifecycle via a new `onDaemonSuspensionSwept`, doing the slot-release + restart decision `onDaemonRunFinished` would have done, but out-of-band from the (already gone) run goroutine:

- Releases the `daemonRuns` slot under `daemonMu` using the same slot-match guard as `onDaemonRunFinished`/`resumeDaemonBody` — a concurrent resume that adopted the slot wins and is not clobbered. (The status-guarded sweep UPDATE already ensures the sweep and a resume can't both transition the same run, so a resumed run is excluded from the swept set; the guard keeps slot ownership consistent regardless.)
- Clears `DaemonSuspended`.
- Lets the restart policy decide, reusing a factored-out `restartDaemonAfterExit` shared with `onDaemonRunFinished` (respecting `restartGates` and the backoff so it doesn't race a concurrent register/restart).

Pipeline-stage daemon runs (`TriggerPipelineStage`) are owned by the `PipelineRunner`, not the standalone-daemon machinery, so they are deliberately left untouched — mirroring `run.go`'s existing `onDaemonRunFinished` gate.

## Scope

Only the daemon-sweep-slot seam is touched. Restart semantics for a timed-out suspension follow the policy on the `cancelled`/resume-timeout status: `always` restarts; `on-failure`/`never` do not restart and land in `DaemonCrashed`.

Part of #95

References #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon restart handling after cancellations and suspension timeouts.
  * Daemon slots are now released correctly when a suspended run expires, preventing stuck or wedged restarts.
  * Restart behavior now respects the final run state more reliably, including “restart on failure” and “restart never” cases.
  * Pipeline-stage runs are excluded from standalone daemon restart handling, avoiding unintended side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->