### PR TITLE
fix(startup): silence three startup log-noise sources

### DIFF
--- a/pkg/registry/inputstore.go
+++ b/pkg/registry/inputstore.go
@@ -22,6 +22,13 @@ type TaskRunner interface {
 // abort the operation rather than retry.
 var ErrInputUnavailable = errors.New("run input unavailable (gc'd or never stored)")
 
+// ErrStorageTaskNotRegistered wraps Persist/Fetch/Delete failures that stem
+// purely from the configured storage task not yet being in the registry.
+// Daemon-triggered runs can fire before buildin/local-storage registers at
+// startup (#523); callers use errors.Is to treat this transient window
+// distinctly from a genuine storage write failure.
+var ErrStorageTaskNotRegistered = errors.New("storage task not registered")
+
 // InputStore marshals PersistedInput, encrypts it with InputCrypto, and
 // delegates byte storage to a configured storage task via a TaskRunner.
 //

--- a/pkg/registry/reconciler.go
+++ b/pkg/registry/reconciler.go
@@ -271,14 +271,27 @@ func (rc *Reconciler) handle(ev source.Event) {
 		// pipelines declare no env providers.
 		if spec, ok := k.(*task.Spec); ok {
 			if err := rc.validateTaskProviders(spec); err != nil {
-				rc.log.Warn("task references unknown provider; queued for retry after next registration",
+				// Warn only on the transition into "queued"; every successful
+				// registration re-runs this check for all still-pending tasks,
+				// so warning each time turns one unresolved dependency into N
+				// identical lines during startup (#521). Repeat re-checks of an
+				// already-queued task drop to debug — the signal is preserved
+				// (a task that resolves is deleted from pending, and a later
+				// re-failure warns again as a fresh transition).
+				rc.mu.Lock()
+				_, alreadyQueued := rc.pending[ev.TaskID]
+				rc.pending[ev.TaskID] = ev
+				rc.mu.Unlock()
+				fields := []zap.Field{
 					zap.String("task", ev.TaskID),
 					zap.String("source", ev.Source),
 					zap.Error(err),
-				)
-				rc.mu.Lock()
-				rc.pending[ev.TaskID] = ev
-				rc.mu.Unlock()
+				}
+				if alreadyQueued {
+					rc.log.Debug("task still references unknown provider; remains queued for retry", fields...)
+				} else {
+					rc.log.Warn("task references unknown provider; queued for retry after next registration", fields...)
+				}
 				return
 			}
 		}

--- a/pkg/registry/reconciler_test.go
+++ b/pkg/registry/reconciler_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/dicode/dicode/pkg/source"
 	"github.com/dicode/dicode/pkg/task"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // fakeSource is a controllable source for testing the reconciler.
@@ -432,5 +434,63 @@ permissions:
 	want := dataDir + "/some-subdir"
 	if spec.Permissions.FS[0].Path != want {
 		t.Errorf("FS[0].Path = %q, want %q (${DATADIR} was not expanded)", spec.Permissions.FS[0].Path, want)
+	}
+}
+
+// TestReconciler_QueuedWarnLoggedOnce verifies that an unresolved provider
+// dependency warns exactly once even when the queued-retry check re-runs on
+// every subsequent registration (#521). Repeat re-checks drop to debug so one
+// unresolved task does not emit N identical WARN lines during startup.
+func TestReconciler_QueuedWarnLoggedOnce(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+
+	fs := newFakeSource("test")
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := New(d)
+	rc := NewReconciler(reg, []source.Source{fs}, "", zap.New(core))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go rc.Run(ctx)
+
+	time.Sleep(20 * time.Millisecond) // let Run() set up merged channel
+
+	consumer := &task.Spec{
+		ID:   "waiting-consumer",
+		Name: "waiting-consumer",
+		Permissions: task.Permissions{
+			Env: []task.EnvEntry{{Name: "PG_URL", From: "task:missing-provider"}},
+		},
+		Trigger: task.TriggerConfig{Manual: true},
+	}
+	// Consumer queued: provider never registers, so it stays unresolved.
+	fs.ch <- source.Event{Kind: source.EventAdded, TaskID: "waiting-consumer", Kinded: consumer, Source: "test"}
+	time.Sleep(50 * time.Millisecond)
+
+	// Register several unrelated tasks. Each successful registration re-runs
+	// retryPending, re-checking the still-unresolved consumer.
+	for i := 0; i < 5; i++ {
+		other := &task.Spec{
+			ID:      "other-" + string(rune('a'+i)),
+			Name:    "other",
+			Trigger: task.TriggerConfig{Manual: true},
+		}
+		fs.ch <- source.Event{Kind: source.EventAdded, TaskID: other.ID, Kinded: other, Source: "test"}
+		time.Sleep(20 * time.Millisecond)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	const warnMsg = "task references unknown provider; queued for retry after next registration"
+	warnCount := logs.FilterMessage(warnMsg).Len()
+	if warnCount != 1 {
+		t.Fatalf("expected exactly 1 WARN for the unresolved provider, got %d", warnCount)
+	}
+	// The repeat re-checks must still leave a trail at debug level.
+	if debugCount := logs.FilterMessage("task still references unknown provider; remains queued for retry").Len(); debugCount == 0 {
+		t.Fatal("expected repeat queued re-checks to be logged at debug, got none")
 	}
 }

--- a/pkg/trigger/engine_input_persistence_test.go
+++ b/pkg/trigger/engine_input_persistence_test.go
@@ -5,8 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dicode/dicode/pkg/db"
 	"github.com/dicode/dicode/pkg/registry"
 	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // fakeRunner is a minimal in-memory TaskRunner for testing the engine's
@@ -287,6 +291,65 @@ export default async function main({ params, dicode }: any) {
 	}
 	if afterRun.InputStoredAt != 0 {
 		t.Errorf("InputStoredAt not cleared after delete_input; got %d", afterRun.InputStoredAt)
+	}
+}
+
+// TestEngine_PersistStorageTaskNotReady_NotWarned verifies the #523 startup
+// race: when a run's input persist fails purely because the backing storage
+// task is not yet registered, the engine logs at debug (self-healing startup
+// window) rather than emitting a false-alarm WARN. A genuine persist error
+// would still warn (see the error_class="persist" branch).
+func TestEngine_PersistStorageTaskNotReady_NotWarned(t *testing.T) {
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	// nil executor: dispatch fails after the run record is created, but the
+	// synchronous persist hook in startRunWithParent runs first — which is all
+	// this test exercises.
+	eng := New(reg, nil, zap.New(core))
+	eng.SetDB(d)
+
+	// Real runner backed by this engine, pointed at a storage task that is
+	// deliberately never registered so RunTaskSync returns
+	// registry.ErrStorageTaskNotRegistered.
+	runner := NewInputStoreTaskRunner(eng)
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	is := registry.NewInputStore(registry.NewInputCrypto(key), runner, "buildin/local-storage")
+	eng.SetInputStore(is)
+
+	spec := &task.Spec{
+		ID:      "daemon-ish-task",
+		Name:    "daemon-ish-task",
+		Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true},
+		Timeout: 30 * time.Second,
+		Enabled: true,
+	}
+	_ = reg.Register(spec)
+
+	runID, err := eng.FireManual(context.Background(), "daemon-ish-task", map[string]string{"a": "b"})
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	waitForTerminal(t, eng, runID, 30*time.Second)
+
+	if n := logs.FilterMessage("run-input persist failed").Len(); n != 0 {
+		t.Errorf("storage-not-ready must not WARN; got %d 'run-input persist failed' logs", n)
+	}
+	debug := logs.FilterMessage("run-input persist skipped: storage task not yet registered")
+	if debug.Len() == 0 {
+		t.Fatal("expected a debug log for the storage-not-ready persist window, got none")
+	}
+	if lvl := debug.All()[0].Level; lvl != zapcore.DebugLevel {
+		t.Errorf("storage-not-ready log level = %v, want debug", lvl)
 	}
 }
 

--- a/pkg/trigger/inputstore_runner.go
+++ b/pkg/trigger/inputstore_runner.go
@@ -21,7 +21,7 @@ type inputStoreTaskRunner struct{ e *Engine }
 func (r *inputStoreTaskRunner) RunTaskSync(ctx context.Context, taskID string, params map[string]string) (any, error) {
 	spec, ok := r.e.registry.Get(taskID)
 	if !ok {
-		return nil, fmt.Errorf("storage task %q not registered", taskID)
+		return nil, fmt.Errorf("storage task %q: %w", taskID, registry.ErrStorageTaskNotRegistered)
 	}
 	_, result, err := r.e.fireSync(ctx, spec, pkgruntime.RunOptions{Params: params}, "input-storage")
 	if err != nil {

--- a/pkg/trigger/run.go
+++ b/pkg/trigger/run.go
@@ -183,11 +183,22 @@ func (e *Engine) startRunWithParent(parent context.Context, spec *task.Spec, opt
 		in := registry.BuildPersistedInputFromRunOpts(string(source), opts.Params, opts.Input, web)
 		key, size, storedAt, perr := e.inputStore.Persist(context.Background(), opts.RunID, in)
 		if perr != nil {
-			e.log.Warn("run-input persist failed",
-				zap.String("run", opts.RunID),
-				zap.String("task", spec.ID),
-				zap.String("error_class", "persist"),
-			)
+			if errors.Is(perr, registry.ErrStorageTaskNotRegistered) {
+				// Startup race (#523): daemon-triggered runs (tray, relay-*,
+				// nginx-start) fire before buildin/local-storage registers, so
+				// the backing store isn't ready yet. Expected and self-healing —
+				// debug, not warn. Genuine persist failures still warn below.
+				e.log.Debug("run-input persist skipped: storage task not yet registered",
+					zap.String("run", opts.RunID),
+					zap.String("task", spec.ID),
+				)
+			} else {
+				e.log.Warn("run-input persist failed",
+					zap.String("run", opts.RunID),
+					zap.String("task", spec.ID),
+					zap.String("error_class", "persist"),
+				)
+			}
 		} else {
 			if opts.WebhookCtx != nil {
 				// Bound RAM exposure: RawBody is no longer needed now that the

--- a/tasks/examples/doppler-secret-demo/task.yaml
+++ b/tasks/examples/doppler-secret-demo/task.yaml
@@ -28,9 +28,9 @@ trigger:
 permissions:
   env:
     - name: PG_URL
-      from: task:secret-providers/doppler
+      from: task:buildin/secret-providers/doppler
     - name: REDIS_URL
-      from: task:secret-providers/doppler
+      from: task:buildin/secret-providers/doppler
       optional: true
 
 timeout: 10s


### PR DESCRIPTION
## Summary

A clean daemon boot printed a burst of WARN lines that made a healthy startup look broken. Three independent, unrelated conditions were responsible; this PR quiets all three without hiding any real signal.

**Reconciler queued-retry spam (#521).** Every successful task registration re-runs the unknown-provider check for all still-pending tasks. A single unresolved provider dependency therefore emitted one identical WARN per registration event — roughly 35 copies during startup. The warning now fires only on the *transition* into the queued state; repeat re-checks of an already-queued task drop to debug. The signal is preserved: a task that resolves is cleared from the pending set, and a later re-failure warns again as a fresh transition, so a dependency that never resolves is still visible.

**Run-input persist startup race (#523).** Daemon-triggered runs (tray, relay-*, nginx-start) fire before `buildin/local-storage` — the backing persistence task — has registered, so the input persist write fails inside a self-healing startup window and logged a false-alarm WARN. A sentinel error, `registry.ErrStorageTaskNotRegistered`, now distinguishes "storage task not yet registered" from a genuine write failure. The transient case logs at debug; real persist errors (`error_class=persist`) still WARN, so nothing is silently swallowed.

**Doppler example wrong provider id (#522).** The example referenced the provider by its source-relative id (`task:secret-providers/doppler`), which never resolves from a different source and directly drove the retry spam above. Corrected to the fully-qualified `task:buildin/secret-providers/doppler`.

## Tests

- `TestReconciler_QueuedWarnLoggedOnce` — one unresolved task across many registrations warns exactly once and leaves a debug trail on repeats.
- `TestEngine_PersistStorageTaskNotReady_NotWarned` — the storage-not-ready persist path logs at debug, not WARN.

Closes #521
Closes #522
Closes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)