### PR TITLE
docs(examples): branching deploy-wizard suspend example

### DIFF
--- a/docs/concepts/suspendable-tasks.md
+++ b/docs/concepts/suspendable-tasks.md
@@ -308,6 +308,18 @@ runner dispatches the next handler by the `to` name with no step switch. The sam
 flow works from the CLI — `dicode resume` lists the suspended run and
 `dicode resume <run-id> project_name=acme` (etc.) submits each step.
 
+### A branching example
+
+[`tasks/examples/deploy-wizard/`](../../tasks/examples/deploy-wizard/) goes
+further: a deploy wizard where each step runs real **async work** (a candidate
+scan, a check run, the deploy itself — stand-ins that log progress) and the
+**next step is chosen at runtime**. Because `to` is a plain value, `if/else` on an
+async result or on `ctx.input` picks the branch: a failed coverage gate suspends
+to an override prompt, `prod` takes an extra confirmation, and three paths
+converge on the same deploy step. It needs no network or secrets. Same primitives
+as above — the only new idea is that the step graph is decided by code, not
+declared.
+
 ---
 
 ## Rules and gotchas

--- a/tasks/examples/deploy-wizard/task.test.ts
+++ b/tasks/examples/deploy-wizard/task.test.ts
@@ -1,0 +1,75 @@
+import { setupHarness } from "../../sdk-test.ts";
+import { steps } from "./task.ts";
+await setupHarness(import.meta.url);
+
+// suspend isn't part of the default mock surface; capture the request and throw
+// to mimic that it never returns, so the handler under test stops there.
+function captureSuspend() {
+  const calls: Record<string, unknown>[] = [];
+  const suspend = (req: Record<string, unknown>) => {
+    calls.push(req);
+    throw new Error("__suspended__");
+  };
+  return { calls, suspend };
+}
+
+async function expectSuspend(fn: () => Promise<unknown>) {
+  let threw = false;
+  try { await fn(); } catch { threw = true; }
+  assert.ok(threw, "handler was expected to suspend");
+}
+
+test("main scans the candidate and suspends to pickEnv", async () => {
+  const { calls, suspend } = captureSuspend();
+  (dicode as Record<string, unknown>).suspend = suspend;
+  await expectSuspend(() => runTask());
+  assert.equal(calls[0].to, "pickEnv");
+  const schema = calls[0].schema as { properties: { env: { enum: string[] } } };
+  assert.equal(schema.properties.env.enum.length, 3);
+});
+
+test("pickEnv: a lower env that passes checks goes straight to deploy", async () => {
+  const { calls, suspend } = captureSuspend();
+  await expectSuspend(() =>
+    steps.pickEnv({ dicode: { suspend }, input: { env: "dev" }, state: { candidate: { version: "1.4.0" } } } as never)
+  );
+  assert.equal(calls[0].to, "runDeploy");
+});
+
+test("pickEnv: prod fails the coverage gate and branches to the override prompt", async () => {
+  const { calls, suspend } = captureSuspend();
+  await expectSuspend(() =>
+    steps.pickEnv({ dicode: { suspend }, input: { env: "prod" }, state: { candidate: { version: "1.4.0" } } } as never)
+  );
+  assert.equal(calls[0].to, "confirmOverride");
+});
+
+test("confirmOverride: declining the override aborts without deploying", async () => {
+  const result = await steps.confirmOverride({
+    input: { override: false },
+    state: { candidate: { version: "1.4.0" }, env: "prod" },
+  } as never);
+  assert.equal((result as { deployed: boolean }).deployed, false);
+});
+
+test("confirmOverride: overriding a lower env proceeds to the deploy note", async () => {
+  const { calls, suspend } = captureSuspend();
+  await expectSuspend(() =>
+    steps.confirmOverride({
+      dicode: { suspend },
+      input: { override: true },
+      state: { candidate: { version: "1.4.0" }, env: "staging" },
+    } as never)
+  );
+  assert.equal(calls[0].to, "runDeploy");
+});
+
+test("runDeploy: performs the async deploy and returns the result", async () => {
+  const result = await steps.runDeploy({
+    input: { note: "ship it" },
+    state: { candidate: { version: "1.4.0" }, env: "dev" },
+  } as never);
+  assert.equal((result as { deployed: boolean }).deployed, true);
+  assert.equal((result as { version: string }).version, "1.4.0");
+  assert.ok((result as { url: string }).url.includes("dev"));
+});

--- a/tasks/examples/deploy-wizard/task.test.ts
+++ b/tasks/examples/deploy-wizard/task.test.ts
@@ -64,6 +64,26 @@ test("confirmOverride: overriding a lower env proceeds to the deploy note", asyn
   assert.equal(calls[0].to, "runDeploy");
 });
 
+test("confirmProd: declining the prod confirmation aborts without deploying", async () => {
+  const result = await steps.confirmProd({
+    input: { confirm: false },
+    state: { candidate: { version: "1.4.0" }, env: "prod" },
+  } as never);
+  assert.equal((result as { deployed: boolean }).deployed, false);
+});
+
+test("confirmProd: confirming prod proceeds to the deploy note", async () => {
+  const { calls, suspend } = captureSuspend();
+  await expectSuspend(() =>
+    steps.confirmProd({
+      dicode: { suspend },
+      input: { confirm: true },
+      state: { candidate: { version: "1.4.0" }, env: "prod" },
+    } as never)
+  );
+  assert.equal(calls[0].to, "runDeploy");
+});
+
 test("runDeploy: performs the async deploy and returns the result", async () => {
   const result = await steps.runDeploy({
     input: { note: "ship it" },

--- a/tasks/examples/deploy-wizard/task.ts
+++ b/tasks/examples/deploy-wizard/task.ts
@@ -1,0 +1,149 @@
+import type { DicodeSdk } from "../../sdk.ts";
+
+// A branching deploy wizard. Two ideas it demonstrates beyond the linear
+// suspend-wizard:
+//   1. Steps do real async work between pauses — the helpers below stand in for
+//      API calls / builds / scans (a delay + progress logs make the work visible
+//      in the run's Logs panel).
+//   2. The next step is chosen at runtime. `dicode.suspend({ to })` persists a
+//      plain string, so `if/else` on an async result or on ctx.input picks the
+//      branch — there is no static step graph.
+//
+// The run re-executes from the top on every resume (it is re-run, not frozen),
+// so anything a later step needs is threaded through suspend({ state }) and read
+// back as ctx.state. Nothing survives in a local variable across a pause.
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function gatherCandidate(): Promise<{ version: string; commits: number }> {
+  console.log("deploy-wizard: scanning commits for the release candidate…");
+  await delay(400);
+  return { version: "1.4.0", commits: 7 };
+}
+
+async function runChecks(env: string): Promise<{ passed: boolean; coverage: number }> {
+  console.log(`deploy-wizard: running tests + lint for ${env}…`);
+  await delay(600);
+  // Pretend prod runs a stricter suite that this candidate doesn't clear yet.
+  const coverage = env === "prod" ? 71 : 88;
+  return { passed: coverage >= 80, coverage };
+}
+
+async function deploy(env: string, version: string): Promise<{ url: string }> {
+  console.log(`deploy-wizard: deploying ${version} to ${env}…`);
+  await delay(800);
+  return { url: `https://${env}.example.com/${version}` };
+}
+
+// The deploy-note step is reached from three branches (checks passed, override,
+// prod confirmed); factored out so each branch just names it via `to`.
+function deployNoteSchema(env: string, title: string) {
+  return {
+    to: "runDeploy",
+    schema: {
+      type: "object",
+      title,
+      description: `Deploying to ${env}.`,
+      properties: { note: { type: "string", title: "Deploy note (optional)" } },
+    },
+  };
+}
+
+export default async function main({ dicode }: DicodeSdk) {
+  const candidate = await gatherCandidate();
+  await dicode.suspend({
+    to: "pickEnv",
+    state: { candidate },
+    schema: {
+      type: "object",
+      title: `Release ${candidate.version}`,
+      description: `${candidate.commits} commits since the last tag. Where should it go?`,
+      properties: {
+        env: { type: "string", title: "Environment", enum: ["dev", "staging", "prod"] },
+      },
+      required: ["env"],
+    },
+  });
+}
+
+export const steps = {
+  async pickEnv({ dicode, input, state }: DicodeSdk) {
+    const { candidate } = state as { candidate: { version: string } };
+    const env = (input as { env: string }).env;
+
+    const checks = await runChecks(env);
+
+    // Branch on the async result: a failed gate asks whether to override.
+    if (!checks.passed) {
+      await dicode.suspend({
+        to: "confirmOverride",
+        state: { candidate, env, coverage: checks.coverage },
+        schema: {
+          type: "object",
+          title: "Checks failed",
+          description: `Coverage ${checks.coverage}% is below the 80% gate for ${env}. Override and deploy anyway?`,
+          properties: { override: { type: "boolean", title: "Override the gate" } },
+          required: ["override"],
+        },
+      });
+    }
+
+    // Checks passed: prod takes an extra confirmation, lower envs go straight on.
+    if (env === "prod") {
+      await dicode.suspend({
+        to: "confirmProd",
+        state: { candidate, env },
+        schema: {
+          type: "object",
+          title: "Confirm production",
+          description: `Ship ${candidate.version} to PROD?`,
+          properties: { confirm: { type: "boolean", title: "Ship it" } },
+          required: ["confirm"],
+        },
+      });
+    }
+    await dicode.suspend({ ...deployNoteSchema(env, `Deploy to ${env}`), state: { candidate, env } });
+  },
+
+  async confirmOverride({ dicode, input, state }: DicodeSdk) {
+    const { candidate, env } = state as { candidate: { version: string }; env: string };
+    if (!(input as { override: boolean }).override) {
+      console.log("deploy-wizard: override declined — aborting");
+      return { version: candidate.version, env, deployed: false, reason: "gate failed, override declined" };
+    }
+    // Overridden — prod still confirms; others go to the deploy note.
+    if (env === "prod") {
+      await dicode.suspend({
+        to: "confirmProd",
+        state: { candidate, env },
+        schema: {
+          type: "object",
+          title: "Confirm production (overridden)",
+          description: `Ship ${candidate.version} to PROD despite the failed gate?`,
+          properties: { confirm: { type: "boolean", title: "Ship it" } },
+          required: ["confirm"],
+        },
+      });
+    }
+    await dicode.suspend({ ...deployNoteSchema(env, `Deploy to ${env} (overridden)`), state: { candidate, env } });
+  },
+
+  async confirmProd({ dicode, input, state }: DicodeSdk) {
+    const { candidate, env } = state as { candidate: { version: string }; env: string };
+    if (!(input as { confirm: boolean }).confirm) {
+      console.log("deploy-wizard: prod confirmation declined — aborting");
+      return { version: candidate.version, env, deployed: false, reason: "prod confirmation declined" };
+    }
+    await dicode.suspend({ ...deployNoteSchema(env, "Deploy note"), state: { candidate, env } });
+  },
+
+  async runDeploy({ input, state }: DicodeSdk) {
+    const { candidate, env } = state as { candidate: { version: string }; env: string };
+    const note = (input as { note?: string }).note ?? "";
+    const result = await deploy(env, candidate.version);
+    console.log(`deploy-wizard: done — ${candidate.version} live at ${result.url}`);
+    return { version: candidate.version, env, deployed: true, url: result.url, note };
+  },
+};

--- a/tasks/examples/deploy-wizard/task.yaml
+++ b/tasks/examples/deploy-wizard/task.yaml
@@ -1,0 +1,14 @@
+apiVersion: dicode/v1
+kind: Task
+name: Deploy Wizard (example)
+description: >
+  A branching suspend/resume wizard. Each step runs real async work (simulated
+  with delays + progress logs) and chooses the next step at runtime: a release
+  candidate is scanned, checks are run, and the flow branches on the results and
+  your answers — failed checks prompt an override, prod needs an extra
+  confirmation — before a simulated deploy. Needs no network or secrets. Trigger
+  it manually from the Web UI or `dicode run examples/deploy-wizard`.
+runtime: deno
+trigger:
+  manual: true
+timeout: 30s

--- a/tasks/examples/taskset.yaml
+++ b/tasks/examples/taskset.yaml
@@ -40,6 +40,10 @@ spec:
       ref:
         path: ./suspend-wizard/task.yaml
 
+    deploy-wizard:
+      ref:
+        path: ./deploy-wizard/task.yaml
+
     github-stars:
       ref:
         path: ./github-stars/task.yaml


### PR DESCRIPTION
## Summary

The shipped `suspend-wizard` is a linear 3-pause wizard. This adds a second example — `tasks/examples/deploy-wizard/` — that demonstrates the two things a linear wizard doesn't:

- **Async work between pauses.** Each step awaits a "long" async helper (candidate scan → check run → deploy), each logging progress so it's visible in the run's Logs panel. No network or secrets — the helpers are self-contained stand-ins.
- **A runtime-decided step graph.** `dicode.suspend({ to })` persists a plain string, so the next step is chosen with `if/else` on an async result or on `ctx.input`: a failed coverage gate suspends to an override prompt, `prod` takes an extra confirmation, and three branches converge on the same deploy step. Early `return`s abort without deploying.

Same primitives as the linear example (re-run-not-freeze, state carried via `suspend({ state })`, JSON-Schema forms, auto-dispatch) — the only new idea is that the branching is code, not a declared graph.

Ships with `task.test.ts` covering the branch points; linked from the suspendable-tasks concept doc. Verified via `dicode task test` (6/6) and a live end-to-end run through real suspend/resume.