### PR TITLE
fix(suspend): robustness hardening from v2 integration audit (#517)

### DIFF
--- a/docs/concepts/suspendable-tasks.md
+++ b/docs/concepts/suspendable-tasks.md
@@ -111,6 +111,12 @@ on the `deno` and `python` runtimes. It is **not** available on `docker` /
 in. Server-side validation rejects a submission that doesn't conform (Web UI:
 `400` with the failing property; CLI: a clear error) before the task resumes.
 
+The daemon compiles the schema the moment you call `dicode.suspend`, so a
+malformed schema surfaces as an error to the task immediately — while it can
+still react — instead of silently suspending and then failing every resume
+attempt. External or `file://` `$ref`s are refused; a suspend schema must be
+self-contained.
+
 Use an `object` schema whose `properties` are the fields to collect:
 
 ```jsonc
@@ -333,6 +339,13 @@ flow works from the CLI — `dicode resume` lists the suspended run and
 - **A suspended run resumes exactly once.** The resume handle is single-use and
   consumed atomically — a second resume of the same run fails with "already
   resumed".
+
+- **`suspend({ to })` must name a handler in the exported `steps` map.** If it
+  names a step that isn't present (a typo, or a step you removed while a run was
+  mid-wizard), the resume **fails loudly** with a clear error and a non-zero exit
+  rather than silently falling back to `main`/`resume` against mid-wizard state.
+  The single-`main` and `main` + `resume` shapes (which export no `steps` map)
+  are unaffected.
 
 - **Deno / Python only.** `docker` and `podman` tasks cannot suspend; a
   `suspend()` attempt there fails with a permission-denied error rather than

--- a/docs/deno-runtime.md
+++ b/docs/deno-runtime.md
@@ -163,9 +163,11 @@ export async function resume({ input }) {
 ```
 
 For a multi-step wizard, export a **`steps`** map and name the next handler with
-`suspend({ to })`. `schema` is a [JSON Schema](https://json-schema.org) (draft
-2020-12); the daemon validates the submission against it before resuming, so
-`ctx.input` conforms.
+`suspend({ to })`. A `to` that names no exported step fails the run loudly rather
+than falling back to `main`/`resume`. `schema` is a
+[JSON Schema](https://json-schema.org) (draft 2020-12); the daemon compiles it at
+`suspend()` time (rejecting a malformed schema up front) and validates the
+submission against it before resuming, so `ctx.input` conforms.
 
 See [Suspendable Tasks](./concepts/suspendable-tasks.md) for the dispatch rules,
 the `steps` wizard shape, lifecycle (`suspended` → `resumed`), and how to resume

--- a/docs/python-runtime.md
+++ b/docs/python-runtime.md
@@ -169,10 +169,12 @@ async def resume():
 ```
 
 For a multi-step wizard, define a **`steps`** map and name the next handler with
-`suspend(to=...)`. A handler may also take `ctx` as an argument
+`suspend(to=...)`. A `to` that names no defined step fails the run loudly rather
+than falling back to `main`/`resume`. A handler may also take `ctx` as an argument
 (`async def resume(ctx):`) instead of reading the module-global `ctx`. `schema`
-is a [JSON Schema](https://json-schema.org) (draft 2020-12) the daemon validates
-against before resuming.
+is a [JSON Schema](https://json-schema.org) (draft 2020-12) the daemon compiles at
+`suspend()` time (rejecting a malformed schema up front) and validates against
+before resuming.
 
 Do not wrap `suspend()` in a `try/except` that swallows the signal — the run
 fails loudly if you do. See [Suspendable Tasks](./concepts/suspendable-tasks.md)

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -1,6 +1,7 @@
 package ipc
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -751,19 +752,23 @@ func (s *Server) handleConn(conn net.Conn) {
 				reply(req.ID, nil, "ipc: permission denied (suspend)")
 				continue
 			}
-			// Probe the schema now, while the task can still react: an
-			// un-compilable schema stored here would fail every resume with a
-			// 400 and brick the run until the TTL sweep, with no author feedback.
-			if len(req.Schema) > 0 {
-				if _, err := schemavalidate.Compile(req.Schema); err != nil {
-					reply(req.ID, nil, "ipc: invalid suspend schema: "+err.Error())
-					continue
-				}
+			// A null or empty schema means "no constraint": normalize it to nil
+			// so it is neither probed as an invalid document nor persisted as the
+			// literal `null` (which would 400 every resume). A present schema must
+			// compile now, while the task can still react — an un-compilable schema
+			// stored here would brick every resume until the TTL sweep, with no
+			// author feedback.
+			schema := req.Schema
+			if len(bytes.TrimSpace(schema)) == 0 || bytes.Equal(bytes.TrimSpace(schema), []byte("null")) {
+				schema = nil
+			} else if _, err := schemavalidate.Compile(schema); err != nil {
+				reply(req.ID, nil, "ipc: invalid suspend schema: "+err.Error())
+				continue
 			}
 			s.mu.Lock()
 			s.suspend = &SuspendResult{
 				State:    req.State,
-				Schema:   req.Schema,
+				Schema:   schema,
 				Deadline: req.Deadline,
 			}
 			s.mu.Unlock()

--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dicode/dicode/pkg/db"
 	mcpclient "github.com/dicode/dicode/pkg/mcp/client"
 	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/schemavalidate"
 	"github.com/dicode/dicode/pkg/secrets"
 	gitsource "github.com/dicode/dicode/pkg/source/git"
 	"github.com/dicode/dicode/pkg/task"
@@ -92,6 +93,11 @@ type Server struct {
 	// ctx.state / ctx.input via the "resume" IPC method. Both
 	// are nil on a first (non-resume) invocation. Set via SetResume before
 	// Start; read-only afterwards, so no mutex is needed.
+	//
+	// resumed is the authoritative resume signal reported to the SDK: carried
+	// state can be genuinely null on a resume, so its presence cannot stand in
+	// for it.
+	resumed     bool
 	resumeState json.RawMessage
 	resumeInput json.RawMessage
 
@@ -414,9 +420,11 @@ func (s *Server) Suspend() *SuspendResult {
 }
 
 // SetResume injects the prior-run state and user input for a resumed run,
-// exposed to the task as ctx.state / ctx.input (#95). Both are
-// opaque JSON blobs; nil means "not a resume". Must be called before Start.
-func (s *Server) SetResume(state, input json.RawMessage) {
+// exposed to the task as ctx.state / ctx.input (#95). resumed is the
+// authoritative resume signal the SDK dispatches on; state/input are opaque JSON
+// blobs and may be nil even on a resume. Must be called before Start.
+func (s *Server) SetResume(resumed bool, state, input json.RawMessage) {
+	s.resumed = resumed
 	s.resumeState = state
 	s.resumeInput = input
 }
@@ -637,14 +645,16 @@ func (s *Server) handleConn(conn net.Conn) {
 			// Returns the prior-run state + user input for a resumed run
 			// (#95), exposed to the task as ctx.state / ctx.input.
 			// Gated by the same cap as input — it is contextual run input.
-			// Both fields are nil on a first (non-resume) invocation.
+			// `resumed` is the resume signal the SDK dispatches on; state/input
+			// are nil on a first invocation and may be nil even on a resume.
 			if !hasCap(caps, CapInputRead) {
 				reply(req.ID, nil, "ipc: permission denied (input.read)")
 				continue
 			}
 			reply(req.ID, map[string]any{
-				"state": s.resumeState,
-				"input": s.resumeInput,
+				"resumed": s.resumed,
+				"state":   s.resumeState,
+				"input":   s.resumeInput,
 			}, "")
 
 		case "kv.get":
@@ -740,6 +750,15 @@ func (s *Server) handleConn(conn net.Conn) {
 			if !hasCap(caps, CapSuspend) {
 				reply(req.ID, nil, "ipc: permission denied (suspend)")
 				continue
+			}
+			// Probe the schema now, while the task can still react: an
+			// un-compilable schema stored here would fail every resume with a
+			// 400 and brick the run until the TTL sweep, with no author feedback.
+			if len(req.Schema) > 0 {
+				if _, err := schemavalidate.Compile(req.Schema); err != nil {
+					reply(req.ID, nil, "ipc: invalid suspend schema: "+err.Error())
+					continue
+				}
 			}
 			s.mu.Lock()
 			s.suspend = &SuspendResult{

--- a/pkg/ipc/server_test.go
+++ b/pkg/ipc/server_test.go
@@ -2574,6 +2574,47 @@ func TestServer_Suspend_RejectsInvalidSchema(t *testing.T) {
 	}
 }
 
+// A null (or empty) schema means "no constraint": the suspend-time probe is
+// skipped and the schema is normalized to empty so it is not persisted as the
+// literal `null`, which would otherwise 400 every resume (#517). A schema-less
+// dicode.suspend (e.g. the Python approval-gate pattern) must still suspend.
+func TestServer_Suspend_NullSchemaTreatedAsAbsent(t *testing.T) {
+	cases := []struct {
+		name   string
+		schema json.RawMessage
+	}{
+		{"literal null", json.RawMessage(`null`)},
+		{"whitespace null", json.RawMessage(" null ")},
+		{"empty", json.RawMessage(``)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newTestEnv(t)
+			conn, srv := e.startWithSpec(t, nil, nil, &task.Spec{Runtime: task.RuntimeDeno}, nil)
+			msg := map[string]any{
+				"id":     "1",
+				"method": "dicode.suspend",
+				"state":  json.RawMessage(`{"step":1}`),
+			}
+			if len(tc.schema) > 0 {
+				msg["schema"] = tc.schema
+			}
+			sendMsg(t, conn, msg)
+			resp := recvMsg(t, conn)
+			if resp["error"] != nil {
+				t.Fatalf("a null/absent schema must be accepted, got error: %v", resp["error"])
+			}
+			s := srv.Suspend()
+			if s == nil {
+				t.Fatal("expected the suspend payload to be recorded")
+			}
+			if len(s.Schema) != 0 {
+				t.Fatalf("a null schema must be normalized to empty (not persisted), got %q", s.Schema)
+			}
+		})
+	}
+}
+
 // A valid schema on dicode.suspend passes the suspend-time probe and is recorded.
 func TestServer_Suspend_AcceptsValidSchema(t *testing.T) {
 	e := newTestEnv(t)

--- a/pkg/ipc/server_test.go
+++ b/pkg/ipc/server_test.go
@@ -2542,6 +2542,57 @@ func TestServer_Suspend_DeniedForDocker(t *testing.T) {
 	}
 }
 
+// A dicode.suspend carrying a structurally-invalid schema must be rejected at
+// suspend time (#517) — while the task can still react — rather than stored and
+// left to fail every resume with a 400 until the TTL sweep.
+func TestServer_Suspend_RejectsInvalidSchema(t *testing.T) {
+	cases := []struct {
+		name   string
+		schema string
+	}{
+		{"non-string type", `{"type":123}`},
+		{"external file ref", `{"$ref":"file:///etc/passwd"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newTestEnv(t)
+			conn, srv := e.startWithSpec(t, nil, nil, &task.Spec{Runtime: task.RuntimeDeno}, nil)
+			sendMsg(t, conn, map[string]any{
+				"id":     "1",
+				"method": "dicode.suspend",
+				"state":  json.RawMessage(`{"step":1}`),
+				"schema": json.RawMessage(tc.schema),
+			})
+			resp := recvMsg(t, conn)
+			if errMsg, _ := resp["error"].(string); !strings.Contains(errMsg, "invalid suspend schema") {
+				t.Fatalf("expected invalid-schema rejection; got error=%v result=%v", resp["error"], resp["result"])
+			}
+			if srv.Suspend() != nil {
+				t.Fatal("an un-resumable schema must not be recorded")
+			}
+		})
+	}
+}
+
+// A valid schema on dicode.suspend passes the suspend-time probe and is recorded.
+func TestServer_Suspend_AcceptsValidSchema(t *testing.T) {
+	e := newTestEnv(t)
+	conn, srv := e.startWithSpec(t, nil, nil, &task.Spec{Runtime: task.RuntimeDeno}, nil)
+	sendMsg(t, conn, map[string]any{
+		"id":     "1",
+		"method": "dicode.suspend",
+		"state":  json.RawMessage(`{"step":1}`),
+		"schema": json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`),
+	})
+	resp := recvMsg(t, conn)
+	if resp["error"] != nil {
+		t.Fatalf("valid schema rejected: %v", resp["error"])
+	}
+	if srv.Suspend() == nil {
+		t.Fatal("expected suspend payload recorded for a valid schema")
+	}
+}
+
 // A deno task's dicode.suspend is accepted and records the payload.
 func TestServer_Suspend_GrantedForDeno(t *testing.T) {
 	e := newTestEnv(t)

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -69,6 +69,10 @@ type RunOptions struct {
 	// task as ctx.state / ctx.input. Nil on a first (non-resume) invocation.
 	ResumeState json.RawMessage
 	ResumeInput json.RawMessage
+
+	// Resumed marks this run as a resume continuation. It is the resume signal
+	// the SDK dispatches on; carried state may legitimately be null.
+	Resumed bool
 }
 
 // RunResult is returned by Run.
@@ -250,7 +254,7 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		srv.SetCryptoHandler(d)
 	}
 	// Inject a resumed run's prior state + user input (#95); nil on first run.
-	srv.SetResume(opts.ResumeState, opts.ResumeInput)
+	srv.SetResume(opts.Resumed, opts.ResumeState, opts.ResumeInput)
 	socketPath, token, err := srv.Start(srvCtx)
 	if err != nil {
 		result.Error = fmt.Errorf("start socket server: %w", err)
@@ -306,17 +310,28 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		"  Deno.exit(1);\n" +
 		"}\n" +
 		// Auto-dispatch (#512): a first run calls main; a resume runs steps[to]
-		// (wizard shape) if the marker names an exported step, else the exported
+		// (wizard shape) when the marker names an exported step, else the exported
 		// resume (two-function shape), else falls back to main so a single-main
 		// task keeps working. The author reads ctx.state / ctx.input, never a step
-		// switch. main is the entry (first) step.
+		// switch. main is the entry (first) step. When `steps` is exported but the
+		// marker names no matching step (typo, or the task was edited mid-wizard),
+		// fail loudly rather than silently re-running an unrelated handler against
+		// mid-wizard state.
 		"const __ctx__ = { params, kv, input, state, output, mcp, dicode };\n" +
 		"const __main__ = __mod__.default;\n" +
 		"const __resumeFn__ = __mod__.resume;\n" +
 		"const __steps__ = __mod__.steps;\n" +
 		"let __handler__ = __main__;\n" +
 		"if (__resumed__) {\n" +
-		"  if (__resumeStep__ && __steps__ && typeof __steps__[__resumeStep__] === \"function\") { __handler__ = __steps__[__resumeStep__]; }\n" +
+		"  if (__steps__ && __resumeStep__) {\n" +
+		"    if (typeof __steps__[__resumeStep__] === \"function\") { __handler__ = __steps__[__resumeStep__]; }\n" +
+		"    else {\n" +
+		"      console.error(\"[dicode] resume step \\\"\" + __resumeStep__ + \"\\\" is not an exported step function\");\n" +
+		"      await __flush__();\n" +
+		"      try { __conn__.close(); } catch {}\n" +
+		"      Deno.exit(1);\n" +
+		"    }\n" +
+		"  }\n" +
 		"  else if (typeof __resumeFn__ === \"function\") { __handler__ = __resumeFn__; }\n" +
 		"}\n" +
 		"if (typeof __handler__ !== \"function\") {\n" +
@@ -660,6 +675,7 @@ func (rt *Runtime) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 		Params:         opts.Params,
 		Input:          opts.Input,
 		PreResolvedEnv: opts.PreResolvedEnv,
+		Resumed:        opts.Resumed,
 		ResumeState:    opts.ResumeState,
 		ResumeInput:    opts.ResumeInput,
 	})

--- a/pkg/runtime/deno/sdk/shim.ts
+++ b/pkg/runtime/deno/sdk/shim.ts
@@ -369,8 +369,8 @@ const kv: KV = {
 
 const __triggerInput__ = await __call__({ method: "input" });
 const __resume__ = await __call__({ method: "resume" }) as
-  { state?: unknown; input?: unknown } | null;
-const __resumed__ = __resume__ != null && __resume__.state != null;
+  { resumed?: boolean; state?: unknown; input?: unknown } | null;
+const __resumed__ = __resume__ != null && __resume__.resumed === true;
 
 function __unwrapState__(raw: unknown): { step: string | undefined; state: unknown } {
   if (raw && typeof raw === "object" && "__step" in (raw as Record<string, unknown>)) {

--- a/pkg/runtime/deno/suspend_test.go
+++ b/pkg/runtime/deno/suspend_test.go
@@ -135,6 +135,7 @@ export default async function main({ dicode, state, input }) {
 	// Replay the stored envelope exactly as the resume path would.
 	second, err := rt.Run(ctx, spec, RunOptions{
 		RunID:       "run-loopguard-2",
+		Resumed:     true,
 		ResumeState: json.RawMessage(first.ResumeState),
 		ResumeInput: json.RawMessage(`{"project_name":"acme"}`),
 	})
@@ -199,6 +200,7 @@ export async function resume({ state, input }) {
 
 	second, err := rt.Run(ctx, spec, RunOptions{
 		RunID:       "run-twofunc-2",
+		Resumed:     true,
 		ResumeState: json.RawMessage(first.ResumeState),
 		ResumeInput: json.RawMessage(`{"project_name":"acme"}`),
 	})
@@ -286,6 +288,7 @@ export const steps = {
 	// Run 2 — chooseFramework sees the framework input, suspends to deploy.
 	r2, err := rt.Run(ctx, spec, RunOptions{
 		RunID:       "run-steps-2",
+		Resumed:     true,
 		ResumeState: json.RawMessage(r1.ResumeState),
 		ResumeInput: json.RawMessage(`{"framework":"deno"}`),
 	})
@@ -314,6 +317,7 @@ export const steps = {
 	// Run 3 — deploy sees the prior state + the new env input and finishes.
 	r3, err := rt.Run(ctx, spec, RunOptions{
 		RunID:       "run-steps-3",
+		Resumed:     true,
 		ResumeState: json.RawMessage(r2.ResumeState),
 		ResumeInput: json.RawMessage(`{"env":"prod"}`),
 	})
@@ -419,6 +423,7 @@ export default async function main({ state, input }) {
 
 	res, err := rt.Run(ctx, spec, RunOptions{
 		RunID:       "run-resume-1",
+		Resumed:     true,
 		ResumeState: json.RawMessage(`{"__step":null,"state":{"step":"ask_framework","name":"proj"}}`),
 		ResumeInput: json.RawMessage(`{"project_name":"acme"}`),
 	})
@@ -449,6 +454,118 @@ export default async function main({ state, input }) {
 	}
 	if inp["project_name"] != "acme" {
 		t.Errorf("ctx.input = %#v, want project_name=acme", inp)
+	}
+}
+
+// TestRun_ResumeWithNullStateDispatchesResume guards the resume-detection fix
+// (#517): a resume whose carried author state is genuinely null must still be
+// treated as a resume and dispatch the resume handler with the validated input —
+// not fall through to main as a fresh run and drop the submission. The signal is
+// the explicit `resumed` flag, never the presence of state.
+func TestRun_ResumeWithNullStateDispatchesResume(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rt, reg, cleanup := newTestRuntime(t)
+	defer cleanup()
+
+	spec := writeProviderTask(t, "nullstate", `
+export default async function main() {
+  return { via: "main" };
+}
+export async function resume({ state, input }) {
+  return { via: "resume", stateNull: state === null || state === undefined, name: (input as any).project_name };
+}
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := rt.Run(ctx, spec, RunOptions{
+		RunID:       "run-nullstate-1",
+		Resumed:     true,
+		ResumeState: nil, // genuinely-null carried state
+		ResumeInput: json.RawMessage(`{"project_name":"acme"}`),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Error != nil {
+		t.Fatalf("run error: %v", res.Error)
+	}
+	ret, ok := res.ReturnValue.(map[string]any)
+	if !ok {
+		t.Fatalf("ReturnValue = %#v, want map", res.ReturnValue)
+	}
+	if ret["via"] != "resume" {
+		t.Errorf("dispatch went to %#v, want the resume handler (not a fresh main)", ret["via"])
+	}
+	if ret["stateNull"] != true {
+		t.Errorf("resume must see the null carried state, got stateNull=%#v", ret["stateNull"])
+	}
+	if ret["name"] != "acme" {
+		t.Errorf("validated submission dropped: ctx.input.project_name = %#v, want acme", ret["name"])
+	}
+}
+
+// TestRun_ResumeMissingStepFailsLoudly guards the missing-marker fix (#517): when
+// `steps` is exported but the resume marker names no matching step (typo, or the
+// task was edited mid-wizard), the run must FAIL loudly rather than silently
+// re-run main/resume against mid-wizard state.
+func TestRun_ResumeMissingStepFailsLoudly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	rt, reg, cleanup := newTestRuntime(t)
+	defer cleanup()
+
+	spec := writeProviderTask(t, "missingstep", `
+export default async function main() {
+  return { via: "main" };
+}
+export const steps = {
+  async known() { return { via: "known" }; },
+};
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := rt.Run(ctx, spec, RunOptions{
+		RunID:       "run-missingstep-1",
+		Resumed:     true,
+		ResumeState: json.RawMessage(`{"__step":"gone","state":{}}`),
+		ResumeInput: json.RawMessage(`{"x":"y"}`),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Error == nil {
+		t.Fatalf("resume to a missing step must fail the run, got no error")
+	}
+	if res.ReturnValue != nil {
+		t.Errorf("resume to a missing step must not run main, got return %#v", res.ReturnValue)
+	}
+	if res.Suspended {
+		t.Errorf("resume to a missing step must not be classified as suspended")
+	}
+
+	logs, _ := reg.GetRunLogs(ctx, "run-missingstep-1")
+	found := false
+	for _, l := range logs {
+		if strings.Contains(l.Message, "is not an exported step function") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a clear diagnostic naming the missing step, logs = %+v", logs)
 	}
 }
 

--- a/pkg/runtime/executor.go
+++ b/pkg/runtime/executor.go
@@ -64,6 +64,11 @@ type RunOptions struct {
 	// them to the subprocess.
 	ResumeState []byte
 	ResumeInput []byte
+
+	// Resumed marks this run as the continuation of a suspended one. It is the
+	// authoritative resume signal the SDK dispatches on — carried state may be
+	// genuinely null, so presence of state cannot stand in for it.
+	Resumed bool
 }
 
 // RunResult is returned by every Executor.

--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -222,7 +222,7 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 
 	srv := e.BridgeDeps.NewIPCServer(runID, spec, mergedParams, opts.Input, redactor, &e.parent.BridgeDeps)
 	// Inject a resumed run's prior state + user input (#95); nil on first run.
-	srv.SetResume(opts.ResumeState, opts.ResumeInput)
+	srv.SetResume(opts.Resumed, opts.ResumeState, opts.ResumeInput)
 	socketPath, token, err := srv.Start(srvCtx)
 	if err != nil {
 		result.Error = fmt.Errorf("start socket server: %w", err)

--- a/pkg/runtime/python/sdk/dicode_sdk.py
+++ b/pkg/runtime/python/sdk/dicode_sdk.py
@@ -361,8 +361,8 @@ def _dispatch(g):
     steps = g.get("steps")
     if not ctx._resumed:
         handler = main
-    elif isinstance(steps, dict) and ctx._step is not None:
-        handler = steps.get(ctx._step)
+    elif steps is not None and ctx._step is not None:
+        handler = steps.get(ctx._step) if isinstance(steps, dict) else None
         if not callable(handler):
             sys.stderr.write(
                 '[dicode] resume step "%s" is not an exported step function\n' % ctx._step
@@ -601,9 +601,15 @@ class _Dicode:
         # captures state/schema/deadline synchronously in response to this call.
         # Persist an envelope so the runner can dispatch steps[to] on resume; the
         # author's blob rides in `state` and is unwrapped before any handler runs.
-        _call({"method": "dicode.suspend",
-               "state": {"__step": to, "state": state}, "schema": schema,
-               "deadline": deadline or 0})
+        # Omit `schema` when absent (mirroring Deno's dropped-undefined-key
+        # behavior) so a schema-less suspend carries no constraint rather than a
+        # `null` the daemon would have to reject as an invalid schema.
+        req = {"method": "dicode.suspend",
+               "state": {"__step": to, "state": state},
+               "deadline": deadline or 0}
+        if schema is not None:
+            req["schema"] = schema
+        _call(req)
         _suspend_requested = True
         raise SuspendSignal()
 

--- a/pkg/runtime/python/sdk/dicode_sdk.py
+++ b/pkg/runtime/python/sdk/dicode_sdk.py
@@ -322,7 +322,7 @@ class _Context:
     def __init__(self, trigger_input):
         r = _call({"method": "resume"}) or {}
         raw = r.get("state")
-        self._resumed = raw is not None
+        self._resumed = r.get("resumed") is True
         self._step, self.state = _unwrap_state(raw)
         self.input = r.get("input") if self._resumed else trigger_input
 
@@ -353,14 +353,23 @@ def _dispatch(g):
     → main; a resume with a step marker → steps[step] (wizard shape); a resume
     without → resume() if exported, else main (two-function / single-main shape).
     g is the task module globals(). Falls through to the module-level `result`
-    for a top-level (no-main) task."""
+    for a top-level (no-main) task. When `steps` is exported but the marker names
+    no matching step (typo, or the task was edited mid-wizard), fail loudly rather
+    than silently re-running an unrelated handler against mid-wizard state."""
     main = g.get("main")
     resume = g.get("resume")
     steps = g.get("steps")
     if not ctx._resumed:
         handler = main
-    elif ctx._step is not None and isinstance(steps, dict) and callable(steps.get(ctx._step)):
+    elif isinstance(steps, dict) and ctx._step is not None:
         handler = steps.get(ctx._step)
+        if not callable(handler):
+            sys.stderr.write(
+                '[dicode] resume step "%s" is not an exported step function\n' % ctx._step
+            )
+            sys.stderr.flush()
+            _flush_and_close()
+            os._exit(1)
     elif callable(resume):
         handler = resume
     else:

--- a/pkg/runtime/python/sdk/test_dicode_sdk.py
+++ b/pkg/runtime/python/sdk/test_dicode_sdk.py
@@ -376,6 +376,24 @@ class SuspendTests(SDKTestBase):
         self.assertEqual(captured["schema"]["title"], "Name?")
         self.assertEqual(captured["deadline"], 1893456000000)
 
+    def test_suspend_without_schema_omits_the_field(self):
+        # A schema-less suspend must send no `schema` field at all (not `null`),
+        # mirroring Deno's dropped-undefined-key behavior, so the daemon records
+        # no constraint instead of rejecting a `null` schema (#517).
+        captured = {}
+
+        def on_suspend(msg):
+            captured["msg"] = msg
+            return True  # ack
+        self.server.handlers["dicode.suspend"] = on_suspend
+
+        sdk = self.load_sdk()
+        with self.assertRaises(sdk.SuspendSignal):
+            sdk.dicode.suspend(state={"step": "one"})
+        self.assertNotIn("schema", captured["msg"])
+        self.assertEqual(captured["msg"]["state"],
+                         {"__step": None, "state": {"step": "one"}})
+
     def test_suspend_signal_is_exception_subclass(self):
         # Mirrors the Deno SDK: the signal is a plain Error/Exception so a broad
         # `except Exception` swallows it — exactly the footgun the wrapper's

--- a/pkg/runtime/python/sdk/test_dicode_sdk.py
+++ b/pkg/runtime/python/sdk/test_dicode_sdk.py
@@ -394,6 +394,7 @@ class ResumeContextTests(SDKTestBase):
         # The real path persists a { __step, state } envelope; the SDK unwraps
         # it so the author sees only their own blob on ctx.state.
         self.server.handlers["resume"] = lambda _: {
+            "resumed": True,
             "state": {"__step": "deploy", "state": {"name": "proj"}},
             "input": {"project_name": "acme"},
         }

--- a/pkg/runtime/python/suspend_test.go
+++ b/pkg/runtime/python/suspend_test.go
@@ -234,6 +234,7 @@ async def main():
 	}
 	second, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{
 		RunID:       runID2,
+		Resumed:     true,
 		ResumeState: json.RawMessage(first.ResumeState),
 		ResumeInput: json.RawMessage(`{"project_name":"acme"}`),
 	})
@@ -303,6 +304,7 @@ async def resume(ctx):
 	}
 	second, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{
 		RunID:       runID2,
+		Resumed:     true,
 		ResumeState: json.RawMessage(first.ResumeState),
 		ResumeInput: json.RawMessage(`{"project_name":"acme"}`),
 	})
@@ -397,6 +399,7 @@ steps = {"choose_framework": choose_framework, "deploy": deploy}
 	}
 	r2, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{
 		RunID:       runID2,
+		Resumed:     true,
 		ResumeState: json.RawMessage(r1.ResumeState),
 		ResumeInput: json.RawMessage(`{"framework":"deno"}`),
 	})
@@ -430,6 +433,7 @@ steps = {"choose_framework": choose_framework, "deploy": deploy}
 	}
 	r3, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{
 		RunID:       runID3,
+		Resumed:     true,
 		ResumeState: json.RawMessage(r2.ResumeState),
 		ResumeInput: json.RawMessage(`{"env":"prod"}`),
 	})
@@ -539,6 +543,7 @@ async def main():
 
 	res, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{
 		RunID:       runID,
+		Resumed:     true,
 		ResumeState: json.RawMessage(`{"__step":null,"state":{"step":"ask_framework","name":"proj"}}`),
 		ResumeInput: json.RawMessage(`{"project_name":"acme"}`),
 	})
@@ -570,6 +575,124 @@ async def main():
 	}
 	if inp["project_name"] != "acme" {
 		t.Errorf("ctx.input = %#v, want project_name=acme", inp)
+	}
+}
+
+// TestExecute_ResumeWithNullStateDispatchesResume guards the resume-detection
+// fix (#517): a resume whose carried author state is genuinely None must still be
+// treated as a resume and dispatch the resume handler with the validated input —
+// not fall through to main as a fresh run. The signal is the explicit `resumed`
+// flag, never the presence of state.
+func TestExecute_ResumeWithNullStateDispatchesResume(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires uv subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	reg, ex := newSuspendExecutor(t)
+
+	spec := writePythonTask(t, "examples/nullstate", `
+async def main():
+    return {"via": "main"}
+
+async def resume(ctx):
+    return {"via": "resume", "state_none": ctx.state is None, "name": ctx.input["project_name"]}
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+	runID, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{
+		RunID:       runID,
+		Resumed:     true,
+		ResumeState: nil, // genuinely-null carried state
+		ResumeInput: json.RawMessage(`{"project_name":"acme"}`),
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	logs, _ := reg.GetRunLogs(ctx, runID)
+	if res.Error != nil {
+		t.Fatalf("run error: %v\nlogs:\n%s", res.Error, joinLogs(logs))
+	}
+	ret, ok := res.ChainInput.(map[string]any)
+	if !ok {
+		t.Fatalf("ChainInput = %#v, want map\nlogs:\n%s", res.ChainInput, joinLogs(logs))
+	}
+	if ret["via"] != "resume" {
+		t.Errorf("dispatch went to %#v, want the resume handler (not a fresh main)", ret["via"])
+	}
+	if ret["state_none"] != true {
+		t.Errorf("resume must see the None carried state, got state_none=%#v", ret["state_none"])
+	}
+	if ret["name"] != "acme" {
+		t.Errorf("validated submission dropped: ctx.input[project_name] = %#v, want acme", ret["name"])
+	}
+}
+
+// TestExecute_ResumeMissingStepFailsLoudly guards the missing-marker fix (#517):
+// when `steps` is exported but the resume marker names no matching step, the run
+// must FAIL loudly rather than silently re-run main/resume against mid-wizard
+// state.
+func TestExecute_ResumeMissingStepFailsLoudly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires uv subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	reg, ex := newSuspendExecutor(t)
+
+	spec := writePythonTask(t, "examples/missingstep", `
+async def main():
+    return {"via": "main"}
+
+async def known(ctx):
+    return {"via": "known"}
+
+steps = {"known": known}
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+	runID, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{
+		RunID:       runID,
+		Resumed:     true,
+		ResumeState: json.RawMessage(`{"__step":"gone","state":{}}`),
+		ResumeInput: json.RawMessage(`{"x":"y"}`),
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	logs, _ := reg.GetRunLogs(ctx, runID)
+	if res.Error == nil {
+		t.Fatalf("resume to a missing step must fail the run, got no error\nlogs:\n%s", joinLogs(logs))
+	}
+	if res.ChainInput != nil {
+		t.Errorf("resume to a missing step must not run main, got return %#v", res.ChainInput)
+	}
+	if res.Suspended {
+		t.Errorf("resume to a missing step must not be classified as suspended")
+	}
+	found := false
+	for _, l := range logs {
+		if strings.Contains(l.Message, "is not an exported step function") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a clear diagnostic naming the missing step, logs:\n%s", joinLogs(logs))
 	}
 }
 

--- a/pkg/runtime/python/suspend_test.go
+++ b/pkg/runtime/python/suspend_test.go
@@ -578,6 +578,81 @@ async def main():
 	}
 }
 
+// TestExecute_SchemalessSuspendAndResume guards the schema-less suspend path
+// (#517): a task that calls dicode.suspend(state=...) with NO schema must suspend
+// cleanly (the Python SDK sends no `schema` field, so the daemon records no
+// constraint) rather than failing with "invalid suspend schema", and a resume
+// with input must then succeed.
+func TestExecute_SchemalessSuspendAndResume(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires uv subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	reg, ex := newSuspendExecutor(t)
+
+	spec := writePythonTask(t, "examples/schemaless", `
+async def main():
+    if ctx.state is None:
+        dicode.suspend(state={"step": "ask"})
+    return {"resumed": ctx.state is not None, "name": ctx.input.get("project_name")}
+`)
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+	runID, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{RunID: runID})
+	if err != nil {
+		t.Fatalf("Execute (suspend): %v", err)
+	}
+	logs, _ := reg.GetRunLogs(ctx, runID)
+	if first.Error != nil {
+		t.Fatalf("schema-less suspend must not fail, got error: %v\nlogs:\n%s", first.Error, joinLogs(logs))
+	}
+	if !first.Suspended {
+		t.Fatalf("schema-less suspend must suspend the run\nlogs:\n%s", joinLogs(logs))
+	}
+	if len(first.ResumeSchema) != 0 {
+		t.Errorf("schema-less suspend must record no schema, got %q", first.ResumeSchema)
+	}
+
+	runID2, err := reg.StartRun(ctx, spec.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{
+		RunID:       runID2,
+		Resumed:     true,
+		ResumeState: json.RawMessage(first.ResumeState),
+		ResumeInput: json.RawMessage(`{"project_name":"acme"}`),
+	})
+	if err != nil {
+		t.Fatalf("Execute (resume): %v", err)
+	}
+	logs2, _ := reg.GetRunLogs(ctx, runID2)
+	if second.Error != nil {
+		t.Fatalf("schema-less resume must succeed, got error: %v\nlogs:\n%s", second.Error, joinLogs(logs2))
+	}
+	if second.Suspended {
+		t.Fatalf("resume must not re-suspend\nlogs:\n%s", joinLogs(logs2))
+	}
+	ret, ok := second.ChainInput.(map[string]any)
+	if !ok {
+		t.Fatalf("ChainInput = %#v, want map\nlogs:\n%s", second.ChainInput, joinLogs(logs2))
+	}
+	if ret["resumed"] != true {
+		t.Errorf("ctx.state must be set on resume, got resumed=%#v", ret["resumed"])
+	}
+	if ret["name"] != "acme" {
+		t.Errorf("ctx.input[project_name] = %#v, want acme", ret["name"])
+	}
+}
+
 // TestExecute_ResumeWithNullStateDispatchesResume guards the resume-detection
 // fix (#517): a resume whose carried author state is genuinely None must still be
 // treated as a resume and dispatch the resume handler with the validated input —

--- a/pkg/trigger/resume.go
+++ b/pkg/trigger/resume.go
@@ -146,6 +146,7 @@ func (e *Engine) ResumeRun(ctx context.Context, token string, input []byte) (str
 
 	opts := pkgruntime.RunOptions{
 		ParentRunID: run.ID,
+		Resumed:     true,
 		ResumeState: run.ResumeState,
 		ResumeInput: input,
 	}

--- a/pkg/webui/resume.go
+++ b/pkg/webui/resume.go
@@ -60,7 +60,11 @@ func (s *Server) apiResumeRun(w http.ResponseWriter, r *http.Request) {
 
 	values := map[string]any{}
 	if r.Body != nil && r.ContentLength != 0 {
-		if err := json.NewDecoder(r.Body).Decode(&values); err != nil && err != io.EOF {
+		dec := json.NewDecoder(r.Body)
+		// Preserve numbers as json.Number so integers > 2^53 survive the
+		// re-marshal below without being coerced through float64.
+		dec.UseNumber()
+		if err := dec.Decode(&values); err != nil && err != io.EOF {
 			jsonErr(w, "invalid JSON body: "+err.Error(), http.StatusBadRequest)
 			return
 		}

--- a/pkg/webui/resume_test.go
+++ b/pkg/webui/resume_test.go
@@ -105,6 +105,31 @@ func TestApiResumeRun_MissingRequiredField(t *testing.T) {
 	}
 }
 
+// A submitted integer larger than 2^53 must reach the task without being coerced
+// through float64 (#517): the endpoint decodes with json.Number so the exact
+// digits survive the re-marshal into the resume input.
+func TestApiResumeRun_LargeIntegerPreservesPrecision(t *testing.T) {
+	srv, reg := newTestServer(t)
+	fr := &fakeResumer{newRunID: "cont"}
+	srv.SetResumer(fr)
+	schema := []byte(`{"type":"object","properties":{"big":{"type":"integer"}}}`)
+	runID := seedSuspendedRun(t, reg, schema, "tok")
+
+	const big = "9007199254740993" // 2^53 + 1 — not representable exactly as float64
+	req := httptest.NewRequest(http.MethodPost, "/api/runs/"+runID+"/resume",
+		strings.NewReader(`{"big":`+big+`}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(string(fr.gotInput), big) {
+		t.Fatalf("large integer lost precision: forwarded input = %s, want it to contain %s", fr.gotInput, big)
+	}
+}
+
 func TestApiResumeRun_NotSuspended(t *testing.T) {
 	srv, reg := newTestServer(t)
 	srv.SetResumer(&fakeResumer{})

--- a/tasks/buildin/webui/app/components/dc-run-detail.js
+++ b/tasks/buildin/webui/app/components/dc-run-detail.js
@@ -180,7 +180,7 @@ class DcRunDetail extends LitElement {
     const form = e.target;
     const values = {};
     for (const [name, prop] of Object.entries(props)) {
-      const el = form.elements[name];
+      const el = form.elements.namedItem(name);
       if (!el) continue;
       const v = this._coerceValue(prop, el);
       if (this._isRequired(name) && (v === '' || v === null || v === undefined)) {


### PR DESCRIPTION
## Summary

A Fable integration audit of the merged suspendable-tasks v2 (Phase A #514 × Phase B #515) found the design sound and closed on four cheap in-area robustness footguns. None change behavior for current-version tasks; each removes a way a suspend/resume could silently misbehave.

**Resume detection no longer infers from carried state.** Both SDKs decided "is this a resume?" from the carried state being non-null. Current tasks always persist a non-null `{__step, state}` envelope, but a suspension with a genuinely-null state would resume as a *fresh* run — dispatching `main` with trigger input and dropping the validated form submission, after the single-use resume token was already spent. An explicit `resumed` flag is now threaded from the trigger through the `"resume"` IPC reply, and both SDKs dispatch on that flag instead of on state presence.

**A missing/renamed step fails loudly.** When a task exports `steps` but the resume marker names no matching handler (a typo, or a task edited mid-wizard), dispatch silently fell back to `resume`/`main` against mid-wizard state. Both runtimes now emit a clear `[dicode]` diagnostic and exit non-zero. The single-`main` / two-function compatibility fallback is preserved for tasks that do not export `steps`.

**The suspend schema is probed at suspend time.** `dicode.suspend` stored `req.Schema` unvalidated; a parseable-but-un-compilable schema only failed at *resume*, returning 400 on every attempt and bricking the run until the TTL sweep, with zero author feedback. The handler now compiles the schema with the same validator used at resume and surfaces the failure to the task while it can still react. An empty schema stays unconstrained.

**Form renderer + number precision.** The resume form renderer read fields via `form.elements[name]`, so a schema property named `length`/`item`/`namedItem` resolved to a built-in collection member; it now uses `namedItem()`. Separately, the resume endpoint round-tripped submitted numbers through `map[string]any`, coercing integers above 2^53 through `float64` before validation; it now decodes with `json.Number` so the exact digits survive (santhosh-tekuri v6 validates `json.Number` natively).

## Testing

Each fix has a dedicated test: null-state-resume dispatch and missing-step loud failure in both `pkg/runtime/deno` and `pkg/runtime/python`; suspend-time schema rejection in `pkg/ipc`; and a large-integer precision round-trip in `pkg/webui`. Full `go test ./...` and `go vet ./...` pass.

Closes #517. Part of #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resume actions now carry an explicit resumed status, improving reliability when continuing suspended runs.
  * Resume forms preserve large numeric values accurately.

* **Bug Fixes**
  * Resuming now works correctly even when prior state is empty or null.
  * Invalid resume/suspend schemas are rejected instead of being saved.
  * Attempts to resume into a missing step now fail clearly rather than continuing incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->