### PR TITLE
docs(suspend): shipped example wizard + comment cleanup

### DIFF
--- a/docs/concepts/suspendable-tasks.md
+++ b/docs/concepts/suspendable-tasks.md
@@ -277,6 +277,33 @@ passes are distinguishable.
 
 ---
 
+## Try the shipped example
+
+A ready-to-run wizard ships under
+[`tasks/examples/suspend-wizard/`](../../tasks/examples/suspend-wizard/). It is a
+manually-triggered, three-step "new project" wizard built on the `steps` map and
+the JSON-Schema resume form — the same shape as the worked example above, one hop
+longer.
+
+1. In the Web UI, open the **Suspend Wizard (example)** task and **Run** it. The
+   run immediately goes `suspended` and its detail page renders a form.
+2. **Step 1 — Project name.** `main` suspends `to: "chooseFramework"` asking for a
+   `project_name` (string, required). Fill it in and submit.
+3. **Step 2 — Framework.** `chooseFramework` reads the name from `ctx.input`,
+   carries it in `state`, and suspends `to: "confirm"` asking for a `framework`
+   (an `enum` of `deno` / `node` / `bun`, rendered as a select).
+4. **Step 3 — Confirm.** `confirm` suspends `to: "summarize"` with a `confirmed`
+   boolean (a checkbox), carrying name + framework forward.
+5. **Finish.** `summarize` returns `{ project, framework, confirmed }` — the run
+   ends `resumed` and the continuation's result is on its run detail page.
+
+Each pause auto-renders from the schema, so there is no form code to write; the
+runner dispatches the next handler by the `to` name with no step switch. The same
+flow works from the CLI — `dicode resume` lists the suspended run and
+`dicode resume <run-id> project_name=acme` (etc.) submits each step.
+
+---
+
 ## Rules and gotchas
 
 - **`state` must be JSON-serializable.** It is persisted as JSON, so functions,

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -264,6 +264,7 @@ CLI dispatcher + daemon mode in one binary:
 | `hello-python/` | manual | python |
 | `nginx-start/` | daemon | docker |
 | `github-push-webhook/` | webhook + HMAC auth | deno |
+| `suspend-wizard/` | manual | deno — multi-step suspend/resume wizard with JSON-Schema forms |
 | `webui/` | webhook (SPA shell) | deno |
 | **`ai/`** | **webhook (auth)** | **deno** — generic OpenAI-compatible agent; uses `dicode.run_task()` as tools in a tool-use loop |
 | **`failure-monitor/`** | **on_failure_chain** | **deno** — AI-powered failure diagnosis; receives `{ taskID, runID, status }` via `input` |

--- a/pkg/ipc/control_resume.go
+++ b/pkg/ipc/control_resume.go
@@ -83,7 +83,7 @@ func (cs *ControlServer) handleResume(ctx context.Context, req Request) (ResumeR
 	}
 
 	// The key=value pairs arrive as a JSON object in Params; pass through as the
-	// opaque resume input the task reads as ctx.resume_input.
+	// opaque resume input the task reads as ctx.input.
 	input := []byte(req.Params)
 	if len(input) == 0 {
 		input = []byte("{}")

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -89,7 +89,7 @@ type Server struct {
 
 	// resumeState / resumeInput are the prior-run payload injected when this
 	// run is a resume of a suspended one (#95). Exposed to the task as
-	// ctx.resume_state / ctx.resume_input via the "resume" IPC method. Both
+	// ctx.state / ctx.input via the "resume" IPC method. Both
 	// are nil on a first (non-resume) invocation. Set via SetResume before
 	// Start; read-only afterwards, so no mutex is needed.
 	resumeState json.RawMessage
@@ -414,7 +414,7 @@ func (s *Server) Suspend() *SuspendResult {
 }
 
 // SetResume injects the prior-run state and user input for a resumed run,
-// exposed to the task as ctx.resume_state / ctx.resume_input (#95). Both are
+// exposed to the task as ctx.state / ctx.input (#95). Both are
 // opaque JSON blobs; nil means "not a resume". Must be called before Start.
 func (s *Server) SetResume(state, input json.RawMessage) {
 	s.resumeState = state
@@ -635,7 +635,7 @@ func (s *Server) handleConn(conn net.Conn) {
 
 		case "resume":
 			// Returns the prior-run state + user input for a resumed run
-			// (#95), exposed to the task as ctx.resume_state / ctx.resume_input.
+			// (#95), exposed to the task as ctx.state / ctx.input.
 			// Gated by the same cap as input — it is contextual run input.
 			// Both fields are nil on a first (non-resume) invocation.
 			if !hasCap(caps, CapInputRead) {

--- a/pkg/runtime/executor.go
+++ b/pkg/runtime/executor.go
@@ -59,7 +59,7 @@ type RunOptions struct {
 	// ResumeState / ResumeInput carry a suspended run's prior state and the
 	// user's form submission when the engine re-spawns a task to resume it
 	// (#95). Both are opaque JSON blobs surfaced to the task as
-	// ctx.resume_state / ctx.resume_input. Nil on a first (non-resume) run.
+	// ctx.state / ctx.input. Nil on a first (non-resume) run.
 	// Populated by the resume orchestration (PR 3); the runtime only forwards
 	// them to the subprocess.
 	ResumeState []byte

--- a/pkg/schemavalidate/schemavalidate.go
+++ b/pkg/schemavalidate/schemavalidate.go
@@ -1,7 +1,7 @@
 // Package schemavalidate compiles a stored JSON Schema (draft 2020-12) and
 // validates a submitted input object against it. It is the single validator
 // shared by the WebUI resume endpoint and the CLI resume control method so a
-// suspended task can trust that ctx.resume_input conforms to the schema it
+// suspended task can trust that ctx.input conforms to the schema it
 // declared via dicode.suspend({ schema }).
 package schemavalidate
 

--- a/pkg/webui/resume.go
+++ b/pkg/webui/resume.go
@@ -30,7 +30,7 @@ func (s *Server) SetResumer(r Resumer) { s.resumer = r }
 // resolved from the stored run, never trusted from the client.
 //
 // The submission is validated against the run's stored JSON Schema before the
-// continuation is spawned, so the resumed task can trust ctx.resume_input.
+// continuation is spawned, so the resumed task can trust ctx.input.
 //
 // Status codes:
 //   - 200 — resumed; body returns the continuation run_id.
@@ -67,7 +67,7 @@ func (s *Server) apiResumeRun(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Collected values pass through as opaque JSON — the task reads them as
-	// ctx.resume_input.
+	// ctx.input.
 	input, err := json.Marshal(values)
 	if err != nil {
 		jsonErr(w, "encode input: "+err.Error(), http.StatusInternalServerError)

--- a/tasks/examples/suspend-wizard/task.test.ts
+++ b/tasks/examples/suspend-wizard/task.test.ts
@@ -1,0 +1,59 @@
+import { setupHarness } from "../../sdk-test.ts";
+import { steps } from "./task.ts";
+await setupHarness(import.meta.url);
+
+// suspend isn't part of the default mock surface; capture the request and throw
+// to mimic that it never returns, so the handler under test stops there.
+function captureSuspend() {
+  const calls: Record<string, unknown>[] = [];
+  const suspend = (req: Record<string, unknown>) => {
+    calls.push(req);
+    throw new Error("__suspended__");
+  };
+  return { calls, suspend };
+}
+
+test("main asks for a project name and suspends to chooseFramework", async () => {
+  const { calls, suspend } = captureSuspend();
+  (dicode as Record<string, unknown>).suspend = suspend;
+
+  let threw = false;
+  try {
+    await runTask();
+  } catch {
+    threw = true;
+  }
+  assert.ok(threw);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].to, "chooseFramework");
+
+  const schema = calls[0].schema as { type: string; required: string[] };
+  assert.equal(schema.type, "object");
+  assert.equal(schema.required[0], "project_name");
+});
+
+test("chooseFramework carries the project name forward and suspends to confirm", async () => {
+  const { calls, suspend } = captureSuspend();
+  let threw = false;
+  try {
+    await steps.chooseFramework({
+      dicode: { suspend },
+      input: { project_name: "acme" },
+    } as never);
+  } catch {
+    threw = true;
+  }
+  assert.ok(threw);
+  assert.equal(calls[0].to, "confirm");
+  assert.equal((calls[0].state as { project: string }).project, "acme");
+});
+
+test("summarize returns the collected summary", async () => {
+  const result = await steps.summarize({
+    input: { confirmed: true },
+    state: { project: "acme", framework: "deno" },
+  } as never);
+  assert.equal((result as { project: string }).project, "acme");
+  assert.equal((result as { framework: string }).framework, "deno");
+  assert.equal((result as { confirmed: boolean }).confirmed, true);
+});

--- a/tasks/examples/suspend-wizard/task.ts
+++ b/tasks/examples/suspend-wizard/task.ts
@@ -1,0 +1,74 @@
+import type { DicodeSdk } from "../../sdk.ts";
+
+// A "new project" wizard that pauses for input three times. Each pause names the
+// step that handles the answer via suspend({ to }); the runner dispatches the
+// matching entry in `steps` on resume, so there is no hand-rolled step switch and
+// no `if (state)` branching. `state` carries earlier answers forward — the run is
+// re-run from the top on every resume, so nothing lives in memory between pauses.
+
+export default async function main({ dicode }: DicodeSdk) {
+  await dicode.suspend({
+    to: "chooseFramework",
+    schema: {
+      type: "object",
+      title: "New project",
+      description: "Let's scaffold a project. What should we call it?",
+      properties: {
+        project_name: { type: "string", title: "Project name" },
+      },
+      required: ["project_name"],
+    },
+  });
+  // Unreachable — suspend() never returns.
+}
+
+export const steps = {
+  // The project name arrives on ctx.input; ask for a framework and carry the
+  // name forward in state so the confirm step can echo it back.
+  async chooseFramework({ dicode, input }: DicodeSdk) {
+    const project = (input as { project_name: string }).project_name;
+    await dicode.suspend({
+      to: "confirm",
+      state: { project },
+      schema: {
+        type: "object",
+        title: `Framework for ${project}`,
+        properties: {
+          framework: {
+            type: "string",
+            title: "Framework",
+            enum: ["deno", "node", "bun"],
+          },
+        },
+        required: ["framework"],
+      },
+    });
+  },
+
+  // Both prior answers are in hand (name in state, framework in input); ask for a
+  // final confirmation, carrying name + framework forward.
+  async confirm({ dicode, input, state }: DicodeSdk) {
+    const project = (state as { project: string }).project;
+    const framework = (input as { framework: string }).framework;
+    await dicode.suspend({
+      to: "summarize",
+      state: { project, framework },
+      schema: {
+        type: "object",
+        title: "Confirm",
+        description: `Create ${project} (${framework})?`,
+        properties: {
+          confirmed: { type: "boolean", title: "Create the project?" },
+        },
+        required: ["confirmed"],
+      },
+    });
+  },
+
+  // Terminal step: return the collected summary.
+  summarize({ input, state }: DicodeSdk) {
+    const { project, framework } = state as { project: string; framework: string };
+    const confirmed = (input as { confirmed: boolean }).confirmed;
+    return { project, framework, confirmed };
+  },
+};

--- a/tasks/examples/suspend-wizard/task.yaml
+++ b/tasks/examples/suspend-wizard/task.yaml
@@ -1,0 +1,14 @@
+apiVersion: dicode/v1
+kind: Task
+name: Suspend Wizard (example)
+description: |
+  A multi-step "new project" wizard that demonstrates suspendable tasks. Trigger
+  it manually from the Web UI: the run pauses and renders an auto-generated form
+  at each step (project name → framework → confirm), then finishes with a summary.
+  Shows the steps-map + JSON-Schema resume flow with no hand-rolled step switch.
+runtime: deno
+
+trigger:
+  manual: true
+
+timeout: 30s

--- a/tasks/examples/taskset.yaml
+++ b/tasks/examples/taskset.yaml
@@ -36,6 +36,10 @@ spec:
       ref:
         path: ./webhook-dashboard/task.yaml
 
+    suspend-wizard:
+      ref:
+        path: ./suspend-wizard/task.yaml
+
     github-stars:
       ref:
         path: ./github-stars/task.yaml


### PR DESCRIPTION
## Summary

There was no user-facing example of suspend/resume under `tasks/examples/` — only an e2e test fixture. This adds one a user can Run from the Web UI to see the JSON-Schema resume form, and folds in a small stale-comment sweep plus doc updates.

The new `tasks/examples/suspend-wizard/` is a manually-triggered, three-step "new project" wizard built on the v2 `steps`-map auto-dispatch: `main` asks for a project name and suspends `to: "chooseFramework"`, which carries the name forward in `state` and asks for a framework (`enum` → select), then `confirm` asks for a boolean, and the terminal `summarize` returns `{ project, framework, confirmed }`. It exercises the v2 suspend feature end to end — `steps` dispatch, carried `state`, validated `ctx.input`, and the auto-rendered form at each hop — and doubles as a copyable template. It ships with a `task.test.ts` in the repo's harness style.

Phase B (#515) renamed the resume SDK surface from `ctx.resume_state`/`ctx.resume_input` to `ctx.state`/`ctx.input`, but several engine comments still described the old names. Those narrative comments are corrected; DB columns and Go field identifiers deliberately keep their names.

Docs get a "Try the shipped example" walkthrough in the suspendable-tasks concept doc (kept in step with the actual handler and schema names so it can't drift from the code) and a row in the current-state examples table.

Context: #95 (suspendable tasks). Closes nothing.

## Verification

- `deno test` on the new example: 3 passed / 0 failed.
- `make build`, `make lint` clean; affected Go packages (`ipc`, `runtime/...`, `schemavalidate`, `webui`, `trigger`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)