### PR TITLE
fix(trigger): drain in-flight runs before shutdown closes the DB

### DIFF
--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -4,6 +4,7 @@ package trigger
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -103,9 +104,18 @@ type Engine struct {
 	// pipeline-parent runs via firePipeline). Start drains it before returning
 	// so the daemon's deferred database.Close() cannot run while a run goroutine
 	// is still executing FinishRun/status writes — the DB must outlive run
-	// finalization (issue #520). Add is always called before `go`, never inside
-	// the goroutine, so Wait cannot race past a not-yet-started run.
-	runWG sync.WaitGroup
+	// finalization (issue #520).
+	//
+	// Every fire that leads to a FinishRun goes through trackRun, which does the
+	// runWG.Add under wgMu and refuses (returns false) once shutdown has begun.
+	// wgMu makes Add mutually exclusive with beginShutdown's flag write, so no
+	// Add can race the drain's Wait — this both prevents the "Add called
+	// concurrently with Wait" panic and stops a chain/sweep fire spawned in a
+	// detached goroutine from touching the DB after the drain (the escaped
+	// goroutine's own Add is what gets refused).
+	wgMu         sync.Mutex
+	shuttingDown bool
+	runWG        sync.WaitGroup
 
 	// drainGrace bounds the shutdown drain of runWG. Defaults to
 	// shutdownDrainGrace; overridable in tests.
@@ -371,6 +381,12 @@ func (e *Engine) Start(ctx context.Context) error {
 
 	<-ctx.Done()
 	e.cron.Stop()
+
+	// Latch the gate before killing/draining: from here trackRun refuses new
+	// runs, so any chain/sweep/reconciler fire triggered by a run finalizing
+	// during shutdown is turned away before it touches the DB, and no Add can
+	// race the drain's Wait below.
+	e.beginShutdown()
 
 	e.daemonMu.Lock()
 	killList := make(map[string]string, len(e.daemonRuns))
@@ -731,6 +747,35 @@ func (e *Engine) isShuttingDown() bool {
 	ctx := e.shutdownCtx
 	e.shutdownMu.RUnlock()
 	return ctx != nil && ctx.Err() != nil
+}
+
+// errEngineShuttingDown is returned by fire paths that refuse to start a new run
+// because the engine is draining toward shutdown. Callers treat it as "do not
+// fire" — a handler surfaces it as an error; a chain/sweep dispatch skips.
+var errEngineShuttingDown = errors.New("trigger: engine is shutting down")
+
+// trackRun reserves a runWG slot for a run goroutine that is about to be
+// launched, returning false once shutdown has begun (in which case the caller
+// must not fire and must not call Done). The Add happens under wgMu, mutually
+// exclusive with beginShutdown, so it can never race the drain's Wait. On
+// success the caller owns exactly one Done.
+func (e *Engine) trackRun() bool {
+	e.wgMu.Lock()
+	defer e.wgMu.Unlock()
+	if e.shuttingDown {
+		return false
+	}
+	e.runWG.Add(1)
+	return true
+}
+
+// beginShutdown latches the shutting-down flag so no further trackRun can add to
+// runWG. It must be called before the drain's Wait so the counter only ever
+// decreases from that point on.
+func (e *Engine) beginShutdown() {
+	e.wgMu.Lock()
+	e.shuttingDown = true
+	e.wgMu.Unlock()
 }
 
 func (e *Engine) getShutdownCtx() context.Context {

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -99,6 +99,18 @@ type Engine struct {
 	shutdownMu  sync.RWMutex
 	shutdownCtx context.Context
 
+	// runWG tracks every in-flight run goroutine (task runs via fireAsync and
+	// pipeline-parent runs via firePipeline). Start drains it before returning
+	// so the daemon's deferred database.Close() cannot run while a run goroutine
+	// is still executing FinishRun/status writes — the DB must outlive run
+	// finalization (issue #520). Add is always called before `go`, never inside
+	// the goroutine, so Wait cannot race past a not-yet-started run.
+	runWG sync.WaitGroup
+
+	// drainGrace bounds the shutdown drain of runWG. Defaults to
+	// shutdownDrainGrace; overridable in tests.
+	drainGrace time.Duration
+
 	daemonMu    sync.Mutex
 	daemonRuns  map[string]string
 	daemonSpecs map[string]*task.Spec
@@ -197,6 +209,7 @@ func New(r *registry.Registry, defaultExec pkgruntime.Executor, log *zap.Logger)
 		livePipelines:      make(map[string]*PipelineRunner),
 		deferredPipelines:  make(map[string]*task.PipelineTask),
 		guards:             newChainGuards(),
+		drainGrace:         shutdownDrainGrace,
 	}
 	e.executors[task.RuntimeDeno] = defaultExec
 	return e
@@ -370,8 +383,48 @@ func (e *Engine) Start(ctx context.Context) error {
 		e.log.Info("stopping daemon on shutdown", zap.String("task", taskID), zap.String("run", runID))
 		e.KillRun(runID)
 	}
+
+	// Pipeline terminal-daemon runs are not tracked in daemonRuns (they are
+	// owned by the PipelineRunner, not the standalone-daemon machinery), so the
+	// loop above misses them. Kill them explicitly so their run goroutines exit
+	// and finalize within the drain window below instead of running past DB
+	// close.
+	e.livePipelineMu.Lock()
+	pipelineDaemonRuns := make([]string, 0, len(e.livePipelines))
+	for _, r := range e.livePipelines {
+		r.mu.Lock()
+		runID := r.daemonRunID
+		r.mu.Unlock()
+		if runID != "" {
+			pipelineDaemonRuns = append(pipelineDaemonRuns, runID)
+		}
+	}
+	e.livePipelineMu.Unlock()
+	for _, runID := range pipelineDaemonRuns {
+		e.KillRun(runID)
+	}
+
+	// Drain in-flight run goroutines before returning so the daemon's deferred
+	// database.Close() runs only after every FinishRun/status write completes.
+	// Bounded by drainGrace so a wedged run cannot hang shutdown forever.
+	drained := make(chan struct{})
+	go func() {
+		e.runWG.Wait()
+		close(drained)
+	}()
+	select {
+	case <-drained:
+	case <-time.After(e.drainGrace):
+		e.log.Warn("shutdown drain grace elapsed with runs still in flight; proceeding to close",
+			zap.Duration("grace", e.drainGrace))
+	}
 	return nil
 }
+
+// shutdownDrainGrace bounds how long Start waits for in-flight run goroutines to
+// finalize after shutdown kills are issued. A wedged run cannot exceed this
+// ceiling, so shutdown always makes progress.
+const shutdownDrainGrace = 10 * time.Second
 
 // Register adds or updates trigger registrations for the given task, routing by
 // kind: a *task.PipelineTask is validated via registerPipeline; a *task.Spec

--- a/pkg/trigger/pipeline_runner.go
+++ b/pkg/trigger/pipeline_runner.go
@@ -162,7 +162,14 @@ func (e *Engine) firePipeline(ctx context.Context, p *task.PipelineTask, opts pk
 		triggerInput:  triggerInput,
 		triggerParams: opts.Params,
 	}
-	go r.run(runCtx)
+	// Add before `go` so a shutdown drain cannot race past a not-yet-started
+	// pipeline. run finalizes the parent run row (r.finish); the DB must outlive
+	// it (issue #520).
+	e.runWG.Add(1)
+	go func() {
+		defer e.runWG.Done()
+		r.run(runCtx)
+	}()
 	return runID, nil
 }
 

--- a/pkg/trigger/pipeline_runner.go
+++ b/pkg/trigger/pipeline_runner.go
@@ -70,6 +70,20 @@ type PipelineRunner struct {
 // that lost the reconcile-ordering race, see #341) is rejected loudly here
 // rather than dispatched and failed mid-flight.
 func (e *Engine) firePipeline(ctx context.Context, p *task.PipelineTask, opts pkgruntime.RunOptions, source registry.TriggerSource) (string, error) {
+	// Reserve a drain slot before creating the parent run row. Refused once
+	// shutdown has begun so a chain-dispatched pipeline can't finalize past the
+	// drain (#520). Released by the runner goroutine's deferred Done, or here if
+	// we bail before spawning it.
+	if !e.trackRun() {
+		return "", errEngineShuttingDown
+	}
+	spawned := false
+	defer func() {
+		if !spawned {
+			e.runWG.Done()
+		}
+	}()
+
 	if err := e.validatePipelineRefs(p); err != nil {
 		return "", fmt.Errorf("pipeline %q failed validation: %w", p.ID, err)
 	}
@@ -162,10 +176,9 @@ func (e *Engine) firePipeline(ctx context.Context, p *task.PipelineTask, opts pk
 		triggerInput:  triggerInput,
 		triggerParams: opts.Params,
 	}
-	// Add before `go` so a shutdown drain cannot race past a not-yet-started
-	// pipeline. run finalizes the parent run row (r.finish); the DB must outlive
-	// it (issue #520).
-	e.runWG.Add(1)
+	// The runWG slot reserved by trackRun above transfers to this goroutine; it
+	// finalizes the parent run row (r.finish), and the DB must outlive it (#520).
+	spawned = true
 	go func() {
 		defer e.runWG.Done()
 		r.run(runCtx)

--- a/pkg/trigger/run.go
+++ b/pkg/trigger/run.go
@@ -410,6 +410,21 @@ func (e *Engine) fireAsync(ctx context.Context, spec *task.Spec, opts pkgruntime
 		opts.RunID = uuid.New().String()
 	}
 
+	// Reserve a drain slot before creating any run record. Once shutdown has
+	// begun this is refused so no new run — including one dispatched by a chain
+	// edge from a run finalizing mid-shutdown — starts a DB write after the
+	// drain (#520). The slot is released by the run goroutine's deferred Done,
+	// or here if we bail before spawning it.
+	if !e.trackRun() {
+		return "", errEngineShuttingDown
+	}
+	spawned := false
+	defer func() {
+		if !spawned {
+			e.runWG.Done()
+		}
+	}()
+
 	runCtx, cleanup, err := e.startRun(spec, &opts, source)
 	if err != nil {
 		return "", err
@@ -430,8 +445,7 @@ func (e *Engine) fireAsync(ctx context.Context, spec *task.Spec, opts pkgruntime
 		}
 	}
 
-	// Add before `go` so a shutdown drain cannot race past a not-yet-started run.
-	e.runWG.Add(1)
+	spawned = true
 	go func() {
 		// First deferred statement → runs last (LIFO), after cleanup and all
 		// finalization, so the drain releases only once the DB writes are done.

--- a/pkg/trigger/run.go
+++ b/pkg/trigger/run.go
@@ -430,7 +430,12 @@ func (e *Engine) fireAsync(ctx context.Context, spec *task.Spec, opts pkgruntime
 		}
 	}
 
+	// Add before `go` so a shutdown drain cannot race past a not-yet-started run.
+	e.runWG.Add(1)
 	go func() {
+		// First deferred statement → runs last (LIFO), after cleanup and all
+		// finalization, so the drain releases only once the DB writes are done.
+		defer e.runWG.Done()
 		defer cleanup()
 
 		// Daemon tasks are long-running; they must not consume semaphore slots

--- a/pkg/trigger/shutdown_drain_test.go
+++ b/pkg/trigger/shutdown_drain_test.go
@@ -37,9 +37,25 @@ type drainExec struct {
 	// block, when non-nil, is waited on INSTEAD of ctx — a wedged run that
 	// ignores KillRun. The test releases it during teardown.
 	block chan struct{}
+
+	mu        sync.Mutex
+	execCount map[string]int // per-task Execute invocations
 }
 
-func (d *drainExec) Execute(ctx context.Context, _ *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
+func (d *drainExec) count(taskID string) int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.execCount[taskID]
+}
+
+func (d *drainExec) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
+	d.mu.Lock()
+	if d.execCount == nil {
+		d.execCount = map[string]int{}
+	}
+	d.execCount[spec.ID]++
+	d.mu.Unlock()
+
 	d.startedOnce.Do(func() { close(d.started) })
 	if d.block != nil {
 		<-d.block
@@ -169,4 +185,100 @@ func TestShutdownDrainBoundedByGrace(t *testing.T) {
 	// open DB before the deferred db.Close runs.
 	close(exec.block)
 	eng.runWG.Wait()
+}
+
+// TestShutdownGatesChainDispatch proves the drain is a fence, not a snapshot: a
+// run finalizing during shutdown fires its chain edge in a detached goroutine
+// (FireChain → `go fireAsync`), and that dispatch must be refused rather than
+// escape the drain and write to a closed DB. The downstream task must never
+// execute and must leave no run row.
+func TestShutdownGatesChainDispatch(t *testing.T) {
+	exec := &drainExec{started: make(chan struct{})}
+	eng, reg := newDrainEnv(t, exec)
+
+	daemon := drainDaemonSpec() // "drain-daemon", killed on shutdown → finalizes
+	target := &task.Spec{
+		ID:      "chain-target",
+		Name:    "chain-target",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		// Fires on ANY terminal status of the daemon, including its shutdown kill.
+		Trigger: task.TriggerConfig{Chain: &task.ChainTrigger{From: daemon.ID, On: "always"}},
+		Enabled: true,
+	}
+	for _, s := range []*task.Spec{daemon, target} {
+		if err := reg.Register(s); err != nil {
+			t.Fatalf("reg.Register %s: %v", s.ID, err)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	startDone := make(chan error, 1)
+	go func() { startDone <- eng.Start(ctx) }()
+
+	runningDaemonRunID(t, eng, exec, daemon.ID)
+
+	cancel()
+
+	select {
+	case <-startDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after shutdown")
+	}
+
+	// Give the detached chain-dispatch goroutine time to run and be refused.
+	time.Sleep(150 * time.Millisecond)
+
+	if n := exec.count(target.ID); n != 0 {
+		t.Errorf("downstream %q executed %d time(s); chain dispatch escaped the shutdown gate", target.ID, n)
+	}
+	runs, err := reg.ListRuns(context.Background(), target.ID, 10)
+	if err != nil {
+		t.Fatalf("ListRuns(%q): %v", target.ID, err)
+	}
+	if len(runs) != 0 {
+		t.Errorf("downstream %q has %d run row(s); a gated dispatch must create none", target.ID, len(runs))
+	}
+}
+
+// TestTrackRunGateRaceWithShutdown exercises many concurrent trackRun fires
+// against beginShutdown + the drain's Wait. The wgMu serialization must keep
+// every Add out of the Wait window, so this never trips Go's
+// "sync: WaitGroup misuse: Add called concurrently with Wait" panic. Run under
+// -race for the full effect.
+func TestTrackRunGateRaceWithShutdown(t *testing.T) {
+	exec := &drainExec{started: make(chan struct{})}
+	eng, _ := newDrainEnv(t, exec)
+
+	var fires sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		fires.Add(1)
+		go func() {
+			defer fires.Done()
+			if eng.trackRun() {
+				// Won the gate before shutdown latched → must balance the Add.
+				eng.runWG.Done()
+			}
+		}()
+	}
+
+	// Latch shutdown concurrently with the fires, then drain.
+	eng.beginShutdown()
+	drained := make(chan struct{})
+	go func() {
+		eng.runWG.Wait()
+		close(drained)
+	}()
+
+	select {
+	case <-drained:
+	case <-time.After(5 * time.Second):
+		t.Fatal("drain did not complete")
+	}
+	fires.Wait()
+
+	// After shutdown latched, every subsequent trackRun must be refused.
+	if eng.trackRun() {
+		t.Fatal("trackRun granted a slot after beginShutdown")
+	}
 }

--- a/pkg/trigger/shutdown_drain_test.go
+++ b/pkg/trigger/shutdown_drain_test.go
@@ -1,0 +1,172 @@
+package trigger
+
+// Shutdown-drain regression tests (issue #520).
+//
+// On shutdown the engine killed in-flight daemon runs but returned before their
+// per-run goroutines finished FinishRun/status writes. The daemon then closed
+// the DB (deferred after the errgroup unblocks), so finalization hit
+// `sql: database is closed`. Start now drains runWG before returning, bounded by
+// drainGrace so a wedged run cannot hang shutdown forever.
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
+)
+
+// drainExec is a daemon body whose termination behaviour the test controls.
+// It signals when the body begins so the test can find the run's ID before
+// triggering shutdown.
+type drainExec struct {
+	started     chan struct{}
+	startedOnce sync.Once
+
+	// onCancelDelay, when > 0, is slept after the run context is cancelled and
+	// before Execute returns — widening the window in which the run's
+	// finalization runs, so a Start that failed to drain would return with the
+	// run still non-terminal.
+	onCancelDelay time.Duration
+
+	// block, when non-nil, is waited on INSTEAD of ctx — a wedged run that
+	// ignores KillRun. The test releases it during teardown.
+	block chan struct{}
+}
+
+func (d *drainExec) Execute(ctx context.Context, _ *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
+	d.startedOnce.Do(func() { close(d.started) })
+	if d.block != nil {
+		<-d.block
+		return &pkgruntime.RunResult{RunID: opts.RunID}, nil
+	}
+	<-ctx.Done()
+	if d.onCancelDelay > 0 {
+		time.Sleep(d.onCancelDelay)
+	}
+	return &pkgruntime.RunResult{RunID: opts.RunID}, nil
+}
+
+func newDrainEnv(t *testing.T, exec *drainExec) (*Engine, *registry.Registry) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+	eng := New(reg, exec, zap.NewNop())
+	eng.RegisterExecutor(task.RuntimeDocker, exec)
+	return eng, reg
+}
+
+func drainDaemonSpec() *task.Spec {
+	return &task.Spec{
+		ID:      "drain-daemon",
+		Name:    "drain-daemon",
+		Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{Daemon: true, Restart: "never"},
+		Enabled: true,
+	}
+}
+
+// runningDaemonRunID waits until the daemon body has begun and returns its run
+// ID from the engine's daemonRuns slot.
+func runningDaemonRunID(t *testing.T, eng *Engine, exec *drainExec, taskID string) string {
+	t.Helper()
+	select {
+	case <-exec.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon body never started")
+	}
+	var runID string
+	waitUntil(t, 2*time.Second, func() bool {
+		eng.daemonMu.Lock()
+		runID = eng.daemonRuns[taskID]
+		eng.daemonMu.Unlock()
+		return runID != ""
+	}, "daemon run slot never populated")
+	return runID
+}
+
+// TestShutdownDrainsInFlightRunFinalization proves the DB-outlives-finalization
+// invariant: a daemon run in flight when Start's ctx is cancelled must have its
+// FinishRun/status write completed by the time Start returns. The executor
+// sleeps after cancellation so a non-draining Start would observe the run still
+// in `running`.
+func TestShutdownDrainsInFlightRunFinalization(t *testing.T) {
+	exec := &drainExec{started: make(chan struct{}), onCancelDelay: 150 * time.Millisecond}
+	eng, reg := newDrainEnv(t, exec)
+
+	spec := drainDaemonSpec()
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("reg.Register: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	startDone := make(chan error, 1)
+	go func() { startDone <- eng.Start(ctx) }()
+
+	runID := runningDaemonRunID(t, eng, exec, spec.ID)
+
+	cancel()
+
+	select {
+	case <-startDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after shutdown")
+	}
+
+	// Start has returned; the run goroutine's finalization must already be done.
+	run, err := reg.GetRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("GetRun(%q): %v", runID, err)
+	}
+	if run.Status == registry.StatusRunning || run.Status == "" {
+		t.Fatalf("run %q status = %q; Start returned before finalization drained", runID, run.Status)
+	}
+}
+
+// TestShutdownDrainBoundedByGrace proves the drain cannot hang shutdown: a run
+// that ignores its kill still lets Start return once drainGrace elapses.
+func TestShutdownDrainBoundedByGrace(t *testing.T) {
+	exec := &drainExec{started: make(chan struct{}), block: make(chan struct{})}
+	eng, reg := newDrainEnv(t, exec)
+	eng.drainGrace = 200 * time.Millisecond
+
+	spec := drainDaemonSpec()
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("reg.Register: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	startDone := make(chan error, 1)
+	go func() { startDone <- eng.Start(ctx) }()
+
+	runningDaemonRunID(t, eng, exec, spec.ID)
+
+	start := time.Now()
+	cancel()
+
+	select {
+	case <-startDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start hung past the drain grace on a wedged run")
+	}
+	elapsed := time.Since(start)
+
+	if elapsed < eng.drainGrace {
+		t.Errorf("Start returned after %v, before the %v grace — it did not wait for the drain", elapsed, eng.drainGrace)
+	}
+
+	// Release the wedged body and let its goroutine finalize against the still-
+	// open DB before the deferred db.Close runs.
+	close(exec.block)
+	eng.runWG.Wait()
+}


### PR DESCRIPTION
## Summary

On daemon shutdown, `FinishRun`/status reads were failing with `sql: database is closed`. `Engine.Start`, on `ctx.Done()`, killed each daemon run and returned immediately — but `KillRun` only *requests* a cancellation. The per-run goroutines were still finalizing (`FinishRunWithResult`, the daemon finish-hook status read) when the daemon errgroup unblocked and the deferred `database.Close()` ran. Nothing kept the DB alive until in-flight runs finished.

## Approach

The engine now tracks every in-flight run goroutine in a `sync.WaitGroup` (`runWG`) — the `fireAsync` task-run goroutine and the `firePipeline` pipeline-parent goroutine, the two paths that write terminal run state. `Add` happens before `go` in each launcher; `Done` is the goroutine's first deferred statement, so it fires only after cleanup and finalization.

`Start`, after issuing the shutdown kills, drains `runWG` before returning, bounded by a grace timeout (`drainGrace`, default 10s) so a wedged run can't hang shutdown forever — it logs and proceeds if the grace elapses. Because `Start` runs inside the daemon's errgroup and `database.Close()` is deferred after `g.Wait()`, blocking `Start` on the drain is sufficient to keep the DB open until finalization completes; no other errgroup member closes the DB earlier.

Pipeline terminal-daemon runs are owned by the `PipelineRunner`, not the standalone-daemon machinery, so they never appear in `daemonRuns` and the existing kill loop misses them. Left unkilled, their run goroutines would keep `runWG` non-zero until the grace elapsed and then still race the close. `Start` now kills live-pipeline daemon runs explicitly before the drain so they finalize inside the window too.

The drain grace is an engine field defaulting to the package const, overridable in tests.

## Tests

`TestShutdownDrainsInFlightRunFinalization` proves the invariant: a daemon run in flight when `Start`'s ctx is cancelled has its status write completed by the time `Start` returns (the fake executor sleeps after cancellation, so a non-draining `Start` observes the run still `running` — verified this test fails without the drain). `TestShutdownDrainBoundedByGrace` proves a run that ignores its kill still lets `Start` return once the grace elapses, without hanging.

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown behavior so in-flight runs are drained more safely and shutdown completes only after active work is finalized.
  * Added a timeout to prevent shutdown from hanging indefinitely if a run does not stop promptly.
  * Prevented new work from starting once shutdown has begun, reducing race conditions during termination.
  * Ensured additional active runs are stopped during shutdown, including ones that could previously be missed.

* **Tests**
  * Added regression coverage for shutdown draining, bounded timeout behavior, and shutdown race handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->