### PR TITLE
feat(suspend): JSON-Schema forms + server-side validation (v2 phase A)

### DIFF
--- a/.claude/skills/dicode-task-dev/SKILL.md
+++ b/.claude/skills/dicode-task-dev/SKILL.md
@@ -83,7 +83,7 @@ on_failure_chain: <task-id>      # run on failure; "" disables global default
 - `output.html()/text()` — render UI instead of returning JSON.
 - `await dicode.run_task(id, params?)` / `list_tasks()` / `get_runs(id, opts)` / `secrets_set()/secrets_delete()` — gated by `permissions.dicode`.
 - `await mcp.list_tools(server)` / `mcp.call(server, tool, args)` — gated by `permissions.dicode.mcp`.
-- `await dicode.suspend({ state, form, deadline? })` — pause for user input; reads back as `resume_state` / `resume_input` (Python: `ctx.resume_state`). See below.
+- `await dicode.suspend({ state, schema, deadline? })` — pause for user input; reads back as `resume_state` / `resume_input` (Python: `ctx.resume_state`). See below.
 - `return <json>` — value handed to downstream chain tasks; keep it under ~1MB.
 
 ### Suspendable tasks (pause for user input)
@@ -91,24 +91,33 @@ on_failure_chain: <task-id>      # run on failure; "" disables global default
 `dicode.suspend()` pauses a run to collect input from a human, then continues.
 It never returns — the process exits, the run becomes `suspended`, and on resume
 the task **re-runs from the top** with `resume_state` (the blob you passed) and
-`resume_input` (the submitted form) populated (both `undefined`/`None` on a first
-run). Branch on `resume_state` to resume where you left off. Deno/Python only; no
-permission declaration needed.
+`resume_input` (the submitted values) populated (both `undefined`/`None` on a
+first run). Branch on `resume_state` to resume where you left off. Deno/Python
+only; no permission declaration needed.
+
+`schema` is a JSON Schema (draft 2020-12) for the input object; the daemon
+validates the submission against it server-side before resuming.
 
 ```typescript
 if (!resume_state) {
   await dicode.suspend({
     state: { step: "confirm" },
-    form: { title: "Approve?", fields: [{ name: "ok", label: "OK?", type: "boolean", required: true }] },
+    schema: {
+      type: "object",
+      properties: { ok: { type: "boolean", title: "OK?" } },
+      required: ["ok"],
+    },
   })  // unreachable — never returns
 }
 const answers = resume_input as Record<string, unknown>
 ```
 
-Field types: `string | text | number | boolean | select` (`select` needs
-`options: [{ value, label }]`). Never swallow the suspend signal in a `try/catch`
-(the run fails loudly). Resume via the WebUI run-detail form or the CLI:
-`dicode resume` lists suspended runs, `dicode resume <run-id> field=value` submits.
+Default renderer maps: `type:string`→text (`format:"textarea"`→textarea),
+`enum`→select, `type:boolean`→checkbox, `type:number|integer`→number; honors
+`title`/`description`/`default`/`required`. Never swallow the suspend signal in a
+`try/catch` (the run fails loudly). Resume via the WebUI run-detail form or the
+CLI: `dicode resume` lists suspended runs, `dicode resume <run-id> field=value`
+submits (values coerced to the schema's declared types).
 Full reference: [docs/concepts/suspendable-tasks.md](../../../docs/concepts/suspendable-tasks.md).
 
 ## Test harness (`task.test.ts`)

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -991,6 +991,22 @@ func parseResumeProps(schemaJSON []byte) ([]resumePropEntry, map[string]bool, er
 // yields a JSON number, a boolean a JSON bool) rather than a string.
 func coerceResumeValue(p resumeProp, raw string) (any, error) {
 	s := strings.TrimSpace(raw)
+	// enum: match the raw string against the declared choices and return the
+	// matching entry with its original JSON type. This mirrors the WebUI's
+	// option-index approach, so a numeric enum like {enum:[1,2]} coerces to a
+	// number even when `type` is omitted — not just a bare string.
+	if len(p.Enum) > 0 {
+		for _, e := range p.Enum {
+			if fmt.Sprintf("%v", e) == s {
+				return e, nil
+			}
+		}
+		opts := make([]string, len(p.Enum))
+		for i, e := range p.Enum {
+			opts[i] = fmt.Sprintf("%v", e)
+		}
+		return nil, fmt.Errorf("must be one of %s", strings.Join(opts, ", "))
+	}
 	switch p.Type {
 	case "boolean":
 		switch strings.ToLower(s) {

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -27,18 +27,23 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/dicode/dicode/pkg/daemon"
 	"github.com/dicode/dicode/pkg/ipc"
+	"github.com/dicode/dicode/pkg/schemavalidate"
 	"github.com/dicode/dicode/pkg/tasktest"
 )
 
@@ -924,30 +929,236 @@ func cmdStatus(c *ipc.ControlClient, taskID string) error {
 	return nil
 }
 
-// parseResumeInput turns `field=value` CLI args into the JSON object the
-// daemon forwards to the resumed task as ctx.resume_input. An arg without an
-// `=` is a usage error. An empty arg list yields an empty object.
-func parseResumeInput(kvArgs []string) ([]byte, error) {
-	input := map[string]string{}
+// resumeProp is the subset of a JSON Schema property the CLI reads to prompt
+// for and coerce a value.
+type resumeProp struct {
+	Type        string `json:"type"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Enum        []any  `json:"enum"`
+	Default     any    `json:"default"`
+}
+
+// resumePropEntry pairs a property name with its schema, preserving the
+// author's declaration order (a map would randomize the prompt order).
+type resumePropEntry struct {
+	Name string
+	Prop resumeProp
+}
+
+// parseResumeProps extracts the ordered top-level properties and the required
+// set from a JSON Schema. An empty schema yields no properties (the resume then
+// carries whatever the caller supplied, subject to server-side validation).
+func parseResumeProps(schemaJSON []byte) ([]resumePropEntry, map[string]bool, error) {
+	required := map[string]bool{}
+	if len(bytes.TrimSpace(schemaJSON)) == 0 {
+		return nil, required, nil
+	}
+	var top struct {
+		Properties json.RawMessage `json:"properties"`
+		Required   []string        `json:"required"`
+	}
+	if err := json.Unmarshal(schemaJSON, &top); err != nil {
+		return nil, nil, err
+	}
+	for _, r := range top.Required {
+		required[r] = true
+	}
+	var entries []resumePropEntry
+	if len(bytes.TrimSpace(top.Properties)) > 0 {
+		dec := json.NewDecoder(bytes.NewReader(top.Properties))
+		if _, err := dec.Token(); err != nil { // opening '{'
+			return nil, nil, err
+		}
+		for dec.More() {
+			keyTok, err := dec.Token()
+			if err != nil {
+				return nil, nil, err
+			}
+			name, _ := keyTok.(string)
+			var p resumeProp
+			if err := dec.Decode(&p); err != nil {
+				return nil, nil, err
+			}
+			entries = append(entries, resumePropEntry{Name: name, Prop: p})
+		}
+	}
+	return entries, required, nil
+}
+
+// coerceResumeValue converts a raw CLI/prompt string to the JSON type the
+// property declares, so the resumed task sees a typed value (a number field
+// yields a JSON number, a boolean a JSON bool) rather than a string.
+func coerceResumeValue(p resumeProp, raw string) (any, error) {
+	s := strings.TrimSpace(raw)
+	switch p.Type {
+	case "boolean":
+		switch strings.ToLower(s) {
+		case "true", "1", "yes", "y", "on":
+			return true, nil
+		case "false", "0", "no", "n", "off":
+			return false, nil
+		}
+		return nil, fmt.Errorf("expected a boolean (true/false), got %q", raw)
+	case "integer":
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("expected an integer, got %q", raw)
+		}
+		return n, nil
+	case "number":
+		f, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return nil, fmt.Errorf("expected a number, got %q", raw)
+		}
+		return f, nil
+	case "array", "object":
+		var v any
+		if err := json.Unmarshal([]byte(raw), &v); err != nil {
+			return nil, fmt.Errorf("expected JSON for %s, got %q", p.Type, raw)
+		}
+		return v, nil
+	default:
+		return raw, nil
+	}
+}
+
+// collectResumeArgs coerces `field=value` args to their declared JSON types.
+// A field absent from the schema passes through as a string — server-side
+// validation has the final say on whether it is acceptable.
+func collectResumeArgs(entries []resumePropEntry, kvArgs []string) (map[string]any, error) {
+	props := map[string]resumeProp{}
+	for _, e := range entries {
+		props[e.Name] = e.Prop
+	}
+	out := map[string]any{}
 	for _, kv := range kvArgs {
 		parts := strings.SplitN(kv, "=", 2)
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("invalid form value %q — expected field=value", kv)
 		}
-		input[parts[0]] = parts[1]
+		name, raw := parts[0], parts[1]
+		if p, ok := props[name]; ok {
+			v, err := coerceResumeValue(p, raw)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", name, err)
+			}
+			out[name] = v
+		} else {
+			out[name] = raw
+		}
 	}
-	return json.Marshal(input)
+	return out, nil
 }
 
-// cmdResume submits collected form values as the resume input for a suspended
-// run. It sends only the run id and the key=value pairs — the daemon resolves
-// the run's resume token server-side and calls the engine's resume, returning
-// the continuation run id.
+// promptResumeInput walks the schema's properties in order, prompting on stderr
+// (so a piped stdout stays clean) and coercing each answer to its declared
+// type. An empty answer takes the property's default, or is skipped when the
+// property is optional; a required property with no default re-prompts.
+func promptResumeInput(entries []resumePropEntry, required map[string]bool) (map[string]any, error) {
+	reader := bufio.NewReader(os.Stdin)
+	out := map[string]any{}
+	for _, e := range entries {
+		p := e.Prop
+		label := p.Title
+		if label == "" {
+			label = e.Name
+		}
+		if p.Description != "" {
+			fmt.Fprintf(os.Stderr, "%s\n", p.Description)
+		}
+		if len(p.Enum) > 0 {
+			opts := make([]string, len(p.Enum))
+			for i, o := range p.Enum {
+				opts[i] = fmt.Sprintf("%v", o)
+			}
+			fmt.Fprintf(os.Stderr, "  choices: %s\n", strings.Join(opts, ", "))
+		}
+		for {
+			suffix := ""
+			if p.Default != nil {
+				suffix = fmt.Sprintf(" [%v]", p.Default)
+			} else if required[e.Name] {
+				suffix = " (required)"
+			}
+			fmt.Fprintf(os.Stderr, "%s%s: ", label, suffix)
+
+			line, err := reader.ReadString('\n')
+			eof := errors.Is(err, io.EOF)
+			if err != nil && !eof {
+				return nil, err
+			}
+			raw := strings.TrimRight(line, "\r\n")
+			if strings.TrimSpace(raw) == "" {
+				if p.Default != nil {
+					out[e.Name] = p.Default
+				} else if required[e.Name] {
+					if eof {
+						return nil, fmt.Errorf("%s is required", e.Name)
+					}
+					fmt.Fprintln(os.Stderr, "  required — please enter a value")
+					continue
+				}
+				break
+			}
+			v, err := coerceResumeValue(p, raw)
+			if err != nil {
+				if eof {
+					return nil, fmt.Errorf("%s: %w", e.Name, err)
+				}
+				fmt.Fprintf(os.Stderr, "  %v\n", err)
+				continue
+			}
+			out[e.Name] = v
+			break
+		}
+	}
+	return out, nil
+}
+
+// cmdResume submits collected resume input for a suspended run. It first pulls
+// the run's JSON Schema (cli.resume.get), then either interactively prompts per
+// property (no field=value args) or coerces the supplied field=value pairs to
+// their declared types, validates locally against the schema, and submits. The
+// daemon re-validates authoritatively and resolves the resume token itself.
 func cmdResume(c *ipc.ControlClient, runID string, kvArgs []string) error {
-	inputJSON, err := parseResumeInput(kvArgs)
+	infoResp, err := c.Send(ipc.Request{Method: "cli.resume.get", RunID: runID})
 	if err != nil {
 		return err
 	}
+	if infoResp.Error != "" {
+		return fmt.Errorf("%s", infoResp.Error)
+	}
+	var info ipc.ResumeInfo
+	if err := remarshal(infoResp.Result, &info); err != nil {
+		return err
+	}
+
+	entries, required, err := parseResumeProps(info.Schema)
+	if err != nil {
+		return fmt.Errorf("read resume schema: %w", err)
+	}
+
+	var values map[string]any
+	if len(kvArgs) == 0 {
+		values, err = promptResumeInput(entries, required)
+	} else {
+		values, err = collectResumeArgs(entries, kvArgs)
+	}
+	if err != nil {
+		return err
+	}
+
+	inputJSON, err := json.Marshal(values)
+	if err != nil {
+		return err
+	}
+	// Fail fast with a clear message before the round-trip; the daemon still
+	// validates authoritatively (an empty schema imposes no constraint).
+	if err := schemavalidate.Validate(info.Schema, inputJSON); err != nil {
+		return fmt.Errorf("invalid input: %w", err)
+	}
+
 	resp, err := c.Send(ipc.Request{
 		Method: "cli.resume",
 		RunID:  runID,

--- a/cmd/dicode/resume_test.go
+++ b/cmd/dicode/resume_test.go
@@ -81,6 +81,36 @@ func TestCoerceResumeValue_Types(t *testing.T) {
 	}
 }
 
+func TestCoerceResumeValue_UntypedNumericEnum(t *testing.T) {
+	// enum with no `type`: the CLI must match the raw string against the choices
+	// and return the entry's original JSON type (number), not a bare string.
+	p := resumeProp{Enum: []any{float64(1), float64(2)}}
+	got, err := coerceResumeValue(p, "2")
+	if err != nil {
+		t.Fatalf("coerce untyped numeric enum: %v", err)
+	}
+	if got != float64(2) {
+		t.Errorf("got %#v, want float64(2)", got)
+	}
+	if _, err := coerceResumeValue(p, "3"); err == nil {
+		t.Error("expected error for a value outside the enum")
+	}
+}
+
+func TestCoerceResumeValue_StringEnum(t *testing.T) {
+	p := resumeProp{Type: "string", Enum: []any{"staging", "prod"}}
+	got, err := coerceResumeValue(p, "prod")
+	if err != nil {
+		t.Fatalf("coerce string enum: %v", err)
+	}
+	if got != "prod" {
+		t.Errorf("got %#v, want prod", got)
+	}
+	if _, err := coerceResumeValue(p, "dev"); err == nil {
+		t.Error("expected error for a value outside the enum")
+	}
+}
+
 func TestCoerceResumeValue_Errors(t *testing.T) {
 	if _, err := coerceResumeValue(resumeProp{Type: "integer"}, "abc"); err == nil {
 		t.Error("expected error coercing non-integer")

--- a/cmd/dicode/resume_test.go
+++ b/cmd/dicode/resume_test.go
@@ -1,54 +1,138 @@
 package main
 
 import (
-	"encoding/json"
 	"testing"
 )
 
-func TestParseResumeInput_KeyValueToJSON(t *testing.T) {
-	got, err := parseResumeInput([]string{"approve=yes", "note=looks good"})
+const resumeTestSchema = `{
+  "type": "object",
+  "properties": {
+    "project_name": { "type": "string", "title": "Project name" },
+    "count":  { "type": "integer" },
+    "ratio":  { "type": "number" },
+    "notify": { "type": "boolean" },
+    "env":    { "type": "string", "enum": ["staging", "prod"] }
+  },
+  "required": ["project_name", "env"]
+}`
+
+func mustParseProps(t *testing.T) []resumePropEntry {
+	t.Helper()
+	entries, _, err := parseResumeProps([]byte(resumeTestSchema))
 	if err != nil {
-		t.Fatalf("parseResumeInput: %v", err)
+		t.Fatalf("parseResumeProps: %v", err)
 	}
-	var m map[string]string
-	if err := json.Unmarshal(got, &m); err != nil {
-		t.Fatalf("unmarshal: %v", err)
+	return entries
+}
+
+func TestParseResumeProps_OrderAndRequired(t *testing.T) {
+	entries, required, err := parseResumeProps([]byte(resumeTestSchema))
+	if err != nil {
+		t.Fatalf("parseResumeProps: %v", err)
 	}
-	if m["approve"] != "yes" {
-		t.Errorf("approve = %q, want yes", m["approve"])
+	wantOrder := []string{"project_name", "count", "ratio", "notify", "env"}
+	if len(entries) != len(wantOrder) {
+		t.Fatalf("got %d properties, want %d", len(entries), len(wantOrder))
 	}
-	// Values may contain `=` and spaces — only the first `=` splits.
-	if m["note"] != "looks good" {
-		t.Errorf("note = %q, want 'looks good'", m["note"])
+	for i, w := range wantOrder {
+		if entries[i].Name != w {
+			t.Errorf("property %d = %q, want %q (declaration order not preserved)", i, entries[i].Name, w)
+		}
+	}
+	if !required["project_name"] || !required["env"] {
+		t.Errorf("required set = %v, want project_name and env", required)
+	}
+	if required["count"] {
+		t.Errorf("count should not be required")
 	}
 }
 
-func TestParseResumeInput_ValueWithEquals(t *testing.T) {
-	got, err := parseResumeInput([]string{"expr=a=b"})
+func TestParseResumeProps_EmptySchema(t *testing.T) {
+	entries, required, err := parseResumeProps(nil)
 	if err != nil {
-		t.Fatalf("parseResumeInput: %v", err)
+		t.Fatalf("parseResumeProps(nil): %v", err)
 	}
-	var m map[string]string
-	if err := json.Unmarshal(got, &m); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if m["expr"] != "a=b" {
-		t.Errorf("expr = %q, want a=b", m["expr"])
+	if len(entries) != 0 || len(required) != 0 {
+		t.Fatalf("empty schema should yield no props/required, got %v %v", entries, required)
 	}
 }
 
-func TestParseResumeInput_EmptyIsEmptyObject(t *testing.T) {
-	got, err := parseResumeInput(nil)
-	if err != nil {
-		t.Fatalf("parseResumeInput: %v", err)
+func TestCoerceResumeValue_Types(t *testing.T) {
+	cases := []struct {
+		typ  string
+		raw  string
+		want any
+	}{
+		{"integer", "10", int64(10)},
+		{"number", "3.5", 3.5},
+		{"boolean", "yes", true},
+		{"boolean", "false", false},
+		{"string", "hello", "hello"},
+		{"", "bare", "bare"},
 	}
-	if string(got) != "{}" {
-		t.Errorf("got %s, want {}", got)
+	for _, c := range cases {
+		got, err := coerceResumeValue(resumeProp{Type: c.typ}, c.raw)
+		if err != nil {
+			t.Fatalf("coerce(%s,%q): %v", c.typ, c.raw, err)
+		}
+		if got != c.want {
+			t.Errorf("coerce(%s,%q) = %#v, want %#v", c.typ, c.raw, got, c.want)
+		}
 	}
 }
 
-func TestParseResumeInput_MissingEqualsIsError(t *testing.T) {
-	if _, err := parseResumeInput([]string{"approve"}); err == nil {
+func TestCoerceResumeValue_Errors(t *testing.T) {
+	if _, err := coerceResumeValue(resumeProp{Type: "integer"}, "abc"); err == nil {
+		t.Error("expected error coercing non-integer")
+	}
+	if _, err := coerceResumeValue(resumeProp{Type: "number"}, "x"); err == nil {
+		t.Error("expected error coercing non-number")
+	}
+	if _, err := coerceResumeValue(resumeProp{Type: "boolean"}, "maybe"); err == nil {
+		t.Error("expected error coercing non-boolean")
+	}
+}
+
+func TestCollectResumeArgs_CoercesByType(t *testing.T) {
+	entries := mustParseProps(t)
+	got, err := collectResumeArgs(entries, []string{"project_name=api", "count=7", "notify=true", "env=prod"})
+	if err != nil {
+		t.Fatalf("collectResumeArgs: %v", err)
+	}
+	if got["project_name"] != "api" {
+		t.Errorf("project_name = %#v", got["project_name"])
+	}
+	if got["count"] != int64(7) {
+		t.Errorf("count = %#v, want int64(7)", got["count"])
+	}
+	if got["notify"] != true {
+		t.Errorf("notify = %#v, want true", got["notify"])
+	}
+	if got["env"] != "prod" {
+		t.Errorf("env = %#v", got["env"])
+	}
+}
+
+func TestCollectResumeArgs_ValueWithEquals(t *testing.T) {
+	got, err := collectResumeArgs(nil, []string{"expr=a=b"})
+	if err != nil {
+		t.Fatalf("collectResumeArgs: %v", err)
+	}
+	// Unknown field, only the first '=' splits; passes through as a string.
+	if got["expr"] != "a=b" {
+		t.Errorf("expr = %#v, want a=b", got["expr"])
+	}
+}
+
+func TestCollectResumeArgs_MissingEqualsIsError(t *testing.T) {
+	if _, err := collectResumeArgs(nil, []string{"approve"}); err == nil {
 		t.Fatal("expected error for arg without '='")
+	}
+}
+
+func TestCollectResumeArgs_BadTypeIsError(t *testing.T) {
+	entries := mustParseProps(t)
+	if _, err := collectResumeArgs(entries, []string{"count=notanumber"}); err == nil {
+		t.Fatal("expected error coercing count=notanumber")
 	}
 }

--- a/docs/concepts/suspendable-tasks.md
+++ b/docs/concepts/suspendable-tasks.md
@@ -1,12 +1,18 @@
 # Suspendable Tasks
 
 A task can **pause mid-run to ask a human for input**, then continue once the
-form is filled. Call `dicode.suspend({ state, form })`: the run ends as
+form is filled. Call `dicode.suspend({ state, schema })`: the run ends as
 `suspended`, dicode collects the input via the Web UI or the `dicode resume`
-CLI, and the task runs again — this time with the answers in hand.
+CLI, validates it against the schema, and the task runs again — this time with
+the answers in hand.
 
 Use it for approval gates, wizards, "which of these do you mean?" disambiguation,
 or any step that can't proceed without a person.
+
+The form is described with a **[JSON Schema](https://json-schema.org)** (draft
+2020-12). That is a standard, portable vocabulary: the same schema drives the
+default Web UI form, the CLI prompts, and the **server-side validation** that
+guarantees `resume_input` conforms before your task re-runs.
 
 ---
 
@@ -15,12 +21,13 @@ or any step that can't proceed without a person.
 Suspend is **not** VM suspension. Nothing is frozen in memory.
 
 1. The task calls `dicode.suspend(...)`.
-2. dicode records the `state` blob and the `form`, then the **process exits
+2. dicode records the `state` blob and the `schema`, then the **process exits
    cleanly** (exit 0). The run row is marked `suspended`.
-3. When someone submits the form, dicode starts a **brand-new process** for the
-   same task and re-runs `task.ts` / `task.py` **from the top**.
+3. When someone submits the form, dicode **validates the submission against the
+   schema**, then starts a **brand-new process** for the same task and re-runs
+   `task.ts` / `task.py` **from the top**.
 4. On that re-run the task reads `resume_state` (the blob it passed to
-   `suspend`) and `resume_input` (the submitted form values) to pick up where it
+   `suspend`) and `resume_input` (the submitted values) to pick up where it
    left off.
 
 Because the whole file runs again from the top, your task owns its control flow:
@@ -48,8 +55,8 @@ pass instead (from the top of the file).
 
 ```typescript
 interface SuspendRequest {
-  state: unknown       // JSON-serializable; echoed back as resume_state on resume
-  form: FormSchema     // the input to collect before resume
+  state?: unknown      // JSON-serializable; echoed back as resume_state on resume
+  schema: JSONSchema   // JSON Schema (draft 2020-12) for the input to collect
   deadline?: number    // optional Unix-ms instant; resumable until then (default: 24h)
 }
 ```
@@ -57,7 +64,7 @@ interface SuspendRequest {
 Python signature (keyword args):
 
 ```python
-dicode.suspend(state=<json>, form=<dict>, deadline=<unix_ms>)
+dicode.suspend(state=<json>, schema=<dict>, deadline=<unix_ms>)
 ```
 
 ### Reading the resume context
@@ -65,66 +72,66 @@ dicode.suspend(state=<json>, form=<dict>, deadline=<unix_ms>)
 | | First run | Resume run |
 |---|---|---|
 | Deno global `resume_state` | `undefined` | the `state` you passed to `suspend()` |
-| Deno global `resume_input` | `undefined` | the submitted form values, keyed by field `name` |
+| Deno global `resume_input` | `undefined` | the submitted values, keyed by property name |
 | Python `ctx.resume_state` | `None` | the `state` you passed to `suspend()` |
-| Python `ctx.resume_input` | `None` | the submitted form values, keyed by field `name` |
+| Python `ctx.resume_input` | `None` | the submitted values, keyed by property name |
 
-`resume_input` values from the CLI are always strings; the Web UI submits the
-value for the field's `type` (a `number` field submits a number, `boolean` a
-bool). Coerce defensively.
+`resume_input` is validated against the schema before your task re-runs, and its
+values arrive with the **declared JSON types** — a `number`/`integer` property
+is a number, a `boolean` is a bool. (Coerce defensively anyway.)
 
 `dicode.suspend` needs **no permission declaration** — it is granted by default
 on the `deno` and `python` runtimes. It is **not** available on `docker` /
-`podman` (see [Limits](#limits)).
+`podman` (see the Deno / Python only note under [Rules and gotchas](#rules-and-gotchas)).
 
 ---
 
-## Form reference
+## The form — JSON Schema
 
-### `FormSchema`
+`schema` is a JSON Schema object describing the **input object** the user fills
+in. Server-side validation rejects a submission that doesn't conform (Web UI:
+`400` with the failing property; CLI: a clear error) before the task resumes.
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `title` | string | no | Heading shown above the form |
-| `description` | string | no | Sub-text under the title |
-| `fields` | `FormField[]` | **yes** | The inputs to collect |
-
-### `FormField`
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `name` | string | **yes** | Key the answer appears under in `resume_input` |
-| `label` | string | **yes** | Shown next to the input |
-| `type` | `"string"` \| `"text"` \| `"number"` \| `"boolean"` \| `"select"` | **yes** | Which widget to render |
-| `required` | boolean | no | Reject resume if left empty (a `boolean` counts as answered once present — `false` is a valid answer) |
-| `default` | string \| number \| boolean | no | Pre-filled value |
-| `options` | `{ value, label }[]` | for `select` | Choices; **required** when `type` is `"select"` |
-| `placeholder` | string | no | Placeholder text |
-
-### The five field types
+Use an `object` schema whose `properties` are the fields to collect:
 
 ```jsonc
-// string — single-line text
-{ "name": "title", "label": "Title", "type": "string", "required": true, "placeholder": "Weekly report" }
-
-// text — multi-line textarea
-{ "name": "notes", "label": "Notes", "type": "text", "placeholder": "Anything to add?" }
-
-// number
-{ "name": "count", "label": "How many?", "type": "number", "default": 10 }
-
-// boolean — checkbox
-{ "name": "notify", "label": "Send a notification?", "type": "boolean", "default": true }
-
-// select — needs options
 {
-  "name": "env", "label": "Environment", "type": "select", "required": true,
-  "options": [
-    { "value": "staging", "label": "Staging" },
-    { "value": "prod",    "label": "Production" }
-  ]
+  "type": "object",
+  "title": "Deploy",                 // heading shown above the form
+  "description": "Pick a target.",   // sub-text under the title
+  "properties": {
+    "project": { "type": "string", "title": "Project name" },
+    "notes":   { "type": "string", "title": "Notes", "format": "textarea" },
+    "count":   { "type": "integer", "title": "How many?", "default": 10 },
+    "notify":  { "type": "boolean", "title": "Send a notification?", "default": true },
+    "env":     { "type": "string", "title": "Environment", "enum": ["staging", "prod"] }
+  },
+  "required": ["project", "env"]
 }
 ```
+
+### What the default renderer maps
+
+The built-in Web UI form renders the common JSON-Schema subset with zero author
+effort. Each property in `properties` becomes one control:
+
+| Schema | Control |
+|---|---|
+| `type: "string"` | text input |
+| `type: "string"`, `format: "textarea"` (or `"multiline"`) | textarea |
+| `enum: [...]` (any type) | select |
+| `type: "boolean"` | checkbox |
+| `type: "number"` / `"integer"` | number input |
+
+Honored keywords: `title` (label — falls back to the property name),
+`description` (help text), `default` (pre-filled value), `enum` (choices),
+and the top-level `required` array (marks a field required and drives the
+missing-field validation). Standard constraint keywords (`minimum`,
+`maxLength`, `pattern`, …) are enforced by the server-side validator even when
+the default renderer has no special widget for them.
+
+The renderer covers the 90% case; anything the schema expresses is still
+validated server-side regardless of how it renders.
 
 ---
 
@@ -139,18 +146,20 @@ state machine keyed by a `step` field carried in `state`.
 type WizardState = { step: "name" } | { step: "env"; name: string }
 
 const state = resume_state as WizardState | undefined
-const answers = (resume_input ?? {}) as Record<string, string>
+const answers = (resume_input ?? {}) as Record<string, unknown>
 
 // First run — ask for the project name and pause.
 if (!state) {
   await dicode.suspend({
     state: { step: "name" },
-    form: {
+    schema: {
+      type: "object",
       title: "New project",
       description: "What should we call it?",
-      fields: [
-        { name: "project", label: "Project name", type: "string", required: true },
-      ],
+      properties: {
+        project: { type: "string", title: "Project name" },
+      },
+      required: ["project"],
     },
   })
   // unreachable — suspend() never returns
@@ -158,23 +167,16 @@ if (!state) {
 
 // Second run — the name is in, ask for the environment and pause again.
 if (state.step === "name") {
-  const project = answers.project ?? ""
+  const project = String(answers.project ?? "")
   await dicode.suspend({
     state: { step: "env", name: project },
-    form: {
+    schema: {
+      type: "object",
       title: `Deploy ${project}`,
-      fields: [
-        {
-          name: "env",
-          label: "Target environment",
-          type: "select",
-          required: true,
-          options: [
-            { value: "staging", label: "Staging" },
-            { value: "prod", label: "Production" },
-          ],
-        },
-      ],
+      properties: {
+        env: { type: "string", title: "Target environment", enum: ["staging", "prod"] },
+      },
+      required: ["env"],
     },
   })
 }
@@ -193,12 +195,12 @@ answers = ctx.resume_input or {}
 if state is None:
     dicode.suspend(
         state={"step": "name"},
-        form={
+        schema={
+            "type": "object",
             "title": "New project",
             "description": "What should we call it?",
-            "fields": [
-                {"name": "project", "label": "Project name", "type": "string", "required": True},
-            ],
+            "properties": {"project": {"type": "string", "title": "Project name"}},
+            "required": ["project"],
         },
     )
     # unreachable — suspend() raises and the process exits
@@ -208,20 +210,13 @@ if state["step"] == "name":
     project = answers.get("project", "")
     dicode.suspend(
         state={"step": "env", "name": project},
-        form={
+        schema={
+            "type": "object",
             "title": f"Deploy {project}",
-            "fields": [
-                {
-                    "name": "env",
-                    "label": "Target environment",
-                    "type": "select",
-                    "required": True,
-                    "options": [
-                        {"value": "staging", "label": "Staging"},
-                        {"value": "prod", "label": "Production"},
-                    ],
-                },
-            ],
+            "properties": {
+                "env": {"type": "string", "title": "Target environment", "enum": ["staging", "prod"]},
+            },
+            "required": ["env"],
         },
     )
 
@@ -230,7 +225,8 @@ result = {"project": state["name"], "env": answers.get("env", "staging")}
 ```
 
 Each `suspend()` mints its own resume, so a task can suspend any number of times
-— that's what chains the wizard steps together.
+— that's what chains the wizard steps together. (Each step still branches on
+`resume_state` by hand; automatic step dispatch is a separate follow-up.)
 
 ---
 
@@ -294,34 +290,45 @@ continuation carries on from `resume_state`.
 
 ### Web UI
 
-Open the suspended run's detail page. It renders the `form` the task declared;
-fill it in and submit. That POSTs the collected values to
-`/api/runs/{runID}/resume`, which validates required fields and spawns the
-continuation run. The raw resume handle is resolved server-side from the stored
-run — the browser session (or API key) is the authorization.
+Open the suspended run's detail page. It renders a form from the JSON Schema the
+task declared; fill it in and submit. That POSTs the collected values to
+`/api/runs/{runID}/resume`, which **validates them against the stored schema**
+and spawns the continuation run. The raw resume handle is resolved server-side
+from the stored run — the browser session (or API key) is the authorization.
 
 ### CLI
 
-List what's waiting:
+List what's waiting (the `FIELDS` column shows the schema's required
+properties):
 
 ```console
 $ dicode resume
 RUN ID                               TASK                     SUSPENDED AT         FIELDS
-b1c2…                                examples/deploy-wizard   2026-07-08T09:12:00Z project
-
-resume with: dicode resume <run-id> [field=value ...]
+b1c2…                                examples/deploy-wizard   2026-07-08T09:12:00Z project,env
 ```
 
-Submit the answers as `field=value` pairs:
+Resume interactively — dicode reads the schema and prompts for each property,
+honoring its type, `enum` choices, `required`, and `default`:
 
 ```console
-$ dicode resume b1c2… project=acme-api
+$ dicode resume b1c2…
+Project name (required): acme-api
+Target environment
+  choices: staging, prod
+env (required): prod
+resumed: continuation run 7f8a…
+```
+
+Or pass the answers as `field=value` pairs — each value is coerced to the
+property's declared type and validated against the schema before submit:
+
+```console
+$ dicode resume b1c2… project=acme-api env=prod
 resumed: continuation run 7f8a…
 follow: dicode logs 7f8a…
 ```
 
 The continuation runs asynchronously; follow it with `dicode logs <run-id>`.
-CLI values are always strings.
 
 ---
 

--- a/docs/concepts/suspendable-tasks.md
+++ b/docs/concepts/suspendable-tasks.md
@@ -55,11 +55,17 @@ pass instead (from the top of the file).
 
 ```typescript
 interface SuspendRequest {
-  state?: unknown      // JSON-serializable; echoed back as resume_state on resume
+  state: unknown       // REQUIRED; JSON-serializable; echoed back as resume_state on resume
   schema: JSONSchema   // JSON Schema (draft 2020-12) for the input to collect
   deadline?: number    // optional Unix-ms instant; resumable until then (default: 24h)
 }
 ```
+
+`state` is **required** — it is the only signal that distinguishes a first run
+(`resume_state` undefined / `None`) from a resume (`resume_state` = the object
+you passed). Pass at least `{}` when you carry nothing across the pause; a
+missing state would read back as undefined and re-fire your `if (!resume_state)`
+guard, re-suspending forever.
 
 Python signature (keyword args):
 

--- a/docs/deno-runtime.md
+++ b/docs/deno-runtime.md
@@ -138,21 +138,28 @@ return { count: 42, status: "ok" }
 
 ### `suspend` / `resume_state` / `resume_input`
 
-Pause a run to collect input from a human. `dicode.suspend({ state, form })`
+Pause a run to collect input from a human. `dicode.suspend({ state, schema })`
 never returns — the process exits, the run becomes `suspended`, and on resume the
 task re-runs from the top with `resume_state` (the blob you passed) and
-`resume_input` (the submitted form) populated (both `undefined` on a first run).
+`resume_input` (the submitted input) populated (both `undefined` on a first run).
+`schema` is a [JSON Schema](https://json-schema.org) (draft 2020-12) describing
+the expected input object; the daemon validates the submission against it before
+resuming, so `resume_input` conforms.
 
 ```typescript
 if (!resume_state) {
   await dicode.suspend({
     state: { step: "confirm" },
-    form: { title: "Approve?", fields: [{ name: "ok", label: "OK?", type: "boolean", required: true }] },
+    schema: {
+      type: "object",
+      properties: { ok: { type: "boolean", title: "OK?" } },
+      required: ["ok"],
+    },
   })  // unreachable — never returns
 }
 ```
 
-See [Suspendable Tasks](./concepts/suspendable-tasks.md) for the form schema,
+See [Suspendable Tasks](./concepts/suspendable-tasks.md) for the JSON-Schema form,
 lifecycle (`suspended` → `resumed`), and how to resume via the Web UI or
 `dicode resume`.
 

--- a/docs/python-runtime.md
+++ b/docs/python-runtime.md
@@ -145,24 +145,29 @@ result = {"count": 42, "status": "ok"}
 
 ### `suspend` / `ctx.resume_state` / `ctx.resume_input`
 
-Pause a run to collect input from a human. `dicode.suspend(state=..., form=...)`
+Pause a run to collect input from a human. `dicode.suspend(state=..., schema=...)`
 never returns — it raises a control signal, the process exits, the run becomes
 `suspended`, and on resume the task re-runs from the top with `ctx.resume_state`
-(the blob you passed) and `ctx.resume_input` (the submitted form) populated (both
-`None` on a first run).
+(the blob you passed) and `ctx.resume_input` (the submitted input) populated (both
+`None` on a first run). `schema` is a [JSON Schema](https://json-schema.org)
+(draft 2020-12) the daemon validates the submission against before resuming.
 
 ```python
 if ctx.resume_state is None:
     dicode.suspend(
         state={"step": "confirm"},
-        form={"title": "Approve?", "fields": [{"name": "ok", "label": "OK?", "type": "boolean", "required": True}]},
+        schema={
+            "type": "object",
+            "properties": {"ok": {"type": "boolean", "title": "OK?"}},
+            "required": ["ok"],
+        },
     )  # unreachable — never returns
 ```
 
 Do not wrap `suspend()` in a `try/except` that swallows the signal — the run
 fails loudly if you do. See [Suspendable Tasks](./concepts/suspendable-tasks.md)
-for the form schema, lifecycle (`suspended` → `resumed`), and how to resume via
-the Web UI or `dicode resume`.
+for the JSON-Schema form, lifecycle (`suspended` → `resumed`), and how to resume
+via the Web UI or `dicode resume`.
 
 ### Async tasks
 

--- a/go.mod
+++ b/go.mod
@@ -15,11 +15,13 @@ require (
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/google/uuid v1.6.0
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	go.uber.org/zap v1.28.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
+	golang.org/x/text v0.38.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.53.0
 )

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
 github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.7.0 h1:6SsRfJddP22WMrCkj19x9WKjEDTB+ahsdiGYf0mN39c=
@@ -130,6 +132,8 @@ github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -242,6 +242,9 @@ func (cs *ControlServer) dispatch(ctx context.Context, req Request) (any, error)
 	case "cli.resume.list":
 		return cs.handleResumeList(ctx)
 
+	case "cli.resume.get":
+		return cs.handleResumeGet(ctx, req)
+
 	case "cli.secrets.list":
 		return cs.handleSecretsList(ctx)
 

--- a/pkg/ipc/control_resume.go
+++ b/pkg/ipc/control_resume.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/schemavalidate"
 	"go.uber.org/zap"
 )
 
@@ -40,9 +41,18 @@ type ResumeResult struct {
 	RunID string `json:"runID"`
 }
 
+// ResumeInfo is the cli.resume.get response: a suspended run's JSON Schema so
+// the CLI can prompt per property, coerce values to their declared types, and
+// validate before submitting.
+type ResumeInfo struct {
+	RunID  string          `json:"runID"`
+	TaskID string          `json:"taskID"`
+	Schema json.RawMessage `json:"schema,omitempty"`
+}
+
 // SuspendedRunSummary is one row in the cli.resume.list response. Fields is the
-// list of form field names the task declared via dicode.suspend(), so the CLI
-// can hint which key=value pairs to supply.
+// list of property names the task's JSON Schema requires, so the CLI can hint
+// which key=value pairs to supply.
 type SuspendedRunSummary struct {
 	RunID       string   `json:"runID"`
 	TaskID      string   `json:"taskID"`
@@ -55,7 +65,8 @@ type SuspendedRunSummary struct {
 // The client supplies only the run id and the collected key=value input — never
 // the token: the token is read from the stored run, mirroring the webui's
 // authorization model where the session (here, the trusted control socket) is
-// the authority and the resume handle stays server-side.
+// the authority and the resume handle stays server-side. The input is validated
+// against the run's stored JSON Schema before the continuation is spawned.
 func (cs *ControlServer) handleResume(ctx context.Context, req Request) (ResumeResult, error) {
 	if cs.resumer == nil {
 		return ResumeResult{}, errors.New("resume not available (engine not wired)")
@@ -78,6 +89,10 @@ func (cs *ControlServer) handleResume(ctx context.Context, req Request) (ResumeR
 		input = []byte("{}")
 	}
 
+	if err := schemavalidate.Validate(run.ResumeSchema, input); err != nil {
+		return ResumeResult{}, fmt.Errorf("invalid resume input: %w", err)
+	}
+
 	newRunID, err := cs.resumer.ResumeRun(ctx, run.ResumeToken, input)
 	if err != nil {
 		switch {
@@ -97,6 +112,26 @@ func (cs *ControlServer) handleResume(ctx context.Context, req Request) (ResumeR
 	return ResumeResult{RunID: newRunID}, nil
 }
 
+// handleResumeGet returns a suspended run's JSON Schema so the CLI can build its
+// prompt and coerce/validate the input locally before submitting.
+func (cs *ControlServer) handleResumeGet(ctx context.Context, req Request) (ResumeInfo, error) {
+	if req.RunID == "" {
+		return ResumeInfo{}, errors.New("runID required")
+	}
+	run, err := cs.reg.GetRun(ctx, req.RunID)
+	if err != nil {
+		return ResumeInfo{}, fmt.Errorf("run %q not found", req.RunID)
+	}
+	if run.Status != registry.StatusSuspended || run.ResumeToken == "" {
+		return ResumeInfo{}, errors.New("run is not suspended")
+	}
+	info := ResumeInfo{RunID: run.ID, TaskID: run.TaskID}
+	if len(run.ResumeSchema) > 0 {
+		info.Schema = json.RawMessage(run.ResumeSchema)
+	}
+	return info, nil
+}
+
 // handleResumeList returns the runs currently awaiting resume so the CLI can
 // show the operator what's resumable without hunting through per-task logs.
 func (cs *ControlServer) handleResumeList(ctx context.Context) ([]SuspendedRunSummary, error) {
@@ -109,7 +144,7 @@ func (cs *ControlServer) handleResumeList(ctx context.Context) ([]SuspendedRunSu
 		s := SuspendedRunSummary{
 			RunID:  r.ID,
 			TaskID: r.TaskID,
-			Fields: resumeFormFieldNames(r.ResumeForm),
+			Fields: schemaRequiredFields(r.ResumeSchema),
 		}
 		if r.SuspendedAt > 0 {
 			s.SuspendedAt = time.UnixMilli(r.SuspendedAt).UTC().Format(time.RFC3339)
@@ -122,26 +157,28 @@ func (cs *ControlServer) handleResumeList(ctx context.Context) ([]SuspendedRunSu
 	return out, nil
 }
 
-// resumeFormFieldNames extracts the field names from a persisted FormSchema
-// blob. A malformed or empty schema yields no names — the listing degrades to
-// run id + task rather than failing.
-func resumeFormFieldNames(formJSON []byte) []string {
-	if len(formJSON) == 0 {
+// schemaRequiredFields extracts the required property names from a persisted
+// JSON Schema. When the schema declares no required list, it falls back to all
+// declared property names so the listing still hints at what to supply. A
+// malformed or empty schema yields no names — the listing degrades to run id +
+// task rather than failing.
+func schemaRequiredFields(schemaJSON []byte) []string {
+	if len(schemaJSON) == 0 {
 		return nil
 	}
 	var schema struct {
-		Fields []struct {
-			Name string `json:"name"`
-		} `json:"fields"`
+		Required   []string                   `json:"required"`
+		Properties map[string]json.RawMessage `json:"properties"`
 	}
-	if err := json.Unmarshal(formJSON, &schema); err != nil {
+	if err := json.Unmarshal(schemaJSON, &schema); err != nil {
 		return nil
 	}
-	names := make([]string, 0, len(schema.Fields))
-	for _, f := range schema.Fields {
-		if f.Name != "" {
-			names = append(names, f.Name)
-		}
+	if len(schema.Required) > 0 {
+		return schema.Required
+	}
+	names := make([]string, 0, len(schema.Properties))
+	for name := range schema.Properties {
+		names = append(names, name)
 	}
 	return names
 }

--- a/pkg/ipc/control_resume_test.go
+++ b/pkg/ipc/control_resume_test.go
@@ -30,7 +30,7 @@ func (f *fakeResumer) ResumeRun(_ context.Context, token string, input []byte) (
 }
 
 // newResumeReg returns an in-memory registry holding one run, optionally
-// suspended with the given token and form.
+// suspended with the given token and JSON Schema.
 func newResumeReg(t *testing.T) (*registry.Registry, db.DB) {
 	t.Helper()
 	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
@@ -41,21 +41,23 @@ func newResumeReg(t *testing.T) (*registry.Registry, db.DB) {
 	return registry.New(d), d
 }
 
-func suspendRun(t *testing.T, reg *registry.Registry, runID, token string, form []byte) {
+func suspendRun(t *testing.T, reg *registry.Registry, runID, token string, schema []byte) {
 	t.Helper()
 	ctx := context.Background()
 	if _, err := reg.StartRunWithID(ctx, runID, "task-x", "", string(registry.TriggerManual), registry.RunKindTask); err != nil {
 		t.Fatalf("StartRunWithID: %v", err)
 	}
 	deadline := time.Now().Add(time.Hour).UnixMilli()
-	if err := reg.SuspendRun(ctx, runID, []byte(`{"step":1}`), form, token, time.Now().UnixMilli(), deadline, nil); err != nil {
+	if err := reg.SuspendRun(ctx, runID, []byte(`{"step":1}`), schema, token, time.Now().UnixMilli(), deadline, nil); err != nil {
 		t.Fatalf("SuspendRun: %v", err)
 	}
 }
 
+const approveSchema = `{"type":"object","properties":{"approve":{"type":"string"}},"required":["approve"]}`
+
 func TestResume_Success_CallsResumerWithParsedInput(t *testing.T) {
 	reg, _ := newResumeReg(t)
-	suspendRun(t, reg, "run-1", "tok-abc", []byte(`{"fields":[{"name":"approve"}]}`))
+	suspendRun(t, reg, "run-1", "tok-abc", []byte(approveSchema))
 
 	fr := &fakeResumer{newRunID: "run-2"}
 	cs := &ControlServer{reg: reg, resumer: fr, log: zap.NewNop()}
@@ -99,6 +101,50 @@ func TestResume_EmptyParamsBecomesEmptyObject(t *testing.T) {
 	}
 	if string(fr.gotInput) != `{}` {
 		t.Fatalf("input = %s, want {}", fr.gotInput)
+	}
+}
+
+func TestResume_InvalidInputRejectedBeforeResumer(t *testing.T) {
+	reg, _ := newResumeReg(t)
+	suspendRun(t, reg, "run-1", "tok-abc", []byte(approveSchema))
+
+	fr := &fakeResumer{newRunID: "run-2"}
+	cs := &ControlServer{reg: reg, resumer: fr, log: zap.NewNop()}
+
+	// Missing the required "approve" property → schema validation must reject.
+	_, err := cs.dispatch(context.Background(), Request{
+		ID: "1", Method: "cli.resume", RunID: "run-1",
+		Params: json.RawMessage(`{}`),
+	})
+	if err == nil {
+		t.Fatal("expected validation error for missing required field")
+	}
+	if !strings.Contains(err.Error(), "approve") {
+		t.Fatalf("error should name the missing field; got %v", err)
+	}
+	if fr.called {
+		t.Fatal("resumer must not be called when validation fails")
+	}
+}
+
+func TestResumeGet_ReturnsSchema(t *testing.T) {
+	reg, _ := newResumeReg(t)
+	suspendRun(t, reg, "run-1", "tok-abc", []byte(approveSchema))
+
+	cs := &ControlServer{reg: reg, log: zap.NewNop()}
+	res, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.resume.get", RunID: "run-1"})
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	info, ok := res.(ResumeInfo)
+	if !ok {
+		t.Fatalf("result type %T", res)
+	}
+	if info.RunID != "run-1" || info.TaskID != "task-x" {
+		t.Fatalf("info = %+v", info)
+	}
+	if !strings.Contains(string(info.Schema), "approve") {
+		t.Fatalf("schema = %s, want it to carry the approve property", info.Schema)
 	}
 }
 
@@ -169,7 +215,7 @@ func TestResume_NotConfigured(t *testing.T) {
 
 func TestResumeList_ReportsSuspendedRunsWithFields(t *testing.T) {
 	reg, _ := newResumeReg(t)
-	suspendRun(t, reg, "run-1", "tok-1", []byte(`{"fields":[{"name":"approve"},{"name":"note"}]}`))
+	suspendRun(t, reg, "run-1", "tok-1", []byte(`{"type":"object","properties":{"approve":{"type":"string"},"note":{"type":"string"}},"required":["approve","note"]}`))
 
 	cs := &ControlServer{reg: reg, log: zap.NewNop()}
 	res, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.resume.list"})

--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -101,13 +101,13 @@ type Request struct {
 	// dicode.set_group — free-text label for the caller's run (#116).
 	Group string `json:"group,omitempty"`
 
-	// dicode.suspend — pause the run and yield a form for the user (#95).
-	// State is the opaque JSON blob to rehydrate on resume; Form is the
-	// FormSchema describing the input to collect; Deadline is an optional
-	// Unix-ms TTL (0 = unset, engine applies its default). Kept as raw JSON
-	// so the runtime threads the blobs through without re-encoding.
+	// dicode.suspend — pause the run and collect user input (#512). State is
+	// the opaque JSON blob to rehydrate on resume; Schema is the JSON Schema
+	// (draft 2020-12) the submission is validated against; Deadline is an
+	// optional Unix-ms TTL (0 = unset, engine applies its default). Kept as raw
+	// JSON so the runtime threads the blobs through without re-encoding.
 	State    json.RawMessage `json:"state,omitempty"`
-	Form     json.RawMessage `json:"form,omitempty"`
+	Schema   json.RawMessage `json:"schema,omitempty"`
 	Deadline int64           `json:"deadline,omitempty"`
 
 	// dicode.sources.set_dev_mode — toggles dev mode on a configured source (#234)
@@ -182,13 +182,13 @@ type OutputResult struct {
 // IsSet reports whether any output was recorded.
 func (o *OutputResult) IsSet() bool { return o != nil && o.ContentType != "" }
 
-// SuspendResult captures a dicode.suspend() request (#95): the opaque state
-// blob to rehydrate on resume, the FormSchema describing the input to
-// collect, and an optional Unix-ms deadline (0 = unset). State and Form are
+// SuspendResult captures a dicode.suspend() request (#512): the opaque state
+// blob to rehydrate on resume, the JSON Schema the submission is validated
+// against, and an optional Unix-ms deadline (0 = unset). State and Schema are
 // kept as raw JSON so the runtime forwards them to the engine unchanged.
 type SuspendResult struct {
 	State    json.RawMessage `json:"state,omitempty"`
-	Form     json.RawMessage `json:"form,omitempty"`
+	Schema   json.RawMessage `json:"schema,omitempty"`
 	Deadline int64           `json:"deadline,omitempty"`
 }
 

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -744,7 +744,7 @@ func (s *Server) handleConn(conn net.Conn) {
 			s.mu.Lock()
 			s.suspend = &SuspendResult{
 				State:    req.State,
-				Form:     req.Form,
+				Schema:   req.Schema,
 				Deadline: req.Deadline,
 			}
 			s.mu.Unlock()

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -90,7 +90,7 @@ type Run struct {
 	// list queries omit them (mirrors the input-persistence fields above).
 	// Zero values mean "not suspended".
 	ResumeState    []byte // opaque task-provided state blob; nil when absent
-	ResumeForm     []byte // form schema JSON to render on resume; nil when absent
+	ResumeSchema   []byte // JSON Schema to validate the resume submission against; nil when absent
 	ResumeToken    string // unguessable resume handle; empty when absent
 	SuspendedAt    int64  // Unix ms the run suspended; 0 when absent
 	ResumeDeadline int64  // Unix ms TTL; 0 when no deadline set
@@ -254,19 +254,22 @@ func (r *Registry) FinishRunWithResult(ctx context.Context, runID, status, retur
 }
 
 // SuspendRun records a run as suspended awaiting user input, persisting the
-// opaque state/form blobs, the resume token, and the suspend timestamp. It
-// deliberately leaves finished_at NULL: suspended is a non-terminal status, so
-// the run is neither running (CleanupStaleRuns skips it) nor finished.
+// opaque state blob, the JSON Schema, the resume token, and the suspend
+// timestamp. It deliberately leaves finished_at NULL: suspended is a
+// non-terminal status, so the run is neither running (CleanupStaleRuns skips
+// it) nor finished.
 //
-// A deadline of 0 stores NULL (no TTL). state, form, and resumeParams may be nil.
-func (r *Registry) SuspendRun(ctx context.Context, runID string, state, form []byte, token string, suspendedAt, deadline int64, resumeParams []byte) error {
+// A deadline of 0 stores NULL (no TTL). state, schema, and resumeParams may be
+// nil. The schema is persisted in the legacy resume_form BLOB column (reused
+// as-is to avoid a migration).
+func (r *Registry) SuspendRun(ctx context.Context, runID string, state, schema []byte, token string, suspendedAt, deadline int64, resumeParams []byte) error {
 	var deadlineArg any
 	if deadline > 0 {
 		deadlineArg = deadline
 	}
 	return r.db.Exec(ctx,
 		`UPDATE runs SET status = ?, resume_state = ?, resume_form = ?, resume_token = ?, suspended_at = ?, resume_deadline = ?, resume_params = ? WHERE id = ?`,
-		StatusSuspended, state, form, token, suspendedAt, deadlineArg, resumeParams, runID,
+		StatusSuspended, state, schema, token, suspendedAt, deadlineArg, resumeParams, runID,
 	)
 }
 
@@ -392,7 +395,7 @@ func scanRun(rows db.Scanner, withInput, withResume bool) (*Run, error) {
 	}
 	if withResume {
 		dest = append(dest,
-			&run.ResumeState, &run.ResumeForm, &run.ResumeToken, &run.SuspendedAt, &run.ResumeDeadline,
+			&run.ResumeState, &run.ResumeSchema, &run.ResumeToken, &run.SuspendedAt, &run.ResumeDeadline,
 			&run.ResumeParams)
 	}
 	if err := rows.Scan(dest...); err != nil {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -483,12 +483,12 @@ func TestSuspendRun_RoundTrip(t *testing.T) {
 	}
 
 	state := []byte(`{"step":"ask_name"}`)
-	form := []byte(`{"fields":[{"name":"project_name"}]}`)
+	schema := []byte(`{"type":"object","properties":{"project_name":{"type":"string"}}}`)
 	token := "resume-token-xyz"
 	suspendedAt := time.Now().UnixMilli()
 	deadline := suspendedAt + 86_400_000
 
-	if err := r.SuspendRun(ctx, runID, state, form, token, suspendedAt, deadline, nil); err != nil {
+	if err := r.SuspendRun(ctx, runID, state, schema, token, suspendedAt, deadline, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -506,8 +506,8 @@ func TestSuspendRun_RoundTrip(t *testing.T) {
 	if string(run.ResumeState) != string(state) {
 		t.Errorf("resume_state = %q, want %q", run.ResumeState, state)
 	}
-	if string(run.ResumeForm) != string(form) {
-		t.Errorf("resume_form = %q, want %q", run.ResumeForm, form)
+	if string(run.ResumeSchema) != string(schema) {
+		t.Errorf("resume_schema = %q, want %q", run.ResumeSchema, schema)
 	}
 	if run.ResumeToken != token {
 		t.Errorf("resume_token = %q, want %q", run.ResumeToken, token)
@@ -520,7 +520,7 @@ func TestSuspendRun_RoundTrip(t *testing.T) {
 	}
 }
 
-// A zero deadline persists as NULL and reads back as 0; nil state/form blobs
+// A zero deadline persists as NULL and reads back as 0; nil state/schema blobs
 // round-trip as nil rather than a zero-length slice mismatch.
 func TestSuspendRun_NoDeadlineNilBlobs(t *testing.T) {
 	t.Parallel()
@@ -548,8 +548,8 @@ func TestSuspendRun_NoDeadlineNilBlobs(t *testing.T) {
 	if run.ResumeState != nil {
 		t.Errorf("resume_state = %v, want nil", run.ResumeState)
 	}
-	if run.ResumeForm != nil {
-		t.Errorf("resume_form = %v, want nil", run.ResumeForm)
+	if run.ResumeSchema != nil {
+		t.Errorf("resume_schema = %v, want nil", run.ResumeSchema)
 	}
 }
 

--- a/pkg/registry/resume_test.go
+++ b/pkg/registry/resume_test.go
@@ -26,7 +26,7 @@ func seedSuspendedRun(t *testing.T, r *Registry, runID, token string, deadline i
 	if _, err := r.StartRunWithID(ctx, runID, "task-x", "", string(TriggerManual), RunKindTask); err != nil {
 		t.Fatalf("StartRunWithID: %v", err)
 	}
-	if err := r.SuspendRun(ctx, runID, []byte(`{"step":1}`), []byte(`{"fields":[]}`), token, time.Now().UnixMilli(), deadline, nil); err != nil {
+	if err := r.SuspendRun(ctx, runID, []byte(`{"step":1}`), []byte(`{"type":"object","properties":{}}`), token, time.Now().UnixMilli(), deadline, nil); err != nil {
 		t.Fatalf("SuspendRun: %v", err)
 	}
 }

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -80,12 +80,12 @@ type RunResult struct {
 	Error       error
 
 	// Suspended is set when the task called dicode.suspend() (#95): the run
-	// paused cleanly rather than completing or failing. ResumeState/ResumeForm
+	// paused cleanly rather than completing or failing. ResumeState/ResumeSchema
 	// are the opaque state blob and form schema; ResumeDeadline is an optional
 	// Unix-ms TTL (0 = unset).
 	Suspended      bool
 	ResumeState    []byte
-	ResumeForm     []byte
+	ResumeSchema   []byte
 	ResumeDeadline int64
 }
 
@@ -455,7 +455,7 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	if sr := srv.Suspend(); sr != nil && result.Error == nil {
 		result.Suspended = true
 		result.ResumeState = sr.State
-		result.ResumeForm = sr.Form
+		result.ResumeSchema = sr.Schema
 		result.ResumeDeadline = sr.Deadline
 	}
 
@@ -657,7 +657,7 @@ func (rt *Runtime) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	if result.Suspended {
 		r.Suspended = true
 		r.ResumeState = result.ResumeState
-		r.ResumeForm = result.ResumeForm
+		r.ResumeSchema = result.ResumeSchema
 		r.ResumeDeadline = result.ResumeDeadline
 	}
 	return r, nil

--- a/pkg/runtime/deno/sdk/sdk.d.ts
+++ b/pkg/runtime/deno/sdk/sdk.d.ts
@@ -75,31 +75,30 @@ declare interface TaskSummary {
   enabled:      boolean;
 }
 
-/** One field in a suspend form (#95). `type` selects the input widget the
- *  WebUI renders; `options` is required for "select". */
-declare interface FormField {
-  name: string;
-  type: "string" | "text" | "number" | "boolean" | "select";
-  label: string;
-  required?: boolean;
-  default?: string | number | boolean;
-  options?: { value: string; label: string }[];
-  placeholder?: string;
-}
-
-/** The form a suspended task asks the user to fill in before resume (#95). */
-declare interface FormSchema {
+/** A JSON Schema (draft 2020-12) object describing the input a suspended task
+ *  collects before resume (#512). The daemon validates the submission against
+ *  it server-side. Loosely typed — any valid JSON Schema is accepted; the
+ *  default WebUI renderer understands `type`, `properties`, `required`, `enum`,
+ *  `default`, `title`, `description`, and `format`. */
+declare type JSONSchema = {
+  type?: string;
   title?: string;
   description?: string;
-  fields: FormField[];
-}
+  properties?: Record<string, JSONSchema>;
+  required?: string[];
+  enum?: unknown[];
+  default?: unknown;
+  format?: string;
+  [keyword: string]: unknown;
+};
 
-/** Argument to dicode.suspend() (#95). `state` is an opaque JSON blob echoed
- *  back as ctx.resume_state on resume; `form` describes the input to collect;
- *  `deadline` is an optional Unix-ms TTL. */
+/** Argument to dicode.suspend() (#512). `state` is an opaque JSON blob echoed
+ *  back as ctx.resume_state on resume; `schema` is the JSON Schema the
+ *  submitted input is validated against; `deadline` is an optional Unix-ms
+ *  TTL. */
 declare interface SuspendRequest {
-  state: unknown;
-  form: FormSchema;
+  state?: unknown;
+  schema: JSONSchema;
   deadline?: number;
 }
 
@@ -111,9 +110,9 @@ declare interface Dicode {
   run_task:       (taskID: string, params?: Record<string, string>) => Promise<unknown>;
   list_tasks:     ()                                                 => Promise<TaskSummary[]>;
   get_runs:       (taskID: string, opts?: { limit?: number })        => Promise<unknown>;
-  /** Pause the run: hand the runtime `state` + `form`, then never resolve —
+  /** Pause the run: hand the runtime `state` + `schema`, then never resolve —
    *  the process exits cleanly and the run ends as `suspended`. On resume the
-   *  task re-runs with ctx.resume_state / ctx.resume_input populated (#95). */
+   *  task re-runs with ctx.resume_state / ctx.resume_input populated (#512). */
   suspend:        (req: SuspendRequest) => Promise<never>;
   secrets_set:    (key: string, value: string) => Promise<void>;
   secrets_delete: (key: string)                => Promise<void>;

--- a/pkg/runtime/deno/sdk/sdk.d.ts
+++ b/pkg/runtime/deno/sdk/sdk.d.ts
@@ -95,9 +95,14 @@ declare type JSONSchema = {
 /** Argument to dicode.suspend() (#512). `state` is an opaque JSON blob echoed
  *  back as ctx.resume_state on resume; `schema` is the JSON Schema the
  *  submitted input is validated against; `deadline` is an optional Unix-ms
- *  TTL. */
+ *  TTL.
+ *
+ *  `state` is REQUIRED — it is the only signal separating a first run
+ *  (ctx.resume_state undefined) from a resume (ctx.resume_state = this object).
+ *  A missing/null state reads back as undefined on resume, re-firing an
+ *  `if (!resume_state)` guard and re-suspending forever. Pass at least `{}`. */
 declare interface SuspendRequest {
-  state?: unknown;
+  state: unknown;
   schema: JSONSchema;
   deadline?: number;
 }

--- a/pkg/runtime/deno/sdk/shim.ts
+++ b/pkg/runtime/deno/sdk/shim.ts
@@ -140,31 +140,28 @@ export interface TaskSummary {
   enabled:      boolean;
 }
 
-// One field in a suspend form (#95). `type` selects the input widget the
-// WebUI renders; `options` is required for "select".
-export interface FormField {
-  name: string;
-  type: "string" | "text" | "number" | "boolean" | "select";
-  label: string;
-  required?: boolean;
-  default?: string | number | boolean;
-  options?: { value: string; label: string }[];
-  placeholder?: string;
-}
-
-// The form a suspended task asks the user to fill in before resume (#95).
-export interface FormSchema {
+// A JSON Schema (draft 2020-12) object describing the input a suspended task
+// collects before resume (#512). The daemon validates the submission against it
+// server-side. Loosely typed — any valid JSON Schema is accepted.
+export type JSONSchema = {
+  type?: string;
   title?: string;
   description?: string;
-  fields: FormField[];
-}
+  properties?: Record<string, JSONSchema>;
+  required?: string[];
+  enum?: unknown[];
+  default?: unknown;
+  format?: string;
+  [keyword: string]: unknown;
+};
 
-// Argument to dicode.suspend() (#95). `state` is an opaque JSON blob echoed
-// back as ctx.resume_state on resume; `form` describes the input to collect;
-// `deadline` is an optional Unix-ms TTL (default applied by the engine).
+// Argument to dicode.suspend() (#512). `state` is an opaque JSON blob echoed
+// back as ctx.resume_state on resume; `schema` is the JSON Schema the submitted
+// input is validated against; `deadline` is an optional Unix-ms TTL (default
+// applied by the engine).
 export interface SuspendRequest {
-  state: unknown;
-  form: FormSchema;
+  state?: unknown;
+  schema: JSONSchema;
   deadline?: number;
 }
 
@@ -182,10 +179,10 @@ export interface Dicode {
   // WebUI to collapse same-group siblings (#116). Last write wins; only
   // affects the current run.
   set_group:      (label: string)      => Promise<void>;
-  // suspend pauses the run: it hands the runtime the state blob + form, then
+  // suspend pauses the run: it hands the runtime the state blob + schema, then
   // never resolves — it throws internally so the process exits cleanly and
   // the run ends as `suspended`. On resume the task is re-run with
-  // ctx.resume_state / ctx.resume_input populated (#95).
+  // ctx.resume_state / ctx.resume_input populated (#512).
   suspend:        (req: SuspendRequest) => Promise<never>;
   secrets_set:    (key: string, value: string) => Promise<void>;
   secrets_delete: (key: string)                => Promise<void>;
@@ -438,12 +435,12 @@ const dicode: Dicode = {
   set_group:      (label)           => __call__({ method: "dicode.set_group",       group: String(label ?? "") }) as Promise<void>,
   suspend:        async (req) => {
     // Await the ack so the payload is recorded before we throw — the read
-    // loop resolves this once the daemon captured state/form/deadline. The
+    // loop resolves this once the daemon captured state/schema/deadline. The
     // call then never resolves normally: it always throws.
     await __call__({
       method: "dicode.suspend",
       state: req.state ?? null,
-      form: req.form,
+      schema: req.schema,
       deadline: req.deadline ?? 0,
     });
     __suspendRequested__ = true;

--- a/pkg/runtime/deno/sdk/shim.ts
+++ b/pkg/runtime/deno/sdk/shim.ts
@@ -158,9 +158,11 @@ export type JSONSchema = {
 // Argument to dicode.suspend() (#512). `state` is an opaque JSON blob echoed
 // back as ctx.resume_state on resume; `schema` is the JSON Schema the submitted
 // input is validated against; `deadline` is an optional Unix-ms TTL (default
-// applied by the engine).
+// applied by the engine). `state` is REQUIRED — it is the only signal that
+// tells a first run (resume_state undefined) apart from a resume, so a
+// missing/null state would re-fire the guard and re-suspend forever.
 export interface SuspendRequest {
-  state?: unknown;
+  state: unknown;
   schema: JSONSchema;
   deadline?: number;
 }

--- a/pkg/runtime/deno/suspend_test.go
+++ b/pkg/runtime/deno/suspend_test.go
@@ -85,6 +85,71 @@ export default async function main({ dicode }) {
 	}
 }
 
+// TestRun_SuspendThenResumeSeesDefinedState is the loop-avoidance regression
+// guard: `state` is required, so the blob a task passes to suspend() is stored
+// and, when fed back on resume, makes ctx.resume_state defined (truthy) — the
+// signal that flips the `if (!resume_state)` guard so the task finishes instead
+// of re-suspending forever. It runs the real suspend pass, takes the captured
+// ResumeState, and replays it exactly as the daemon would.
+func TestRun_SuspendThenResumeSeesDefinedState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rt, reg, cleanup := newTestRuntime(t)
+	defer cleanup()
+
+	// The task suspends on a first run and, on resume, reports whether it saw a
+	// defined resume_state and returns the carried step.
+	spec := writeProviderTask(t, "loopguard", `
+export default async function main({ dicode, resume_state }) {
+  if (!resume_state) {
+    await dicode.suspend({
+      state: { step: "ask_name" },
+      schema: { type: "object", properties: { project_name: { type: "string" } }, required: ["project_name"] },
+    });
+  }
+  return { defined: resume_state !== undefined, step: (resume_state as any).step };
+}
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := rt.Run(ctx, spec, RunOptions{RunID: "run-loopguard-1"})
+	if err != nil {
+		t.Fatalf("Run (suspend): %v", err)
+	}
+	if !first.Suspended || len(first.ResumeState) == 0 {
+		t.Fatalf("first run must suspend and capture a state blob; got suspended=%v state=%q", first.Suspended, first.ResumeState)
+	}
+
+	// Replay the stored state exactly as the resume path would.
+	second, err := rt.Run(ctx, spec, RunOptions{
+		RunID:       "run-loopguard-2",
+		ResumeState: json.RawMessage(first.ResumeState),
+		ResumeInput: json.RawMessage(`{"project_name":"acme"}`),
+	})
+	if err != nil {
+		t.Fatalf("Run (resume): %v", err)
+	}
+	if second.Suspended {
+		t.Fatalf("resume must not re-suspend — the state guard failed to flip")
+	}
+	ret, ok := second.ReturnValue.(map[string]any)
+	if !ok {
+		t.Fatalf("ReturnValue = %#v, want map", second.ReturnValue)
+	}
+	if ret["defined"] != true {
+		t.Errorf("resume_state must be defined on resume, got %#v", ret["defined"])
+	}
+	if ret["step"] != "ask_name" {
+		t.Errorf("resume_state.step = %#v, want ask_name", ret["step"])
+	}
+}
+
 // TestRun_SuspendSwallowedByTaskFails guards the case where a task wraps its
 // body in a broad try/catch that swallows the SuspendSignal thrown by
 // dicode.suspend() and keeps executing (#95). The suspend payload is already

--- a/pkg/runtime/deno/suspend_test.go
+++ b/pkg/runtime/deno/suspend_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 // TestRun_SuspendYieldsSuspendedResult runs a real Deno task that calls
-// dicode.suspend({ state, form, deadline }) and asserts the run ends as a
-// clean suspend (not a failure) with the state/form/deadline captured on the
-// RunResult (#95). The SuspendSignal thrown by the SDK must exit the process
+// dicode.suspend({ state, schema, deadline }) and asserts the run ends as a
+// clean suspend (not a failure) with the state/schema/deadline captured on the
+// RunResult (#512). The SuspendSignal thrown by the SDK must exit the process
 // with code 0.
 func TestRun_SuspendYieldsSuspendedResult(t *testing.T) {
 	if testing.Short() {
@@ -27,9 +27,11 @@ func TestRun_SuspendYieldsSuspendedResult(t *testing.T) {
 export default async function main({ dicode }) {
   await dicode.suspend({
     state: { step: "ask_name", n: 42 },
-    form: {
+    schema: {
+      type: "object",
       title: "Your name?",
-      fields: [{ name: "project_name", type: "string", label: "Name", required: true }],
+      properties: { project_name: { type: "string", title: "Name" } },
+      required: ["project_name"],
     },
     deadline: 1893456000000,
   });
@@ -69,18 +71,17 @@ export default async function main({ dicode }) {
 		t.Errorf("ResumeState = %+v, want {ask_name 42}", state)
 	}
 
-	var form struct {
-		Title  string `json:"title"`
-		Fields []struct {
-			Name string `json:"name"`
+	var schema struct {
+		Title      string `json:"title"`
+		Properties map[string]struct {
 			Type string `json:"type"`
-		} `json:"fields"`
+		} `json:"properties"`
 	}
-	if err := json.Unmarshal(res.ResumeForm, &form); err != nil {
-		t.Fatalf("ResumeForm not valid JSON (%q): %v", res.ResumeForm, err)
+	if err := json.Unmarshal(res.ResumeSchema, &schema); err != nil {
+		t.Fatalf("ResumeSchema not valid JSON (%q): %v", res.ResumeSchema, err)
 	}
-	if form.Title != "Your name?" || len(form.Fields) != 1 || form.Fields[0].Name != "project_name" {
-		t.Errorf("ResumeForm = %+v, want title + one project_name field", form)
+	if schema.Title != "Your name?" || len(schema.Properties) != 1 || schema.Properties["project_name"].Type != "string" {
+		t.Errorf("ResumeSchema = %+v, want title + one project_name property", schema)
 	}
 }
 
@@ -105,7 +106,7 @@ export default async function main({ dicode }) {
   try {
     await dicode.suspend({
       state: { step: "one" },
-      form: { fields: [{ name: "x", type: "string", label: "X" }] },
+      schema: { type: "object", properties: { x: { type: "string" } } },
     });
   } catch (_e) {
     // Swallow the control-flow signal and keep going — the bug we guard against.

--- a/pkg/runtime/executor.go
+++ b/pkg/runtime/executor.go
@@ -80,13 +80,13 @@ type RunResult struct {
 
 	// Suspended is set when the task called dicode.suspend() (#95): the run
 	// paused cleanly (exit 0, not a failure) and yielded state + a form for
-	// later resume. ResumeState/ResumeForm are opaque JSON blobs; ResumeDeadline
+	// later resume. ResumeState/ResumeSchema are opaque JSON blobs; ResumeDeadline
 	// is an optional Unix-ms TTL (0 = unset). The trigger engine consumes these
 	// to persist the suspended run and mint a resume token (PR 3); this runtime
 	// only produces them.
 	Suspended      bool
 	ResumeState    []byte
-	ResumeForm     []byte
+	ResumeSchema   []byte
 	ResumeDeadline int64
 }
 

--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -351,7 +351,7 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	if sr := srv.Suspend(); sr != nil && result.Error == nil {
 		result.Suspended = true
 		result.ResumeState = sr.State
-		result.ResumeForm = sr.Form
+		result.ResumeSchema = sr.Schema
 		result.ResumeDeadline = sr.Deadline
 	}
 

--- a/pkg/runtime/python/sdk/dicode_sdk.py
+++ b/pkg/runtime/python/sdk/dicode_sdk.py
@@ -255,7 +255,7 @@ input = _call({"method": "input"})
 
 
 # ── suspend / resume (#95) ────────────────────────────────────────────────────
-# dicode.suspend() pauses the run: it hands the daemon a state blob + form, then
+# dicode.suspend() pauses the run: it hands the daemon a state blob + schema, then
 # raises SuspendSignal so the process exits cleanly (exit 0) and the run ends as
 # `suspended`. On resume the task is re-run with ctx.resume_state /
 # ctx.resume_input populated. See runtime.go for how the wrapper turns a clean
@@ -520,17 +520,18 @@ class _Dicode:
         # by the WebUI to collapse same-group siblings. Last write wins.
         _call({"method": "dicode.set_group", "group": str(label or "")})
 
-    def suspend(self, state=None, form=None, deadline=None):
-        """Pause the run and wait for user input (#95). Records the state blob +
-        form over IPC, then raises SuspendSignal — it never returns. The wrapper
-        exits the process cleanly and the run ends as `suspended`; on resume the
-        task is re-run with ctx.resume_state / ctx.resume_input populated. Do not
-        wrap this call in a try/except that swallows the signal."""
+    def suspend(self, state=None, schema=None, deadline=None):
+        """Pause the run and wait for user input (#512). Records the state blob +
+        JSON Schema over IPC, then raises SuspendSignal — it never returns. The
+        wrapper exits the process cleanly and the run ends as `suspended`; on
+        resume the task is re-run with ctx.resume_state / ctx.resume_input
+        populated (the submission, validated against `schema` server-side). Do
+        not wrap this call in a try/except that swallows the signal."""
         global _suspend_requested
         # Await the ack so the payload is recorded before we raise: the daemon
-        # captures state/form/deadline synchronously in response to this call.
+        # captures state/schema/deadline synchronously in response to this call.
         _call({"method": "dicode.suspend",
-               "state": state, "form": form,
+               "state": state, "schema": schema,
                "deadline": deadline or 0})
         _suspend_requested = True
         raise SuspendSignal()

--- a/pkg/runtime/python/sdk/dicode_sdk.py
+++ b/pkg/runtime/python/sdk/dicode_sdk.py
@@ -520,13 +520,19 @@ class _Dicode:
         # by the WebUI to collapse same-group siblings. Last write wins.
         _call({"method": "dicode.set_group", "group": str(label or "")})
 
-    def suspend(self, state=None, schema=None, deadline=None):
+    def suspend(self, state, schema=None, deadline=None):
         """Pause the run and wait for user input (#512). Records the state blob +
         JSON Schema over IPC, then raises SuspendSignal — it never returns. The
         wrapper exits the process cleanly and the run ends as `suspended`; on
         resume the task is re-run with ctx.resume_state / ctx.resume_input
         populated (the submission, validated against `schema` server-side). Do
-        not wrap this call in a try/except that swallows the signal."""
+        not wrap this call in a try/except that swallows the signal.
+
+        `state` is REQUIRED: it is the only signal that tells a first run
+        (ctx.resume_state is None) apart from a resume (ctx.resume_state = this
+        object). A None/missing state reads back as None on resume, so an
+        `if ctx.resume_state is None` guard would fire again and the task would
+        re-suspend forever. Pass at least `{}` when you carry nothing."""
         global _suspend_requested
         # Await the ack so the payload is recorded before we raise: the daemon
         # captures state/schema/deadline synchronously in response to this call.

--- a/pkg/runtime/python/sdk/test_dicode_sdk.py
+++ b/pkg/runtime/python/sdk/test_dicode_sdk.py
@@ -351,7 +351,7 @@ class SuspendTests(SDKTestBase):
 
         def on_suspend(msg):
             captured["state"] = msg.get("state")
-            captured["form"] = msg.get("form")
+            captured["schema"] = msg.get("schema")
             captured["deadline"] = msg.get("deadline")
             return True  # ack
         self.server.handlers["dicode.suspend"] = on_suspend
@@ -361,15 +361,15 @@ class SuspendTests(SDKTestBase):
         with self.assertRaises(sdk.SuspendSignal):
             sdk.dicode.suspend(
                 state={"step": "one", "n": 42},
-                form={"title": "Name?", "fields": [
-                    {"name": "project_name", "type": "string", "label": "Name"}]},
+                schema={"type": "object", "title": "Name?", "properties": {
+                    "project_name": {"type": "string", "title": "Name"}}},
                 deadline=1893456000000,
             )
         # The signal was raised only after the payload was acked, and the
         # module-level flag is set so the wrapper's swallow-guard can fire.
         self.assertTrue(sdk._was_suspend_requested())
         self.assertEqual(captured["state"], {"step": "one", "n": 42})
-        self.assertEqual(captured["form"]["title"], "Name?")
+        self.assertEqual(captured["schema"]["title"], "Name?")
         self.assertEqual(captured["deadline"], 1893456000000)
 
     def test_suspend_signal_is_exception_subclass(self):

--- a/pkg/runtime/python/suspend_test.go
+++ b/pkg/runtime/python/suspend_test.go
@@ -48,9 +48,9 @@ func newSuspendExecutor(t *testing.T) (*registry.Registry, pkgruntime.Executor) 
 }
 
 // TestExecute_SuspendYieldsSuspendedResult runs a real Python task that calls
-// dicode.suspend(state=..., form=..., deadline=...) and asserts the run ends as
-// a clean suspend (not a failure) with the state/form/deadline captured on the
-// RunResult (#95). The SuspendSignal must exit the process with code 0.
+// dicode.suspend(state=..., schema=..., deadline=...) and asserts the run ends
+// as a clean suspend (not a failure) with the state/schema/deadline captured on
+// the RunResult (#512). The SuspendSignal must exit the process with code 0.
 func TestExecute_SuspendYieldsSuspendedResult(t *testing.T) {
 	if testing.Short() {
 		t.Skip("requires uv subprocess")
@@ -64,9 +64,11 @@ func TestExecute_SuspendYieldsSuspendedResult(t *testing.T) {
 async def main():
     dicode.suspend(
         state={"step": "ask_name", "n": 42},
-        form={
+        schema={
+            "type": "object",
             "title": "Your name?",
-            "fields": [{"name": "project_name", "type": "string", "label": "Name", "required": True}],
+            "properties": {"project_name": {"type": "string", "title": "Name"}},
+            "required": ["project_name"],
         },
         deadline=1893456000000,
     )
@@ -110,18 +112,17 @@ async def main():
 		t.Errorf("ResumeState = %+v, want {ask_name 42}", state)
 	}
 
-	var form struct {
-		Title  string `json:"title"`
-		Fields []struct {
-			Name string `json:"name"`
+	var schema struct {
+		Title      string `json:"title"`
+		Properties map[string]struct {
 			Type string `json:"type"`
-		} `json:"fields"`
+		} `json:"properties"`
 	}
-	if err := json.Unmarshal(res.ResumeForm, &form); err != nil {
-		t.Fatalf("ResumeForm not valid JSON (%q): %v", res.ResumeForm, err)
+	if err := json.Unmarshal(res.ResumeSchema, &schema); err != nil {
+		t.Fatalf("ResumeSchema not valid JSON (%q): %v", res.ResumeSchema, err)
 	}
-	if form.Title != "Your name?" || len(form.Fields) != 1 || form.Fields[0].Name != "project_name" {
-		t.Errorf("ResumeForm = %+v, want title + one project_name field", form)
+	if schema.Title != "Your name?" || len(schema.Properties) != 1 || schema.Properties["project_name"].Type != "string" {
+		t.Errorf("ResumeSchema = %+v, want title + one project_name property", schema)
 	}
 }
 
@@ -142,7 +143,7 @@ func TestExecute_SuspendAtTopLevelYieldsSuspendedResult(t *testing.T) {
 if ctx.resume_state is None:
     dicode.suspend(
         state={"step": "sync"},
-        form={"fields": [{"name": "x", "type": "string", "label": "X"}]},
+        schema={"type": "object", "properties": {"x": {"type": "string"}}},
     )
 result = {"reached": True}
 `)
@@ -198,7 +199,7 @@ async def main():
     try:
         dicode.suspend(
             state={"step": "one"},
-            form={"fields": [{"name": "x", "type": "string", "label": "X"}]},
+            schema={"type": "object", "properties": {"x": {"type": "string"}}},
         )
     except Exception:
         # Swallow the control-flow signal and keep going — the bug we guard against.

--- a/pkg/schemavalidate/schemavalidate.go
+++ b/pkg/schemavalidate/schemavalidate.go
@@ -20,6 +20,16 @@ import (
 // kind messages are rendered through it.
 var enPrinter = message.NewPrinter(language.English)
 
+// denyLoader is a jsonschema URLLoader that refuses every external reference. It
+// replaces the library's default FileLoader so a task's suspend schema can
+// never turn a `$ref` into a local-file read (or any other fetch) by the
+// privileged daemon. The error names the offending url without ever opening it.
+type denyLoader struct{}
+
+func (denyLoader) Load(url string) (any, error) {
+	return nil, fmt.Errorf("external $ref not allowed in a suspend schema: %s", url)
+}
+
 // Validate checks input (a JSON document) against schema (a JSON Schema
 // document). A nil/empty schema imposes no constraints. A returned error
 // carries a concise, per-field message suitable for a 400 body or a CLI line.
@@ -42,6 +52,12 @@ func Compile(schema []byte) (*jsonschema.Schema, error) {
 		return nil, fmt.Errorf("invalid schema JSON: %w", err)
 	}
 	c := jsonschema.NewCompiler()
+	// The compiler installs a default FileLoader that resolves file:// $refs off
+	// the daemon's own filesystem — a task-authored schema with
+	// {"$ref":"file:///etc/passwd"} would be read by the privileged daemon,
+	// outside the task's sandbox. A suspend schema is self-contained (internal
+	// $ref/$defs are resolved in-document, no load), so deny every external ref.
+	c.UseLoader(denyLoader{})
 	if err := c.AddResource("schema.json", doc); err != nil {
 		return nil, fmt.Errorf("invalid schema: %w", err)
 	}

--- a/pkg/schemavalidate/schemavalidate.go
+++ b/pkg/schemavalidate/schemavalidate.go
@@ -1,0 +1,113 @@
+// Package schemavalidate compiles a stored JSON Schema (draft 2020-12) and
+// validates a submitted input object against it. It is the single validator
+// shared by the WebUI resume endpoint and the CLI resume control method so a
+// suspended task can trust that ctx.resume_input conforms to the schema it
+// declared via dicode.suspend({ schema }).
+package schemavalidate
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+)
+
+// enPrinter localizes constraint-failure messages to English; the validator's
+// kind messages are rendered through it.
+var enPrinter = message.NewPrinter(language.English)
+
+// Validate checks input (a JSON document) against schema (a JSON Schema
+// document). A nil/empty schema imposes no constraints. A returned error
+// carries a concise, per-field message suitable for a 400 body or a CLI line.
+func Validate(schema, input []byte) error {
+	if len(bytes.TrimSpace(schema)) == 0 {
+		return nil
+	}
+	sch, err := Compile(schema)
+	if err != nil {
+		return err
+	}
+	return ValidateCompiled(sch, input)
+}
+
+// Compile parses and compiles a JSON Schema document. Reuse the result across
+// many Validate calls when validating repeatedly against the same schema.
+func Compile(schema []byte) (*jsonschema.Schema, error) {
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(schema))
+	if err != nil {
+		return nil, fmt.Errorf("invalid schema JSON: %w", err)
+	}
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource("schema.json", doc); err != nil {
+		return nil, fmt.Errorf("invalid schema: %w", err)
+	}
+	sch, err := c.Compile("schema.json")
+	if err != nil {
+		return nil, fmt.Errorf("invalid schema: %w", err)
+	}
+	return sch, nil
+}
+
+// ValidateCompiled validates input against an already-compiled schema.
+func ValidateCompiled(sch *jsonschema.Schema, input []byte) error {
+	if len(bytes.TrimSpace(input)) == 0 {
+		input = []byte("{}")
+	}
+	inst, err := jsonschema.UnmarshalJSON(bytes.NewReader(input))
+	if err != nil {
+		return fmt.Errorf("invalid input JSON: %w", err)
+	}
+	if err := sch.Validate(inst); err != nil {
+		var ve *jsonschema.ValidationError
+		if errors.As(err, &ve) {
+			return errors.New(fieldMessage(ve))
+		}
+		return err
+	}
+	return nil
+}
+
+// message renders a ValidationError tree into one concise line. It walks to the
+// leaf causes (the concrete failures) and formats each as `field: reason`,
+// keyed off the instance location so the caller learns which property is at
+// fault. Falls back to the library's own message for a rootless failure.
+func fieldMessage(ve *jsonschema.ValidationError) string {
+	leaves := leafErrors(ve)
+	parts := make([]string, 0, len(leaves))
+	seen := map[string]bool{}
+	for _, leaf := range leaves {
+		field := strings.Trim(strings.Join(leaf.InstanceLocation, "/"), "/")
+		reason := leaf.ErrorKind.LocalizedString(enPrinter)
+		line := reason
+		if field != "" {
+			line = field + ": " + reason
+		}
+		if seen[line] {
+			continue
+		}
+		seen[line] = true
+		parts = append(parts, line)
+	}
+	if len(parts) == 0 {
+		return "input does not satisfy the schema"
+	}
+	return strings.Join(parts, "; ")
+}
+
+// leafErrors collects the deepest causes — the ones without further causes are
+// the concrete constraint failures; the intermediate nodes only carry schema
+// location context.
+func leafErrors(ve *jsonschema.ValidationError) []*jsonschema.ValidationError {
+	if len(ve.Causes) == 0 {
+		return []*jsonschema.ValidationError{ve}
+	}
+	var out []*jsonschema.ValidationError
+	for _, c := range ve.Causes {
+		out = append(out, leafErrors(c)...)
+	}
+	return out
+}

--- a/pkg/schemavalidate/schemavalidate_test.go
+++ b/pkg/schemavalidate/schemavalidate_test.go
@@ -1,0 +1,89 @@
+package schemavalidate
+
+import (
+	"strings"
+	"testing"
+)
+
+const objSchema = `{
+  "type": "object",
+  "properties": {
+    "project_name": { "type": "string" },
+    "count": { "type": "integer" },
+    "env": { "type": "string", "enum": ["staging", "prod"] },
+    "notify": { "type": "boolean" }
+  },
+  "required": ["project_name", "env"]
+}`
+
+func TestValidate_Valid(t *testing.T) {
+	err := Validate([]byte(objSchema), []byte(`{"project_name":"api","env":"prod","count":3,"notify":true}`))
+	if err != nil {
+		t.Fatalf("expected valid, got: %v", err)
+	}
+}
+
+func TestValidate_EmptySchemaAllowsAnything(t *testing.T) {
+	if err := Validate(nil, []byte(`{"whatever": 1}`)); err != nil {
+		t.Fatalf("empty schema should impose no constraint: %v", err)
+	}
+	if err := Validate([]byte("   "), []byte(`{"x":1}`)); err != nil {
+		t.Fatalf("blank schema should impose no constraint: %v", err)
+	}
+}
+
+func TestValidate_MissingRequired(t *testing.T) {
+	err := Validate([]byte(objSchema), []byte(`{"project_name":"api"}`))
+	if err == nil {
+		t.Fatal("expected error for missing required field env")
+	}
+	if !strings.Contains(err.Error(), "env") {
+		t.Fatalf("error should name the missing field env, got: %v", err)
+	}
+}
+
+func TestValidate_EnumViolation(t *testing.T) {
+	err := Validate([]byte(objSchema), []byte(`{"project_name":"api","env":"dev"}`))
+	if err == nil {
+		t.Fatal("expected enum violation error")
+	}
+	if !strings.Contains(err.Error(), "env") {
+		t.Fatalf("error should reference env, got: %v", err)
+	}
+}
+
+func TestValidate_TypeMismatch(t *testing.T) {
+	err := Validate([]byte(objSchema), []byte(`{"project_name":"api","env":"prod","count":"three"}`))
+	if err == nil {
+		t.Fatal("expected type error for count")
+	}
+	if !strings.Contains(err.Error(), "count") {
+		t.Fatalf("error should reference count, got: %v", err)
+	}
+}
+
+func TestValidate_EmptyInputAgainstRequired(t *testing.T) {
+	err := Validate([]byte(objSchema), nil)
+	if err == nil {
+		t.Fatal("expected error: empty input misses required fields")
+	}
+}
+
+func TestValidate_BadSchema(t *testing.T) {
+	if err := Validate([]byte(`{not json`), []byte(`{}`)); err == nil {
+		t.Fatal("expected error for malformed schema")
+	}
+}
+
+func TestCompileReuse(t *testing.T) {
+	sch, err := Compile([]byte(objSchema))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if err := ValidateCompiled(sch, []byte(`{"project_name":"a","env":"prod"}`)); err != nil {
+		t.Fatalf("valid input rejected: %v", err)
+	}
+	if err := ValidateCompiled(sch, []byte(`{"env":"prod"}`)); err == nil {
+		t.Fatal("expected missing project_name error")
+	}
+}

--- a/pkg/schemavalidate/schemavalidate_test.go
+++ b/pkg/schemavalidate/schemavalidate_test.go
@@ -1,6 +1,8 @@
 package schemavalidate
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -72,6 +74,61 @@ func TestValidate_EmptyInputAgainstRequired(t *testing.T) {
 func TestValidate_BadSchema(t *testing.T) {
 	if err := Validate([]byte(`{not json`), []byte(`{}`)); err == nil {
 		t.Fatal("expected error for malformed schema")
+	}
+}
+
+// A task-authored schema must not be able to turn a $ref into a local-file
+// read by the privileged daemon. The file:// $ref must be denied at compile
+// time, and the secret contents of the referenced file must never surface in
+// the error (no content/existence oracle).
+func TestValidate_FileRefDeniedAndNotLeaked(t *testing.T) {
+	dir := t.TempDir()
+	secretPath := filepath.Join(dir, "secret.json")
+	const sentinel = "TOP-SECRET-SENTINEL-9182"
+	if err := os.WriteFile(secretPath, []byte(`{"type":"string","description":"`+sentinel+`"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	schema := []byte(`{"type":"object","properties":{"x":{"$ref":"file://` + secretPath + `"}}}`)
+
+	err := Validate(schema, []byte(`{"x":"hi"}`))
+	if err == nil {
+		t.Fatal("expected an error: an external file:// $ref must be denied")
+	}
+	if strings.Contains(err.Error(), sentinel) {
+		t.Fatalf("error leaked referenced file contents: %v", err)
+	}
+	if !strings.Contains(err.Error(), "external $ref not allowed") {
+		t.Fatalf("error should explain the denied ref; got: %v", err)
+	}
+}
+
+// A nonexistent file:// $ref must be denied identically — the loader never
+// touches the filesystem, so it cannot be used as an existence oracle.
+func TestValidate_MissingFileRefDeniedSameAsPresent(t *testing.T) {
+	schema := []byte(`{"$ref":"file:///nonexistent/does-not-exist-9182.json"}`)
+	err := Validate(schema, []byte(`{}`))
+	if err == nil {
+		t.Fatal("expected an error for a file:// $ref regardless of existence")
+	}
+	if !strings.Contains(err.Error(), "external $ref not allowed") {
+		t.Fatalf("error should be the deny-loader message, not a file-not-found oracle; got: %v", err)
+	}
+}
+
+// A self-contained schema that resolves an internal $ref against $defs (no
+// external load) still compiles and validates normally.
+func TestValidate_InternalRefStillWorks(t *testing.T) {
+	schema := []byte(`{
+      "type": "object",
+      "properties": { "env": { "$ref": "#/$defs/envName" } },
+      "required": ["env"],
+      "$defs": { "envName": { "type": "string", "enum": ["staging", "prod"] } }
+    }`)
+	if err := Validate(schema, []byte(`{"env":"prod"}`)); err != nil {
+		t.Fatalf("internal $ref schema should validate: %v", err)
+	}
+	if err := Validate(schema, []byte(`{"env":"dev"}`)); err == nil {
+		t.Fatal("internal $ref enum should still reject an out-of-set value")
 	}
 }
 

--- a/pkg/trigger/resume.go
+++ b/pkg/trigger/resume.go
@@ -72,7 +72,7 @@ func (e *Engine) suspendRun(opts *pkgruntime.RunOptions, result *pkgruntime.RunR
 		}
 	}
 	return e.registry.SuspendRun(context.Background(), opts.RunID,
-		result.ResumeState, result.ResumeForm, token, nowMs, deadlineMs, carryJSON)
+		result.ResumeState, result.ResumeSchema, token, nowMs, deadlineMs, carryJSON)
 }
 
 // newResumeToken returns a 32-byte crypto/rand token, hex-encoded. Long and

--- a/pkg/trigger/resume_test.go
+++ b/pkg/trigger/resume_test.go
@@ -44,7 +44,7 @@ func (s *suspendExec) Execute(_ context.Context, _ *task.Spec, opts pkgruntime.R
 			RunID:          opts.RunID,
 			Suspended:      true,
 			ResumeState:    []byte(`{"step":"ask_name"}`),
-			ResumeForm:     []byte(`{"fields":[{"name":"project_name"}]}`),
+			ResumeSchema:   []byte(`{"type":"object","properties":{"project_name":{"type":"string"}}}`),
 			ResumeDeadline: s.firstDeadline,
 		}, nil
 	}
@@ -55,10 +55,10 @@ func (s *suspendExec) Execute(_ context.Context, _ *task.Spec, opts pkgruntime.R
 	s.seenInput = opts.Input
 	if s.suspendAgain {
 		return &pkgruntime.RunResult{
-			RunID:       opts.RunID,
-			Suspended:   true,
-			ResumeState: []byte(`{"step":"ask_framework"}`),
-			ResumeForm:  []byte(`{"fields":[{"name":"framework"}]}`),
+			RunID:        opts.RunID,
+			Suspended:    true,
+			ResumeState:  []byte(`{"step":"ask_framework"}`),
+			ResumeSchema: []byte(`{"type":"object","properties":{"framework":{"type":"string"}}}`),
 		}, nil
 	}
 	return &pkgruntime.RunResult{RunID: opts.RunID, ReturnValue: "wizard-done"}, nil
@@ -611,10 +611,10 @@ func (b *blockingResumeDaemonExec) Execute(_ context.Context, _ *task.Spec, opts
 	if opts.ResumeState == nil {
 		b.firstRuns.Add(1)
 		return &pkgruntime.RunResult{
-			RunID:       opts.RunID,
-			Suspended:   true,
-			ResumeState: []byte(`{"step":"one"}`),
-			ResumeForm:  []byte(`{}`),
+			RunID:        opts.RunID,
+			Suspended:    true,
+			ResumeState:  []byte(`{"step":"one"}`),
+			ResumeSchema: []byte(`{}`),
 		}, nil
 	}
 	b.resumeRuns.Add(1)

--- a/pkg/webui/resume.go
+++ b/pkg/webui/resume.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/schemavalidate"
 	"github.com/dicode/dicode/pkg/trigger"
 	"github.com/go-chi/chi/v5"
 )
@@ -24,26 +25,16 @@ type Resumer interface {
 // Pass nil to disable (the endpoint returns 503).
 func (s *Server) SetResumer(r Resumer) { s.resumer = r }
 
-// resumeFormSchema mirrors the FormSchema the task persisted via
-// dicode.suspend(); only the pieces needed for server-side required-field
-// validation are modelled. Unknown keys are ignored.
-type resumeFormSchema struct {
-	Fields []resumeFormField `json:"fields"`
-}
-
-type resumeFormField struct {
-	Name     string `json:"name"`
-	Type     string `json:"type"`
-	Required bool   `json:"required"`
-}
-
-// apiResumeRun submits a suspended run's form and spawns its continuation.
+// apiResumeRun submits a suspended run's input and spawns its continuation.
 // The session (or API key) is the authorization: the raw resume_token is
 // resolved from the stored run, never trusted from the client.
 //
+// The submission is validated against the run's stored JSON Schema before the
+// continuation is spawned, so the resumed task can trust ctx.resume_input.
+//
 // Status codes:
 //   - 200 — resumed; body returns the continuation run_id.
-//   - 400 — malformed body OR a required form field is missing.
+//   - 400 — malformed body OR the input fails schema validation.
 //   - 404 — run not found OR its token no longer resolves.
 //   - 409 — run is not suspended (already resumed / finished — single-use guard).
 //   - 410 — resume deadline expired.
@@ -75,16 +66,16 @@ func (s *Server) apiResumeRun(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if missing := firstMissingRequiredField(run.ResumeForm, values); missing != "" {
-		jsonErr(w, "missing required field: "+missing, http.StatusBadRequest)
-		return
-	}
-
 	// Collected values pass through as opaque JSON — the task reads them as
 	// ctx.resume_input.
 	input, err := json.Marshal(values)
 	if err != nil {
 		jsonErr(w, "encode input: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := schemavalidate.Validate(run.ResumeSchema, input); err != nil {
+		jsonErr(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -108,35 +99,4 @@ func (s *Server) apiResumeRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	jsonOK(w, map[string]any{"run_id": newRunID})
-}
-
-// firstMissingRequiredField returns the name of the first required field in
-// the persisted form schema that has no usable value in the submission, or ""
-// if all required fields are satisfied. A boolean field counts as satisfied
-// once present (false is a valid answer); other types require a non-empty
-// value. A malformed/empty schema imposes no requirements.
-func firstMissingRequiredField(formJSON []byte, values map[string]any) string {
-	if len(formJSON) == 0 {
-		return ""
-	}
-	var schema resumeFormSchema
-	if err := json.Unmarshal(formJSON, &schema); err != nil {
-		return ""
-	}
-	for _, f := range schema.Fields {
-		if !f.Required {
-			continue
-		}
-		v, ok := values[f.Name]
-		if !ok || v == nil {
-			return f.Name
-		}
-		if f.Type == "boolean" {
-			continue
-		}
-		if s, isStr := v.(string); isStr && s == "" {
-			return f.Name
-		}
-	}
-	return ""
 }

--- a/pkg/webui/resume_test.go
+++ b/pkg/webui/resume_test.go
@@ -31,22 +31,22 @@ func (f *fakeResumer) ResumeRun(_ context.Context, token string, input []byte) (
 	return f.newRunID, f.err
 }
 
-// seedSuspendedRun inserts a run and marks it suspended with the given form
-// and token, returning its run ID.
-func seedSuspendedRun(t *testing.T, reg *registry.Registry, form []byte, token string) string {
+// seedSuspendedRun inserts a run and marks it suspended with the given JSON
+// Schema and token, returning its run ID.
+func seedSuspendedRun(t *testing.T, reg *registry.Registry, schema []byte, token string) string {
 	t.Helper()
 	ctx := context.Background()
 	id, err := reg.StartRunWithID(ctx, "run-suspended-1", "task-a", "", "manual", registry.RunKindTask)
 	if err != nil {
 		t.Fatalf("StartRunWithID: %v", err)
 	}
-	if err := reg.SuspendRun(ctx, id, []byte(`{"step":"x"}`), form, token, 1, 0, nil); err != nil {
+	if err := reg.SuspendRun(ctx, id, []byte(`{"step":"x"}`), schema, token, 1, 0, nil); err != nil {
 		t.Fatalf("SuspendRun: %v", err)
 	}
 	return id
 }
 
-var oneRequiredField = []byte(`{"title":"Name?","fields":[{"name":"project_name","type":"string","label":"Name","required":true}]}`)
+var oneRequiredField = []byte(`{"type":"object","title":"Name?","properties":{"project_name":{"type":"string","title":"Name"}},"required":["project_name"]}`)
 
 func TestApiResumeRun_HappyPath(t *testing.T) {
 	srv, reg := newTestServer(t)
@@ -199,9 +199,9 @@ func TestApiResumeRun_RequiresAuth(t *testing.T) {
 	}
 }
 
-// GET /api/runs/{id} must expose the decoded form for rendering but never leak
-// the resume token (the resume endpoint resolves it server-side).
-func TestApiGetRun_SuspendedExposesFormNotToken(t *testing.T) {
+// GET /api/runs/{id} must expose the decoded JSON Schema for rendering but never
+// leak the resume token (the resume endpoint resolves it server-side).
+func TestApiGetRun_SuspendedExposesSchemaNotToken(t *testing.T) {
 	srv, reg := newTestServer(t)
 	runID := seedSuspendedRun(t, reg, oneRequiredField, "super-secret")
 
@@ -217,12 +217,12 @@ func TestApiGetRun_SuspendedExposesFormNotToken(t *testing.T) {
 		t.Errorf("response leaked resume token: %s", raw)
 	}
 	var body struct {
-		ResumeForm json.RawMessage `json:"resume_form"`
+		ResumeSchema json.RawMessage `json:"resume_schema"`
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if !strings.Contains(string(body.ResumeForm), "project_name") {
-		t.Errorf("resume_form missing form fields; got %s", body.ResumeForm)
+	if !strings.Contains(string(body.ResumeSchema), "project_name") {
+		t.Errorf("resume_schema missing schema properties; got %s", body.ResumeSchema)
 	}
 }

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -2118,16 +2118,16 @@ func (s *Server) apiListRuns(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, runs)
 }
 
-// RunDetail is the shape returned by GET /api/runs/{runID}. ResumeForm carries
-// the suspended run's form as decoded JSON (resume_form) so the WebUI renders
-// it directly; the embedded Run's own ResumeToken/ResumeState/ResumeForm are
-// cleared by apiGetRun before embedding — the token is the resume
-// authorization and must never reach the client, and the state blob is
+// RunDetail is the shape returned by GET /api/runs/{runID}. ResumeSchema
+// carries the suspended run's JSON Schema as raw JSON so the WebUI renders a
+// form from it directly; the embedded Run's own ResumeToken/ResumeState/
+// ResumeSchema are cleared by apiGetRun before embedding — the token is the
+// resume authorization and must never reach the client, and the state blob is
 // task-internal.
 type RunDetail struct {
 	*registry.Run
-	TaskName   string          `json:"task_name"`
-	ResumeForm json.RawMessage `json:"resume_form,omitempty"`
+	TaskName     string          `json:"task_name"`
+	ResumeSchema json.RawMessage `json:"resume_schema,omitempty"`
 }
 
 func (s *Server) apiGetRun(w http.ResponseWriter, r *http.Request) {
@@ -2141,17 +2141,17 @@ func (s *Server) apiGetRun(w http.ResponseWriter, r *http.Request) {
 	if spec, ok := s.registry.Get(run.TaskID); ok {
 		taskName = spec.Name
 	}
-	// Surface the form (for rendering) but strip the token and state blob from
+	// Surface the schema (for rendering) but strip the token and state blob from
 	// the wire — the resume endpoint resolves the token server-side.
-	var form json.RawMessage
-	if run.Status == registry.StatusSuspended && len(run.ResumeForm) > 0 {
-		form = json.RawMessage(run.ResumeForm)
+	var schema json.RawMessage
+	if run.Status == registry.StatusSuspended && len(run.ResumeSchema) > 0 {
+		schema = json.RawMessage(run.ResumeSchema)
 	}
 	safe := *run
 	safe.ResumeToken = ""
 	safe.ResumeState = nil
-	safe.ResumeForm = nil
-	jsonOK(w, RunDetail{Run: &safe, TaskName: taskName, ResumeForm: form})
+	safe.ResumeSchema = nil
+	jsonOK(w, RunDetail{Run: &safe, TaskName: taskName, ResumeSchema: schema})
 }
 
 // LogEntryJSON is the JSON shape returned by GET /api/runs/{runID}/logs.

--- a/tasks/buildin/webui/app/components/dc-run-detail.js
+++ b/tasks/buildin/webui/app/components/dc-run-detail.js
@@ -138,29 +138,58 @@ class DcRunDetail extends LitElement {
     }
   }
 
-  // #95: submit a suspended run's form. Values are collected from the light-DOM
-  // form and POSTed; the server resolves the resume token itself. On success we
-  // navigate to the continuation run.
+  // #512: is this JSON-Schema property required? Derived from the schema's
+  // top-level `required` array.
+  _isRequired(name) {
+    const req = this._run?.resume_schema?.required;
+    return Array.isArray(req) && req.includes(name);
+  }
+
+  // #512: render a textarea for a string property when the schema hints at
+  // multi-line input (format:"textarea"/"multiline") — otherwise a text input.
+  _isTextarea(prop) {
+    return prop?.type === 'string' && (prop.format === 'textarea' || prop.format === 'multiline');
+  }
+
+  // #512: coerce a control's value to the property's declared JSON type so the
+  // task receives a typed value (number field → number, boolean → bool). Empty
+  // optional values return undefined so they are omitted from the submission.
+  _coerceValue(prop, el) {
+    if (prop.type === 'boolean') return el.checked;
+    if (Array.isArray(prop.enum)) {
+      if (el.value === '') return undefined;
+      // The <option> value carries the enum index, preserving the entry's
+      // original JSON type (a numeric enum stays numeric).
+      const i = Number(el.value);
+      return prop.enum[i];
+    }
+    if (el.value === '') return undefined;
+    if (prop.type === 'number' || prop.type === 'integer') return Number(el.value);
+    return el.value;
+  }
+
+  // #512: submit a suspended run's input. Values are collected from the
+  // light-DOM form, coerced to the schema's declared types, and POSTed; the
+  // server validates against the stored schema and resolves the resume token
+  // itself. On success we navigate to the continuation run.
   async _submitResume(e) {
     e.preventDefault();
-    const schema = this._run?.resume_form;
+    const schema = this._run?.resume_schema;
     if (!schema) return;
+    const props = schema.properties || {};
     const form = e.target;
     const values = {};
-    for (const f of (schema.fields || [])) {
-      const el = form.elements[f.name];
+    for (const [name, prop] of Object.entries(props)) {
+      const el = form.elements[name];
       if (!el) continue;
-      let v;
-      if (f.type === 'boolean') v = el.checked;
-      else if (f.type === 'number') v = el.value === '' ? '' : Number(el.value);
-      else v = el.value;
-      if (f.required && (v === '' || v === null || v === undefined)) {
-        this._resumeError = `${f.label || f.name} is required`;
+      const v = this._coerceValue(prop, el);
+      if (this._isRequired(name) && (v === '' || v === null || v === undefined)) {
+        this._resumeError = `${prop.title || name} is required`;
         return;
       }
       // Omit empty optional values so the task sees them as absent.
-      if (v === '' && !f.required) continue;
-      values[f.name] = v;
+      if (v === undefined) continue;
+      values[name] = v;
     }
     this._resumeError = null;
     this._resuming = true;
@@ -175,43 +204,44 @@ class DcRunDetail extends LitElement {
     }
   }
 
-  _renderResumeField(f) {
-    const req = f.required ? html`<span style="color:var(--red)"> *</span>` : '';
+  _renderResumeField(name, prop) {
+    const req = this._isRequired(name) ? html`<span style="color:var(--red)"> *</span>` : '';
+    const label = prop.title || name;
+    const desc = prop.description ? html`<span class="meta" style="display:block;font-weight:normal">${prop.description}</span>` : '';
     let input;
-    switch (f.type) {
-      case 'text':
-        input = html`<textarea name=${f.name} rows="4" placeholder=${f.placeholder || ''} .value=${f.default ?? ''} style="width:100%"></textarea>`;
-        break;
-      case 'number':
-        input = html`<input type="number" name=${f.name} placeholder=${f.placeholder || ''} .value=${f.default ?? ''} style="width:100%">`;
-        break;
-      case 'boolean':
-        return html`<div style="margin-bottom:var(--space-md)">
-          <label><input type="checkbox" name=${f.name} ?checked=${f.default === true}> ${f.label || f.name}${req}</label>
-        </div>`;
-      case 'select':
-        input = html`<select name=${f.name} style="width:100%">
-          ${(f.options || []).map(o => html`<option value=${o.value} ?selected=${o.value === f.default}>${o.label ?? o.value}</option>`)}
-        </select>`;
-        break;
-      default:
-        input = html`<input type="text" name=${f.name} placeholder=${f.placeholder || ''} .value=${f.default ?? ''} style="width:100%">`;
+    if (prop.type === 'boolean') {
+      return html`<div style="margin-bottom:var(--space-md)">
+        <label><input type="checkbox" name=${name} ?checked=${prop.default === true}> ${label}${req}</label>
+        ${desc}
+      </div>`;
+    } else if (Array.isArray(prop.enum)) {
+      input = html`<select name=${name} style="width:100%">
+        ${prop.enum.map((o, i) => html`<option value=${i} ?selected=${o === prop.default}>${String(o)}</option>`)}
+      </select>`;
+    } else if (this._isTextarea(prop)) {
+      input = html`<textarea name=${name} rows="4" .value=${prop.default ?? ''} style="width:100%"></textarea>`;
+    } else if (prop.type === 'number' || prop.type === 'integer') {
+      input = html`<input type="number" name=${name} step=${prop.type === 'integer' ? '1' : 'any'} .value=${prop.default ?? ''} style="width:100%">`;
+    } else {
+      input = html`<input type="text" name=${name} .value=${prop.default ?? ''} style="width:100%">`;
     }
     return html`<div style="margin-bottom:var(--space-md)">
-      <label style="display:block;font-weight:var(--font-semibold);margin-bottom:.25rem">${f.label || f.name}${req}</label>
+      <label style="display:block;font-weight:var(--font-semibold);margin-bottom:.25rem">${label}${req}</label>
+      ${desc}
       ${input}
     </div>`;
   }
 
   _renderResumeForm() {
-    const schema = this._run?.resume_form;
+    const schema = this._run?.resume_schema;
     if (!schema) return '';
+    const props = Object.entries(schema.properties || {});
     return html`
       <h2 style="margin-top:var(--space-lg)">${schema.title || 'Waiting on your input'}</h2>
       <div class="card">
         ${schema.description ? html`<p class="meta" style="margin-top:0">${schema.description}</p>` : ''}
         <form @submit=${e => this._submitResume(e)}>
-          ${(schema.fields || []).map(f => this._renderResumeField(f))}
+          ${props.map(([name, prop]) => this._renderResumeField(name, prop))}
           ${this._resumeError ? html`<p style="color:var(--red)">${this._resumeError}</p>` : ''}
           <div style="margin-top:var(--space-md)">
             <button class="btn" type="submit" ?disabled=${this._resuming}>${this._resuming ? 'Resuming…' : 'Submit'}</button>

--- a/tasks/sdk.ts
+++ b/tasks/sdk.ts
@@ -100,8 +100,14 @@ export type JSONSchema = {
 // Argument to dicode.suspend() (#512). `state` is an opaque JSON blob echoed
 // back as ctx.resume_state on resume; `schema` is the JSON Schema the submitted
 // input is validated against; `deadline` is an optional Unix-ms TTL.
+//
+// `state` is REQUIRED: it is the sole signal that distinguishes a first run
+// (ctx.resume_state undefined) from a resume (ctx.resume_state = this object).
+// A missing/null state reads back as undefined on resume, so an
+// `if (!resume_state)` guard would fire again and the task would re-suspend
+// forever. Pass at least `{}` when you carry nothing.
 export interface SuspendRequest {
-  state?: unknown;
+  state: unknown;
   schema: JSONSchema;
   deadline?: number;
 }

--- a/tasks/sdk.ts
+++ b/tasks/sdk.ts
@@ -79,31 +79,30 @@ export interface DicodeAudit {
   }): Promise<AuditQueryResult>;
 }
 
-// One field in a suspend form (#95). `type` selects the input widget the
-// WebUI renders; `options` is required for "select".
-export interface FormField {
-  name: string;
-  type: "string" | "text" | "number" | "boolean" | "select";
-  label: string;
-  required?: boolean;
-  default?: string | number | boolean;
-  options?: { value: string; label: string }[];
-  placeholder?: string;
-}
-
-// The form a suspended task asks the user to fill in before resume (#95).
-export interface FormSchema {
+// A JSON Schema (draft 2020-12) object describing the input a suspended task
+// asks the user to fill in before resume (#512). The daemon validates the
+// submission against it server-side, so ctx.resume_input conforms on resume.
+// Loosely typed on purpose — any valid JSON Schema is accepted; the common
+// keywords the default WebUI renderer understands are `type`, `properties`,
+// `required`, `enum`, `default`, `title`, `description`, and `format`.
+export type JSONSchema = {
+  type?: string;
   title?: string;
   description?: string;
-  fields: FormField[];
-}
+  properties?: Record<string, JSONSchema>;
+  required?: string[];
+  enum?: unknown[];
+  default?: unknown;
+  format?: string;
+  [keyword: string]: unknown;
+};
 
-// Argument to dicode.suspend() (#95). `state` is an opaque JSON blob echoed
-// back as ctx.resume_state on resume; `form` describes the input to collect;
-// `deadline` is an optional Unix-ms TTL.
+// Argument to dicode.suspend() (#512). `state` is an opaque JSON blob echoed
+// back as ctx.resume_state on resume; `schema` is the JSON Schema the submitted
+// input is validated against; `deadline` is an optional Unix-ms TTL.
 export interface SuspendRequest {
-  state: unknown;
-  form: FormSchema;
+  state?: unknown;
+  schema: JSONSchema;
   deadline?: number;
 }
 
@@ -117,9 +116,9 @@ export interface Dicode {
   run_task(taskID: string, params?: Record<string, string>): Promise<unknown>;
   list_tasks(): Promise<unknown[]>;
   get_runs(taskID: string, opts?: { limit?: number }): Promise<unknown[]>;
-  // Pause the run: hand the runtime `state` + `form`, then never resolve — the
+  // Pause the run: hand the runtime `state` + `schema`, then never resolve — the
   // process exits cleanly and the run ends as `suspended`. On resume the task
-  // re-runs with ctx.resume_state / ctx.resume_input populated (#95).
+  // re-runs with ctx.resume_state / ctx.resume_input populated (#512).
   suspend(req: SuspendRequest): Promise<never>;
   secrets_set(key: string, value: string): Promise<void>;
   secrets_delete(key: string): Promise<void>;

--- a/tasks/skills/dicode-task-dev.md
+++ b/tasks/skills/dicode-task-dev.md
@@ -208,18 +208,24 @@ const result = await mcp.call("github-mcp", "search_repositories", { query: "dic
 Pause a run to collect input from a human, then continue. `dicode.suspend()`
 never returns: the process exits, the run becomes `suspended`, and on resume the
 task re-runs **from the top** with `resume_state` / `resume_input` populated
-(both `undefined` on a first run). Branch on `resume_state` to pick up where you
+(both `undefined` on a first run). `resume_input` is validated against the
+declared JSON Schema server-side. Branch on `resume_state` to pick up where you
 left off. No permission declaration needed; Deno/Python only (not docker/podman).
+
+`schema` is a JSON Schema (draft 2020-12) for the input object; the daemon
+validates the submission against it before resuming, so `resume_input` conforms.
 
 ```typescript
 if (!resume_state) {
   await dicode.suspend({
     state: { step: "confirm" },              // JSON-serializable; echoed back as resume_state
-    form: {
+    schema: {
+      type: "object",
       title: "Deploy to production?",
-      fields: [
-        { name: "approve", label: "Approve?", type: "boolean", required: true },
-      ],
+      properties: {
+        approve: { type: "boolean", title: "Approve?" },
+      },
+      required: ["approve"],
     },
     // deadline: optional Unix-ms; default 24h. On lapse the run is cancelled (resume_timeout).
   })
@@ -229,10 +235,14 @@ const answers = resume_input as Record<string, unknown>
 if (!answers.approve) return { deployed: false }
 ```
 
+Default WebUI renderer maps the common subset: `type:string`→text (`format:"textarea"`→textarea),
+`enum`→select, `type:boolean`→checkbox, `type:number|integer`→number; honors
+`title`/`description`/`default`/`required`.
+
 Rules: never wrap `suspend()` in a `try/catch` that swallows the control signal
 (the run fails loudly if you do); `params` survive a resume but the original
 trigger `input` does not — stash anything you need into `state`. Python uses
-`ctx.resume_state` / `ctx.resume_input` and `dicode.suspend(state=..., form=...)`.
+`ctx.resume_state` / `ctx.resume_input` and `dicode.suspend(state=..., schema=...)`.
 Full reference: [docs/concepts/suspendable-tasks.md](../../docs/concepts/suspendable-tasks.md).
 
 ### `return` — pass data to downstream chain tasks

--- a/tests/e2e/fixtures/tasks/suspend-wizard/task.js
+++ b/tests/e2e/fixtures/tasks/suspend-wizard/task.js
@@ -1,14 +1,16 @@
 // First invocation suspends asking for a project name; the resume invocation
-// echoes the submitted value back as the run's result (#95 e2e).
+// echoes the submitted value back as the run's result (#512 e2e).
 export default async function main({ dicode, resume_state, resume_input }) {
   if (!resume_state) {
     await dicode.suspend({
       state: { step: 'ask_name' },
-      form: {
+      schema: {
+        type: 'object',
         title: "What's the project name?",
-        fields: [
-          { name: 'project_name', type: 'string', label: 'Name', required: true },
-        ],
+        properties: {
+          project_name: { type: 'string', title: 'Name' },
+        },
+        required: ['project_name'],
       },
     });
   }

--- a/tests/e2e/suspend-resume.spec.ts
+++ b/tests/e2e/suspend-resume.spec.ts
@@ -1,9 +1,9 @@
 /**
  * suspend-resume.spec.ts
  *
- * End-to-end coverage for the suspend/resume WebUI surface (#95, PR 4):
+ * End-to-end coverage for the suspend/resume WebUI surface (#512):
  * fire a task that calls dicode.suspend(), confirm the run lands in
- * `suspended` with a form, submit the form via POST /api/runs/<id>/resume,
+ * `suspended` with a JSON Schema, submit the input via POST /api/runs/<id>/resume,
  * and assert the continuation run succeeds with the submitted value while the
  * original run transitions to `resumed`.
  */
@@ -62,10 +62,10 @@ test.describe('suspend/resume webui', () => {
     const { runId } = (await fireRes.json()) as { runId: string };
     expect(runId).toBeTruthy();
 
-    // It must land suspended, carrying a decoded form — and NOT leak a token.
+    // It must land suspended, carrying a decoded JSON Schema — and NOT leak a token.
     const suspended = await waitForStatus(request, runId, 'suspended');
-    const form = suspended.resume_form as { fields?: { name: string }[] } | undefined;
-    expect(form?.fields?.some((f) => f.name === 'project_name')).toBe(true);
+    const schema = suspended.resume_schema as { properties?: Record<string, unknown> } | undefined;
+    expect(schema?.properties?.project_name).toBeTruthy();
     // The token is the resume authorization — it must never reach the client.
     expect(suspended.ResumeToken ?? '').toBe('');
     expect(suspended.ResumeState ?? null).toBeNull();


### PR DESCRIPTION
## Summary

Suspend forms move from the bespoke `FormSchema`/`FormField` shape (with a required-only check) to standard **JSON Schema** (draft 2020-12) everywhere they are produced, stored, validated, and rendered. This is a **breaking** change to the just-shipped suspend API, taken deliberately before it stabilizes so there is no back-compat to carry (per #512).

`dicode.suspend()` now takes `{ state, schema, deadline? }` where `schema` is a JSON Schema describing the expected input object. The **server-side validation is the linchpin**: the daemon validates the submission against the stored schema *before* spawning the continuation, so a resumed task can trust `ctx.resume_input` conforms. One shared Go validator — `pkg/schemavalidate`, built on `github.com/santhosh-tekuri/jsonschema/v6` — is wired into both the WebUI resume endpoint (`400` on failure) and the CLI resume control method (clear error), replacing `firstMissingRequiredField`.

The default WebUI renderer builds a form straight from the schema's `properties` (`string`→text, `format:"textarea"`→textarea, `enum`→select, `boolean`→checkbox, `number`/`integer`→number), coercing values to their declared JSON types before submit and honoring `title`/`description`/`required`/`default`/`enum` (Lit auto-escaping — no `unsafeHTML` on schema-supplied strings). The CLI reads the run's schema to prompt per property interactively, and coerces `field=value` pairs to the declared types, validating locally before submit (the daemon re-validates authoritatively).

## Persistence — reused column, no migration

The stored blob **reuses the existing `runs.resume_form` BLOB column as-is** (now holding the JSON Schema) to avoid a migration. The Go field/accessor is renamed to `ResumeSchema` for clarity while the DB column name stays `resume_form`. The WebUI wire field is renamed `resume_form` → `resume_schema`.

## Scope boundary

The task still hand-rolls its own `if (resume_state)` branching. Automatic `main`/`resume`/`steps` dispatch (Phase B), a pluggable/custom renderer (#222), and other later phases are **out of scope** here and will follow in separate PRs.

## Validation dependency

Added `github.com/santhosh-tekuri/jsonschema/v6 v6.0.2` (and `golang.org/x/text`, promoted to a direct dep for its localized constraint messages). Go-side only — no new Deno/Python deps, `tasks/deno.lock` untouched.

Part of #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)