### PR TITLE
fix(webui): make suspend/resume navigable and self-refreshing in the UI

### DIFF
--- a/tasks/buildin/webui/app/components/dc-run-detail.js
+++ b/tasks/buildin/webui/app/components/dc-run-detail.js
@@ -267,10 +267,10 @@ class DcRunDetail extends LitElement {
     const isRunning    = status === 'running';
     const startedAt    = run.started_at || run.StartedAt;
     const finishedAt   = run.finished_at || run.FinishedAt;
-    const trigSrc      = run.trigger_source;
-    const otype        = run.output_content_type;
-    const ocontent     = run.output_content;
-    const retval       = run.return_value;
+    const trigSrc      = run.trigger_source || run.TriggerSource;
+    const otype        = run.output_content_type || run.OutputContentType;
+    const ocontent     = run.output_content || run.OutputContent;
+    const retval       = run.return_value || run.ReturnValue;
 
     let displayRV = retval;
     if (retval) { try { displayRV = JSON.stringify(JSON.parse(retval), null, 2); } catch(_) {} }

--- a/tasks/buildin/webui/app/components/dc-run-detail.js
+++ b/tasks/buildin/webui/app/components/dc-run-detail.js
@@ -59,6 +59,10 @@ class DcRunDetail extends LitElement {
     this._status = null; this._duration = null;
     this._parent = null; this._children = null;
     this._resuming = false; this._resumeError = null;
+    // Subscribe before fetching: a run can suspend/finish in the window between
+    // the fetch returning "running" and a post-fetch subscribe, and that missed
+    // event is exactly what leaves a just-suspended run without its resume form.
+    this._wireWS();
     try {
       // Children fetch is fire-and-forget — failure here shouldn't block the
       // main run/logs load (Sub-runs panel just stays empty).
@@ -86,8 +90,6 @@ class DcRunDetail extends LitElement {
         catch (_) { this._parent = { ID: parentID }; }
       }
 
-      if (this._status === 'running') this._wireWS();
-
       await this.updateComplete;
       const logEl = this.querySelector('#log-output');
       if (logEl) logEl.scrollTop = logEl.scrollHeight;
@@ -97,6 +99,9 @@ class DcRunDetail extends LitElement {
   }
 
   _wireWS() {
+    // Idempotent — drop any prior subscriptions so a re-_load() can't double-wire.
+    this._offLog?.(); this._offLog = null;
+    this._offFinished?.(); this._offFinished = null;
     this._offLog = wsOn('run:log', d => {
       if (d.runID !== this.runid) return;
       this._logs = [...this._logs, {
@@ -117,9 +122,10 @@ class DcRunDetail extends LitElement {
       this._offFinished?.(); this._offFinished = null;
       this._status = d.status;
       this._duration = (d.durationMs / 1000).toFixed(1) + 's';
-      if (d.outputContentType) {
-        setTimeout(() => navigate(`/runs/${this.runid}`, false), 200);
-      }
+      // The WS event carries neither the resume schema (for a run that just
+      // suspended) nor the output; refetch so the resume form or the finished
+      // result renders without a manual reload.
+      get(`/api/runs/${this.runid}`).then(run => { this._run = run; }).catch(() => {});
     });
   }
 
@@ -255,9 +261,9 @@ class DcRunDetail extends LitElement {
     if (!this._run) return html`<div class="meta">Loading…</div>`;
 
     const run = this._run;
-    const taskName     = run.task_name || run.task_id;
-    const taskID       = run.task_id;
-    const status       = this._status || run.status;
+    const taskName     = run.task_name || run.TaskID || run.task_id;
+    const taskID       = run.TaskID || run.task_id;
+    const status       = this._status || run.status || run.Status;
     const isRunning    = status === 'running';
     const startedAt    = run.started_at || run.StartedAt;
     const finishedAt   = run.finished_at || run.FinishedAt;
@@ -284,7 +290,7 @@ class DcRunDetail extends LitElement {
       ${parent ? html`
         <div class="card" style="margin-bottom:var(--space-md);display:flex;gap:var(--space-md);align-items:center">
           <span class="meta">Parent run</span>
-          <a href="/runs/${parent.ID || parent.id}">
+          <a href="runs/${parent.ID || parent.id}">
             ${parentTask ? `${parentTask} · ` : ''}<code>${(parent.ID || parent.id || '').slice(0,8)}</code>
           </a>
         </div>` : ''}
@@ -314,7 +320,7 @@ class DcRunDetail extends LitElement {
           <tbody>
             ${children.map(c => html`
               <tr>
-                <td><a href="/runs/${c.ID}">${(c.TaskID || '?')} · <code>${c.ID.slice(0,8)}</code></a></td>
+                <td><a href="runs/${c.ID}">${(c.TaskID || '?')} · <code>${c.ID.slice(0,8)}</code></a></td>
                 <td><span class="badge badge-${c.Status}">${c.Status}</span></td>
                 <td class="meta">${fmtTime(c.StartedAt)}</td>
                 <td class="meta">${fmtDuration(c.StartedAt, c.FinishedAt)}</td>

--- a/tasks/buildin/webui/app/components/dc-task-detail.js
+++ b/tasks/buildin/webui/app/components/dc-task-detail.js
@@ -336,7 +336,7 @@ class DcTaskDetail extends LitElement {
         <td class="meta">${fmtTime(r.StartedAt)}</td>
         <td class="meta">${fmtDuration(r.StartedAt, r.FinishedAt)}</td>
         <td>${r.Status === 'suspended' ? html`
-          <a href="/runs/${r.ID}" class="btn btn-sm">Resume ↗</a>`
+          <a href="runs/${r.ID}" class="btn btn-sm">Resume ↗</a>`
           : (r.OutputContentType || r.ReturnValue) ? html`
           <a href="/runs/${r.ID}/result" target="_blank"
              class="btn btn-sm secondary">Result</a>` : ''}</td>

--- a/tasks/examples/suspend-wizard/task.ts
+++ b/tasks/examples/suspend-wizard/task.ts
@@ -7,6 +7,7 @@ import type { DicodeSdk } from "../../sdk.ts";
 // re-run from the top on every resume, so nothing lives in memory between pauses.
 
 export default async function main({ dicode }: DicodeSdk) {
+  console.log("suspend-wizard: step 1 — pausing for the project name");
   await dicode.suspend({
     to: "chooseFramework",
     schema: {
@@ -27,6 +28,7 @@ export const steps = {
   // name forward in state so the confirm step can echo it back.
   async chooseFramework({ dicode, input }: DicodeSdk) {
     const project = (input as { project_name: string }).project_name;
+    console.log(`suspend-wizard: step 2 — project "${project}", pausing for the framework`);
     await dicode.suspend({
       to: "confirm",
       state: { project },
@@ -50,6 +52,7 @@ export const steps = {
   async confirm({ dicode, input, state }: DicodeSdk) {
     const project = (state as { project: string }).project;
     const framework = (input as { framework: string }).framework;
+    console.log(`suspend-wizard: step 3 — ${framework} for "${project}", pausing for confirmation`);
     await dicode.suspend({
       to: "summarize",
       state: { project, framework },
@@ -69,6 +72,7 @@ export const steps = {
   summarize({ input, state }: DicodeSdk) {
     const { project, framework } = state as { project: string; framework: string };
     const confirmed = (input as { confirmed: boolean }).confirmed;
+    console.log(`suspend-wizard: done — ${confirmed ? "created" : "skipped"} ${project} (${framework})`);
     return { project, framework, confirmed };
   },
 };


### PR DESCRIPTION
## Summary

Driving the shipped `suspend-wizard` example from the browser surfaced three defects that together made multi-step resume unusable without manual reloads:

1. **Resume/parent/child links bounced to the task list.** The run-list *Resume* button and the run-detail parent/child links used root-absolute `/runs/…` hrefs, which escape the `/hooks/webui` SPA base — the relative-href click interceptor ignores anything starting with `/`, so those links did a full server-root navigation and fell back to the task list. Made them relative (like the already-working run-id link).
2. **Back-link went to `tasks/undefined`.** The run-detail header read `run.task_id`, but the API serializes the run struct with Go field names (`TaskID`), so it was undefined.
3. **A just-suspended run showed no resume form.** The run detail subscribed to the run WebSocket only *after* its initial fetch, so a run that suspends in the ~40ms after the fetch returned `running` had its `run:finished→suspended` event missed, and the handler never refetched — leaving the run without its resume form. Subscribe before the fetch, refetch on finish, idempotent wiring. This is the "Webui doesn't refetch on a live suspend" item in #516, which turns out to be load-bearing for the multi-step wizard.

Also: the example task now logs a line per step, so its Logs panel shows progress instead of an empty box.

Verified end-to-end in the browser (full 3-pause wizard) and via the CLI.

Addresses the refetch item in #516.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved run detail loading so live updates and finish events are less likely to be missed when resuming or suspending runs.
  * Run details now refresh after completion, ensuring the latest output and status are shown.
  * Fixed run navigation links to use consistent relative paths in the UI.
  * Updated the resume button to use the same relative navigation format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->