### PR TITLE
feat(suspend): auto-dispatch main/resume/steps (v2 phase B)

### DIFF
--- a/.claude/skills/dicode-task-dev/SKILL.md
+++ b/.claude/skills/dicode-task-dev/SKILL.md
@@ -83,25 +83,26 @@ on_failure_chain: <task-id>      # run on failure; "" disables global default
 - `output.html()/text()` — render UI instead of returning JSON.
 - `await dicode.run_task(id, params?)` / `list_tasks()` / `get_runs(id, opts)` / `secrets_set()/secrets_delete()` — gated by `permissions.dicode`.
 - `await mcp.list_tools(server)` / `mcp.call(server, tool, args)` — gated by `permissions.dicode.mcp`.
-- `await dicode.suspend({ state, schema, deadline? })` — pause for user input; reads back as `resume_state` / `resume_input` (Python: `ctx.resume_state`). See below.
+- `await dicode.suspend({ schema, to?, state?, deadline? })` — pause for user input; the runner dispatches a resume handler that reads `ctx.input` / `ctx.state`. See below.
 - `return <json>` — value handed to downstream chain tasks; keep it under ~1MB.
 
 ### Suspendable tasks (pause for user input)
 
 `dicode.suspend()` pauses a run to collect input from a human, then continues.
 It never returns — the process exits, the run becomes `suspended`, and on resume
-the task **re-runs from the top** with `resume_state` (the blob you passed) and
-`resume_input` (the submitted values) populated (both `undefined`/`None` on a
-first run). Branch on `resume_state` to resume where you left off. Deno/Python
-only; no permission declaration needed.
+the runner **re-runs the file and dispatches the right handler for you** (no
+`if (resume_state)` switch). Each handler reads `ctx.state` (the blob you
+carried, `undefined`/`None` on the first run) and `ctx.input` (the validated
+submission). Deno/Python only; no permission declaration needed.
 
-`schema` is a JSON Schema (draft 2020-12) for the input object; the daemon
-validates the submission against it server-side before resuming.
+Export **`main`** (first run) + optionally **`resume`** (the continuation), or a
+**`steps`** map named by `suspend({ to })` for a multi-step wizard. `schema` is a
+JSON Schema (draft 2020-12); the daemon validates the submission against it
+server-side before resuming.
 
 ```typescript
-if (!resume_state) {
+export default async function main({ dicode }) {
   await dicode.suspend({
-    state: { step: "confirm" },
     schema: {
       type: "object",
       properties: { ok: { type: "boolean", title: "OK?" } },
@@ -109,7 +110,9 @@ if (!resume_state) {
     },
   })  // unreachable — never returns
 }
-const answers = resume_input as Record<string, unknown>
+export async function resume({ input }) {
+  return { confirmed: input.ok }
+}
 ```
 
 Default renderer maps: `type:string`→text (`format:"textarea"`→textarea),

--- a/docs/concepts/suspendable-tasks.md
+++ b/docs/concepts/suspendable-tasks.md
@@ -1,10 +1,11 @@
 # Suspendable Tasks
 
 A task can **pause mid-run to ask a human for input**, then continue once the
-form is filled. Call `dicode.suspend({ state, schema })`: the run ends as
-`suspended`, dicode collects the input via the Web UI or the `dicode resume`
-CLI, validates it against the schema, and the task runs again — this time with
-the answers in hand.
+form is filled. Call `dicode.suspend({ schema })`: the run ends as `suspended`,
+dicode collects the input via the Web UI or the `dicode resume` CLI, validates
+it against the schema, and the task runs again — this time with the answers in
+hand, dispatched to a **resume handler you export** so you never write an
+`if (resume_state)` switch.
 
 Use it for approval gates, wizards, "which of these do you mean?" disambiguation,
 or any step that can't proceed without a person.
@@ -12,7 +13,7 @@ or any step that can't proceed without a person.
 The form is described with a **[JSON Schema](https://json-schema.org)** (draft
 2020-12). That is a standard, portable vocabulary: the same schema drives the
 default Web UI form, the CLI prompts, and the **server-side validation** that
-guarantees `resume_input` conforms before your task re-runs.
+guarantees `ctx.input` conforms before your task re-runs.
 
 ---
 
@@ -21,22 +22,21 @@ guarantees `resume_input` conforms before your task re-runs.
 Suspend is **not** VM suspension. Nothing is frozen in memory.
 
 1. The task calls `dicode.suspend(...)`.
-2. dicode records the `state` blob and the `schema`, then the **process exits
-   cleanly** (exit 0). The run row is marked `suspended`.
+2. dicode records the carried `state` blob and the `schema`, then the **process
+   exits cleanly** (exit 0). The run row is marked `suspended`.
 3. When someone submits the form, dicode **validates the submission against the
    schema**, then starts a **brand-new process** for the same task and re-runs
    `task.ts` / `task.py` **from the top**.
-4. On that re-run the task reads `resume_state` (the blob it passed to
-   `suspend`) and `resume_input` (the submitted values) to pick up where it
-   left off.
+4. On that re-run the runner **dispatches the right handler** and hands it
+   `ctx.state` (the blob you carried) and `ctx.input` (the submitted values).
 
-Because the whole file runs again from the top, your task owns its control flow:
-**branch on `resume_state` early** to decide which step you're on. Any side
-effect before the `suspend()` call runs again on every resume, so keep the
-pre-suspend section idempotent (or gate it behind a `resume_state` check).
+Because the whole file re-runs from the top, any side effect at module top level
+runs again on every resume — keep top-level code idempotent and put real work
+inside a handler. You do **not** write a step switch: the runner picks the
+handler for you (see [Auto-dispatch](#the-handlers--auto-dispatch)).
 
-A first (non-resume) run has `resume_state` / `resume_input` **undefined**
-(Deno) or **`None`** (Python) — that's how you detect the initial pass.
+A first (non-resume) run sees `ctx.state` **undefined** (Deno) / **`None`**
+(Python) in `main`; a resumed handler sees the real carried blob.
 
 ---
 
@@ -51,40 +51,53 @@ dicode.suspend(req: SuspendRequest): Promise<never>
 Pauses the run. It records `req` over IPC, then **never returns** — internally
 it throws a control signal that the runtime catches to exit the process. Code
 after `suspend()` does not run on the suspending pass; it runs on the resume
-pass instead (from the top of the file).
+pass instead (in the handler the runner dispatches to).
 
 ```typescript
 interface SuspendRequest {
-  state: unknown       // REQUIRED; JSON-serializable; echoed back as resume_state on resume
   schema: JSONSchema   // JSON Schema (draft 2020-12) for the input to collect
+  to?: string          // name of the steps[] handler to run on resume (wizard shape)
+  state?: unknown      // JSON-serializable blob carried to the resume as ctx.state
   deadline?: number    // optional Unix-ms instant; resumable until then (default: 24h)
 }
 ```
 
-`state` is **required** — it is the only signal that distinguishes a first run
-(`resume_state` undefined / `None`) from a resume (`resume_state` = the object
-you passed). Pass at least `{}` when you carry nothing across the pause; a
-missing state would read back as undefined and re-fire your `if (!resume_state)`
-guard, re-suspending forever.
+- **`to`** names the `steps` handler to dispatch on resume — the wizard shape.
+  Omit it for the two-function (`main` + `resume`) shape.
+- **`state`** is your own carried blob, handed back as `ctx.state` on the
+  resume. The runner persists it wrapped with an internal step marker (so
+  first-vs-resume stays unambiguous) — you never see or manage that marker.
 
 Python signature (keyword args):
 
 ```python
-dicode.suspend(state=<json>, schema=<dict>, deadline=<unix_ms>)
+dicode.suspend(schema=<dict>, to=<str>, state=<json>, deadline=<unix_ms>)
 ```
 
-### Reading the resume context
+### The handlers — auto-dispatch
+
+You export handlers; the runner picks which one runs based on the resume:
+
+| You export | First run | Resume |
+|---|---|---|
+| `main` only | `main` | `main` again (branch on `ctx.state` by hand) |
+| `main` + `resume` | `main` | `resume` |
+| `main` + `steps` map | `main` | `steps[to]` — the handler named by `suspend({ to })` |
+
+`main` is always the entry (first) step. Each handler receives the resume
+context — **Deno**: destructure the argument (`async function resume({ state, input, dicode })`);
+**Python**: read the module-global `ctx` (`ctx.state`, `ctx.input`) or accept it
+as an argument (`async def resume(ctx):`).
 
 | | First run | Resume run |
 |---|---|---|
-| Deno global `resume_state` | `undefined` | the `state` you passed to `suspend()` |
-| Deno global `resume_input` | `undefined` | the submitted values, keyed by property name |
-| Python `ctx.resume_state` | `None` | the `state` you passed to `suspend()` |
-| Python `ctx.resume_input` | `None` | the submitted values, keyed by property name |
+| `ctx.state` | `undefined` / `None` | the `state` you passed to `suspend()` (unwrapped) |
+| `ctx.input` | the trigger input | the submitted values, keyed by property name |
 
-`resume_input` is validated against the schema before your task re-runs, and its
-values arrive with the **declared JSON types** — a `number`/`integer` property
-is a number, a `boolean` is a bool. (Coerce defensively anyway.)
+`ctx.input` on a resume is validated against the schema before your task
+re-runs, and its values arrive with the **declared JSON types** — a
+`number`/`integer` property is a number, a `boolean` is a bool. (Coerce
+defensively anyway.)
 
 `dicode.suspend` needs **no permission declaration** — it is granted by default
 on the `deno` and `python` runtimes. It is **not** available on `docker` /
@@ -141,66 +154,61 @@ validated server-side regardless of how it renders.
 
 ---
 
-## Worked example — a two-step wizard
+## Worked example — a two-step wizard (`steps`)
 
-Collect a project name, then a target environment, then finish. The task is a
-state machine keyed by a `step` field carried in `state`.
+Collect a project name, then a target environment, then finish. `suspend({ to })`
+names the next handler; the runner dispatches it and hands it `ctx.input` (the
+submission) and `ctx.state` (the blob you carried). No step switch.
 
 ### Deno (`task.ts`)
 
 ```typescript
-type WizardState = { step: "name" } | { step: "env"; name: string }
-
-const state = resume_state as WizardState | undefined
-const answers = (resume_input ?? {}) as Record<string, unknown>
-
-// First run — ask for the project name and pause.
-if (!state) {
+export default async function main({ dicode }) {
+  // First run — ask for the project name, resume into the "env" step.
   await dicode.suspend({
-    state: { step: "name" },
+    to: "env",
     schema: {
       type: "object",
       title: "New project",
       description: "What should we call it?",
-      properties: {
-        project: { type: "string", title: "Project name" },
-      },
+      properties: { project: { type: "string", title: "Project name" } },
       required: ["project"],
     },
   })
   // unreachable — suspend() never returns
 }
 
-// Second run — the name is in, ask for the environment and pause again.
-if (state.step === "name") {
-  const project = String(answers.project ?? "")
-  await dicode.suspend({
-    state: { step: "env", name: project },
-    schema: {
-      type: "object",
-      title: `Deploy ${project}`,
-      properties: {
-        env: { type: "string", title: "Target environment", enum: ["staging", "prod"] },
+export const steps = {
+  // Runs on the first resume: the name is in ctx.input; ask for the environment,
+  // carrying the name forward in state.
+  async env({ dicode, input }) {
+    await dicode.suspend({
+      to: "finish",
+      state: { name: input.project },
+      schema: {
+        type: "object",
+        title: `Deploy ${input.project}`,
+        properties: {
+          env: { type: "string", title: "Target environment", enum: ["staging", "prod"] },
+        },
+        required: ["env"],
       },
-      required: ["env"],
-    },
-  })
+    })
+  },
+  // Runs on the second resume: both answers in hand; finish.
+  async finish({ state, input }) {
+    return { project: state.name, env: input.env ?? "staging" }
+  },
 }
-
-// Third run — both answers in hand; finish.
-return { project: state.name, env: answers.env ?? "staging" }
 ```
 
 ### Python (`task.py`)
 
 ```python
-state = ctx.resume_state
-answers = ctx.resume_input or {}
-
-# First run — ask for the project name and pause.
-if state is None:
+async def main():
+    # First run — ask for the project name, resume into the "env" step.
     dicode.suspend(
-        state={"step": "name"},
+        to="env",
         schema={
             "type": "object",
             "title": "New project",
@@ -211,14 +219,16 @@ if state is None:
     )
     # unreachable — suspend() raises and the process exits
 
-# Second run — the name is in, ask for the environment and pause again.
-if state["step"] == "name":
-    project = answers.get("project", "")
+
+async def env(ctx):
+    # First resume: the name is in ctx.input; ask for the environment, carrying
+    # the name forward in state.
     dicode.suspend(
-        state={"step": "env", "name": project},
+        to="finish",
+        state={"name": ctx.input["project"]},
         schema={
             "type": "object",
-            "title": f"Deploy {project}",
+            "title": f"Deploy {ctx.input['project']}",
             "properties": {
                 "env": {"type": "string", "title": "Target environment", "enum": ["staging", "prod"]},
             },
@@ -226,13 +236,44 @@ if state["step"] == "name":
         },
     )
 
-# Third run — both answers in hand; finish.
-result = {"project": state["name"], "env": answers.get("env", "staging")}
+
+async def finish(ctx):
+    # Second resume: both answers in hand; finish.
+    return {"project": ctx.state["name"], "env": ctx.input.get("env", "staging")}
+
+
+steps = {"env": env, "finish": finish}
 ```
 
 Each `suspend()` mints its own resume, so a task can suspend any number of times
-— that's what chains the wizard steps together. (Each step still branches on
-`resume_state` by hand; automatic step dispatch is a separate follow-up.)
+— chaining the wizard steps together, one named handler per pause.
+
+## Simpler — ask once, then finish (`resume`)
+
+When you only pause once, skip the `steps` map: export `main` and `resume`. The
+runner runs `main` on the first pass and `resume` on the continuation.
+
+```typescript
+export default async function main({ dicode }) {
+  await dicode.suspend({
+    schema: {
+      type: "object",
+      title: "Approve deploy?",
+      properties: { ok: { type: "boolean", title: "Ship it?" } },
+      required: ["ok"],
+    },
+  })
+}
+
+export async function resume({ input }) {
+  return { shipped: input.ok }
+}
+```
+
+A task that exports **only `main`** still works: on resume the runner re-runs
+`main`, and you branch on `ctx.state` by hand (undefined on the first run, your
+carried blob on the resume). Pass a `state` when you go this route so the two
+passes are distinguishable.
 
 ---
 
@@ -252,9 +293,10 @@ Each `suspend()` mints its own resume, so a task can suspend any number of times
 
 - **`params` survive a resume; the original trigger input does not.** The
   continuation is a fresh run that restores the suspended run's `params` (so
-  `ctx.params` is unchanged), but the `input` that fired the *original* run (the
-  webhook body, the chain payload) is **not** replayed. If you'll need something
-  from `input` after resuming, **stash it into `state`** before you suspend.
+  `ctx.params` is unchanged). On a resume `ctx.input` is the **form submission**,
+  not the payload that fired the *original* run (the webhook body, the chain
+  payload) — that is **not** replayed. If you'll need something from the original
+  input after resuming, **stash it into `state`** before you suspend.
 
 - **`deadline` is optional.** It's a Unix-ms instant; the run stays resumable
   until then. Omit it (or pass `0`) for the default **24-hour** window. Once the
@@ -288,7 +330,8 @@ running ──suspend()──► suspended ──resume──► resumed        
 The **continuation is a new run** with its own run id, taken through the normal
 execution path — which is why it can suspend again. The original suspended run
 does not itself "become" the continuation; it transitions to `resumed` and the
-continuation carries on from `resume_state`.
+continuation carries on from the handler the runner dispatches, with `ctx.state`
+restored.
 
 ---
 

--- a/docs/deno-runtime.md
+++ b/docs/deno-runtime.md
@@ -136,20 +136,19 @@ output.html(html, { data: { count: 5 } })  // chained tasks receive { count: 5 }
 return { count: 42, status: "ok" }
 ```
 
-### `suspend` / `resume_state` / `resume_input`
+### `suspend` — pause for human input, auto-dispatched
 
-Pause a run to collect input from a human. `dicode.suspend({ state, schema })`
-never returns — the process exits, the run becomes `suspended`, and on resume the
-task re-runs from the top with `resume_state` (the blob you passed) and
-`resume_input` (the submitted input) populated (both `undefined` on a first run).
-`schema` is a [JSON Schema](https://json-schema.org) (draft 2020-12) describing
-the expected input object; the daemon validates the submission against it before
-resuming, so `resume_input` conforms.
+Pause a run to collect input from a human. `dicode.suspend({ schema })` never
+returns — the process exits, the run becomes `suspended`, and on resume the
+runner re-runs the file and **dispatches the right handler for you**: no
+hand-rolled `if (resume_state)` switch. Each handler reads `ctx.state` (the blob
+you carried) and `ctx.input` (the validated submission).
+
+Export **`main`** (the first run) and optionally **`resume`** (the continuation):
 
 ```typescript
-if (!resume_state) {
+export default async function main({ dicode }) {
   await dicode.suspend({
-    state: { step: "confirm" },
     schema: {
       type: "object",
       properties: { ok: { type: "boolean", title: "OK?" } },
@@ -157,11 +156,20 @@ if (!resume_state) {
     },
   })  // unreachable — never returns
 }
+
+export async function resume({ input }) {
+  return { confirmed: input.ok }
+}
 ```
 
-See [Suspendable Tasks](./concepts/suspendable-tasks.md) for the JSON-Schema form,
-lifecycle (`suspended` → `resumed`), and how to resume via the Web UI or
-`dicode resume`.
+For a multi-step wizard, export a **`steps`** map and name the next handler with
+`suspend({ to })`. `schema` is a [JSON Schema](https://json-schema.org) (draft
+2020-12); the daemon validates the submission against it before resuming, so
+`ctx.input` conforms.
+
+See [Suspendable Tasks](./concepts/suspendable-tasks.md) for the dispatch rules,
+the `steps` wizard shape, lifecycle (`suspended` → `resumed`), and how to resume
+via the Web UI or `dicode resume`.
 
 ---
 

--- a/docs/python-runtime.md
+++ b/docs/python-runtime.md
@@ -143,31 +143,41 @@ Assign `result` at module level. The value is passed to chained tasks via `input
 result = {"count": 42, "status": "ok"}
 ```
 
-### `suspend` / `ctx.resume_state` / `ctx.resume_input`
+### `suspend` — pause for human input, auto-dispatched
 
-Pause a run to collect input from a human. `dicode.suspend(state=..., schema=...)`
-never returns — it raises a control signal, the process exits, the run becomes
-`suspended`, and on resume the task re-runs from the top with `ctx.resume_state`
-(the blob you passed) and `ctx.resume_input` (the submitted input) populated (both
-`None` on a first run). `schema` is a [JSON Schema](https://json-schema.org)
-(draft 2020-12) the daemon validates the submission against before resuming.
+Pause a run to collect input from a human. `dicode.suspend(schema=...)` never
+returns — it raises a control signal, the process exits, the run becomes
+`suspended`, and on resume the runner re-runs the file and **dispatches the right
+handler for you**: no hand-rolled `if ctx.state is None` switch. Each handler
+reads `ctx.state` (the blob you carried) and `ctx.input` (the validated
+submission), both `None` on a first run.
+
+Define **`main`** (the first run) and optionally **`resume`** (the continuation):
 
 ```python
-if ctx.resume_state is None:
+async def main():
     dicode.suspend(
-        state={"step": "confirm"},
         schema={
             "type": "object",
             "properties": {"ok": {"type": "boolean", "title": "OK?"}},
             "required": ["ok"],
         },
     )  # unreachable — never returns
+
+async def resume():
+    return {"confirmed": ctx.input["ok"]}
 ```
+
+For a multi-step wizard, define a **`steps`** map and name the next handler with
+`suspend(to=...)`. A handler may also take `ctx` as an argument
+(`async def resume(ctx):`) instead of reading the module-global `ctx`. `schema`
+is a [JSON Schema](https://json-schema.org) (draft 2020-12) the daemon validates
+against before resuming.
 
 Do not wrap `suspend()` in a `try/except` that swallows the signal — the run
 fails loudly if you do. See [Suspendable Tasks](./concepts/suspendable-tasks.md)
-for the JSON-Schema form, lifecycle (`suspended` → `resumed`), and how to resume
-via the Web UI or `dicode resume`.
+for the dispatch rules, the `steps` wizard shape, lifecycle (`suspended` →
+`resumed`), and how to resume via the Web UI or `dicode resume`.
 
 ### Async tasks
 

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -65,8 +65,8 @@ type RunOptions struct {
 
 	// ResumeState / ResumeInput carry a suspended run's prior state and the
 	// user's form submission when this run is a resume (#95). Both are opaque
-	// JSON blobs surfaced to the task as ctx.resume_state / ctx.resume_input.
-	// Nil on a first (non-resume) invocation.
+	// JSON blobs; the SDK unwraps the step envelope and surfaces them to the
+	// task as ctx.state / ctx.input. Nil on a first (non-resume) invocation.
 	ResumeState json.RawMessage
 	ResumeInput json.RawMessage
 }
@@ -295,18 +295,38 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		zap.String("task_script", taskPath),
 		zap.String("runner", runnerPath),
 	)
-	runner := "import { params, kv, input, output, mcp, dicode, resume_state, resume_input, __setReturn__, __conn__, __flush__, __isSuspend__, __wasSuspendRequested__ } from \"" + shimPath + "\";\n" +
-		"let __main__;\n" +
+	runner := "import { params, kv, input, state, output, mcp, dicode, __setReturn__, __conn__, __flush__, __isSuspend__, __wasSuspendRequested__, __resumed__, __resumeStep__ } from \"" + shimPath + "\";\n" +
+		"let __mod__;\n" +
 		"try {\n" +
-		"  __main__ = (await import(\"" + taskPath + "\")).default;\n" +
+		"  __mod__ = await import(\"" + taskPath + "\");\n" +
 		"} catch (__importErr__) {\n" +
 		"  console.error(\"[dicode] task import failed:\", String(__importErr__));\n" +
 		"  await __flush__();\n" +
 		"  try { __conn__.close(); } catch {}\n" +
 		"  Deno.exit(1);\n" +
 		"}\n" +
+		// Auto-dispatch (#512): a first run calls main; a resume runs steps[to]
+		// (wizard shape) if the marker names an exported step, else the exported
+		// resume (two-function shape), else falls back to main so a single-main
+		// task keeps working. The author reads ctx.state / ctx.input, never a step
+		// switch. main is the entry (first) step.
+		"const __ctx__ = { params, kv, input, state, output, mcp, dicode };\n" +
+		"const __main__ = __mod__.default;\n" +
+		"const __resumeFn__ = __mod__.resume;\n" +
+		"const __steps__ = __mod__.steps;\n" +
+		"let __handler__ = __main__;\n" +
+		"if (__resumed__) {\n" +
+		"  if (__resumeStep__ && __steps__ && typeof __steps__[__resumeStep__] === \"function\") { __handler__ = __steps__[__resumeStep__]; }\n" +
+		"  else if (typeof __resumeFn__ === \"function\") { __handler__ = __resumeFn__; }\n" +
+		"}\n" +
+		"if (typeof __handler__ !== \"function\") {\n" +
+		"  console.error(\"[dicode] task has no default export (main) to run\");\n" +
+		"  await __flush__();\n" +
+		"  try { __conn__.close(); } catch {}\n" +
+		"  Deno.exit(1);\n" +
+		"}\n" +
 		"try {\n" +
-		"  const result = await __main__({ params, kv, input, output, mcp, dicode, resume_state, resume_input });\n" +
+		"  const result = await __handler__(__ctx__);\n" +
 		// If main() returned normally yet a suspend was requested, the task
 		// caught the SuspendSignal in its own try/catch and kept running. The
 		// payload is already recorded server-side, so a normal return would

--- a/pkg/runtime/deno/sdk/sdk.d.ts
+++ b/pkg/runtime/deno/sdk/sdk.d.ts
@@ -92,18 +92,18 @@ declare type JSONSchema = {
   [keyword: string]: unknown;
 };
 
-/** Argument to dicode.suspend() (#512). `state` is an opaque JSON blob echoed
- *  back as ctx.resume_state on resume; `schema` is the JSON Schema the
- *  submitted input is validated against; `deadline` is an optional Unix-ms
- *  TTL.
+/** Argument to dicode.suspend() (#512). `schema` is the JSON Schema the
+ *  submitted input is validated against; `deadline` is an optional Unix-ms TTL.
  *
- *  `state` is REQUIRED — it is the only signal separating a first run
- *  (ctx.resume_state undefined) from a resume (ctx.resume_state = this object).
- *  A missing/null state reads back as undefined on resume, re-firing an
- *  `if (!resume_state)` guard and re-suspending forever. Pass at least `{}`. */
+ *  `to` names the step handler to run on resume (wizard shape: the runner
+ *  dispatches `steps[to]`); omit it for the two-function (main + resume) or
+ *  single-main shape. `state` is the author's carried blob, echoed back as
+ *  ctx.state (unwrapped) on resume; the runner persists it wrapped with an
+ *  internal step marker the author never sees. */
 declare interface SuspendRequest {
-  state: unknown;
   schema: JSONSchema;
+  to?: string;
+  state?: unknown;
   deadline?: number;
 }
 
@@ -115,9 +115,10 @@ declare interface Dicode {
   run_task:       (taskID: string, params?: Record<string, string>) => Promise<unknown>;
   list_tasks:     ()                                                 => Promise<TaskSummary[]>;
   get_runs:       (taskID: string, opts?: { limit?: number })        => Promise<unknown>;
-  /** Pause the run: hand the runtime `state` + `schema`, then never resolve —
-   *  the process exits cleanly and the run ends as `suspended`. On resume the
-   *  task re-runs with ctx.resume_state / ctx.resume_input populated (#512). */
+  /** Pause the run: hand the runtime `schema` + carried `state`, then never
+   *  resolve — the process exits cleanly and the run ends as `suspended`. On
+   *  resume the runner dispatches the matching handler (steps[to], resume, or
+   *  main) with ctx.state / ctx.input populated (#512). */
   suspend:        (req: SuspendRequest) => Promise<never>;
   secrets_set:    (key: string, value: string) => Promise<void>;
   secrets_delete: (key: string)                => Promise<void>;
@@ -126,18 +127,25 @@ declare interface Dicode {
   crypto:         DicodeCrypto;
 }
 
-/** All SDK globals passed to your task's main() function. */
+/** The context each task handler (main / resume / steps[x]) receives (#512). */
 declare interface DicodeSdk {
   params: Params;
   kv:     KV;
+  /** The input handed to THIS invocation: the trigger payload on a fresh run,
+   *  the schema-validated form submission on a resume. */
   input:  unknown;
-  /** Prior state blob when this run is a resume of a suspended one; the same
-   *  value passed to dicode.suspend({ state }). Undefined on a first run (#95). */
-  resume_state?: unknown;
-  /** The user's form submission that triggered this resume, keyed by field
-   *  name. Undefined on a first run (#95). */
-  resume_input?: Record<string, unknown>;
+  /** The author's carried blob, unwrapped from dicode.suspend({ state }).
+   *  Undefined on a first run — tells first-vs-resume without a step switch. */
+  state?: unknown;
   output: Output;
   mcp:    MCP;
   dicode: Dicode;
 }
+
+/** A task handler — the default export (`main`, the entry step), an optional
+ *  `resume`, or a named entry in the `steps` map (#512). */
+declare type TaskHandler = (ctx: DicodeSdk) => unknown | Promise<unknown>;
+
+/** The wizard shape: a map of named step handlers. dicode.suspend({ to }) names
+ *  the entry the runner dispatches on resume; `main` is the first step. */
+declare type TaskSteps = Record<string, TaskHandler>;

--- a/pkg/runtime/deno/sdk/shim.ts
+++ b/pkg/runtime/deno/sdk/shim.ts
@@ -155,15 +155,19 @@ export type JSONSchema = {
   [keyword: string]: unknown;
 };
 
-// Argument to dicode.suspend() (#512). `state` is an opaque JSON blob echoed
-// back as ctx.resume_state on resume; `schema` is the JSON Schema the submitted
+// Argument to dicode.suspend() (#512). `schema` is the JSON Schema the submitted
 // input is validated against; `deadline` is an optional Unix-ms TTL (default
-// applied by the engine). `state` is REQUIRED — it is the only signal that
-// tells a first run (resume_state undefined) apart from a resume, so a
-// missing/null state would re-fire the guard and re-suspend forever.
+// applied by the engine).
+//
+// `to` names the step handler to run on resume (wizard shape); omit it for the
+// two-function (main/resume) shape. `state` is the author's carried blob, echoed
+// back as ctx.state (unwrapped) on resume — the runner persists it wrapped with
+// an internal step marker so first-vs-resume stays unambiguous without the author
+// ever seeing the marker.
 export interface SuspendRequest {
-  state: unknown;
   schema: JSONSchema;
+  to?: string;
+  state?: unknown;
   deadline?: number;
 }
 
@@ -183,8 +187,8 @@ export interface Dicode {
   set_group:      (label: string)      => Promise<void>;
   // suspend pauses the run: it hands the runtime the state blob + schema, then
   // never resolves — it throws internally so the process exits cleanly and
-  // the run ends as `suspended`. On resume the task is re-run with
-  // ctx.resume_state / ctx.resume_input populated (#512).
+  // the run ends as `suspended`. On resume the runner dispatches the matching
+  // handler (steps[to], resume, or main) with ctx.state / ctx.input populated (#512).
   suspend:        (req: SuspendRequest) => Promise<never>;
   secrets_set:    (key: string, value: string) => Promise<void>;
   secrets_delete: (key: string)                => Promise<void>;
@@ -355,18 +359,30 @@ const kv: KV = {
   list:   (prefix = "") => __call__({ method: "kv.list", prefix }) as Promise<Record<string, unknown>>,
 };
 
-// ── input ─────────────────────────────────────────────────────────────────────
+// ── input & resume (#512) ──────────────────────────────────────────────────────
+// suspend() persists the carried blob wrapped as { __step, state } so the runner
+// can dispatch the right handler without the author threading a step id. Here we
+// unwrap it: `state` is the author's own blob (never the envelope), `__resumeStep__`
+// names the handler the resume must run, and `input` is the input handed to THIS
+// invocation — the trigger payload on a fresh run, the validated form submission
+// on a resume. Both `state` and the resume `input` are undefined on a first run.
 
-const input = await __call__({ method: "input" });
-
-// ── resume (#95) ────────────────────────────────────────────────────────────────
-// When this run is a resume of a suspended one, the runtime injects the prior
-// state blob and the user's form submission. Both are null on a first run.
-
+const __triggerInput__ = await __call__({ method: "input" });
 const __resume__ = await __call__({ method: "resume" }) as
   { state?: unknown; input?: unknown } | null;
-const resume_state: unknown = __resume__?.state ?? undefined;
-const resume_input: unknown = __resume__?.input ?? undefined;
+const __resumed__ = __resume__ != null && __resume__.state != null;
+
+function __unwrapState__(raw: unknown): { step: string | undefined; state: unknown } {
+  if (raw && typeof raw === "object" && "__step" in (raw as Record<string, unknown>)) {
+    const env = raw as { __step?: unknown; state?: unknown };
+    return { step: typeof env.__step === "string" ? env.__step : undefined, state: env.state };
+  }
+  return { step: undefined, state: raw };
+}
+
+const { step: __resumeStep__, state } =
+  __unwrapState__(__resumed__ ? __resume__!.state : undefined);
+const input: unknown = __resumed__ ? __resume__!.input : __triggerInput__;
 
 // SuspendSignal is thrown by dicode.suspend() after the payload is delivered
 // over IPC. The per-run wrapper catches it (via __isSuspend__) and exits the
@@ -441,7 +457,9 @@ const dicode: Dicode = {
     // call then never resolves normally: it always throws.
     await __call__({
       method: "dicode.suspend",
-      state: req.state ?? null,
+      // Persist an envelope so the runner can dispatch steps[to] on resume; the
+      // author's blob rides in `state` and is unwrapped before any handler runs.
+      state: { __step: req.to ?? null, state: req.state ?? null },
       schema: req.schema,
       deadline: req.deadline ?? 0,
     });
@@ -537,4 +555,4 @@ const dicode: Dicode = {
 // The runner awaits this on exit so fire-and-forget log writes are not lost.
 async function __flush__(): Promise<void> { await __wq__; }
 
-export { params, kv, input, resume_state, resume_input, output, mcp, dicode, __setReturn__, __conn__, __flush__, __isSuspend__, __wasSuspendRequested__ };
+export { params, kv, input, state, output, mcp, dicode, __setReturn__, __conn__, __flush__, __isSuspend__, __wasSuspendRequested__, __resumed__, __resumeStep__ };

--- a/pkg/runtime/deno/suspend_test.go
+++ b/pkg/runtime/deno/suspend_test.go
@@ -11,8 +11,9 @@ import (
 // TestRun_SuspendYieldsSuspendedResult runs a real Deno task that calls
 // dicode.suspend({ state, schema, deadline }) and asserts the run ends as a
 // clean suspend (not a failure) with the state/schema/deadline captured on the
-// RunResult (#512). The SuspendSignal thrown by the SDK must exit the process
-// with code 0.
+// RunResult (#512). The runner persists `state` wrapped in a { __step, state }
+// envelope so it can dispatch handlers on resume; the author's blob rides in
+// `state`. The SuspendSignal thrown by the SDK must exit the process with 0.
 func TestRun_SuspendYieldsSuspendedResult(t *testing.T) {
 	if testing.Short() {
 		t.Skip("requires Deno subprocess")
@@ -60,15 +61,23 @@ export default async function main({ dicode }) {
 		t.Errorf("ResumeDeadline = %d, want 1893456000000", res.ResumeDeadline)
 	}
 
-	var state struct {
-		Step string `json:"step"`
-		N    int    `json:"n"`
+	// ResumeState is the internal envelope: __step null (no `to`), the author's
+	// blob nested under `state`.
+	var env struct {
+		Step  *string `json:"__step"`
+		State struct {
+			Step string `json:"step"`
+			N    int    `json:"n"`
+		} `json:"state"`
 	}
-	if err := json.Unmarshal(res.ResumeState, &state); err != nil {
+	if err := json.Unmarshal(res.ResumeState, &env); err != nil {
 		t.Fatalf("ResumeState not valid JSON (%q): %v", res.ResumeState, err)
 	}
-	if state.Step != "ask_name" || state.N != 42 {
-		t.Errorf("ResumeState = %+v, want {ask_name 42}", state)
+	if env.Step != nil {
+		t.Errorf("__step = %v, want null for a two-function/main suspend", *env.Step)
+	}
+	if env.State.Step != "ask_name" || env.State.N != 42 {
+		t.Errorf("unwrapped state = %+v, want {ask_name 42}", env.State)
 	}
 
 	var schema struct {
@@ -85,13 +94,12 @@ export default async function main({ dicode }) {
 	}
 }
 
-// TestRun_SuspendThenResumeSeesDefinedState is the loop-avoidance regression
-// guard: `state` is required, so the blob a task passes to suspend() is stored
-// and, when fed back on resume, makes ctx.resume_state defined (truthy) — the
-// signal that flips the `if (!resume_state)` guard so the task finishes instead
-// of re-suspending forever. It runs the real suspend pass, takes the captured
-// ResumeState, and replays it exactly as the daemon would.
-func TestRun_SuspendThenResumeSeesDefinedState(t *testing.T) {
+// TestRun_MainOnlyResumeReRunsMain is the single-main back-compat guard: a task
+// exporting only `main` (no `resume`, no `steps`) re-runs `main` on resume, and
+// its author state round-trips through the __step envelope invisibly — the first
+// run sees ctx.state undefined, the resume sees the real unwrapped blob so the
+// author can branch by hand (#512).
+func TestRun_MainOnlyResumeReRunsMain(t *testing.T) {
 	if testing.Short() {
 		t.Skip("requires Deno subprocess")
 	}
@@ -101,17 +109,15 @@ func TestRun_SuspendThenResumeSeesDefinedState(t *testing.T) {
 	rt, reg, cleanup := newTestRuntime(t)
 	defer cleanup()
 
-	// The task suspends on a first run and, on resume, reports whether it saw a
-	// defined resume_state and returns the carried step.
 	spec := writeProviderTask(t, "loopguard", `
-export default async function main({ dicode, resume_state }) {
-  if (!resume_state) {
+export default async function main({ dicode, state, input }) {
+  if (!state) {
     await dicode.suspend({
       state: { step: "ask_name" },
       schema: { type: "object", properties: { project_name: { type: "string" } }, required: ["project_name"] },
     });
   }
-  return { defined: resume_state !== undefined, step: (resume_state as any).step };
+  return { defined: state !== undefined, step: (state as any).step, name: (input as any).project_name };
 }
 `)
 	if err := reg.Register(spec); err != nil {
@@ -126,7 +132,7 @@ export default async function main({ dicode, resume_state }) {
 		t.Fatalf("first run must suspend and capture a state blob; got suspended=%v state=%q", first.Suspended, first.ResumeState)
 	}
 
-	// Replay the stored state exactly as the resume path would.
+	// Replay the stored envelope exactly as the resume path would.
 	second, err := rt.Run(ctx, spec, RunOptions{
 		RunID:       "run-loopguard-2",
 		ResumeState: json.RawMessage(first.ResumeState),
@@ -143,10 +149,189 @@ export default async function main({ dicode, resume_state }) {
 		t.Fatalf("ReturnValue = %#v, want map", second.ReturnValue)
 	}
 	if ret["defined"] != true {
-		t.Errorf("resume_state must be defined on resume, got %#v", ret["defined"])
+		t.Errorf("ctx.state must be defined on resume, got %#v", ret["defined"])
 	}
 	if ret["step"] != "ask_name" {
-		t.Errorf("resume_state.step = %#v, want ask_name", ret["step"])
+		t.Errorf("ctx.state.step = %#v, want ask_name", ret["step"])
+	}
+	if ret["name"] != "acme" {
+		t.Errorf("ctx.input.project_name = %#v, want acme", ret["name"])
+	}
+}
+
+// TestRun_ResumeDispatchesToResumeFn covers the two-function shape: a task
+// exports `main` (first run) and `resume` (resume). The runner must run `resume`
+// on the continuation, handing it the carried state and the validated input via
+// ctx.state / ctx.input (#512).
+func TestRun_ResumeDispatchesToResumeFn(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rt, reg, cleanup := newTestRuntime(t)
+	defer cleanup()
+
+	spec := writeProviderTask(t, "twofunc", `
+export default async function main({ dicode }) {
+  await dicode.suspend({
+    state: { greeting: "hi" },
+    schema: { type: "object", properties: { project_name: { type: "string" } }, required: ["project_name"] },
+  });
+  return { via: "main" };
+}
+export async function resume({ state, input }) {
+  return { via: "resume", greeting: (state as any).greeting, name: (input as any).project_name };
+}
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := rt.Run(ctx, spec, RunOptions{RunID: "run-twofunc-1"})
+	if err != nil {
+		t.Fatalf("Run (suspend): %v", err)
+	}
+	if !first.Suspended {
+		t.Fatalf("first run must suspend")
+	}
+
+	second, err := rt.Run(ctx, spec, RunOptions{
+		RunID:       "run-twofunc-2",
+		ResumeState: json.RawMessage(first.ResumeState),
+		ResumeInput: json.RawMessage(`{"project_name":"acme"}`),
+	})
+	if err != nil {
+		t.Fatalf("Run (resume): %v", err)
+	}
+	if second.Suspended {
+		t.Fatalf("resume must not re-suspend")
+	}
+	ret, ok := second.ReturnValue.(map[string]any)
+	if !ok {
+		t.Fatalf("ReturnValue = %#v, want map", second.ReturnValue)
+	}
+	if ret["via"] != "resume" {
+		t.Errorf("dispatch went to %#v, want the resume handler", ret["via"])
+	}
+	if ret["greeting"] != "hi" {
+		t.Errorf("ctx.state.greeting = %#v, want hi", ret["greeting"])
+	}
+	if ret["name"] != "acme" {
+		t.Errorf("ctx.input.project_name = %#v, want acme", ret["name"])
+	}
+}
+
+// TestRun_StepsWizardMultiStep drives a full named-step wizard (#512): main
+// suspends `to: "chooseFramework"`, that step sees ctx.input and suspends
+// `to: "deploy"` carrying state, and deploy sees the prior state + the new input
+// and returns. Exercises __step envelope threading across two hops, and asserts
+// main sees ctx.state undefined on the first run even with the internal marker.
+func TestRun_StepsWizardMultiStep(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rt, reg, cleanup := newTestRuntime(t)
+	defer cleanup()
+
+	spec := writeProviderTask(t, "steps-wizard", `
+export default async function main({ dicode, state }) {
+  if (state !== undefined) throw new Error("main must see ctx.state undefined on the first run");
+  await dicode.suspend({
+    to: "chooseFramework",
+    schema: { type: "object", properties: { framework: { type: "string" } }, required: ["framework"] },
+  });
+  return { via: "main" };
+}
+export const steps = {
+  async chooseFramework({ dicode, input }) {
+    await dicode.suspend({
+      to: "deploy",
+      state: { framework: (input as any).framework },
+      schema: { type: "object", properties: { env: { type: "string" } }, required: ["env"] },
+    });
+    return { via: "chooseFramework" };
+  },
+  async deploy({ state, input }) {
+    return { framework: (state as any).framework, env: (input as any).env };
+  },
+};
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run 1 — main suspends to chooseFramework.
+	r1, err := rt.Run(ctx, spec, RunOptions{RunID: "run-steps-1"})
+	if err != nil {
+		t.Fatalf("Run 1: %v", err)
+	}
+	if !r1.Suspended {
+		t.Fatalf("run 1 must suspend")
+	}
+	var env1 struct {
+		Step string `json:"__step"`
+	}
+	if err := json.Unmarshal(r1.ResumeState, &env1); err != nil {
+		t.Fatalf("run 1 ResumeState: %v", err)
+	}
+	if env1.Step != "chooseFramework" {
+		t.Fatalf("__step = %q, want chooseFramework", env1.Step)
+	}
+
+	// Run 2 — chooseFramework sees the framework input, suspends to deploy.
+	r2, err := rt.Run(ctx, spec, RunOptions{
+		RunID:       "run-steps-2",
+		ResumeState: json.RawMessage(r1.ResumeState),
+		ResumeInput: json.RawMessage(`{"framework":"deno"}`),
+	})
+	if err != nil {
+		t.Fatalf("Run 2: %v", err)
+	}
+	if !r2.Suspended {
+		t.Fatalf("run 2 must suspend again")
+	}
+	var env2 struct {
+		Step  string `json:"__step"`
+		State struct {
+			Framework string `json:"framework"`
+		} `json:"state"`
+	}
+	if err := json.Unmarshal(r2.ResumeState, &env2); err != nil {
+		t.Fatalf("run 2 ResumeState: %v", err)
+	}
+	if env2.Step != "deploy" {
+		t.Errorf("__step = %q, want deploy", env2.Step)
+	}
+	if env2.State.Framework != "deno" {
+		t.Errorf("carried state.framework = %q, want deno", env2.State.Framework)
+	}
+
+	// Run 3 — deploy sees the prior state + the new env input and finishes.
+	r3, err := rt.Run(ctx, spec, RunOptions{
+		RunID:       "run-steps-3",
+		ResumeState: json.RawMessage(r2.ResumeState),
+		ResumeInput: json.RawMessage(`{"env":"prod"}`),
+	})
+	if err != nil {
+		t.Fatalf("Run 3: %v", err)
+	}
+	if r3.Suspended {
+		t.Fatalf("run 3 must finish, not suspend")
+	}
+	ret, ok := r3.ReturnValue.(map[string]any)
+	if !ok {
+		t.Fatalf("ReturnValue = %#v, want map", r3.ReturnValue)
+	}
+	if ret["framework"] != "deno" {
+		t.Errorf("deploy ctx.state.framework = %#v, want deno", ret["framework"])
+	}
+	if ret["env"] != "prod" {
+		t.Errorf("deploy ctx.input.env = %#v, want prod", ret["env"])
 	}
 }
 
@@ -210,11 +395,9 @@ export default async function main({ dicode }) {
 	}
 }
 
-// TestRun_ResumeStateAndInputExposed injects a prior-run state blob and a
-// user form submission via RunOptions and asserts the task sees them on
-// ctx.resume_state / ctx.resume_input (#95). Nothing in PR 2 populates these
-// from a real suspended run yet — this verifies the accept + expose mechanism
-// with an injected value.
+// TestRun_ResumeStateAndInputExposed injects a prior-run state envelope and a
+// user form submission via RunOptions and asserts the handler sees the UNWRAPPED
+// state on ctx.state and the submission on ctx.input (#512).
 func TestRun_ResumeStateAndInputExposed(t *testing.T) {
 	if testing.Short() {
 		t.Skip("requires Deno subprocess")
@@ -226,8 +409,8 @@ func TestRun_ResumeStateAndInputExposed(t *testing.T) {
 	defer cleanup()
 
 	spec := writeProviderTask(t, "resumer", `
-export default async function main({ resume_state, resume_input }) {
-  return { st: resume_state, inp: resume_input };
+export default async function main({ state, input }) {
+  return { st: state, inp: input };
 }
 `)
 	if err := reg.Register(spec); err != nil {
@@ -236,7 +419,7 @@ export default async function main({ resume_state, resume_input }) {
 
 	res, err := rt.Run(ctx, spec, RunOptions{
 		RunID:       "run-resume-1",
-		ResumeState: json.RawMessage(`{"step":"ask_framework","name":"proj"}`),
+		ResumeState: json.RawMessage(`{"__step":null,"state":{"step":"ask_framework","name":"proj"}}`),
 		ResumeInput: json.RawMessage(`{"project_name":"acme"}`),
 	})
 	if err != nil {
@@ -255,23 +438,23 @@ export default async function main({ resume_state, resume_input }) {
 	}
 	st, ok := ret["st"].(map[string]any)
 	if !ok {
-		t.Fatalf("resume_state not exposed: %#v", ret["st"])
+		t.Fatalf("ctx.state not exposed (unwrapped): %#v", ret["st"])
 	}
 	if st["step"] != "ask_framework" || st["name"] != "proj" {
-		t.Errorf("resume_state = %#v, want step=ask_framework name=proj", st)
+		t.Errorf("ctx.state = %#v, want step=ask_framework name=proj", st)
 	}
 	inp, ok := ret["inp"].(map[string]any)
 	if !ok {
-		t.Fatalf("resume_input not exposed: %#v", ret["inp"])
+		t.Fatalf("ctx.input not exposed: %#v", ret["inp"])
 	}
 	if inp["project_name"] != "acme" {
-		t.Errorf("resume_input = %#v, want project_name=acme", inp)
+		t.Errorf("ctx.input = %#v, want project_name=acme", inp)
 	}
 }
 
-// TestRun_NoResumeIsUndefined verifies that a first (non-resume) invocation
-// sees ctx.resume_state / ctx.resume_input as undefined (#95), so a task can
-// branch on their presence.
+// TestRun_NoResumeIsUndefined verifies that a first (non-resume) invocation sees
+// ctx.state undefined (#512), so a handler can branch on its presence. ctx.input
+// on a first run is the trigger input (nil here), not the resume submission.
 func TestRun_NoResumeIsUndefined(t *testing.T) {
 	if testing.Short() {
 		t.Skip("requires Deno subprocess")
@@ -283,8 +466,8 @@ func TestRun_NoResumeIsUndefined(t *testing.T) {
 	defer cleanup()
 
 	spec := writeProviderTask(t, "firstrun", `
-export default async function main({ resume_state, resume_input }) {
-  return { hasState: resume_state !== undefined, hasInput: resume_input !== undefined };
+export default async function main({ state }) {
+  return { hasState: state !== undefined };
 }
 `)
 	if err := reg.Register(spec); err != nil {
@@ -302,7 +485,7 @@ export default async function main({ resume_state, resume_input }) {
 	if !ok {
 		t.Fatalf("ReturnValue = %#v, want map", res.ReturnValue)
 	}
-	if ret["hasState"] != false || ret["hasInput"] != false {
-		t.Errorf("expected resume_state/resume_input undefined on first run, got %#v", ret)
+	if ret["hasState"] != false {
+		t.Errorf("expected ctx.state undefined on first run, got %#v", ret)
 	}
 }

--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -419,23 +419,23 @@ func buildWrapper(scriptBytes []byte, pol guardPolicy) (string, error) {
 	w.WriteString(body)
 	w.WriteString("\n# === return capture ===\n")
 	w.WriteString("import sys as _sys\n")
-	w.WriteString("_asyncio_mod = _sys.modules['asyncio']\n")
-	// A clean dicode.suspend() from inside main() raises SuspendSignal after the
-	// payload is recorded — exit 0 without a return value (a suspend is not a
-	// failure). If task code instead swallowed the signal and returned, the
-	// suspend flag is still set: fail loudly rather than record a contradictory
-	// suspended-and-returned run (#95). A suspend at task top level (sync tasks)
-	// unwinds past this block and is handled by the SDK's sys.excepthook.
+	// _dispatch auto-selects the task handler from the resume context (#512):
+	// first run → main; a resume → steps[to] (wizard) or resume() (two-function),
+	// falling back to main so a single-main task keeps working. The author reads
+	// ctx.state / ctx.input, never a step switch. A clean dicode.suspend() raises
+	// SuspendSignal after the payload is recorded — exit 0 without a return value
+	// (a suspend is not a failure). If task code instead swallowed the signal and
+	// returned, the suspend flag is still set: fail loudly rather than record a
+	// contradictory suspended-and-returned run (#95). A suspend at task top level
+	// (sync tasks) unwinds past this block and is handled by the SDK's excepthook.
 	w.WriteString("try:\n")
-	w.WriteString("    _main = globals().get('main')\n")
-	w.WriteString("    if _main is not None and _asyncio_mod.iscoroutinefunction(_main):\n")
-	w.WriteString("        result = _asyncio_mod.run(_main())\n")
+	w.WriteString("    result = _dispatch(globals())\n")
 	w.WriteString("    if _was_suspend_requested():\n")
 	w.WriteString("        _sys.stderr.write(\"[dicode] dicode.suspend() was called but its control-flow signal was caught by task code — do not wrap dicode.suspend() in a try/except that swallows it\\n\")\n")
 	w.WriteString("        _sys.stderr.flush()\n")
 	w.WriteString("        _flush_and_close()\n")
 	w.WriteString("        _sys.exit(1)\n")
-	w.WriteString("    _set_return(globals().get('result', None))\n")
+	w.WriteString("    _set_return(result)\n")
 	w.WriteString("except SuspendSignal:\n")
 	w.WriteString("    _flush_and_close()\n")
 	w.WriteString("    _sys.exit(0)\n")

--- a/pkg/runtime/python/sdk/dicode_sdk.py
+++ b/pkg/runtime/python/sdk/dicode_sdk.py
@@ -16,6 +16,7 @@
 #                               dicode.get_runs,
 #                               mcp.list_tools, mcp.call
 import asyncio
+import inspect
 import json
 import os
 import struct
@@ -257,9 +258,9 @@ input = _call({"method": "input"})
 # ── suspend / resume (#95) ────────────────────────────────────────────────────
 # dicode.suspend() pauses the run: it hands the daemon a state blob + schema, then
 # raises SuspendSignal so the process exits cleanly (exit 0) and the run ends as
-# `suspended`. On resume the task is re-run with ctx.resume_state /
-# ctx.resume_input populated. See runtime.go for how the wrapper turns a clean
-# suspend into a suspended RunResult.
+# `suspended`. On resume the runner dispatches the matching handler with ctx.state
+# / ctx.input populated. See runtime.go for how the wrapper turns a clean suspend
+# into a suspended RunResult.
 
 
 class SuspendSignal(Exception):
@@ -301,18 +302,72 @@ def _flush_and_close():
         pass
 
 
+def _unwrap_state(raw):
+    """Unwrap the { __step, state } envelope suspend() persists (#512). Returns
+    (step, author_state). A raw value without a __step key is treated as the
+    author state directly (step None)."""
+    if isinstance(raw, dict) and "__step" in raw:
+        step = raw.get("__step")
+        return (step if isinstance(step, str) else None), raw.get("state")
+    return None, raw
+
+
 class _Context:
-    """Resume context (#95). resume_state is the prior suspended run's opaque
-    state blob; resume_input is the user's form submission. Both are None on a
-    first (non-resume) invocation. Fetched once at import time."""
+    """Resume context (#512). `state` is the author's carried blob (unwrapped
+    from the internal step envelope); `input` is the input handed to THIS
+    invocation — the trigger input on a fresh run, the validated form submission
+    on a resume. `state` and the resume input are None on a first run. `_step`
+    names the handler the resume dispatches to. Fetched once at import time."""
 
-    def __init__(self):
+    def __init__(self, trigger_input):
         r = _call({"method": "resume"}) or {}
-        self.resume_state = r.get("state")
-        self.resume_input = r.get("input")
+        raw = r.get("state")
+        self._resumed = raw is not None
+        self._step, self.state = _unwrap_state(raw)
+        self.input = r.get("input") if self._resumed else trigger_input
 
 
-ctx = _Context()
+ctx = _Context(input)
+
+
+def _call_handler(fn):
+    """Invoke a task handler, passing `ctx` if it declares a positional
+    parameter and awaiting it if it returns a coroutine (#512). A no-arg
+    handler keeps reading the module-global `ctx`."""
+    wants_arg = False
+    try:
+        for p in inspect.signature(fn).parameters.values():
+            if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD, p.VAR_POSITIONAL):
+                wants_arg = True
+                break
+    except (TypeError, ValueError):
+        pass
+    res = fn(ctx) if wants_arg else fn()
+    if asyncio.iscoroutine(res):
+        res = asyncio.run(res)
+    return res
+
+
+def _dispatch(g):
+    """Select and run the task handler from the resume context (#512). First run
+    → main; a resume with a step marker → steps[step] (wizard shape); a resume
+    without → resume() if exported, else main (two-function / single-main shape).
+    g is the task module globals(). Falls through to the module-level `result`
+    for a top-level (no-main) task."""
+    main = g.get("main")
+    resume = g.get("resume")
+    steps = g.get("steps")
+    if not ctx._resumed:
+        handler = main
+    elif ctx._step is not None and isinstance(steps, dict) and callable(steps.get(ctx._step)):
+        handler = steps.get(ctx._step)
+    elif callable(resume):
+        handler = resume
+    else:
+        handler = main
+    if not callable(handler):
+        return g.get("result")
+    return _call_handler(handler)
 
 
 # A dicode.suspend() at task top level (a synchronous task) raises SuspendSignal
@@ -520,24 +575,25 @@ class _Dicode:
         # by the WebUI to collapse same-group siblings. Last write wins.
         _call({"method": "dicode.set_group", "group": str(label or "")})
 
-    def suspend(self, state, schema=None, deadline=None):
+    def suspend(self, state=None, schema=None, to=None, deadline=None):
         """Pause the run and wait for user input (#512). Records the state blob +
         JSON Schema over IPC, then raises SuspendSignal — it never returns. The
         wrapper exits the process cleanly and the run ends as `suspended`; on
-        resume the task is re-run with ctx.resume_state / ctx.resume_input
-        populated (the submission, validated against `schema` server-side). Do
-        not wrap this call in a try/except that swallows the signal.
+        resume the runner dispatches the matching handler with ctx.state /
+        ctx.input populated (the submission, validated against `schema`
+        server-side). Do not wrap this call in a try/except that swallows the
+        signal.
 
-        `state` is REQUIRED: it is the only signal that tells a first run
-        (ctx.resume_state is None) apart from a resume (ctx.resume_state = this
-        object). A None/missing state reads back as None on resume, so an
-        `if ctx.resume_state is None` guard would fire again and the task would
-        re-suspend forever. Pass at least `{}` when you carry nothing."""
+        `to` names the step handler to run on resume (wizard shape); omit it for
+        the two-function (main/resume) or single-main shape. `state` is the
+        author's carried blob, echoed back as ctx.state (unwrapped) on resume."""
         global _suspend_requested
         # Await the ack so the payload is recorded before we raise: the daemon
         # captures state/schema/deadline synchronously in response to this call.
+        # Persist an envelope so the runner can dispatch steps[to] on resume; the
+        # author's blob rides in `state` and is unwrapped before any handler runs.
         _call({"method": "dicode.suspend",
-               "state": state, "schema": schema,
+               "state": {"__step": to, "state": state}, "schema": schema,
                "deadline": deadline or 0})
         _suspend_requested = True
         raise SuspendSignal()

--- a/pkg/runtime/python/sdk/test_dicode_sdk.py
+++ b/pkg/runtime/python/sdk/test_dicode_sdk.py
@@ -360,6 +360,7 @@ class SuspendTests(SDKTestBase):
         self.assertFalse(sdk._was_suspend_requested())
         with self.assertRaises(sdk.SuspendSignal):
             sdk.dicode.suspend(
+                to="deploy",
                 state={"step": "one", "n": 42},
                 schema={"type": "object", "title": "Name?", "properties": {
                     "project_name": {"type": "string", "title": "Name"}}},
@@ -368,7 +369,10 @@ class SuspendTests(SDKTestBase):
         # The signal was raised only after the payload was acked, and the
         # module-level flag is set so the wrapper's swallow-guard can fire.
         self.assertTrue(sdk._was_suspend_requested())
-        self.assertEqual(captured["state"], {"step": "one", "n": 42})
+        # State is persisted wrapped in a { __step, state } envelope so the runner
+        # can dispatch steps[to] on resume; the author's blob rides in `state`.
+        self.assertEqual(captured["state"],
+                         {"__step": "deploy", "state": {"step": "one", "n": 42}})
         self.assertEqual(captured["schema"]["title"], "Name?")
         self.assertEqual(captured["deadline"], 1893456000000)
 
@@ -383,18 +387,21 @@ class SuspendTests(SDKTestBase):
 class ResumeContextTests(SDKTestBase):
     def test_ctx_none_on_first_run(self):
         sdk = self.load_sdk()
-        self.assertIsNone(sdk.ctx.resume_state)
-        self.assertIsNone(sdk.ctx.resume_input)
+        self.assertFalse(sdk.ctx._resumed)
+        self.assertIsNone(sdk.ctx.state)
 
-    def test_ctx_exposes_injected_state_and_input(self):
+    def test_ctx_unwraps_step_envelope(self):
+        # The real path persists a { __step, state } envelope; the SDK unwraps
+        # it so the author sees only their own blob on ctx.state.
         self.server.handlers["resume"] = lambda _: {
-            "state": {"step": "ask_framework", "name": "proj"},
+            "state": {"__step": "deploy", "state": {"name": "proj"}},
             "input": {"project_name": "acme"},
         }
         sdk = self.load_sdk()
-        self.assertEqual(sdk.ctx.resume_state,
-                         {"step": "ask_framework", "name": "proj"})
-        self.assertEqual(sdk.ctx.resume_input, {"project_name": "acme"})
+        self.assertTrue(sdk.ctx._resumed)
+        self.assertEqual(sdk.ctx._step, "deploy")
+        self.assertEqual(sdk.ctx.state, {"name": "proj"})
+        self.assertEqual(sdk.ctx.input, {"project_name": "acme"})
 
 
 class ReturnTests(SDKTestBase):

--- a/pkg/runtime/python/suspend_test.go
+++ b/pkg/runtime/python/suspend_test.go
@@ -50,7 +50,8 @@ func newSuspendExecutor(t *testing.T) (*registry.Registry, pkgruntime.Executor) 
 // TestExecute_SuspendYieldsSuspendedResult runs a real Python task that calls
 // dicode.suspend(state=..., schema=..., deadline=...) and asserts the run ends
 // as a clean suspend (not a failure) with the state/schema/deadline captured on
-// the RunResult (#512). The SuspendSignal must exit the process with code 0.
+// the RunResult (#512). The runner persists `state` wrapped in a { __step, state }
+// envelope; the SuspendSignal must exit the process with code 0.
 func TestExecute_SuspendYieldsSuspendedResult(t *testing.T) {
 	if testing.Short() {
 		t.Skip("requires uv subprocess")
@@ -101,15 +102,23 @@ async def main():
 		t.Errorf("ResumeDeadline = %d, want 1893456000000", res.ResumeDeadline)
 	}
 
-	var state struct {
-		Step string `json:"step"`
-		N    int    `json:"n"`
+	// ResumeState is the internal envelope: __step null (no `to`), the author's
+	// blob nested under `state`.
+	var env struct {
+		Step  *string `json:"__step"`
+		State struct {
+			Step string `json:"step"`
+			N    int    `json:"n"`
+		} `json:"state"`
 	}
-	if err := json.Unmarshal(res.ResumeState, &state); err != nil {
+	if err := json.Unmarshal(res.ResumeState, &env); err != nil {
 		t.Fatalf("ResumeState not valid JSON (%q): %v", res.ResumeState, err)
 	}
-	if state.Step != "ask_name" || state.N != 42 {
-		t.Errorf("ResumeState = %+v, want {ask_name 42}", state)
+	if env.Step != nil {
+		t.Errorf("__step = %v, want null for a two-function/main suspend", *env.Step)
+	}
+	if env.State.Step != "ask_name" || env.State.N != 42 {
+		t.Errorf("unwrapped state = %+v, want {ask_name 42}", env.State)
 	}
 
 	var schema struct {
@@ -127,9 +136,9 @@ async def main():
 }
 
 // TestExecute_SuspendAtTopLevelYieldsSuspendedResult covers a synchronous task
-// that calls dicode.suspend() at module top level (no async main). The
-// SuspendSignal unwinds past the return-capture epilogue and is caught by the
-// SDK's sys.excepthook, which still exits the process cleanly (#95).
+// that calls dicode.suspend() at module top level (no main). The SuspendSignal
+// unwinds past the return-capture epilogue and is caught by the SDK's
+// sys.excepthook, which still exits the process cleanly (#95).
 func TestExecute_SuspendAtTopLevelYieldsSuspendedResult(t *testing.T) {
 	if testing.Short() {
 		t.Skip("requires uv subprocess")
@@ -140,7 +149,7 @@ func TestExecute_SuspendAtTopLevelYieldsSuspendedResult(t *testing.T) {
 	reg, ex := newSuspendExecutor(t)
 
 	spec := writePythonTask(t, "examples/sync-wizard", `
-if ctx.resume_state is None:
+if ctx.state is None:
     dicode.suspend(
         state={"step": "sync"},
         schema={"type": "object", "properties": {"x": {"type": "string"}}},
@@ -169,14 +178,277 @@ result = {"reached": True}
 	if res.ChainInput != nil {
 		t.Errorf("suspend must not produce a return value, got %#v", res.ChainInput)
 	}
-	var state struct {
-		Step string `json:"step"`
+	var env struct {
+		State struct {
+			Step string `json:"step"`
+		} `json:"state"`
 	}
-	if err := json.Unmarshal(res.ResumeState, &state); err != nil {
+	if err := json.Unmarshal(res.ResumeState, &env); err != nil {
 		t.Fatalf("ResumeState not valid JSON (%q): %v", res.ResumeState, err)
 	}
-	if state.Step != "sync" {
-		t.Errorf("ResumeState = %+v, want step=sync", state)
+	if env.State.Step != "sync" {
+		t.Errorf("unwrapped state = %+v, want step=sync", env.State)
+	}
+}
+
+// TestExecute_MainOnlyResumeReRunsMain is the single-main back-compat guard: a
+// task defining only `main` re-runs `main` on resume, its author state round-trips
+// through the __step envelope invisibly, and the handler reads ctx.state /
+// ctx.input from the module-global ctx (#512).
+func TestExecute_MainOnlyResumeReRunsMain(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires uv subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	reg, ex := newSuspendExecutor(t)
+
+	spec := writePythonTask(t, "examples/loopguard", `
+async def main():
+    if ctx.state is None:
+        dicode.suspend(
+            state={"step": "ask_name"},
+            schema={"type": "object", "properties": {"project_name": {"type": "string"}}, "required": ["project_name"]},
+        )
+    return {"defined": ctx.state is not None, "step": ctx.state["step"], "name": ctx.input["project_name"]}
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+	runID, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{RunID: runID})
+	if err != nil {
+		t.Fatalf("Execute (suspend): %v", err)
+	}
+	if !first.Suspended || len(first.ResumeState) == 0 {
+		t.Fatalf("first run must suspend and capture a state blob; got suspended=%v", first.Suspended)
+	}
+
+	runID2, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{
+		RunID:       runID2,
+		ResumeState: json.RawMessage(first.ResumeState),
+		ResumeInput: json.RawMessage(`{"project_name":"acme"}`),
+	})
+	if err != nil {
+		t.Fatalf("Execute (resume): %v", err)
+	}
+	logs, _ := reg.GetRunLogs(ctx, runID2)
+	if second.Suspended {
+		t.Fatalf("resume must not re-suspend\nlogs:\n%s", joinLogs(logs))
+	}
+	ret, ok := second.ChainInput.(map[string]any)
+	if !ok {
+		t.Fatalf("ChainInput = %#v, want map\nlogs:\n%s", second.ChainInput, joinLogs(logs))
+	}
+	if ret["defined"] != true {
+		t.Errorf("ctx.state must be defined on resume, got %#v", ret["defined"])
+	}
+	if ret["step"] != "ask_name" {
+		t.Errorf("ctx.state[step] = %#v, want ask_name", ret["step"])
+	}
+	if ret["name"] != "acme" {
+		t.Errorf("ctx.input[project_name] = %#v, want acme", ret["name"])
+	}
+}
+
+// TestExecute_ResumeDispatchesToResumeFn covers the two-function shape: main
+// (no args, reads global ctx) suspends, and `resume(ctx)` (arg style) runs on
+// the continuation with the carried state + validated input (#512).
+func TestExecute_ResumeDispatchesToResumeFn(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires uv subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	reg, ex := newSuspendExecutor(t)
+
+	spec := writePythonTask(t, "examples/twofunc", `
+async def main():
+    dicode.suspend(
+        state={"greeting": "hi"},
+        schema={"type": "object", "properties": {"project_name": {"type": "string"}}, "required": ["project_name"]},
+    )
+    return {"via": "main"}
+
+async def resume(ctx):
+    return {"via": "resume", "greeting": ctx.state["greeting"], "name": ctx.input["project_name"]}
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+	runID, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{RunID: runID})
+	if err != nil {
+		t.Fatalf("Execute (suspend): %v", err)
+	}
+	if !first.Suspended {
+		t.Fatalf("first run must suspend")
+	}
+
+	runID2, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{
+		RunID:       runID2,
+		ResumeState: json.RawMessage(first.ResumeState),
+		ResumeInput: json.RawMessage(`{"project_name":"acme"}`),
+	})
+	if err != nil {
+		t.Fatalf("Execute (resume): %v", err)
+	}
+	logs, _ := reg.GetRunLogs(ctx, runID2)
+	if second.Suspended {
+		t.Fatalf("resume must not re-suspend\nlogs:\n%s", joinLogs(logs))
+	}
+	ret, ok := second.ChainInput.(map[string]any)
+	if !ok {
+		t.Fatalf("ChainInput = %#v, want map\nlogs:\n%s", second.ChainInput, joinLogs(logs))
+	}
+	if ret["via"] != "resume" {
+		t.Errorf("dispatch went to %#v, want the resume handler", ret["via"])
+	}
+	if ret["greeting"] != "hi" {
+		t.Errorf("ctx.state[greeting] = %#v, want hi", ret["greeting"])
+	}
+	if ret["name"] != "acme" {
+		t.Errorf("ctx.input[project_name] = %#v, want acme", ret["name"])
+	}
+}
+
+// TestExecute_StepsWizardMultiStep drives a full named-step wizard (#512): main
+// suspends to="choose_framework", that step sees ctx.input and suspends
+// to="deploy" carrying state, and deploy sees the prior state + the new input
+// and returns. Step handlers take ctx as an argument.
+func TestExecute_StepsWizardMultiStep(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires uv subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	reg, ex := newSuspendExecutor(t)
+
+	spec := writePythonTask(t, "examples/steps-wizard", `
+async def main():
+    assert ctx.state is None, "main must see ctx.state None on the first run"
+    dicode.suspend(
+        to="choose_framework",
+        schema={"type": "object", "properties": {"framework": {"type": "string"}}, "required": ["framework"]},
+    )
+    return {"via": "main"}
+
+async def choose_framework(ctx):
+    dicode.suspend(
+        to="deploy",
+        state={"framework": ctx.input["framework"]},
+        schema={"type": "object", "properties": {"env": {"type": "string"}}, "required": ["env"]},
+    )
+    return {"via": "choose_framework"}
+
+async def deploy(ctx):
+    return {"framework": ctx.state["framework"], "env": ctx.input["env"]}
+
+steps = {"choose_framework": choose_framework, "deploy": deploy}
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run 1 — main suspends to choose_framework.
+	runID1, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r1, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{RunID: runID1})
+	if err != nil {
+		t.Fatalf("Run 1: %v", err)
+	}
+	logs1, _ := reg.GetRunLogs(ctx, runID1)
+	if !r1.Suspended {
+		t.Fatalf("run 1 must suspend\nlogs:\n%s", joinLogs(logs1))
+	}
+	var env1 struct {
+		Step string `json:"__step"`
+	}
+	if err := json.Unmarshal(r1.ResumeState, &env1); err != nil {
+		t.Fatalf("run 1 ResumeState: %v", err)
+	}
+	if env1.Step != "choose_framework" {
+		t.Fatalf("__step = %q, want choose_framework", env1.Step)
+	}
+
+	// Run 2 — choose_framework sees the framework input, suspends to deploy.
+	runID2, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r2, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{
+		RunID:       runID2,
+		ResumeState: json.RawMessage(r1.ResumeState),
+		ResumeInput: json.RawMessage(`{"framework":"deno"}`),
+	})
+	if err != nil {
+		t.Fatalf("Run 2: %v", err)
+	}
+	logs2, _ := reg.GetRunLogs(ctx, runID2)
+	if !r2.Suspended {
+		t.Fatalf("run 2 must suspend again\nlogs:\n%s", joinLogs(logs2))
+	}
+	var env2 struct {
+		Step  string `json:"__step"`
+		State struct {
+			Framework string `json:"framework"`
+		} `json:"state"`
+	}
+	if err := json.Unmarshal(r2.ResumeState, &env2); err != nil {
+		t.Fatalf("run 2 ResumeState: %v", err)
+	}
+	if env2.Step != "deploy" {
+		t.Errorf("__step = %q, want deploy", env2.Step)
+	}
+	if env2.State.Framework != "deno" {
+		t.Errorf("carried state.framework = %q, want deno", env2.State.Framework)
+	}
+
+	// Run 3 — deploy sees the prior state + the new env input and finishes.
+	runID3, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r3, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{
+		RunID:       runID3,
+		ResumeState: json.RawMessage(r2.ResumeState),
+		ResumeInput: json.RawMessage(`{"env":"prod"}`),
+	})
+	if err != nil {
+		t.Fatalf("Run 3: %v", err)
+	}
+	logs3, _ := reg.GetRunLogs(ctx, runID3)
+	if r3.Suspended {
+		t.Fatalf("run 3 must finish, not suspend\nlogs:\n%s", joinLogs(logs3))
+	}
+	ret, ok := r3.ChainInput.(map[string]any)
+	if !ok {
+		t.Fatalf("ChainInput = %#v, want map\nlogs:\n%s", r3.ChainInput, joinLogs(logs3))
+	}
+	if ret["framework"] != "deno" {
+		t.Errorf("deploy ctx.state[framework] = %#v, want deno", ret["framework"])
+	}
+	if ret["env"] != "prod" {
+		t.Errorf("deploy ctx.input[env] = %#v, want prod", ret["env"])
 	}
 }
 
@@ -241,9 +513,9 @@ async def main():
 	}
 }
 
-// TestExecute_ResumeStateAndInputExposed injects a prior-run state blob and a
-// user form submission via RunOptions and asserts the task sees them on
-// ctx.resume_state / ctx.resume_input (#95).
+// TestExecute_ResumeStateAndInputExposed injects a prior-run state envelope and a
+// user form submission via RunOptions and asserts the handler sees the UNWRAPPED
+// state on ctx.state and the submission on ctx.input (#512).
 func TestExecute_ResumeStateAndInputExposed(t *testing.T) {
 	if testing.Short() {
 		t.Skip("requires uv subprocess")
@@ -255,7 +527,7 @@ func TestExecute_ResumeStateAndInputExposed(t *testing.T) {
 
 	spec := writePythonTask(t, "examples/resumer", `
 async def main():
-    return {"st": ctx.resume_state, "inp": ctx.resume_input}
+    return {"st": ctx.state, "inp": ctx.input}
 `)
 	if err := reg.Register(spec); err != nil {
 		t.Fatal(err)
@@ -267,7 +539,7 @@ async def main():
 
 	res, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{
 		RunID:       runID,
-		ResumeState: json.RawMessage(`{"step":"ask_framework","name":"proj"}`),
+		ResumeState: json.RawMessage(`{"__step":null,"state":{"step":"ask_framework","name":"proj"}}`),
 		ResumeInput: json.RawMessage(`{"project_name":"acme"}`),
 	})
 	if err != nil {
@@ -287,23 +559,22 @@ async def main():
 	}
 	st, ok := ret["st"].(map[string]any)
 	if !ok {
-		t.Fatalf("resume_state not exposed: %#v", ret["st"])
+		t.Fatalf("ctx.state not exposed (unwrapped): %#v", ret["st"])
 	}
 	if st["step"] != "ask_framework" || st["name"] != "proj" {
-		t.Errorf("resume_state = %#v, want step=ask_framework name=proj", st)
+		t.Errorf("ctx.state = %#v, want step=ask_framework name=proj", st)
 	}
 	inp, ok := ret["inp"].(map[string]any)
 	if !ok {
-		t.Fatalf("resume_input not exposed: %#v", ret["inp"])
+		t.Fatalf("ctx.input not exposed: %#v", ret["inp"])
 	}
 	if inp["project_name"] != "acme" {
-		t.Errorf("resume_input = %#v, want project_name=acme", inp)
+		t.Errorf("ctx.input = %#v, want project_name=acme", inp)
 	}
 }
 
 // TestExecute_NoResumeIsNone verifies that a first (non-resume) invocation sees
-// ctx.resume_state / ctx.resume_input as None (#95), so a task can branch on
-// their presence.
+// ctx.state as None (#512), so a handler can branch on its presence.
 func TestExecute_NoResumeIsNone(t *testing.T) {
 	if testing.Short() {
 		t.Skip("requires uv subprocess")
@@ -315,7 +586,7 @@ func TestExecute_NoResumeIsNone(t *testing.T) {
 
 	spec := writePythonTask(t, "examples/firstrun", `
 async def main():
-    return {"has_state": ctx.resume_state is not None, "has_input": ctx.resume_input is not None}
+    return {"has_state": ctx.state is not None}
 `)
 	if err := reg.Register(spec); err != nil {
 		t.Fatal(err)
@@ -337,7 +608,7 @@ async def main():
 	if !ok {
 		t.Fatalf("ChainInput = %#v, want map", res.ChainInput)
 	}
-	if ret["has_state"] != false || ret["has_input"] != false {
-		t.Errorf("expected resume_state/resume_input None on first run, got %#v", ret)
+	if ret["has_state"] != false {
+		t.Errorf("expected ctx.state None on first run, got %#v", ret)
 	}
 }

--- a/tasks/sdk.ts
+++ b/tasks/sdk.ts
@@ -81,7 +81,7 @@ export interface DicodeAudit {
 
 // A JSON Schema (draft 2020-12) object describing the input a suspended task
 // asks the user to fill in before resume (#512). The daemon validates the
-// submission against it server-side, so ctx.resume_input conforms on resume.
+// submission against it server-side, so ctx.input conforms on resume.
 // Loosely typed on purpose — any valid JSON Schema is accepted; the common
 // keywords the default WebUI renderer understands are `type`, `properties`,
 // `required`, `enum`, `default`, `title`, `description`, and `format`.
@@ -97,18 +97,18 @@ export type JSONSchema = {
   [keyword: string]: unknown;
 };
 
-// Argument to dicode.suspend() (#512). `state` is an opaque JSON blob echoed
-// back as ctx.resume_state on resume; `schema` is the JSON Schema the submitted
+// Argument to dicode.suspend() (#512). `schema` is the JSON Schema the submitted
 // input is validated against; `deadline` is an optional Unix-ms TTL.
 //
-// `state` is REQUIRED: it is the sole signal that distinguishes a first run
-// (ctx.resume_state undefined) from a resume (ctx.resume_state = this object).
-// A missing/null state reads back as undefined on resume, so an
-// `if (!resume_state)` guard would fire again and the task would re-suspend
-// forever. Pass at least `{}` when you carry nothing.
+// `to` names the step handler to run on resume — the wizard shape: the runner
+// dispatches `steps[to]`. Omit `to` for the two-function shape (main + resume)
+// or a single-main task that branches by hand. `state` is the author's carried
+// blob, echoed back as ctx.state (unwrapped) on the resume; the runner persists
+// it wrapped with an internal step marker the author never sees.
 export interface SuspendRequest {
-  state: unknown;
   schema: JSONSchema;
+  to?: string;
+  state?: unknown;
   deadline?: number;
 }
 
@@ -122,9 +122,10 @@ export interface Dicode {
   run_task(taskID: string, params?: Record<string, string>): Promise<unknown>;
   list_tasks(): Promise<unknown[]>;
   get_runs(taskID: string, opts?: { limit?: number }): Promise<unknown[]>;
-  // Pause the run: hand the runtime `state` + `schema`, then never resolve — the
-  // process exits cleanly and the run ends as `suspended`. On resume the task
-  // re-runs with ctx.resume_state / ctx.resume_input populated (#512).
+  // Pause the run: hand the runtime `schema` + carried `state`, then never
+  // resolve — the process exits cleanly and the run ends as `suspended`. On
+  // resume the runner dispatches the matching handler (steps[to], resume, or
+  // main) with ctx.state / ctx.input populated (#512).
   suspend(req: SuspendRequest): Promise<never>;
   secrets_set(key: string, value: string): Promise<void>;
   secrets_delete(key: string): Promise<void>;
@@ -132,17 +133,26 @@ export interface Dicode {
   audit: DicodeAudit;
 }
 
+// The context each task handler (main / resume / steps[x]) receives (#512).
 export interface DicodeSdk {
   params: Params;
   kv:     KV;
+  // The input handed to THIS invocation: the trigger payload on a fresh run, the
+  // schema-validated form submission on a resume.
   input:  unknown;
-  // Prior state blob when this run is a resume of a suspended one; the same
-  // value passed to dicode.suspend({ state }). Undefined on a first run (#95).
-  resume_state?: unknown;
-  // The user's form submission that triggered this resume, keyed by field name.
-  // Undefined on a first run (#95).
-  resume_input?: Record<string, unknown>;
+  // The author's carried blob, unwrapped from dicode.suspend({ state }). Undefined
+  // on a first run — so a handler can tell first-vs-resume without a step switch.
+  state?: unknown;
   output: Output;
   mcp:    MCP;
   dicode: Dicode;
 }
+
+// A task handler — the default export (`main`, the entry step), an optional
+// `resume`, or a named entry in the `steps` map (#512). Each receives the
+// resume context and returns the run's result (or suspends again).
+export type TaskHandler = (ctx: DicodeSdk) => unknown | Promise<unknown>;
+
+// The wizard shape: a map of named step handlers. dicode.suspend({ to }) names
+// the entry the runner dispatches on resume; `main` is the first step.
+export type TaskSteps = Record<string, TaskHandler>;

--- a/tasks/skills/dicode-task-dev.md
+++ b/tasks/skills/dicode-task-dev.md
@@ -204,21 +204,22 @@ const tools  = await mcp.list_tools("github-mcp")
 const result = await mcp.call("github-mcp", "search_repositories", { query: "dicode" })
 ```
 
-### `suspend` / `resume_state` / `resume_input` — pause for user input
+### `suspend` — pause for user input, auto-dispatched
 Pause a run to collect input from a human, then continue. `dicode.suspend()`
 never returns: the process exits, the run becomes `suspended`, and on resume the
-task re-runs **from the top** with `resume_state` / `resume_input` populated
-(both `undefined` on a first run). `resume_input` is validated against the
-declared JSON Schema server-side. Branch on `resume_state` to pick up where you
-left off. No permission declaration needed; Deno/Python only (not docker/podman).
+runner **re-runs the file and dispatches the right handler** — you never write an
+`if (resume_state)` switch. Each handler reads `ctx.state` (the blob you carried,
+`undefined`/`None` on the first run) and `ctx.input` (the validated submission).
+No permission declaration needed; Deno/Python only (not docker/podman).
 
-`schema` is a JSON Schema (draft 2020-12) for the input object; the daemon
-validates the submission against it before resuming, so `resume_input` conforms.
+Export **`main`** (first run) + optionally **`resume`** (the continuation), or a
+**`steps`** map named by `suspend({ to })` for a multi-step wizard. `schema` is a
+JSON Schema (draft 2020-12); the daemon validates the submission against it
+before resuming, so `ctx.input` conforms.
 
 ```typescript
-if (!resume_state) {
+export default async function main({ dicode }) {
   await dicode.suspend({
-    state: { step: "confirm" },              // JSON-serializable; echoed back as resume_state
     schema: {
       type: "object",
       title: "Deploy to production?",
@@ -231,8 +232,10 @@ if (!resume_state) {
   })
   // unreachable — suspend() never returns
 }
-const answers = resume_input as Record<string, unknown>
-if (!answers.approve) return { deployed: false }
+
+export async function resume({ input }) {
+  return { deployed: Boolean(input.approve) }
+}
 ```
 
 Default WebUI renderer maps the common subset: `type:string`→text (`format:"textarea"`→textarea),
@@ -241,8 +244,10 @@ Default WebUI renderer maps the common subset: `type:string`→text (`format:"te
 
 Rules: never wrap `suspend()` in a `try/catch` that swallows the control signal
 (the run fails loudly if you do); `params` survive a resume but the original
-trigger `input` does not — stash anything you need into `state`. Python uses
-`ctx.resume_state` / `ctx.resume_input` and `dicode.suspend(state=..., schema=...)`.
+trigger `input` does not — stash anything you need into `state`. Python defines
+`main` / `resume` / `steps` and reads the module-global `ctx` (`ctx.state`,
+`ctx.input`), or accepts it as a handler argument (`async def resume(ctx):`);
+`dicode.suspend(schema=..., to=..., state=...)`.
 Full reference: [docs/concepts/suspendable-tasks.md](../../docs/concepts/suspendable-tasks.md).
 
 ### `return` — pass data to downstream chain tasks

--- a/tests/e2e/fixtures/tasks/suspend-wizard/task.js
+++ b/tests/e2e/fixtures/tasks/suspend-wizard/task.js
@@ -1,18 +1,19 @@
-// First invocation suspends asking for a project name; the resume invocation
-// echoes the submitted value back as the run's result (#512 e2e).
-export default async function main({ dicode, resume_state, resume_input }) {
-  if (!resume_state) {
-    await dicode.suspend({
-      state: { step: 'ask_name' },
-      schema: {
-        type: 'object',
-        title: "What's the project name?",
-        properties: {
-          project_name: { type: 'string', title: 'Name' },
-        },
-        required: ['project_name'],
+// Two-function shape (#512): main suspends asking for a project name; the runner
+// dispatches the exported `resume` on the continuation, which echoes the
+// submitted value back as the run's result — no hand-rolled resume switch.
+export default async function main({ dicode }) {
+  await dicode.suspend({
+    schema: {
+      type: 'object',
+      title: "What's the project name?",
+      properties: {
+        project_name: { type: 'string', title: 'Name' },
       },
-    });
-  }
-  return { created: resume_input?.project_name };
+      required: ['project_name'],
+    },
+  });
+}
+
+export async function resume({ input }) {
+  return { created: input?.project_name };
 }


### PR DESCRIPTION
## Summary

Phase B of the suspendable-tasks ergonomics redesign (#512): the SDK runner now auto-generates the resume dispatch, so task authors stop writing `if (!resume_state) … else …` by hand.

On a resume the runner re-runs the task file and picks the handler for you:

- **first run** → `main` (the entry / first step)
- **resume, named step** → `steps[to]` when `dicode.suspend({ to })` named one (the wizard shape)
- **resume, no step** → the exported `resume` (the two-function "ask once → finish" shape)
- **resume, only `main`** → re-runs `main`, so a single-`main` task keeps working and can branch by hand

Both supported shapes — `main` + `resume` **and** a `steps` map — are dispatched by the runner.

### The context shape

Each handler receives a `ctx` exposing:

- `ctx.input` — the schema-validated user submission on a resume; the trigger payload on a fresh run
- `ctx.state` — the author's carried blob, **unwrapped** (`undefined`/`None` on a first run so first-vs-resume is unambiguous)

Deno destructures the argument (`async function resume({ state, input, dicode })`); Python reads the module-global `ctx` or accepts it as a handler argument (`async def resume(ctx):`). `dicode.suspend()` still returns `Promise<never>` and the swallow-guard is intact.

### The `__step` marker

`dicode.suspend({ to, schema, state? })` persists state wrapped as `{ __step: to, state }`. The runner stores and reads this envelope entirely inside the SDK — the author never sees or manages `__step`, and on resume the wrapped `state` is unwrapped before any handler runs. This is what lets a first-run handler see `ctx.state === undefined` while a resumed handler sees the real carried blob, even with the internal marker present. `to` is optional (present → steps dispatch); `state` is now optional too.

### Scope

Implemented purely in the two SDK runners (`shim.ts` / `dicode_sdk.py` + the per-run wrappers) plus a tiny `suspend()` signature change. **No engine change** — the daemon still treats `resume_state` as an opaque blob, so the envelope round-trips transparently.

The author-facing `resume_state`/`resume_input` were **renamed** to `ctx.state`/`ctx.input` (v2, no back-compat), and the SDK type stubs, docs, skill guides, and the e2e wizard fixture were updated to match.

## Testing

- Deno + Python real-subprocess suspend tests: `main`-only re-run (back-compat), `main`+`resume` dispatch, a multi-step `steps` wizard (state + input threaded across two hops), first-vs-resume disambiguation with the `__step` marker, and the swallow-guard.
- `go build`, `go vet`, `gofmt -l`, full `go test ./...`, and `go test -race ./pkg/runtime/...` all pass. Python SDK unit tests pass. The e2e suite's setup (npm + chromium) isn't available in this environment; the fixture was converted to the two-function shape, which the Go subprocess tests cover.

Part of #512
Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)