### PR TITLE
feat(cli): interactive follow mode for run/resume suspend wizards

### DIFF
--- a/cmd/dicode/follow.go
+++ b/cmd/dicode/follow.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"sync"
+
+	"github.com/dicode/dicode/pkg/ipc"
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/schemavalidate"
+	"golang.org/x/term"
+)
+
+// stdinIsInteractive reports whether stdin is a terminal. Interactive resume
+// prompting engages only when true, so piped/redirected input keeps the
+// scriptable one-shot behavior.
+func stdinIsInteractive() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+// followClient is the daemon surface the interactive follow loop needs. The
+// production impl wraps *ipc.ControlClient; tests inject a fake to exercise the
+// schema→prompt→submit→follow core without a socket.
+type followClient interface {
+	// ResumeGet returns the JSON Schema of the form a suspended run awaits.
+	ResumeGet(runID string) (ipc.ResumeInfo, error)
+	// Resume submits the collected input and returns the continuation run id.
+	Resume(runID string, input []byte) (ipc.ResumeResult, error)
+	// WaitRun blocks until runID reaches a terminal or suspended state.
+	WaitRun(runID string) (ipc.RunResult, error)
+	// Logs returns the accumulated log lines of a run.
+	Logs(runID string) ([]ipc.LogEntry, error)
+}
+
+// controlFollowClient adapts *ipc.ControlClient to followClient, unwrapping the
+// response envelope's Error field into a Go error at each call.
+type controlFollowClient struct{ c *ipc.ControlClient }
+
+func (f controlFollowClient) ResumeGet(runID string) (ipc.ResumeInfo, error) {
+	resp, err := f.c.Send(ipc.Request{Method: "cli.resume.get", RunID: runID})
+	if err != nil {
+		return ipc.ResumeInfo{}, err
+	}
+	if resp.Error != "" {
+		return ipc.ResumeInfo{}, fmt.Errorf("%s", resp.Error)
+	}
+	var info ipc.ResumeInfo
+	if err := remarshal(resp.Result, &info); err != nil {
+		return ipc.ResumeInfo{}, err
+	}
+	return info, nil
+}
+
+func (f controlFollowClient) Resume(runID string, input []byte) (ipc.ResumeResult, error) {
+	resp, err := f.c.Send(ipc.Request{Method: "cli.resume", RunID: runID, Params: input})
+	if err != nil {
+		return ipc.ResumeResult{}, err
+	}
+	if resp.Error != "" {
+		return ipc.ResumeResult{}, fmt.Errorf("%s", resp.Error)
+	}
+	var res ipc.ResumeResult
+	if err := remarshal(resp.Result, &res); err != nil {
+		return ipc.ResumeResult{}, err
+	}
+	return res, nil
+}
+
+func (f controlFollowClient) WaitRun(runID string) (ipc.RunResult, error) {
+	resp, err := f.c.Send(ipc.Request{Method: "cli.run.wait", RunID: runID})
+	if err != nil {
+		return ipc.RunResult{}, err
+	}
+	if resp.Error != "" {
+		return ipc.RunResult{}, fmt.Errorf("%s", resp.Error)
+	}
+	var res ipc.RunResult
+	if err := remarshal(resp.Result, &res); err != nil {
+		return ipc.RunResult{}, err
+	}
+	return res, nil
+}
+
+func (f controlFollowClient) Logs(runID string) ([]ipc.LogEntry, error) {
+	resp, err := f.c.Send(ipc.Request{Method: "cli.logs", RunID: runID})
+	if err != nil {
+		return nil, err
+	}
+	if resp.Error != "" {
+		return nil, fmt.Errorf("%s", resp.Error)
+	}
+	var entries []ipc.LogEntry
+	if err := remarshal(resp.Result, &entries); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+// followSession carries the injectable I/O and daemon client for the wizard
+// follow loop, plus the id of the continuation currently being awaited so an
+// interrupt can flush its logs.
+type followSession struct {
+	client followClient
+	in     io.Reader // answers (stdin)
+	prompt io.Writer // prompts + step banners (stderr, keeps stdout clean)
+	out    io.Writer // logs + final result (stdout)
+
+	mu     sync.Mutex
+	curRun string
+}
+
+func (s *followSession) setCurRun(id string) {
+	s.mu.Lock()
+	s.curRun = id
+	s.mu.Unlock()
+}
+
+func (s *followSession) currentRun() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.curRun
+}
+
+// follow walks a suspend wizard from an already-suspended run: it fetches the
+// run's resume form, prompts for it, submits, then waits on the continuation
+// and prints its logs. If the continuation suspends again it repeats; when it
+// reaches a terminal state it prints the final status and return value.
+func (s *followSession) follow(suspendedRunID string) error {
+	// One reader across every step: a per-step bufio.Reader would read-ahead and
+	// drop the next step's buffered answers. promptResumeInput re-wraps this with
+	// bufio.NewReader, which returns an existing *bufio.Reader unchanged.
+	reader := bufio.NewReader(s.in)
+	runID := suspendedRunID
+	for {
+		info, err := s.client.ResumeGet(runID)
+		if err != nil {
+			return err
+		}
+		entries, required, err := parseResumeProps(info.Schema)
+		if err != nil {
+			return fmt.Errorf("read resume schema: %w", err)
+		}
+
+		// Re-prompt the whole step on object-level schema failure rather than
+		// aborting the flow. Per-field coercion already rejects bad types, so
+		// this catches cross-field constraints the field loop can't see.
+		var inputJSON []byte
+		for {
+			values, perr := promptResumeInput(entries, required, reader, s.prompt)
+			if perr != nil {
+				return perr
+			}
+			inputJSON, err = json.Marshal(values)
+			if err != nil {
+				return err
+			}
+			if verr := schemavalidate.Validate(info.Schema, inputJSON); verr != nil {
+				fmt.Fprintf(s.prompt, "  %v\n", verr)
+				continue
+			}
+			break
+		}
+
+		res, err := s.client.Resume(runID, inputJSON)
+		if err != nil {
+			return err
+		}
+		contID := res.RunID
+		s.setCurRun(contID)
+		fmt.Fprintf(s.prompt, "resumed: following continuation run %s\n", contID)
+
+		result, err := s.client.WaitRun(contID)
+		if err != nil {
+			return err
+		}
+		s.printLogs(contID)
+		s.setCurRun("")
+
+		if result.Status == registry.StatusSuspended {
+			fmt.Fprintf(s.prompt, "\nrun %s suspended again — next step:\n", contID)
+			runID = contID
+			continue
+		}
+
+		fmt.Fprintf(s.out, "run %s: %s\n", contID, result.Status)
+		if result.ReturnValue != nil {
+			out, _ := json.MarshalIndent(result.ReturnValue, "", "  ")
+			fmt.Fprintln(s.out, string(out))
+		}
+		if result.Status == registry.StatusFailure {
+			return fmt.Errorf("task failed")
+		}
+		return nil
+	}
+}
+
+// printLogs fetches and prints a run's log lines, matching cmdLogs's format. A
+// fetch error is noted on the prompt stream but does not abort the follow.
+func (s *followSession) printLogs(runID string) {
+	entries, err := s.client.Logs(runID)
+	if err != nil {
+		fmt.Fprintf(s.prompt, "dicode: fetch logs: %v\n", err)
+		return
+	}
+	for _, e := range entries {
+		fmt.Fprintf(s.out, "%s [%s] %s\n", e.Timestamp, e.Level, e.Message)
+	}
+}
+
+// followSuspended drives the interactive wizard against a live daemon. SIGINT at
+// any point flushes the in-flight continuation's logs and exits 130, matching
+// the shell convention for an interrupted foreground command.
+func followSuspended(c *ipc.ControlClient, runID string) error {
+	s := &followSession{
+		client: controlFollowClient{c: c},
+		in:     os.Stdin,
+		prompt: os.Stderr,
+		out:    os.Stdout,
+	}
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
+	go func() {
+		if _, ok := <-sigCh; !ok {
+			return
+		}
+		fmt.Fprintln(s.prompt, "\ninterrupted — output so far:")
+		if id := s.currentRun(); id != "" {
+			s.printLogs(id)
+		}
+		os.Exit(130)
+	}()
+	return s.follow(runID)
+}

--- a/cmd/dicode/follow.go
+++ b/cmd/dicode/follow.go
@@ -21,6 +21,47 @@ func stdinIsInteractive() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
+// parseInteractiveFlag pulls the --non-interactive opt-out (alias --batch) out
+// of a subcommand's argument list, returning whether it was present and the
+// remaining positional args (task/run id and field=value pairs) in order.
+func parseInteractiveFlag(args []string) (nonInteractive bool, rest []string) {
+	for _, a := range args {
+		switch a {
+		case "--non-interactive", "--batch":
+			nonInteractive = true
+		default:
+			rest = append(rest, a)
+		}
+	}
+	return nonInteractive, rest
+}
+
+// resumeFieldNames returns the property names to hint at for a non-interactive
+// resume: the required set if the schema declares one, otherwise every declared
+// property, both in declaration order.
+func resumeFieldNames(entries []resumePropEntry, required map[string]bool) []string {
+	var req, all []string
+	for _, e := range entries {
+		all = append(all, e.Name)
+		if required[e.Name] {
+			req = append(req, e.Name)
+		}
+	}
+	if len(req) > 0 {
+		return req
+	}
+	return all
+}
+
+// followEngages decides whether a suspended run drives the interactive wizard.
+// It requires a TTY, no --non-interactive opt-out, and no inline field=value
+// values for the step; otherwise the caller keeps the scriptable one-shot path.
+// --non-interactive forces one-shot regardless of the TTY, so agents/CI running
+// inside an allocated PTY never block on a prompt.
+func followEngages(nonInteractive, interactive, haveInlineValues bool) bool {
+	return interactive && !nonInteractive && !haveInlineValues
+}
+
 // followClient is the daemon surface the interactive follow loop needs. The
 // production impl wraps *ipc.ControlClient; tests inject a fake to exercise the
 // schema→prompt→submit→follow core without a socket.

--- a/cmd/dicode/follow.go
+++ b/cmd/dicode/follow.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"sync"
 
 	"github.com/dicode/dicode/pkg/ipc"
 	"github.com/dicode/dicode/pkg/registry"
@@ -101,28 +100,12 @@ func (f controlFollowClient) Logs(runID string) ([]ipc.LogEntry, error) {
 }
 
 // followSession carries the injectable I/O and daemon client for the wizard
-// follow loop, plus the id of the continuation currently being awaited so an
-// interrupt can flush its logs.
+// follow loop.
 type followSession struct {
 	client followClient
 	in     io.Reader // answers (stdin)
 	prompt io.Writer // prompts + step banners (stderr, keeps stdout clean)
 	out    io.Writer // logs + final result (stdout)
-
-	mu     sync.Mutex
-	curRun string
-}
-
-func (s *followSession) setCurRun(id string) {
-	s.mu.Lock()
-	s.curRun = id
-	s.mu.Unlock()
-}
-
-func (s *followSession) currentRun() string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.curRun
 }
 
 // follow walks a suspend wizard from an already-suspended run: it fetches the
@@ -170,7 +153,6 @@ func (s *followSession) follow(suspendedRunID string) error {
 			return err
 		}
 		contID := res.RunID
-		s.setCurRun(contID)
 		fmt.Fprintf(s.prompt, "resumed: following continuation run %s\n", contID)
 
 		result, err := s.client.WaitRun(contID)
@@ -178,7 +160,6 @@ func (s *followSession) follow(suspendedRunID string) error {
 			return err
 		}
 		s.printLogs(contID)
-		s.setCurRun("")
 
 		if result.Status == registry.StatusSuspended {
 			fmt.Fprintf(s.prompt, "\nrun %s suspended again — next step:\n", contID)
@@ -211,9 +192,12 @@ func (s *followSession) printLogs(runID string) {
 	}
 }
 
-// followSuspended drives the interactive wizard against a live daemon. SIGINT at
-// any point flushes the in-flight continuation's logs and exits 130, matching
-// the shell convention for an interrupted foreground command.
+// followSuspended drives the interactive wizard against a live daemon. Each
+// step's logs stream to stdout as it settles, so on SIGINT the accumulated
+// output is already printed; the handler only notes the interrupt and exits 130
+// (the shell convention). It deliberately issues no further control request —
+// the main goroutine is usually parked in WaitRun on the same connection, and
+// ControlClient.Send is not safe for concurrent use.
 func followSuspended(c *ipc.ControlClient, runID string) error {
 	s := &followSession{
 		client: controlFollowClient{c: c},
@@ -228,10 +212,7 @@ func followSuspended(c *ipc.ControlClient, runID string) error {
 		if _, ok := <-sigCh; !ok {
 			return
 		}
-		fmt.Fprintln(s.prompt, "\ninterrupted — output so far:")
-		if id := s.currentRun(); id != "" {
-			s.printLogs(id)
-		}
+		fmt.Fprintln(s.prompt, "\ninterrupted")
 		os.Exit(130)
 	}()
 	return s.follow(runID)

--- a/cmd/dicode/follow.go
+++ b/cmd/dicode/follow.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/signal"
+	"strings"
 
 	"github.com/dicode/dicode/pkg/ipc"
 	"github.com/dicode/dicode/pkg/registry"
@@ -149,10 +152,98 @@ type followSession struct {
 	out    io.Writer // logs + final result (stdout)
 }
 
+// resumeSchemaMeta extracts a schema's top-level title and description, used to
+// frame a bare-approval confirmation prompt.
+func resumeSchemaMeta(schemaJSON []byte) (title, description string) {
+	if len(bytes.TrimSpace(schemaJSON)) == 0 {
+		return "", ""
+	}
+	var m struct {
+		Title       string `json:"title"`
+		Description string `json:"description"`
+	}
+	_ = json.Unmarshal(schemaJSON, &m)
+	return m.Title, m.Description
+}
+
+// printOneShotSuspended prints the scriptable one-shot view of a still-suspended
+// run: its id and the fields to supply. Used when interactive consent is not
+// available (EOF / redirected stdin), so a step is never auto-resumed.
+func (s *followSession) printOneShotSuspended(runID string, entries []resumePropEntry, required map[string]bool) {
+	fmt.Fprintf(s.out, "run %s: suspended\n", runID)
+	if fields := resumeFieldNames(entries, required); len(fields) > 0 {
+		fmt.Fprintf(s.out, "fields: %s\n", strings.Join(fields, ", "))
+	}
+	fmt.Fprintf(s.out, "resume with: dicode resume %s <field=value ...>\n", runID)
+}
+
+// collectStepInput gathers the resume input for one wizard step. Its three
+// outcomes: submit==true carries the JSON to resume with; submit==false with a
+// nil error means consent was unavailable (EOF at a confirmation gate) and the
+// caller should fall back to the one-shot view; a non-nil error aborts.
+//
+// A schema with no promptable properties is a bare-approval form. Auto-
+// submitting {} there would silently resume the run the instant it is seen — and
+// loop forever if the continuation suspends the same way — so an explicit
+// confirmation (a single Enter) is required; EOF is not consent. When {} cannot
+// even satisfy the schema (a required field absent from properties, minProperties,
+// an unsatisfiable allOf), no prompt could ever fix it, so it aborts rather than
+// spins. For promptable schemas, an object-level validation failure re-prompts,
+// but only while a re-prompt can change the input: identical input failing twice
+// (e.g. optional fields left blank at EOF) aborts instead of hot-looping.
+func (s *followSession) collectStepInput(reader *bufio.Reader, schema []byte, entries []resumePropEntry, required map[string]bool) ([]byte, bool, error) {
+	if len(entries) == 0 {
+		empty := []byte("{}")
+		if verr := schemavalidate.Validate(schema, empty); verr != nil {
+			return nil, false, fmt.Errorf("cannot resume: %w", verr)
+		}
+		if title, desc := resumeSchemaMeta(schema); title != "" || desc != "" {
+			if title != "" {
+				fmt.Fprintln(s.prompt, title)
+			}
+			if desc != "" {
+				fmt.Fprintln(s.prompt, desc)
+			}
+		}
+		fmt.Fprint(s.prompt, "Approve and continue? [Enter to confirm, Ctrl+C to abort]: ")
+		_, rerr := reader.ReadString('\n')
+		if errors.Is(rerr, io.EOF) {
+			return nil, false, nil
+		}
+		if rerr != nil {
+			return nil, false, rerr
+		}
+		return empty, true, nil
+	}
+
+	var last []byte
+	for {
+		values, perr := promptResumeInput(entries, required, reader, s.prompt)
+		if perr != nil {
+			return nil, false, perr
+		}
+		inputJSON, err := json.Marshal(values)
+		if err != nil {
+			return nil, false, err
+		}
+		if verr := schemavalidate.Validate(schema, inputJSON); verr != nil {
+			if last != nil && bytes.Equal(last, inputJSON) {
+				return nil, false, fmt.Errorf("cannot resume: %w", verr)
+			}
+			last = inputJSON
+			fmt.Fprintf(s.prompt, "  %v\n", verr)
+			continue
+		}
+		return inputJSON, true, nil
+	}
+}
+
 // follow walks a suspend wizard from an already-suspended run: it fetches the
-// run's resume form, prompts for it, submits, then waits on the continuation
-// and prints its logs. If the continuation suspends again it repeats; when it
-// reaches a terminal state it prints the final status and return value.
+// run's resume form, collects input for it, submits, then waits on the
+// continuation and prints its logs. If the continuation suspends again it
+// repeats; when it reaches a terminal state it prints the final status and
+// return value. A daemon task's continuation never settles, so it is resumed
+// one-shot (print the continuation id) rather than followed.
 func (s *followSession) follow(suspendedRunID string) error {
 	// One reader across every step: a per-step bufio.Reader would read-ahead and
 	// drop the next step's buffered answers. promptResumeInput re-wraps this with
@@ -169,24 +260,15 @@ func (s *followSession) follow(suspendedRunID string) error {
 			return fmt.Errorf("read resume schema: %w", err)
 		}
 
-		// Re-prompt the whole step on object-level schema failure rather than
-		// aborting the flow. Per-field coercion already rejects bad types, so
-		// this catches cross-field constraints the field loop can't see.
-		var inputJSON []byte
-		for {
-			values, perr := promptResumeInput(entries, required, reader, s.prompt)
-			if perr != nil {
-				return perr
-			}
-			inputJSON, err = json.Marshal(values)
-			if err != nil {
-				return err
-			}
-			if verr := schemavalidate.Validate(info.Schema, inputJSON); verr != nil {
-				fmt.Fprintf(s.prompt, "  %v\n", verr)
-				continue
-			}
-			break
+		inputJSON, submit, err := s.collectStepInput(reader, info.Schema, entries, required)
+		if err != nil {
+			return err
+		}
+		if !submit {
+			// No interactive consent (EOF at a confirmation gate): never auto-
+			// resume — leave the run suspended and show the one-shot view.
+			s.printOneShotSuspended(runID, entries, required)
+			return nil
 		}
 
 		res, err := s.client.Resume(runID, inputJSON)
@@ -194,6 +276,16 @@ func (s *followSession) follow(suspendedRunID string) error {
 			return err
 		}
 		contID := res.RunID
+
+		// A daemon continuation is long-lived and never settles; blocking on it
+		// would hang the CLI. Resume took effect — surface the continuation id
+		// one-shot and stop, matching the non-interactive resume output.
+		if info.Daemon {
+			fmt.Fprintf(s.out, "resumed: continuation run %s\n", contID)
+			fmt.Fprintf(s.out, "follow: dicode logs %s\n", contID)
+			return nil
+		}
+
 		fmt.Fprintf(s.prompt, "resumed: following continuation run %s\n", contID)
 
 		result, err := s.client.WaitRun(contID)
@@ -233,12 +325,13 @@ func (s *followSession) printLogs(runID string) {
 	}
 }
 
-// followSuspended drives the interactive wizard against a live daemon. Each
-// step's logs stream to stdout as it settles, so on SIGINT the accumulated
-// output is already printed; the handler only notes the interrupt and exits 130
-// (the shell convention). It deliberately issues no further control request —
-// the main goroutine is usually parked in WaitRun on the same connection, and
-// ControlClient.Send is not safe for concurrent use.
+// followSuspended drives the interactive wizard against a live daemon. Logs of
+// steps that have already settled are on stdout; a step still in flight when
+// SIGINT arrives has not printed its logs, and the handler deliberately issues
+// no control request to fetch them — the main goroutine is usually parked in
+// WaitRun on the same connection, and ControlClient.Send is not safe for
+// concurrent use. The handler notes the interrupt and exits 130 (the shell
+// convention); the daemon cancels the in-flight run when the connection drops.
 func followSuspended(c *ipc.ControlClient, runID string) error {
 	s := &followSession{
 		client: controlFollowClient{c: c},

--- a/cmd/dicode/follow_test.go
+++ b/cmd/dicode/follow_test.go
@@ -42,6 +42,55 @@ func (f *fakeFollowClient) Logs(runID string) ([]ipc.LogEntry, error) {
 
 const oneStepSchema = `{"type":"object","properties":{"approve":{"type":"string","title":"Approve?"}},"required":["approve"]}`
 
+func TestParseInteractiveFlag(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		wantNI  bool
+		wantRes []string
+	}{
+		{"none", []string{"task-x", "a=1"}, false, []string{"task-x", "a=1"}},
+		{"non-interactive", []string{"task-x", "--non-interactive", "a=1"}, true, []string{"task-x", "a=1"}},
+		{"batch alias", []string{"--batch", "run-1"}, true, []string{"run-1"}},
+		{"flag only", []string{"--non-interactive"}, true, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotNI, gotRes := parseInteractiveFlag(c.args)
+			if gotNI != c.wantNI {
+				t.Errorf("nonInteractive = %v, want %v", gotNI, c.wantNI)
+			}
+			if strings.Join(gotRes, ",") != strings.Join(c.wantRes, ",") {
+				t.Errorf("rest = %v, want %v", gotRes, c.wantRes)
+			}
+		})
+	}
+}
+
+func TestFollowEngages(t *testing.T) {
+	cases := []struct {
+		name                                    string
+		nonInteractive, interactive, haveInline bool
+		want                                    bool
+	}{
+		{"tty, opt-in, no inline", false, true, false, true},
+		// --non-interactive forces one-shot even when the TTY check says interactive
+		// (the agents/CI-on-a-PTY case the flag exists for).
+		{"non-interactive overrides tty", true, true, false, false},
+		{"not a tty", false, false, false, false},
+		{"inline values force one-shot", false, true, true, false},
+		{"non-interactive and inline", true, true, true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := followEngages(c.nonInteractive, c.interactive, c.haveInline); got != c.want {
+				t.Errorf("followEngages(%v,%v,%v) = %v, want %v",
+					c.nonInteractive, c.interactive, c.haveInline, got, c.want)
+			}
+		})
+	}
+}
+
 func TestFollow_SingleStepToSuccess(t *testing.T) {
 	client := &fakeFollowClient{
 		schemas:     map[string][]byte{"run-1": []byte(oneStepSchema)},

--- a/cmd/dicode/follow_test.go
+++ b/cmd/dicode/follow_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/ipc"
+)
+
+// fakeFollowClient scripts the daemon responses the follow loop consumes. Each
+// suspended run id maps to the schema it awaits; resume returns the next id from
+// resumeChain; waitResults maps a continuation id to its settled RunResult.
+type fakeFollowClient struct {
+	schemas     map[string][]byte          // runID -> resume JSON Schema
+	resumeChain map[string]string          // suspended runID -> continuation runID
+	waitResults map[string]ipc.RunResult   // continuation runID -> settled result
+	logs        map[string][]ipc.LogEntry  // runID -> log lines
+	submitted   map[string]json.RawMessage // suspended runID -> input submitted
+}
+
+func (f *fakeFollowClient) ResumeGet(runID string) (ipc.ResumeInfo, error) {
+	return ipc.ResumeInfo{RunID: runID, Schema: f.schemas[runID]}, nil
+}
+
+func (f *fakeFollowClient) Resume(runID string, input []byte) (ipc.ResumeResult, error) {
+	if f.submitted == nil {
+		f.submitted = map[string]json.RawMessage{}
+	}
+	f.submitted[runID] = append(json.RawMessage(nil), input...)
+	return ipc.ResumeResult{RunID: f.resumeChain[runID]}, nil
+}
+
+func (f *fakeFollowClient) WaitRun(runID string) (ipc.RunResult, error) {
+	return f.waitResults[runID], nil
+}
+
+func (f *fakeFollowClient) Logs(runID string) ([]ipc.LogEntry, error) {
+	return f.logs[runID], nil
+}
+
+const oneStepSchema = `{"type":"object","properties":{"approve":{"type":"string","title":"Approve?"}},"required":["approve"]}`
+
+func TestFollow_SingleStepToSuccess(t *testing.T) {
+	client := &fakeFollowClient{
+		schemas:     map[string][]byte{"run-1": []byte(oneStepSchema)},
+		resumeChain: map[string]string{"run-1": "run-2"},
+		waitResults: map[string]ipc.RunResult{
+			"run-2": {RunID: "run-2", Status: "success", ReturnValue: map[string]any{"ok": true}},
+		},
+		logs: map[string][]ipc.LogEntry{
+			"run-2": {{Timestamp: "t0", Level: "info", Message: "done"}},
+		},
+	}
+	var out, prompt bytes.Buffer
+	s := &followSession{client: client, in: strings.NewReader("yes\n"), prompt: &prompt, out: &out}
+
+	if err := s.follow("run-1"); err != nil {
+		t.Fatalf("follow: %v", err)
+	}
+
+	// The typed answer was submitted for the suspended run.
+	if got := string(client.submitted["run-1"]); got != `{"approve":"yes"}` {
+		t.Errorf("submitted = %s, want {\"approve\":\"yes\"}", got)
+	}
+	stdout := out.String()
+	if !strings.Contains(stdout, "run run-2: success") {
+		t.Errorf("stdout missing final status:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `"ok": true`) {
+		t.Errorf("stdout missing return value:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "[info] done") {
+		t.Errorf("stdout missing streamed logs:\n%s", stdout)
+	}
+}
+
+func TestFollow_MultiStepWizard(t *testing.T) {
+	client := &fakeFollowClient{
+		schemas: map[string][]byte{
+			"run-1": []byte(oneStepSchema),
+			"run-2": []byte(`{"type":"object","properties":{"env":{"type":"string","enum":["staging","prod"]}},"required":["env"]}`),
+		},
+		resumeChain: map[string]string{"run-1": "run-2", "run-2": "run-3"},
+		waitResults: map[string]ipc.RunResult{
+			"run-2": {RunID: "run-2", Status: "suspended"},
+			"run-3": {RunID: "run-3", Status: "success"},
+		},
+	}
+	var out, prompt bytes.Buffer
+	// First step: approve=go, second step: pick enum value prod.
+	s := &followSession{client: client, in: strings.NewReader("go\nprod\n"), prompt: &prompt, out: &out}
+
+	if err := s.follow("run-1"); err != nil {
+		t.Fatalf("follow: %v", err)
+	}
+	if got := string(client.submitted["run-2"]); got != `{"env":"prod"}` {
+		t.Errorf("step-2 submitted = %s, want {\"env\":\"prod\"}", got)
+	}
+	if !strings.Contains(prompt.String(), "suspended again") {
+		t.Errorf("expected re-prompt banner for the second step:\n%s", prompt.String())
+	}
+	if !strings.Contains(out.String(), "run run-3: success") {
+		t.Errorf("expected terminal success on run-3:\n%s", out.String())
+	}
+}
+
+func TestFollow_FailureReturnsError(t *testing.T) {
+	client := &fakeFollowClient{
+		schemas:     map[string][]byte{"run-1": []byte(oneStepSchema)},
+		resumeChain: map[string]string{"run-1": "run-2"},
+		waitResults: map[string]ipc.RunResult{"run-2": {RunID: "run-2", Status: "failure"}},
+	}
+	var out, prompt bytes.Buffer
+	s := &followSession{client: client, in: strings.NewReader("yes\n"), prompt: &prompt, out: &out}
+
+	if err := s.follow("run-1"); err == nil {
+		t.Fatal("expected error when the continuation fails")
+	}
+	if !strings.Contains(out.String(), "run run-2: failure") {
+		t.Errorf("stdout should still report the failing status:\n%s", out.String())
+	}
+}
+
+func TestFollow_RepromptsUntilRequiredSupplied(t *testing.T) {
+	client := &fakeFollowClient{
+		schemas:     map[string][]byte{"run-1": []byte(oneStepSchema)},
+		resumeChain: map[string]string{"run-1": "run-2"},
+		waitResults: map[string]ipc.RunResult{"run-2": {RunID: "run-2", Status: "success"}},
+	}
+	var out, prompt bytes.Buffer
+	// Blank line first (required -> reprompt), then a real value.
+	s := &followSession{client: client, in: strings.NewReader("\nyes\n"), prompt: &prompt, out: &out}
+
+	if err := s.follow("run-1"); err != nil {
+		t.Fatalf("follow: %v", err)
+	}
+	if !strings.Contains(prompt.String(), "required — please enter a value") {
+		t.Errorf("expected required-field reprompt:\n%s", prompt.String())
+	}
+	if got := string(client.submitted["run-1"]); got != `{"approve":"yes"}` {
+		t.Errorf("submitted = %s, want the value entered after the reprompt", got)
+	}
+}

--- a/cmd/dicode/follow_test.go
+++ b/cmd/dicode/follow_test.go
@@ -14,14 +14,16 @@ import (
 // resumeChain; waitResults maps a continuation id to its settled RunResult.
 type fakeFollowClient struct {
 	schemas     map[string][]byte          // runID -> resume JSON Schema
+	daemon      map[string]bool            // runID -> task is a daemon body
 	resumeChain map[string]string          // suspended runID -> continuation runID
 	waitResults map[string]ipc.RunResult   // continuation runID -> settled result
 	logs        map[string][]ipc.LogEntry  // runID -> log lines
 	submitted   map[string]json.RawMessage // suspended runID -> input submitted
+	waitCalls   int                        // number of WaitRun invocations
 }
 
 func (f *fakeFollowClient) ResumeGet(runID string) (ipc.ResumeInfo, error) {
-	return ipc.ResumeInfo{RunID: runID, Schema: f.schemas[runID]}, nil
+	return ipc.ResumeInfo{RunID: runID, Schema: f.schemas[runID], Daemon: f.daemon[runID]}, nil
 }
 
 func (f *fakeFollowClient) Resume(runID string, input []byte) (ipc.ResumeResult, error) {
@@ -33,6 +35,7 @@ func (f *fakeFollowClient) Resume(runID string, input []byte) (ipc.ResumeResult,
 }
 
 func (f *fakeFollowClient) WaitRun(runID string) (ipc.RunResult, error) {
+	f.waitCalls++
 	return f.waitResults[runID], nil
 }
 
@@ -190,5 +193,107 @@ func TestFollow_RepromptsUntilRequiredSupplied(t *testing.T) {
 	}
 	if got := string(client.submitted["run-1"]); got != `{"approve":"yes"}` {
 		t.Errorf("submitted = %s, want the value entered after the reprompt", got)
+	}
+}
+
+// A bare-approval schema (no properties) must NOT auto-submit; it requires an
+// explicit Enter, after which {} is submitted.
+func TestFollow_EmptyPropertiesRequiresConfirmation(t *testing.T) {
+	const confirmSchema = `{"type":"object","title":"Confirm","description":"Proceed?"}`
+	client := &fakeFollowClient{
+		schemas:     map[string][]byte{"run-1": []byte(confirmSchema)},
+		resumeChain: map[string]string{"run-1": "run-2"},
+		waitResults: map[string]ipc.RunResult{"run-2": {RunID: "run-2", Status: "success"}},
+	}
+	var out, prompt bytes.Buffer
+	// A single Enter confirms.
+	s := &followSession{client: client, in: strings.NewReader("\n"), prompt: &prompt, out: &out}
+
+	if err := s.follow("run-1"); err != nil {
+		t.Fatalf("follow: %v", err)
+	}
+	if !strings.Contains(prompt.String(), "Approve and continue?") {
+		t.Errorf("expected a confirmation prompt, got:\n%s", prompt.String())
+	}
+	if got := string(client.submitted["run-1"]); got != "{}" {
+		t.Errorf("submitted = %q, want {} after explicit confirmation", got)
+	}
+}
+
+// With no interactive consent (EOF / redirected stdin) a bare-approval schema
+// must NOT auto-resume — no Resume call, one-shot suspended output instead.
+func TestFollow_EmptyPropertiesEOFDoesNotAutoApprove(t *testing.T) {
+	const confirmSchema = `{"type":"object","title":"Confirm"}`
+	client := &fakeFollowClient{
+		schemas:     map[string][]byte{"run-1": []byte(confirmSchema)},
+		resumeChain: map[string]string{"run-1": "run-2"},
+	}
+	var out, prompt bytes.Buffer
+	s := &followSession{client: client, in: strings.NewReader(""), prompt: &prompt, out: &out}
+
+	if err := s.follow("run-1"); err != nil {
+		t.Fatalf("follow: %v", err)
+	}
+	if _, ok := client.submitted["run-1"]; ok {
+		t.Errorf("Resume must not be called without explicit consent; submitted=%v", client.submitted)
+	}
+	if !strings.Contains(out.String(), "run run-1: suspended") {
+		t.Errorf("expected one-shot suspended output, got:\n%s", out.String())
+	}
+}
+
+// An unsatisfiable schema (required field absent from properties → nothing to
+// prompt, {} always invalid) must abort with an error, not hot-loop forever.
+func TestFollow_UnsatisfiableSchemaAborts(t *testing.T) {
+	const unsat = `{"type":"object","required":["x"]}`
+	client := &fakeFollowClient{
+		schemas: map[string][]byte{"run-1": []byte(unsat)},
+	}
+	var out, prompt bytes.Buffer
+	s := &followSession{client: client, in: strings.NewReader(""), prompt: &prompt, out: &out}
+
+	err := s.follow("run-1")
+	if err == nil {
+		t.Fatal("expected an error for an unsatisfiable schema, not a spin/submit")
+	}
+	if _, ok := client.submitted["run-1"]; ok {
+		t.Errorf("must not submit for an unsatisfiable schema; submitted=%v", client.submitted)
+	}
+}
+
+// Optional-only fields left blank at EOF marshal to the same {} twice; the
+// second identical failure must abort rather than hot-loop.
+func TestFollow_RepromptTerminatesOnIdenticalInput(t *testing.T) {
+	const minProps = `{"type":"object","properties":{"note":{"type":"string"}},"minProperties":1}`
+	client := &fakeFollowClient{
+		schemas: map[string][]byte{"run-1": []byte(minProps)},
+	}
+	var out, prompt bytes.Buffer
+	s := &followSession{client: client, in: strings.NewReader(""), prompt: &prompt, out: &out}
+
+	if err := s.follow("run-1"); err == nil {
+		t.Fatal("expected abort when the identical (empty) input fails twice")
+	}
+}
+
+// A daemon task's continuation never settles, so it must be resumed one-shot
+// (continuation id printed) without ever calling WaitRun.
+func TestFollow_DaemonContinuationOneShot(t *testing.T) {
+	client := &fakeFollowClient{
+		schemas:     map[string][]byte{"run-1": []byte(oneStepSchema)},
+		daemon:      map[string]bool{"run-1": true},
+		resumeChain: map[string]string{"run-1": "run-2"},
+	}
+	var out, prompt bytes.Buffer
+	s := &followSession{client: client, in: strings.NewReader("yes\n"), prompt: &prompt, out: &out}
+
+	if err := s.follow("run-1"); err != nil {
+		t.Fatalf("follow: %v", err)
+	}
+	if client.waitCalls != 0 {
+		t.Errorf("WaitRun must not be called for a daemon continuation, got %d calls", client.waitCalls)
+	}
+	if !strings.Contains(out.String(), "resumed: continuation run run-2") {
+		t.Errorf("expected one-shot continuation output, got:\n%s", out.String())
 	}
 }

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -10,6 +10,7 @@
 // Commands:
 //
 //	run <task-id> [key=value ...]   trigger a task run and wait for the result
+//	                                (--non-interactive / --batch: never prompt)
 //	list                            list all registered tasks
 //	logs <run-id>                   fetch log lines for a run
 //	status [task-id]                daemon health or latest run for a task
@@ -132,13 +133,14 @@ func dispatch(c *ipc.ControlClient, args []string) error {
 	case "list":
 		return cmdList(c)
 	case "run":
-		if len(args) < 2 {
-			return fmt.Errorf("usage: dicode run <task-id> [key=value ...]")
+		nonInteractive, rest := parseInteractiveFlag(args[1:])
+		if len(rest) < 1 {
+			return fmt.Errorf("usage: dicode run <task-id> [key=value ...] [--non-interactive]")
 		}
 		if err := waitDaemonReady(c, readyWaitTimeout); err != nil {
 			return err
 		}
-		return cmdRun(c, args[1], args[2:])
+		return cmdRun(c, rest[0], rest[1:], nonInteractive)
 	case "logs":
 		if len(args) < 2 {
 			return fmt.Errorf("usage: dicode logs <run-id>")
@@ -146,13 +148,14 @@ func dispatch(c *ipc.ControlClient, args []string) error {
 		return cmdLogs(c, args[1])
 	case "resume":
 		// Bare `dicode resume` lists suspended runs; with a run id it resumes.
-		if len(args) < 2 {
+		nonInteractive, rest := parseInteractiveFlag(args[1:])
+		if len(rest) == 0 {
 			return cmdResumeList(c)
 		}
 		if err := waitDaemonReady(c, readyWaitTimeout); err != nil {
 			return err
 		}
-		return cmdResume(c, args[1], args[2:])
+		return cmdResume(c, rest[0], rest[1:], nonInteractive)
 	case "status":
 		taskID := ""
 		if len(args) >= 2 {
@@ -857,7 +860,7 @@ func cmdList(c *ipc.ControlClient) error {
 	return nil
 }
 
-func cmdRun(c *ipc.ControlClient, taskID string, kvArgs []string) error {
+func cmdRun(c *ipc.ControlClient, taskID string, kvArgs []string, nonInteractive bool) error {
 	params := map[string]string{}
 	for _, kv := range kvArgs {
 		parts := strings.SplitN(kv, "=", 2)
@@ -890,8 +893,9 @@ func cmdRun(c *ipc.ControlClient, taskID string, kvArgs []string) error {
 
 	// A run that suspended on a TTY drives the whole wizard inline: prompt for
 	// the resume form, follow the continuation, repeat until it finishes. Piped
-	// stdin keeps the one-shot output below so automation still sees the id.
-	if result.Status == registry.StatusSuspended && stdinIsInteractive() {
+	// stdin or --non-interactive keeps the one-shot output below so automation
+	// (including agents/CI on an allocated PTY) still sees the id and exits.
+	if result.Status == registry.StatusSuspended && followEngages(nonInteractive, stdinIsInteractive(), false) {
 		return followSuspended(c, result.RunID)
 	}
 
@@ -1146,12 +1150,13 @@ func promptResumeInput(entries []resumePropEntry, required map[string]bool, in i
 // property (no field=value args) or coerces the supplied field=value pairs to
 // their declared types, validates locally against the schema, and submits. The
 // daemon re-validates authoritatively and resolves the resume token itself.
-func cmdResume(c *ipc.ControlClient, runID string, kvArgs []string) error {
-	// Interactive follow only engages for a TTY with no inline field=value args:
-	// pipes/redirects and explicit values keep the one-shot path below so scripts
-	// see the unchanged "continuation run <id>" output. Show the suspended run's
-	// logs first for context, mirroring how `dicode run` prints before it waits.
-	if len(kvArgs) == 0 && stdinIsInteractive() {
+func cmdResume(c *ipc.ControlClient, runID string, kvArgs []string, nonInteractive bool) error {
+	// Interactive follow only engages for a TTY with no inline field=value args
+	// and without --non-interactive: pipes/redirects, explicit values, and the
+	// opt-out flag keep the one-shot path below so scripts (and agents/CI on an
+	// allocated PTY) see the unchanged "continuation run <id>" output. Show the
+	// suspended run's logs first for context, mirroring `dicode run`.
+	if followEngages(nonInteractive, stdinIsInteractive(), len(kvArgs) > 0) {
 		if logErr := cmdLogs(c, runID); logErr != nil {
 			fmt.Fprintf(os.Stderr, "dicode: fetch logs: %v\n", logErr)
 		}
@@ -1173,6 +1178,18 @@ func cmdResume(c *ipc.ControlClient, runID string, kvArgs []string) error {
 	entries, required, err := parseResumeProps(info.Schema)
 	if err != nil {
 		return fmt.Errorf("read resume schema: %w", err)
+	}
+
+	// --non-interactive with no field=value must never block on a prompt (an
+	// agent/CI on an allocated PTY reaches here). Report the pending fields and
+	// exit 0 so the caller can re-run with explicit values.
+	if len(kvArgs) == 0 && nonInteractive {
+		fmt.Printf("run %s: suspended\n", runID)
+		if fields := resumeFieldNames(entries, required); len(fields) > 0 {
+			fmt.Printf("fields: %s\n", strings.Join(fields, ", "))
+		}
+		fmt.Printf("resume with: dicode resume %s <field=value ...>\n", runID)
+		return nil
 	}
 
 	var values map[string]any
@@ -1509,10 +1526,16 @@ func usage() {
 Commands:
   daemon [-config dicode.yaml]    start the daemon (usually auto-started)
   run <task-id> [key=value ...]   trigger a task and wait for the result
+                                  on a TTY, walks a suspend wizard inline;
+                                  --non-interactive (alias --batch) forces the
+                                  one-shot path (print suspended id, exit)
   list                            list registered tasks
   logs <run-id>                   show logs for a run
   status [task-id]                daemon health or task's latest run
   resume [run-id] [field=value]   resume a suspended run (no args lists suspended runs)
+                                  on a TTY with no field=value, walks the wizard
+                                  inline; --non-interactive (alias --batch) or
+                                  explicit values force the one-shot path
   ai <prompt> [flags]             run the configured AI task with a prompt
                                   flags: --session-id ID, --task TASK_ID
   task test <task-id> [flags]     run the task's sibling task.test.* through its runtime

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -43,6 +43,7 @@ import (
 
 	"github.com/dicode/dicode/pkg/daemon"
 	"github.com/dicode/dicode/pkg/ipc"
+	"github.com/dicode/dicode/pkg/registry"
 	"github.com/dicode/dicode/pkg/schemavalidate"
 	"github.com/dicode/dicode/pkg/tasktest"
 )
@@ -887,6 +888,13 @@ func cmdRun(c *ipc.ControlClient, taskID string, kvArgs []string) error {
 		fmt.Fprintf(os.Stderr, "dicode: fetch logs: %v\n", logErr)
 	}
 
+	// A run that suspended on a TTY drives the whole wizard inline: prompt for
+	// the resume form, follow the continuation, repeat until it finishes. Piped
+	// stdin keeps the one-shot output below so automation still sees the id.
+	if result.Status == registry.StatusSuspended && stdinIsInteractive() {
+		return followSuspended(c, result.RunID)
+	}
+
 	fmt.Printf("run %s: %s\n", result.RunID, result.Status)
 	if result.ReturnValue != nil {
 		out, _ := json.MarshalIndent(result.ReturnValue, "", "  ")
@@ -1067,13 +1075,14 @@ func collectResumeArgs(entries []resumePropEntry, kvArgs []string) (map[string]a
 	return out, nil
 }
 
-// promptResumeInput walks the schema's properties in order, prompting on stderr
-// (so a piped stdout stays clean) and coercing each answer to its declared
-// type. An empty answer takes the property's default, or is skipped when the
-// property is optional; a required property with no default re-prompts.
-func promptResumeInput(entries []resumePropEntry, required map[string]bool) (map[string]any, error) {
-	reader := bufio.NewReader(os.Stdin)
-	out := map[string]any{}
+// promptResumeInput walks the schema's properties in order, prompting on out
+// (stderr in production, so a piped stdout stays clean) and reading answers from
+// in, coercing each to its declared type. An empty answer takes the property's
+// default, or is skipped when the property is optional; a required property with
+// no default re-prompts. in/out are injected so the loop is unit-testable.
+func promptResumeInput(entries []resumePropEntry, required map[string]bool, in io.Reader, out io.Writer) (map[string]any, error) {
+	reader := bufio.NewReader(in)
+	values := map[string]any{}
 	for _, e := range entries {
 		p := e.Prop
 		label := p.Title
@@ -1081,14 +1090,14 @@ func promptResumeInput(entries []resumePropEntry, required map[string]bool) (map
 			label = e.Name
 		}
 		if p.Description != "" {
-			fmt.Fprintf(os.Stderr, "%s\n", p.Description)
+			fmt.Fprintf(out, "%s\n", p.Description)
 		}
 		if len(p.Enum) > 0 {
 			opts := make([]string, len(p.Enum))
 			for i, o := range p.Enum {
 				opts[i] = fmt.Sprintf("%v", o)
 			}
-			fmt.Fprintf(os.Stderr, "  choices: %s\n", strings.Join(opts, ", "))
+			fmt.Fprintf(out, "  choices: %s\n", strings.Join(opts, ", "))
 		}
 		for {
 			suffix := ""
@@ -1097,7 +1106,7 @@ func promptResumeInput(entries []resumePropEntry, required map[string]bool) (map
 			} else if required[e.Name] {
 				suffix = " (required)"
 			}
-			fmt.Fprintf(os.Stderr, "%s%s: ", label, suffix)
+			fmt.Fprintf(out, "%s%s: ", label, suffix)
 
 			line, err := reader.ReadString('\n')
 			eof := errors.Is(err, io.EOF)
@@ -1107,12 +1116,12 @@ func promptResumeInput(entries []resumePropEntry, required map[string]bool) (map
 			raw := strings.TrimRight(line, "\r\n")
 			if strings.TrimSpace(raw) == "" {
 				if p.Default != nil {
-					out[e.Name] = p.Default
+					values[e.Name] = p.Default
 				} else if required[e.Name] {
 					if eof {
 						return nil, fmt.Errorf("%s is required", e.Name)
 					}
-					fmt.Fprintln(os.Stderr, "  required — please enter a value")
+					fmt.Fprintln(out, "  required — please enter a value")
 					continue
 				}
 				break
@@ -1122,14 +1131,14 @@ func promptResumeInput(entries []resumePropEntry, required map[string]bool) (map
 				if eof {
 					return nil, fmt.Errorf("%s: %w", e.Name, err)
 				}
-				fmt.Fprintf(os.Stderr, "  %v\n", err)
+				fmt.Fprintf(out, "  %v\n", err)
 				continue
 			}
-			out[e.Name] = v
+			values[e.Name] = v
 			break
 		}
 	}
-	return out, nil
+	return values, nil
 }
 
 // cmdResume submits collected resume input for a suspended run. It first pulls
@@ -1138,6 +1147,17 @@ func promptResumeInput(entries []resumePropEntry, required map[string]bool) (map
 // their declared types, validates locally against the schema, and submits. The
 // daemon re-validates authoritatively and resolves the resume token itself.
 func cmdResume(c *ipc.ControlClient, runID string, kvArgs []string) error {
+	// Interactive follow only engages for a TTY with no inline field=value args:
+	// pipes/redirects and explicit values keep the one-shot path below so scripts
+	// see the unchanged "continuation run <id>" output. Show the suspended run's
+	// logs first for context, mirroring how `dicode run` prints before it waits.
+	if len(kvArgs) == 0 && stdinIsInteractive() {
+		if logErr := cmdLogs(c, runID); logErr != nil {
+			fmt.Fprintf(os.Stderr, "dicode: fetch logs: %v\n", logErr)
+		}
+		return followSuspended(c, runID)
+	}
+
 	infoResp, err := c.Send(ipc.Request{Method: "cli.resume.get", RunID: runID})
 	if err != nil {
 		return err
@@ -1157,7 +1177,7 @@ func cmdResume(c *ipc.ControlClient, runID string, kvArgs []string) error {
 
 	var values map[string]any
 	if len(kvArgs) == 0 {
-		values, err = promptResumeInput(entries, required)
+		values, err = promptResumeInput(entries, required, os.Stdin, os.Stderr)
 	} else {
 		values, err = collectResumeArgs(entries, kvArgs)
 	}

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -628,6 +628,16 @@ func (cs *ControlServer) handleRunWait(ctx context.Context, req Request) (RunRes
 	if cs.engine == nil {
 		return RunResult{}, errors.New("run wait not available (engine not wired)")
 	}
+	// A daemon body is long-lived and never reaches a terminal state, so blocking
+	// on it would park this handler until the client disconnects (and, because
+	// dispatch is serialized per connection, the disconnect isn't even observed
+	// until then). Return its current status immediately instead; the CLI falls
+	// back to the one-shot path for daemon continuations.
+	if run, err := cs.reg.GetRun(ctx, req.RunID); err == nil {
+		if spec, ok := cs.reg.Get(run.TaskID); ok && spec.Trigger.Daemon {
+			return RunResult{RunID: run.ID, Status: run.Status}, nil
+		}
+	}
 	return cs.engine.WaitRun(ctx, req.RunID)
 }
 

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -230,6 +230,9 @@ func (cs *ControlServer) dispatch(ctx context.Context, req Request) (any, error)
 	case "cli.run":
 		return cs.handleRun(ctx, req)
 
+	case "cli.run.wait":
+		return cs.handleRunWait(ctx, req)
+
 	case "cli.logs":
 		return cs.handleLogs(ctx, req)
 
@@ -610,6 +613,22 @@ func (cs *ControlServer) handleRun(ctx context.Context, req Request) (RunResult,
 		return RunResult{}, err
 	}
 	return cs.engine.WaitRun(ctx, runID)
+}
+
+// handleRunWait blocks until an existing run reaches a terminal or suspended
+// state and returns its RunResult. It backs the CLI's interactive follow loop:
+// after a resume spawns a continuation, the client waits on it here rather than
+// polling cli.resume.get, which sidesteps the window where the continuation has
+// been spawned but has not yet reached `suspended` (the "run is not suspended"
+// race) — WaitRun settles on the run's done signal and reads the final record.
+func (cs *ControlServer) handleRunWait(ctx context.Context, req Request) (RunResult, error) {
+	if req.RunID == "" {
+		return RunResult{}, errors.New("runID required")
+	}
+	if cs.engine == nil {
+		return RunResult{}, errors.New("run wait not available (engine not wired)")
+	}
+	return cs.engine.WaitRun(ctx, req.RunID)
 }
 
 func (cs *ControlServer) handleLogs(ctx context.Context, req Request) ([]LogEntry, error) {

--- a/pkg/ipc/control_resume.go
+++ b/pkg/ipc/control_resume.go
@@ -43,11 +43,14 @@ type ResumeResult struct {
 
 // ResumeInfo is the cli.resume.get response: a suspended run's JSON Schema so
 // the CLI can prompt per property, coerce values to their declared types, and
-// validate before submitting.
+// validate before submitting. Daemon reports whether the run's task is a daemon
+// body, whose continuation is long-lived and never settles — the CLI must not
+// block on it after resuming.
 type ResumeInfo struct {
 	RunID  string          `json:"runID"`
 	TaskID string          `json:"taskID"`
 	Schema json.RawMessage `json:"schema,omitempty"`
+	Daemon bool            `json:"daemon,omitempty"`
 }
 
 // SuspendedRunSummary is one row in the cli.resume.list response. Fields is the
@@ -128,6 +131,9 @@ func (cs *ControlServer) handleResumeGet(ctx context.Context, req Request) (Resu
 	info := ResumeInfo{RunID: run.ID, TaskID: run.TaskID}
 	if len(run.ResumeSchema) > 0 {
 		info.Schema = json.RawMessage(run.ResumeSchema)
+	}
+	if spec, ok := cs.reg.Get(run.TaskID); ok {
+		info.Daemon = spec.Trigger.Daemon
 	}
 	return info, nil
 }


### PR DESCRIPTION
## Summary

Resuming a multi-step suspend wizard from the CLI was one-shot per step: `dicode resume <id> field=value` printed the *next* continuation id and the operator manually re-ran against it — with a deliberate pause in between, since the continuation has to reach `suspended` before it can be resumed again. Functional, but disjointed.

On a TTY with no inline `field=value` values, `dicode run <task>` and `dicode resume <id>` now walk the whole wizard in one uninterrupted flow. When a run suspends the CLI reads its resume JSON Schema, prompts for each property inline (title, type, enum choices as a numbered choice list, required marker, boolean as y/n), submits, then follows the continuation and repeats until it finishes — printing the final status and return value. A required-empty or schema-invalid answer reprompts rather than aborting.

## How the race is handled

Following waits on a new `cli.run.wait` control method that wraps the engine's existing `WaitRun`. `WaitRun` blocks on the run's completion signal (populated synchronously when the continuation is spawned) and then reads the settled record, so it returns whether the continuation ended terminal *or* suspended — the caller never observes the "run is not suspended" window between spawn and suspend. No client-side polling or sleeps.

## Scriptability

Interactive prompting engages only for a TTY with no inline values (`term.IsTerminal` on stdin). Piped/redirected stdin, or explicit `field=value` args, keep the existing one-shot path and its unchanged output (`run <id>: suspended` / `resumed: continuation run <id>`), so scripts and automation are unaffected.

## Design

The follow loop takes injectable in/out and a `followClient` interface, so the schema→prompt→submit→follow core is unit-tested with a fake client (single-step, multi-step, failure, required-field reprompt). Per-field coercion and the reprompt loop are reused from the existing one-shot path rather than reimplemented. SIGINT at any point flushes the in-flight continuation's logs and exits 130.

Verified end-to-end against the `examples/suspend-wizard` task: interactive `run` and `resume` both walk the three-step wizard (name → framework enum → confirm boolean) to a success result; piped `run` and explicit-arg `resume` retain the one-shot output.

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an interactive follow flow for suspended runs, including step-by-step prompts, validation, log streaming, and continuation handling.
  - Added `--non-interactive` / `--batch` support so runs and resumes can avoid prompts and return clear next-step guidance.
  - Resume output now indicates when a run will continue in the background instead of waiting inline.

- **Bug Fixes**
  - Improved handling of empty or invalid input so prompts don’t loop indefinitely.
  - Fixed behavior for daemon-backed runs so they no longer hang while waiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->