### PR TITLE
feat(cli): pre-supply suspend-wizard answers with --field to auto-advance run/resume

### DIFF
--- a/cmd/dicode/follow.go
+++ b/cmd/dicode/follow.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"sort"
 	"strings"
 
 	"github.com/dicode/dicode/pkg/ipc"
@@ -24,19 +25,103 @@ func stdinIsInteractive() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
-// parseInteractiveFlag pulls the --non-interactive opt-out (alias --batch) out
-// of a subcommand's argument list, returning whether it was present and the
-// remaining positional args (task/run id and field=value pairs) in order.
-func parseInteractiveFlag(args []string) (nonInteractive bool, rest []string) {
-	for _, a := range args {
-		switch a {
-		case "--non-interactive", "--batch":
+// parseWizardFlags pulls the wizard control flags out of a run/resume argument
+// list: the --non-interactive opt-out (alias --batch) and repeatable --field
+// name=value pre-supplied answers (both `--field name=value` and
+// `--field=name=value` spellings). The remaining positional args (task/run id
+// and any inline key=value pairs) are returned in order.
+func parseWizardFlags(args []string) (nonInteractive bool, fields, rest []string, err error) {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--non-interactive" || a == "--batch":
 			nonInteractive = true
+		case a == "--field":
+			if i+1 >= len(args) {
+				return false, nil, nil, fmt.Errorf("--field requires a name=value argument")
+			}
+			i++
+			fields = append(fields, args[i])
+		case strings.HasPrefix(a, "--field="):
+			fields = append(fields, strings.TrimPrefix(a, "--field="))
 		default:
 			rest = append(rest, a)
 		}
 	}
-	return nonInteractive, rest
+	return nonInteractive, fields, rest, nil
+}
+
+// prefillPool holds the --field name=value answers pre-supplied for a wizard.
+// Values are matched against each step's schema as the wizard advances and
+// consumed at first match, so a later step that happens to declare the same
+// field name does not inherit an earlier step's value.
+type prefillPool struct {
+	vals map[string]string
+	used map[string]bool
+}
+
+// newPrefillPool parses the raw --field arguments into a name-keyed pool.
+// Duplicate field names are rejected: the pool is matched by name, so a repeated
+// name is ambiguous.
+func newPrefillPool(fields []string) (*prefillPool, error) {
+	p := &prefillPool{vals: map[string]string{}, used: map[string]bool{}}
+	for _, f := range fields {
+		name, raw, ok := strings.Cut(f, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid --field %q — expected name=value", f)
+		}
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return nil, fmt.Errorf("invalid --field %q — empty field name", f)
+		}
+		if _, dup := p.vals[name]; dup {
+			return nil, fmt.Errorf("duplicate --field %q", name)
+		}
+		p.vals[name] = raw
+	}
+	return p, nil
+}
+
+// take returns the raw value for name and marks it consumed, if it is present
+// and not yet used. A nil pool yields no value.
+func (p *prefillPool) take(name string) (string, bool) {
+	if p == nil || p.used[name] {
+		return "", false
+	}
+	raw, ok := p.vals[name]
+	if ok {
+		p.used[name] = true
+	}
+	return raw, ok
+}
+
+// empty reports whether the pool holds no pre-supplied answers.
+func (p *prefillPool) empty() bool {
+	return p == nil || len(p.vals) == 0
+}
+
+// unused returns the names of pre-supplied answers never consumed, sorted. These
+// are typically typos or fields belonging to a branch the wizard did not take.
+func (p *prefillPool) unused() []string {
+	if p == nil {
+		return nil
+	}
+	var names []string
+	for n := range p.vals {
+		if !p.used[n] {
+			names = append(names, n)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// warnUnusedPrefill reports pre-supplied --field answers that were never
+// consumed by any step the wizard reached.
+func warnUnusedPrefill(w io.Writer, p *prefillPool) {
+	if names := p.unused(); len(names) > 0 {
+		fmt.Fprintf(w, "warning: --field value(s) never used by any step reached: %s\n", strings.Join(names, ", "))
+	}
 }
 
 // resumeFieldNames returns the property names to hint at for a non-interactive
@@ -150,6 +235,14 @@ type followSession struct {
 	in     io.Reader // answers (stdin)
 	prompt io.Writer // prompts + step banners (stderr, keeps stdout clean)
 	out    io.Writer // logs + final result (stdout)
+
+	// prefill holds --field name=value answers to auto-advance steps without
+	// prompting. nil/empty means every step is prompted (or fails under
+	// nonInteractive).
+	prefill *prefillPool
+	// nonInteractive suppresses prompting: a reached step whose required fields
+	// are not all pre-supplied fails deterministically instead of blocking.
+	nonInteractive bool
 }
 
 // resumeSchemaMeta extracts a schema's top-level title and description, used to
@@ -191,7 +284,44 @@ func (s *followSession) printOneShotSuspended(runID string, entries []resumeProp
 // spins. For promptable schemas, an object-level validation failure re-prompts,
 // but only while a re-prompt can change the input: identical input failing twice
 // (e.g. optional fields left blank at EOF) aborts instead of hot-looping.
-func (s *followSession) collectStepInput(reader *bufio.Reader, schema []byte, entries []resumePropEntry, required map[string]bool) ([]byte, bool, error) {
+func (s *followSession) collectStepInput(reader *bufio.Reader, label string, schema []byte, entries []resumePropEntry, required map[string]bool) ([]byte, bool, error) {
+	// Pull pre-supplied answers for this step's declared properties out of the
+	// pool, consuming each at first match, and coerce them to the schema's types.
+	pre := map[string]any{}
+	for _, e := range entries {
+		raw, ok := s.prefill.take(e.Name)
+		if !ok {
+			continue
+		}
+		v, err := coerceResumeValue(e.Prop, raw)
+		if err != nil {
+			return nil, false, fmt.Errorf("--field %s: %w", e.Name, err)
+		}
+		pre[e.Name] = v
+	}
+	missing := missingRequiredFields(entries, required, pre)
+
+	// Every required field is pre-supplied (or the step requires nothing and we
+	// will not prompt): submit without asking. An interactive step with no
+	// pre-supplied answer falls through so the operator still drives it.
+	if len(missing) == 0 && (len(pre) > 0 || s.nonInteractive) {
+		inputJSON, err := json.Marshal(pre)
+		if err != nil {
+			return nil, false, err
+		}
+		if verr := schemavalidate.Validate(schema, inputJSON); verr != nil {
+			return nil, false, fmt.Errorf("step %q: %w", label, verr)
+		}
+		return inputJSON, true, nil
+	}
+
+	// Non-interactive with an unfilled required field: fail deterministically
+	// rather than block on a prompt an agent/CI caller cannot answer.
+	if s.nonInteractive {
+		return nil, false, fmt.Errorf("step %q: missing required field(s): %s (supply with --field %s=…)",
+			label, strings.Join(missing, ", "), missing[0])
+	}
+
 	if len(entries) == 0 {
 		empty := []byte("{}")
 		if verr := schemavalidate.Validate(schema, empty); verr != nil {
@@ -216,11 +346,25 @@ func (s *followSession) collectStepInput(reader *bufio.Reader, schema []byte, en
 		return empty, true, nil
 	}
 
+	// Prompt only for properties not already answered by a pre-supplied value,
+	// then merge those back in before validating.
+	promptable := entries
+	if len(pre) > 0 {
+		promptable = promptable[:0:0]
+		for _, e := range entries {
+			if _, ok := pre[e.Name]; !ok {
+				promptable = append(promptable, e)
+			}
+		}
+	}
 	var last []byte
 	for {
-		values, perr := promptResumeInput(entries, required, reader, s.prompt)
+		values, perr := promptResumeInput(promptable, required, reader, s.prompt)
 		if perr != nil {
 			return nil, false, perr
+		}
+		for k, v := range pre {
+			values[k] = v
 		}
 		inputJSON, err := json.Marshal(values)
 		if err != nil {
@@ -236,6 +380,41 @@ func (s *followSession) collectStepInput(reader *bufio.Reader, schema []byte, en
 		}
 		return inputJSON, true, nil
 	}
+}
+
+// missingRequiredFields returns the required property names not answered by the
+// pre-supplied values, in declaration order first (so error messages read in
+// schema order), then any required name that is not a declared property.
+func missingRequiredFields(entries []resumePropEntry, required map[string]bool, pre map[string]any) []string {
+	var missing []string
+	seen := map[string]bool{}
+	for _, e := range entries {
+		if required[e.Name] {
+			seen[e.Name] = true
+			if _, ok := pre[e.Name]; !ok {
+				missing = append(missing, e.Name)
+			}
+		}
+	}
+	var extra []string
+	for name := range required {
+		if !seen[name] {
+			if _, ok := pre[name]; !ok {
+				extra = append(extra, name)
+			}
+		}
+	}
+	sort.Strings(extra)
+	return append(missing, extra...)
+}
+
+// stepLabel names a step for prompts and error messages: its schema title if
+// present, otherwise the suspended run id.
+func stepLabel(schema []byte, runID string) string {
+	if title, _ := resumeSchemaMeta(schema); title != "" {
+		return title
+	}
+	return runID
 }
 
 // follow walks a suspend wizard from an already-suspended run: it fetches the
@@ -260,7 +439,7 @@ func (s *followSession) follow(suspendedRunID string) error {
 			return fmt.Errorf("read resume schema: %w", err)
 		}
 
-		inputJSON, submit, err := s.collectStepInput(reader, info.Schema, entries, required)
+		inputJSON, submit, err := s.collectStepInput(reader, stepLabel(info.Schema, runID), info.Schema, entries, required)
 		if err != nil {
 			return err
 		}
@@ -305,6 +484,7 @@ func (s *followSession) follow(suspendedRunID string) error {
 			out, _ := json.MarshalIndent(result.ReturnValue, "", "  ")
 			fmt.Fprintln(s.out, string(out))
 		}
+		warnUnusedPrefill(s.prompt, s.prefill)
 		if result.Status == registry.StatusFailure {
 			return fmt.Errorf("task failed")
 		}
@@ -332,12 +512,14 @@ func (s *followSession) printLogs(runID string) {
 // WaitRun on the same connection, and ControlClient.Send is not safe for
 // concurrent use. The handler notes the interrupt and exits 130 (the shell
 // convention); the daemon cancels the in-flight run when the connection drops.
-func followSuspended(c *ipc.ControlClient, runID string) error {
+func followSuspended(c *ipc.ControlClient, runID string, prefill *prefillPool, nonInteractive bool) error {
 	s := &followSession{
-		client: controlFollowClient{c: c},
-		in:     os.Stdin,
-		prompt: os.Stderr,
-		out:    os.Stdout,
+		client:         controlFollowClient{c: c},
+		in:             os.Stdin,
+		prompt:         os.Stderr,
+		out:            os.Stdout,
+		prefill:        prefill,
+		nonInteractive: nonInteractive,
 	}
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt)

--- a/cmd/dicode/follow.go
+++ b/cmd/dicode/follow.go
@@ -301,10 +301,13 @@ func (s *followSession) collectStepInput(reader *bufio.Reader, label string, sch
 	}
 	missing := missingRequiredFields(entries, required, pre)
 
-	// Every required field is pre-supplied (or the step requires nothing and we
-	// will not prompt): submit without asking. An interactive step with no
-	// pre-supplied answer falls through so the operator still drives it.
-	if len(missing) == 0 && (len(pre) > 0 || s.nonInteractive) {
+	// Submit without prompting when nothing more can be asked (non-interactive)
+	// or every declared property of the step is pre-supplied. A partially
+	// pre-supplied interactive step falls through so its optional fields are
+	// still offered — pre-supplying the required fields must not silently drop a
+	// gap the operator would otherwise fill.
+	fullyPrefilled := len(pre) > 0 && len(pre) == len(entries)
+	if len(missing) == 0 && (s.nonInteractive || fullyPrefilled) {
 		inputJSON, err := json.Marshal(pre)
 		if err != nil {
 			return nil, false, err
@@ -346,8 +349,8 @@ func (s *followSession) collectStepInput(reader *bufio.Reader, label string, sch
 		return empty, true, nil
 	}
 
-	// Prompt only for properties not already answered by a pre-supplied value,
-	// then merge those back in before validating.
+	// promptResumeInput has no notion of pre-supplied answers, so feed it only the
+	// unanswered properties and fold the pre-supplied ones into its result.
 	promptable := entries
 	if len(pre) > 0 {
 		promptable = promptable[:0:0]

--- a/cmd/dicode/follow_test.go
+++ b/cmd/dicode/follow_test.go
@@ -259,6 +259,30 @@ func TestFollow_PrefillInteractiveFillsGaps(t *testing.T) {
 	}
 }
 
+// On a TTY, pre-supplying a step's required field must not skip prompting for
+// that step's optional fields.
+func TestFollow_PrefillInteractiveStillPromptsOptional(t *testing.T) {
+	client := &fakeFollowClient{
+		schemas: map[string][]byte{
+			"run-1": []byte(`{"type":"object","properties":{"a":{"type":"string"},"note":{"type":"string"}},"required":["a"]}`),
+		},
+		resumeChain: map[string]string{"run-1": "run-2"},
+		waitResults: map[string]ipc.RunResult{"run-2": {RunID: "run-2", Status: "success"}},
+	}
+	pool, _ := newPrefillPool([]string{"a=pre"})
+	var out, prompt bytes.Buffer
+	// a is pre-supplied; the optional note is typed at the prompt.
+	s := &followSession{client: client, in: strings.NewReader("hello\n"), prompt: &prompt, out: &out, prefill: pool}
+
+	if err := s.follow("run-1"); err != nil {
+		t.Fatalf("follow: %v", err)
+	}
+	got := string(client.submitted["run-1"])
+	if !strings.Contains(got, `"a":"pre"`) || !strings.Contains(got, `"note":"hello"`) {
+		t.Errorf("submitted = %s, want both the pre-supplied a and the prompted note", got)
+	}
+}
+
 // Pre-supplied values never consumed (typo or a branch not taken) are reported
 // after the wizard completes.
 func TestFollow_PrefillUnusedWarned(t *testing.T) {

--- a/cmd/dicode/follow_test.go
+++ b/cmd/dicode/follow_test.go
@@ -45,28 +45,237 @@ func (f *fakeFollowClient) Logs(runID string) ([]ipc.LogEntry, error) {
 
 const oneStepSchema = `{"type":"object","properties":{"approve":{"type":"string","title":"Approve?"}},"required":["approve"]}`
 
-func TestParseInteractiveFlag(t *testing.T) {
+func TestParseWizardFlags(t *testing.T) {
 	cases := []struct {
-		name    string
-		args    []string
-		wantNI  bool
-		wantRes []string
+		name       string
+		args       []string
+		wantNI     bool
+		wantFields []string
+		wantRes    []string
+		wantErr    bool
 	}{
-		{"none", []string{"task-x", "a=1"}, false, []string{"task-x", "a=1"}},
-		{"non-interactive", []string{"task-x", "--non-interactive", "a=1"}, true, []string{"task-x", "a=1"}},
-		{"batch alias", []string{"--batch", "run-1"}, true, []string{"run-1"}},
-		{"flag only", []string{"--non-interactive"}, true, nil},
+		{name: "none", args: []string{"task-x", "a=1"}, wantRes: []string{"task-x", "a=1"}},
+		{name: "non-interactive", args: []string{"task-x", "--non-interactive", "a=1"}, wantNI: true, wantRes: []string{"task-x", "a=1"}},
+		{name: "batch alias", args: []string{"--batch", "run-1"}, wantNI: true, wantRes: []string{"run-1"}},
+		{name: "flag only", args: []string{"--non-interactive"}, wantNI: true},
+		{name: "field spaced", args: []string{"wiz", "--field", "a=1", "--field", "b=2"}, wantFields: []string{"a=1", "b=2"}, wantRes: []string{"wiz"}},
+		{name: "field equals", args: []string{"wiz", "--field=a=1"}, wantFields: []string{"a=1"}, wantRes: []string{"wiz"}},
+		{name: "field mixed with params and ni", args: []string{"wiz", "p=q", "--field", "a=1", "--batch"}, wantNI: true, wantFields: []string{"a=1"}, wantRes: []string{"wiz", "p=q"}},
+		{name: "field missing arg", args: []string{"wiz", "--field"}, wantErr: true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			gotNI, gotRes := parseInteractiveFlag(c.args)
+			gotNI, gotFields, gotRes, err := parseWizardFlags(c.args)
+			if c.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if gotNI != c.wantNI {
 				t.Errorf("nonInteractive = %v, want %v", gotNI, c.wantNI)
+			}
+			if strings.Join(gotFields, ",") != strings.Join(c.wantFields, ",") {
+				t.Errorf("fields = %v, want %v", gotFields, c.wantFields)
 			}
 			if strings.Join(gotRes, ",") != strings.Join(c.wantRes, ",") {
 				t.Errorf("rest = %v, want %v", gotRes, c.wantRes)
 			}
 		})
+	}
+}
+
+func TestNewPrefillPool(t *testing.T) {
+	if _, err := newPrefillPool([]string{"noeq"}); err == nil {
+		t.Error("expected error for a field without '='")
+	}
+	if _, err := newPrefillPool([]string{"=v"}); err == nil {
+		t.Error("expected error for an empty field name")
+	}
+	if _, err := newPrefillPool([]string{"a=1", "a=2"}); err == nil {
+		t.Error("expected error for a duplicate field name")
+	}
+	p, err := newPrefillPool([]string{"a=1", "b=x=y"})
+	if err != nil {
+		t.Fatalf("newPrefillPool: %v", err)
+	}
+	// Only the first '=' splits, so the value may itself contain '='.
+	if raw, ok := p.take("b"); !ok || raw != "x=y" {
+		t.Errorf("take(b) = %q,%v, want x=y,true", raw, ok)
+	}
+	// A consumed value is not handed out twice.
+	if _, ok := p.take("b"); ok {
+		t.Error("take(b) a second time must report consumed")
+	}
+	if got := p.unused(); len(got) != 1 || got[0] != "a" {
+		t.Errorf("unused = %v, want [a]", got)
+	}
+}
+
+func TestPrefillPool_NilSafe(t *testing.T) {
+	var p *prefillPool
+	if !p.empty() {
+		t.Error("nil pool must be empty")
+	}
+	if _, ok := p.take("x"); ok {
+		t.Error("nil pool must yield no value")
+	}
+	if p.unused() != nil {
+		t.Error("nil pool must have no unused fields")
+	}
+}
+
+// Pre-supplied answers auto-advance every step of a wizard under
+// --non-interactive with no stdin, coercing each value to its declared type.
+func TestFollow_PrefillAutoAdvances(t *testing.T) {
+	client := &fakeFollowClient{
+		schemas: map[string][]byte{
+			"run-1": []byte(`{"type":"object","properties":{"project_name":{"type":"string"}},"required":["project_name"]}`),
+			"run-2": []byte(`{"type":"object","properties":{"count":{"type":"integer"}},"required":["count"]}`),
+		},
+		resumeChain: map[string]string{"run-1": "run-2", "run-2": "run-3"},
+		waitResults: map[string]ipc.RunResult{
+			"run-2": {RunID: "run-2", Status: "suspended"},
+			"run-3": {RunID: "run-3", Status: "success"},
+		},
+	}
+	pool, _ := newPrefillPool([]string{"project_name=acme", "count=7"})
+	var out, prompt bytes.Buffer
+	s := &followSession{client: client, in: strings.NewReader(""), prompt: &prompt, out: &out, prefill: pool, nonInteractive: true}
+
+	if err := s.follow("run-1"); err != nil {
+		t.Fatalf("follow: %v", err)
+	}
+	if got := string(client.submitted["run-1"]); got != `{"project_name":"acme"}` {
+		t.Errorf("step-1 submitted = %s", got)
+	}
+	// count coerced to a JSON number, not the raw string.
+	if got := string(client.submitted["run-2"]); got != `{"count":7}` {
+		t.Errorf("step-2 submitted = %s, want {\"count\":7}", got)
+	}
+	if !strings.Contains(out.String(), "run run-3: success") {
+		t.Errorf("expected terminal success:\n%s", out.String())
+	}
+}
+
+// A pre-supplied value is consumed at the first step that declares it; a later
+// step sharing the field name does not inherit it.
+func TestFollow_PrefillConsumedAtFirstMatch(t *testing.T) {
+	shared := []byte(`{"type":"object","title":"Step","properties":{"value":{"type":"string"}},"required":["value"]}`)
+	client := &fakeFollowClient{
+		schemas:     map[string][]byte{"run-1": shared, "run-2": shared},
+		resumeChain: map[string]string{"run-1": "run-2"},
+		waitResults: map[string]ipc.RunResult{"run-2": {RunID: "run-2", Status: "suspended"}},
+	}
+	pool, _ := newPrefillPool([]string{"value=first"})
+	var out, prompt bytes.Buffer
+	s := &followSession{client: client, in: strings.NewReader(""), prompt: &prompt, out: &out, prefill: pool, nonInteractive: true}
+
+	err := s.follow("run-1")
+	if err == nil {
+		t.Fatal("expected a missing-field error on the second step")
+	}
+	if got := string(client.submitted["run-1"]); got != `{"value":"first"}` {
+		t.Errorf("step-1 submitted = %s, want the pre-supplied value", got)
+	}
+	if _, ok := client.submitted["run-2"]; ok {
+		t.Error("step-2 must not inherit the first step's consumed value")
+	}
+	if !strings.Contains(err.Error(), "value") {
+		t.Errorf("error should name the missing field: %v", err)
+	}
+}
+
+// Non-interactive with an unfilled required field fails deterministically,
+// naming the step and the field.
+func TestFollow_PrefillNonInteractiveMissingErrors(t *testing.T) {
+	client := &fakeFollowClient{
+		schemas: map[string][]byte{
+			"run-1": []byte(`{"type":"object","title":"New project","properties":{"project_name":{"type":"string"}},"required":["project_name"]}`),
+		},
+	}
+	pool, _ := newPrefillPool([]string{"unrelated=x"})
+	var out, prompt bytes.Buffer
+	s := &followSession{client: client, in: strings.NewReader(""), prompt: &prompt, out: &out, prefill: pool, nonInteractive: true}
+
+	err := s.follow("run-1")
+	if err == nil {
+		t.Fatal("expected a deterministic missing-field error")
+	}
+	if !strings.Contains(err.Error(), "project_name") || !strings.Contains(err.Error(), "New project") {
+		t.Errorf("error should name the field and step: %v", err)
+	}
+}
+
+// A bad type for a pre-supplied value fails before submission.
+func TestFollow_PrefillTypeMismatchErrors(t *testing.T) {
+	client := &fakeFollowClient{
+		schemas: map[string][]byte{
+			"run-1": []byte(`{"type":"object","properties":{"count":{"type":"integer"}},"required":["count"]}`),
+		},
+	}
+	pool, _ := newPrefillPool([]string{"count=notanumber"})
+	var out, prompt bytes.Buffer
+	s := &followSession{client: client, in: strings.NewReader(""), prompt: &prompt, out: &out, prefill: pool, nonInteractive: true}
+
+	if err := s.follow("run-1"); err == nil {
+		t.Fatal("expected a coercion error for count=notanumber")
+	}
+	if _, ok := client.submitted["run-1"]; ok {
+		t.Error("must not submit when a pre-supplied value fails coercion")
+	}
+}
+
+// On a TTY, pre-supplied answers fill the steps they match and un-supplied
+// steps still prompt.
+func TestFollow_PrefillInteractiveFillsGaps(t *testing.T) {
+	client := &fakeFollowClient{
+		schemas: map[string][]byte{
+			"run-1": []byte(`{"type":"object","properties":{"a":{"type":"string"}},"required":["a"]}`),
+			"run-2": []byte(`{"type":"object","properties":{"b":{"type":"string"}},"required":["b"]}`),
+		},
+		resumeChain: map[string]string{"run-1": "run-2", "run-2": "run-3"},
+		waitResults: map[string]ipc.RunResult{
+			"run-2": {RunID: "run-2", Status: "suspended"},
+			"run-3": {RunID: "run-3", Status: "success"},
+		},
+	}
+	pool, _ := newPrefillPool([]string{"a=pre"})
+	var out, prompt bytes.Buffer
+	// a is pre-supplied (no prompt); b is typed at the prompt.
+	s := &followSession{client: client, in: strings.NewReader("typed\n"), prompt: &prompt, out: &out, prefill: pool}
+
+	if err := s.follow("run-1"); err != nil {
+		t.Fatalf("follow: %v", err)
+	}
+	if got := string(client.submitted["run-1"]); got != `{"a":"pre"}` {
+		t.Errorf("step-1 submitted = %s, want the pre-supplied value", got)
+	}
+	if got := string(client.submitted["run-2"]); got != `{"b":"typed"}` {
+		t.Errorf("step-2 submitted = %s, want the prompted value", got)
+	}
+}
+
+// Pre-supplied values never consumed (typo or a branch not taken) are reported
+// after the wizard completes.
+func TestFollow_PrefillUnusedWarned(t *testing.T) {
+	client := &fakeFollowClient{
+		schemas:     map[string][]byte{"run-1": []byte(`{"type":"object","properties":{"a":{"type":"string"}},"required":["a"]}`)},
+		resumeChain: map[string]string{"run-1": "run-2"},
+		waitResults: map[string]ipc.RunResult{"run-2": {RunID: "run-2", Status: "success"}},
+	}
+	pool, _ := newPrefillPool([]string{"a=x", "typo=y"})
+	var out, prompt bytes.Buffer
+	s := &followSession{client: client, in: strings.NewReader(""), prompt: &prompt, out: &out, prefill: pool, nonInteractive: true}
+
+	if err := s.follow("run-1"); err != nil {
+		t.Fatalf("follow: %v", err)
+	}
+	if !strings.Contains(prompt.String(), "typo") {
+		t.Errorf("expected an unused-field warning naming typo:\n%s", prompt.String())
 	}
 }
 

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -10,7 +10,8 @@
 // Commands:
 //
 //	run <task-id> [key=value ...]   trigger a task run and wait for the result
-//	                                (--non-interactive / --batch: never prompt)
+//	                                (--field name=value pre-supplies wizard answers;
+//	                                --non-interactive / --batch: never prompt)
 //	list                            list all registered tasks
 //	logs <run-id>                   fetch log lines for a run
 //	status [task-id]                daemon health or latest run for a task
@@ -133,14 +134,21 @@ func dispatch(c *ipc.ControlClient, args []string) error {
 	case "list":
 		return cmdList(c)
 	case "run":
-		nonInteractive, rest := parseInteractiveFlag(args[1:])
+		nonInteractive, fields, rest, err := parseWizardFlags(args[1:])
+		if err != nil {
+			return err
+		}
 		if len(rest) < 1 {
-			return fmt.Errorf("usage: dicode run <task-id> [key=value ...] [--non-interactive]")
+			return fmt.Errorf("usage: dicode run <task-id> [key=value ...] [--field name=value ...] [--non-interactive]")
+		}
+		prefill, err := newPrefillPool(fields)
+		if err != nil {
+			return err
 		}
 		if err := waitDaemonReady(c, readyWaitTimeout); err != nil {
 			return err
 		}
-		return cmdRun(c, rest[0], rest[1:], nonInteractive)
+		return cmdRun(c, rest[0], rest[1:], nonInteractive, prefill)
 	case "logs":
 		if len(args) < 2 {
 			return fmt.Errorf("usage: dicode logs <run-id>")
@@ -148,14 +156,21 @@ func dispatch(c *ipc.ControlClient, args []string) error {
 		return cmdLogs(c, args[1])
 	case "resume":
 		// Bare `dicode resume` lists suspended runs; with a run id it resumes.
-		nonInteractive, rest := parseInteractiveFlag(args[1:])
+		nonInteractive, fields, rest, err := parseWizardFlags(args[1:])
+		if err != nil {
+			return err
+		}
 		if len(rest) == 0 {
 			return cmdResumeList(c)
+		}
+		prefill, err := newPrefillPool(fields)
+		if err != nil {
+			return err
 		}
 		if err := waitDaemonReady(c, readyWaitTimeout); err != nil {
 			return err
 		}
-		return cmdResume(c, rest[0], rest[1:], nonInteractive)
+		return cmdResume(c, rest[0], rest[1:], nonInteractive, prefill)
 	case "status":
 		taskID := ""
 		if len(args) >= 2 {
@@ -860,7 +875,7 @@ func cmdList(c *ipc.ControlClient) error {
 	return nil
 }
 
-func cmdRun(c *ipc.ControlClient, taskID string, kvArgs []string, nonInteractive bool) error {
+func cmdRun(c *ipc.ControlClient, taskID string, kvArgs []string, nonInteractive bool, prefill *prefillPool) error {
 	params := map[string]string{}
 	for _, kv := range kvArgs {
 		parts := strings.SplitN(kv, "=", 2)
@@ -891,12 +906,16 @@ func cmdRun(c *ipc.ControlClient, taskID string, kvArgs []string, nonInteractive
 		fmt.Fprintf(os.Stderr, "dicode: fetch logs: %v\n", logErr)
 	}
 
-	// A run that suspended on a TTY drives the whole wizard inline: prompt for
-	// the resume form, follow the continuation, repeat until it finishes. Piped
-	// stdin or --non-interactive keeps the one-shot output below so automation
-	// (including agents/CI on an allocated PTY) still sees the id and exits.
-	if result.Status == registry.StatusSuspended && followEngages(nonInteractive, stdinIsInteractive(), false) {
-		return followSuspended(c, result.RunID)
+	// A suspended run drives the whole wizard inline when a TTY can prompt or
+	// --field answers can auto-advance it: submit each step's form, follow the
+	// continuation, repeat until it finishes. Pre-supplied answers also engage
+	// the driver under --non-interactive/piped stdin, where an unfilled required
+	// field fails deterministically instead of prompting. With neither a TTY nor
+	// pre-supplied answers, the one-shot output below prints the id and exits.
+	interactive := stdinIsInteractive()
+	if result.Status == registry.StatusSuspended &&
+		(followEngages(nonInteractive, interactive, false) || !prefill.empty()) {
+		return followSuspended(c, result.RunID, prefill, nonInteractive || !interactive)
 	}
 
 	fmt.Printf("run %s: %s\n", result.RunID, result.Status)
@@ -904,6 +923,7 @@ func cmdRun(c *ipc.ControlClient, taskID string, kvArgs []string, nonInteractive
 		out, _ := json.MarshalIndent(result.ReturnValue, "", "  ")
 		fmt.Println(string(out))
 	}
+	warnUnusedPrefill(os.Stderr, prefill)
 	if result.Status == "failure" {
 		return fmt.Errorf("task failed")
 	}
@@ -1150,17 +1170,26 @@ func promptResumeInput(entries []resumePropEntry, required map[string]bool, in i
 // property (no field=value args) or coerces the supplied field=value pairs to
 // their declared types, validates locally against the schema, and submits. The
 // daemon re-validates authoritatively and resolves the resume token itself.
-func cmdResume(c *ipc.ControlClient, runID string, kvArgs []string, nonInteractive bool) error {
-	// Interactive follow only engages for a TTY with no inline field=value args
-	// and without --non-interactive: pipes/redirects, explicit values, and the
-	// opt-out flag keep the one-shot path below so scripts (and agents/CI on an
-	// allocated PTY) see the unchanged "continuation run <id>" output. Show the
+func cmdResume(c *ipc.ControlClient, runID string, kvArgs []string, nonInteractive bool, prefill *prefillPool) error {
+	// Positional field=value answers the current step in one shot; --field
+	// pre-supplies answers for the current step and any that follow. Mixing the
+	// two is ambiguous about which drives the current step.
+	if len(kvArgs) > 0 && !prefill.empty() {
+		return fmt.Errorf("cannot combine positional field=value with --field; use one or the other")
+	}
+
+	// The wizard driver engages for a TTY with no inline field=value args (so it
+	// can prompt), or whenever --field answers are present (they auto-advance,
+	// and fail deterministically on a gap under --non-interactive/piped stdin).
+	// The opt-out flag and positional values otherwise keep the one-shot path
+	// below so scripts see the unchanged "continuation run <id>" output. Show the
 	// suspended run's logs first for context, mirroring `dicode run`.
-	if followEngages(nonInteractive, stdinIsInteractive(), len(kvArgs) > 0) {
+	interactive := stdinIsInteractive()
+	if followEngages(nonInteractive, interactive, len(kvArgs) > 0) || !prefill.empty() {
 		if logErr := cmdLogs(c, runID); logErr != nil {
 			fmt.Fprintf(os.Stderr, "dicode: fetch logs: %v\n", logErr)
 		}
-		return followSuspended(c, runID)
+		return followSuspended(c, runID, prefill, nonInteractive || !interactive)
 	}
 
 	infoResp, err := c.Send(ipc.Request{Method: "cli.resume.get", RunID: runID})
@@ -1527,15 +1556,21 @@ Commands:
   daemon [-config dicode.yaml]    start the daemon (usually auto-started)
   run <task-id> [key=value ...]   trigger a task and wait for the result
                                   on a TTY, walks a suspend wizard inline;
-                                  --non-interactive (alias --batch) forces the
-                                  one-shot path (print suspended id, exit)
+                                  --field name=value pre-supplies a wizard answer
+                                  (repeatable) to auto-advance steps without
+                                  prompting; matched per step, consumed at first
+                                  match; --non-interactive (alias --batch) forces
+                                  the one-shot path (print suspended id, exit)
+                                  unless --field answers can auto-advance it
   list                            list registered tasks
   logs <run-id>                   show logs for a run
   status [task-id]                daemon health or task's latest run
   resume [run-id] [field=value]   resume a suspended run (no args lists suspended runs)
                                   on a TTY with no field=value, walks the wizard
-                                  inline; --non-interactive (alias --batch) or
-                                  explicit values force the one-shot path
+                                  inline; --field name=value pre-supplies answers
+                                  to auto-advance the current step and those that
+                                  follow; --non-interactive (alias --batch) or
+                                  positional values force the one-shot path
   ai <prompt> [flags]             run the configured AI task with a prompt
                                   flags: --session-id ID, --task TASK_ID
   task test <task-id> [flags]     run the task's sibling task.test.* through its runtime

--- a/docs/concepts/suspendable-tasks.md
+++ b/docs/concepts/suspendable-tasks.md
@@ -431,6 +431,43 @@ follow: dicode logs 7f8a…
 
 The continuation runs asynchronously; follow it with `dicode logs <run-id>`.
 
+### Pre-supply a whole wizard with `--field`
+
+`dicode run` and `dicode resume` accept repeatable `--field name=value` flags that
+**pre-supply wizard answers upfront**. As each step suspends, if a matching value
+was supplied, dicode auto-answers that step (coerced to the schema's type and
+validated server-side) and advances without prompting — so a multi-step wizard
+runs in a single command:
+
+```console
+$ dicode run examples/suspend-wizard \
+    --field project_name=acme --field framework=deno --field confirmed=true
+run …: success
+{ "project": "acme", "framework": "deno", "confirmed": true }
+```
+
+Semantics:
+
+- **Matched per step, consumed at first match.** Each value is offered to the
+  next step whose schema declares that field name, then consumed. If two steps
+  share a field name, the value is used by the **first** step to reach it and
+  does not leak into the later one — supply the later step's answer interactively
+  or with a follow-up `dicode resume`.
+- **Fills the gaps interactively.** On a TTY, a step whose fields aren't all
+  pre-supplied still prompts for the missing ones; pre-supplied fields are not
+  re-asked.
+- **Deterministic under `--non-interactive`.** With `--non-interactive` (alias
+  `--batch`) or piped stdin, a reached step whose required field has no
+  pre-supplied value **fails clearly**, naming the step and the missing field,
+  rather than hanging — ideal for agents and CI.
+- **Type-checked before submit.** A value that can't coerce to its field's type
+  (e.g. `--field count=abc` for an integer) is a hard error. Values that never
+  match any step reached (a typo, or a field on a branch not taken) are reported
+  as a warning once the wizard settles.
+
+Positional `field=value` pairs on `dicode resume` still answer the current step
+one-shot; they cannot be combined with `--field` on the same command.
+
 ---
 
 ## See also


### PR DESCRIPTION
## Summary

The suspendable-tasks wizards can be walked interactively from the CLI, but every step still had to be answered one prompt at a time, and there was no way to run a whole multi-step wizard non-interactively. This adds repeatable `--field name=value` flags to `dicode run` and `dicode resume` that pre-supply step answers upfront.

As each step suspends, if a pre-supplied value matches one of the step's declared properties, dicode auto-answers that step — coercing the string flag value to the schema's declared type (number/boolean/enum/etc.) and validating server-side, exactly as an interactive answer would be — and advances without prompting. A whole wizard therefore runs in a single command, which is the point for agents and CI.

Design choices, both surfaced in `--help` and the docs:

- **Per-step, first-match consumption.** The pre-supplied values are a name-keyed pool. Each value is offered to the first reached step that declares that field name, then consumed, so a later step sharing the name does not silently inherit an earlier step's answer. Supplying different values for a shared name across steps is out of scope for a single command — use interactive mode or a follow-up `dicode resume`.
- **Gaps fall back sensibly.** On a TTY, a step whose fields aren't all pre-supplied still prompts for the missing ones (pre-supplied fields are not re-asked). Under `--non-interactive` (or piped stdin) a reached step with an unfilled required field fails deterministically, naming the step and the missing field, rather than hanging.
- **Validation is never bypassed.** Values still go through the same server-side JSON Schema validation. A value that can't coerce to its field's type is a hard error before submit. Values that never match any step reached — a typo, or a field on a branch the wizard didn't take (branching wizards legitimately skip fields) — are reported as a warning once the wizard settles, not a hard error, so valid branch-dependent runs aren't broken.

Positional `field=value` on `dicode resume` keeps its one-shot behavior and is rejected in combination with `--field` on the same command.

`--field` chosen over the issue's illustrative `--<propname>=value` spelling: it reuses the codebase's uniform "field=value" vocabulary, keeps wizard answers in a namespace distinct from `run`'s positional task params and `resume`'s positional current-step answers, and avoids parsing arbitrary dynamic flag names that would collide with real flags like `--non-interactive`.

## Test plan

- Unit tests (`cmd/dicode`): `--field` flag parsing, pool construction (bad/empty/duplicate names, value-with-`=`), type coercion, auto-advance across steps, first-match consumption, interactive gap-filling, non-interactive missing-field error, type-mismatch error, and the unused-field warning.
- Manual end-to-end against a live daemon:
  - `examples/suspend-wizard` with `--field project_name=acme --field framework=deno --field confirmed=true --non-interactive` → all 3 steps auto-advanced, returned `{project, framework, confirmed}`.
  - `examples/deploy-wizard` prod full branch (`env=prod`, `override`, `confirm`, `note`) → all 4 steps auto-advanced to a successful deploy.
  - `env=prod` alone → clean `step "Checks failed": missing required field(s): override` error.
  - `env=staging` with unused `override`/`confirm` → run succeeds with a warning listing the unused fields.
  - `override=notabool` → hard coercion error before submit.
  - `resume … note=hi --field a=1` → rejected as a combination.

## Gate results

- `make build` — pass
- `go vet ./...` — pass
- `make lint` — pass
- `go test ./... -timeout 60s` — pass (no failures; the noted `TestControl_TaskTest_HappyPath` Deno-403 and `TestGitSource_IdempotentPoll` flakiness did not reproduce this run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)