### PR TITLE
fix(approval): re-hash live task dir at fire time so edited code re-arms the gate

### DIFF
--- a/pkg/approval/gate.go
+++ b/pkg/approval/gate.go
@@ -306,8 +306,10 @@ func (g *Gate) FireGuard(taskID string) error {
 	k, ok := g.admitted[taskID]
 	g.mu.Unlock()
 	if !ok {
-		// Never admitted (unknown to the gate); nothing to verify.
-		return nil
+		// A gate-enabled, non-trusted task the gate has not yet admitted must
+		// not run: fail closed rather than leave a startup window open between
+		// registry registration and the gate's Admit.
+		return fmt.Errorf("%w: %s (awaiting an approval decision)", ErrPending, taskID)
 	}
 	live, err := g.hashFn(k)
 	if err != nil {

--- a/pkg/approval/gate.go
+++ b/pkg/approval/gate.go
@@ -51,6 +51,7 @@ type Gate struct {
 
 	mu          sync.Mutex
 	pending     map[string]pendingEntry
+	admitted    map[string]task.Kinded
 	pendingHook func(k task.Kinded, hash string)
 	bootstrap   bool
 }
@@ -70,12 +71,13 @@ func NewGate(policy Policy, lock *Lock, arm func(task.Kinded) error, log *zap.Lo
 		log = zap.NewNop()
 	}
 	return &Gate{
-		policy:  policy,
-		lock:    lock,
-		arm:     arm,
-		hashFn:  ContentHash,
-		log:     log,
-		pending: map[string]pendingEntry{},
+		policy:   policy,
+		lock:     lock,
+		arm:      arm,
+		hashFn:   ContentHash,
+		log:      log,
+		pending:  map[string]pendingEntry{},
+		admitted: map[string]task.Kinded{},
 	}
 }
 
@@ -136,6 +138,13 @@ func (g *Gate) Admit(k task.Kinded) (armed bool, err error) {
 			zap.String("task", id), zap.Error(hashErr))
 		hash = ""
 	}
+
+	// Retain the live task handle so FireGuard can re-hash the on-disk dir at
+	// fire time — the runtime re-reads task files per run, so an edit that
+	// lands between reconcile cycles must be caught when the task is fired.
+	g.mu.Lock()
+	g.admitted[id] = k
+	g.mu.Unlock()
 
 	var by string
 	switch {
@@ -234,6 +243,9 @@ func (g *Gate) approve(id, wantHash, by string) error {
 // the lock. A re-added task goes through the gate from scratch.
 func (g *Gate) Forget(id string) {
 	g.clearPending(id)
+	g.mu.Lock()
+	delete(g.admitted, id)
+	g.mu.Unlock()
 	if err := g.lock.Remove(id); err != nil {
 		g.log.Warn("approval: lock remove failed",
 			zap.String("task", id), zap.Error(err))
@@ -272,14 +284,58 @@ func (g *Gate) PendingHash(id string) (string, bool) {
 	return ent.hash, true
 }
 
-// FireGuard vetoes any fire of a pending task. Wired into the trigger
-// engine so manual / chain / replay paths — which resolve tasks from the
-// registry rather than from armed triggers — cannot run an unapproved task.
+// FireGuard vetoes any fire of a task whose current on-disk content is not
+// approved. Wired into the trigger engine so manual / chain / replay paths —
+// which resolve tasks from the registry rather than from armed triggers —
+// cannot run an unapproved task.
+//
+// Beyond the pending-set check it re-hashes the live task dir and rejects a
+// task whose content no longer matches its approved hash. The runtime imports
+// task files fresh on every run, so an edit that lands between reconcile
+// cycles would otherwise execute new code under a stale approval before the
+// gate re-pends it. Trusted / builtin tasks (and a disabled gate) skip the
+// re-hash: their trust does not bind to a specific content hash.
 func (g *Gate) FireGuard(taskID string) error {
 	if g.IsPending(taskID) {
 		return fmt.Errorf("%w: %s", ErrPending, taskID)
 	}
+	if g.trusted(taskID) {
+		return nil
+	}
+	g.mu.Lock()
+	k, ok := g.admitted[taskID]
+	g.mu.Unlock()
+	if !ok {
+		// Never admitted (unknown to the gate); nothing to verify.
+		return nil
+	}
+	live, err := g.hashFn(k)
+	if err != nil {
+		return fmt.Errorf("%w: %s (content hash failed: %v)", ErrPending, taskID, err)
+	}
+	if !g.lock.Approved(taskID, live) {
+		return fmt.Errorf("%w: %s (content changed since approval; re-approve to run)", ErrPending, taskID)
+	}
 	return nil
+}
+
+// trusted reports whether id is approved independent of its content hash:
+// builtin tasks, operator-trusted tasks/sources, or a disabled gate. Mirrors
+// the hash-independent auto-approve arms of Admit so FireGuard never vetoes a
+// task Admit would have armed unconditionally.
+func (g *Gate) trusted(id string) bool {
+	switch {
+	case SourceOf(id) == BuiltinSource:
+		return true
+	case g.policy.TrustedTasks[id]:
+		return true
+	case g.policy.TrustedSources[SourceOf(id)]:
+		return true
+	case !g.policy.Enabled:
+		return true
+	default:
+		return false
+	}
 }
 
 func (g *Gate) clearPending(id string) {

--- a/pkg/approval/gate_test.go
+++ b/pkg/approval/gate_test.go
@@ -215,6 +215,22 @@ func TestFireGuardAllowsEditedTrustedTask(t *testing.T) {
 	}
 }
 
+// TestFireGuardFailsClosedForUnadmittedTask covers the startup window: a
+// gate-enabled, non-trusted task that the gate has not yet admitted (registry
+// registration races ahead of Admit) must be vetoed, not allowed through.
+func TestFireGuardFailsClosedForUnadmittedTask(t *testing.T) {
+	g, _, _ := newTestGate(t, enabledPolicy())
+	if err := g.FireGuard("repo/never-admitted"); !errors.Is(err, ErrPending) {
+		t.Fatalf("FireGuard on un-admitted task = %v, want ErrPending (fail closed)", err)
+	}
+
+	// A disabled gate has no opinion — unknown tasks still fire.
+	gOff, _, _ := newTestGate(t, Policy{Enabled: false, TrustedSources: map[string]bool{}, TrustedTasks: map[string]bool{}})
+	if err := gOff.FireGuard("repo/never-admitted"); err != nil {
+		t.Fatalf("disabled gate must not veto: %v", err)
+	}
+}
+
 func TestTrustedTaskOverride(t *testing.T) {
 	p := enabledPolicy()
 	p.TrustedTasks["repo/deploy"] = true

--- a/pkg/approval/gate_test.go
+++ b/pkg/approval/gate_test.go
@@ -157,6 +157,64 @@ func TestTrustedSourceArmsAndRecords(t *testing.T) {
 	}
 }
 
+// TestFireGuardVetoesEditedApprovedTask is the regression for #530: an approved
+// local-source task whose files change on disk must not run its new code until
+// re-approved, even before the reconciler re-hashes the source and re-pends the
+// task. The runtime imports task files fresh per run, so FireGuard re-hashes the
+// live dir rather than trusting the pending set alone.
+func TestFireGuardVetoesEditedApprovedTask(t *testing.T) {
+	g, _, lock := newTestGate(t, enabledPolicy())
+	spec := writeTaskDir(t, t.TempDir(), "repo/deploy", "export default () => 1")
+
+	if armed, err := g.Admit(spec); err != nil || armed {
+		t.Fatalf("Admit = (%v, %v), want (false, nil) pending", armed, err)
+	}
+	if err := g.Approve("repo/deploy"); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	approvedHash, _ := lock.Get("repo/deploy")
+	if err := g.FireGuard("repo/deploy"); err != nil {
+		t.Fatalf("FireGuard on freshly approved task: %v", err)
+	}
+
+	// Edit the task on disk. The reconciler has not yet re-admitted it, so the
+	// pending set is empty and the lock still holds the old approved hash.
+	if err := os.WriteFile(filepath.Join(spec.TaskDir, "task.js"),
+		[]byte("export default () => evil()"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if g.IsPending("repo/deploy") {
+		t.Fatal("precondition: task must not yet be re-pended by the reconciler")
+	}
+
+	if err := g.FireGuard("repo/deploy"); !errors.Is(err, ErrPending) {
+		t.Fatalf("FireGuard after edit = %v, want ErrPending (changed code must not run)", err)
+	}
+	if rec, _ := lock.Get("repo/deploy"); rec.Hash != approvedHash.Hash {
+		t.Fatalf("lock hash mutated by an unapproved edit: %q -> %q", approvedHash.Hash, rec.Hash)
+	}
+}
+
+// TestFireGuardAllowsEditedTrustedTask confirms the re-hash veto does not
+// regress trust:always — a trusted source's edited task still fires, since its
+// trust is not bound to a content hash.
+func TestFireGuardAllowsEditedTrustedTask(t *testing.T) {
+	p := enabledPolicy()
+	p.TrustedSources["repo"] = true
+	g, _, _ := newTestGate(t, p)
+	spec := writeTaskDir(t, t.TempDir(), "repo/deploy", "x")
+
+	if armed, err := g.Admit(spec); err != nil || !armed {
+		t.Fatalf("Admit = (%v, %v), want armed", armed, err)
+	}
+	if err := os.WriteFile(filepath.Join(spec.TaskDir, "task.js"), []byte("y"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.FireGuard("repo/deploy"); err != nil {
+		t.Fatalf("edited trusted-source task must still fire: %v", err)
+	}
+}
+
 func TestTrustedTaskOverride(t *testing.T) {
 	p := enabledPolicy()
 	p.TrustedTasks["repo/deploy"] = true

--- a/pkg/taskset/source.go
+++ b/pkg/taskset/source.go
@@ -675,7 +675,7 @@ func (s *Source) syncAndEmit(ctx context.Context, ch chan<- source.Event) error 
 	current := make(map[string]taskSnap, len(tasks))
 	for _, rt := range tasks {
 		current[rt.ID] = taskSnap{
-			specHash: hashKinded(rt.Kinded),
+			specHash: snapHash(rt.Kinded, rt.TaskDir),
 			kinded:   rt.Kinded,
 			taskDir:  rt.TaskDir,
 		}
@@ -774,4 +774,22 @@ func hashKinded(k task.Kinded) string {
 	b, _ := json.Marshal(k)
 	h := sha256.Sum256(b)
 	return fmt.Sprintf("%x", h)
+}
+
+// snapHash is the change-detection hash for one resolved task. It folds both
+// the resolved spec and the task directory's file content: the runtime imports
+// script files (task.js/task.ts and siblings) that the resolved spec does not
+// capture, so a script-only edit must still perturb the hash — otherwise no
+// update is emitted and the approval gate never re-pends the changed task
+// (#530). A dir-less inline task hashes its spec alone.
+func snapHash(k task.Kinded, taskDir string) string {
+	specHash := hashKinded(k)
+	if taskDir == "" {
+		return specHash
+	}
+	dirHash, err := task.Hash(taskDir)
+	if err != nil {
+		return specHash
+	}
+	return specHash + ":" + dirHash
 }

--- a/pkg/taskset/source_test.go
+++ b/pkg/taskset/source_test.go
@@ -141,6 +141,57 @@ spec:
 	}
 }
 
+// TestSource_ScriptEditEmitsUpdate is the regression for #530: editing a task's
+// script file without touching task.yaml must still emit an update. The runtime
+// imports task.js/task.ts fresh per run, so a script-only edit changes task
+// behaviour; if change detection hashed only the resolved spec it would miss the
+// edit, no update would reach the reconciler, and the approval gate would never
+// re-pend the changed task.
+func TestSource_ScriptEditEmitsUpdate(t *testing.T) {
+	dir := t.TempDir()
+	taskDir := writeTaskDir(t, dir, "deploy")
+
+	tsContent := `
+apiVersion: dicode/v1
+kind: TaskSet
+metadata:
+  name: infra
+spec:
+  entries:
+    deploy:
+      ref:
+        path: ` + filepath.Join(taskDir, "task.yaml") + `
+`
+	tsPath := writeTaskSetFile(t, dir, "taskset.yaml", tsContent)
+
+	src := newTestSource(t, "infra", tsPath)
+	ch0 := make(chan source.Event, 8)
+	if err := src.syncAndEmit(context.Background(), ch0); err != nil {
+		t.Fatal(err)
+	}
+	close(ch0)
+	collectEvents(t, ch0, time.Second) // drain the initial Added
+
+	// Edit only task.js — task.yaml (and thus the resolved spec) is unchanged.
+	if err := os.WriteFile(filepath.Join(taskDir, "task.js"), []byte("// edited"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ch := make(chan source.Event, 8)
+	if err := src.syncAndEmit(context.Background(), ch); err != nil {
+		t.Fatal(err)
+	}
+	close(ch)
+
+	events := collectEvents(t, ch, time.Second)
+	if len(events) != 1 || events[0].Kind != source.EventUpdated {
+		t.Fatalf("script edit: want 1 EventUpdated, got %d: %v", len(events), events)
+	}
+	if events[0].TaskID != "infra/deploy" {
+		t.Errorf("TaskID: %q", events[0].TaskID)
+	}
+}
+
 func TestSource_RemovedEmitted(t *testing.T) {
 	dir := t.TempDir()
 	taskDir := writeTaskDir(t, dir, "deploy")

--- a/tests/e2e/file-change.spec.ts
+++ b/tests/e2e/file-change.spec.ts
@@ -52,9 +52,18 @@ test.describe('File Change Detection', () => {
     const newContent = `export default async function main() {\n  console.log('updated by file-change test');\n  return { message: 'updated message' };\n}\n`;
     fs.writeFileSync(taskJsPath, newContent, 'utf8');
 
-    // Wait a moment for the reconciler's fsnotify to pick up the change.
-    // We verify the change took effect by running the task and checking return value.
-    await new Promise((r) => setTimeout(r, 2000));
+    // The trust-on-change approval gate (#392/#530) re-arms on this edit and
+    // holds the task pending approval, so its new code cannot run until it is
+    // re-approved. Wait for the reconciler's fsnotify to observe the change and
+    // flip the task pending, then approve the new content before running.
+    await waitForTaskCondition(
+      request,
+      MANUAL_TASK_ID,
+      (t) => t.pending_approval === true,
+      20_000,
+    );
+    const approveRes = await request.post(`/api/tasks/${encodeURIComponent(MANUAL_TASK_ID)}/approve`);
+    expect(approveRes.ok()).toBe(true);
 
     // Fire a run and wait for it to complete.
     const runRes = await request.post(`/api/tasks/${encodeURIComponent(MANUAL_TASK_ID)}/run`);
@@ -82,9 +91,19 @@ test.describe('File Change Detection', () => {
     const messages = logs.map((l) => l.message).join('\n');
     expect(messages).toContain('updated by file-change test');
 
-    // Restore original content for subsequent tests.
+    // Restore original content for subsequent tests. Approving the edit above
+    // moved the lock's approved hash, so restoring the file re-pends the task;
+    // re-approve so it returns to its clean armed state for later tests.
     const original = `export default async function main() {\n  console.log('hello from test manual task');\n  return { message: 'hello from test' };\n}\n`;
     fs.writeFileSync(taskJsPath, original, 'utf8');
+    await waitForTaskCondition(
+      request,
+      MANUAL_TASK_ID,
+      (t) => t.pending_approval === true,
+      20_000,
+    );
+    const reApproveRes = await request.post(`/api/tasks/${encodeURIComponent(MANUAL_TASK_ID)}/approve`);
+    expect(reApproveRes.ok()).toBe(true);
   });
 
   test('editing task.yaml (description) is reflected in API response', async ({ request }) => {


### PR DESCRIPTION
## Summary

The trust-on-change approval gate (#392) could be bypassed by an edit to a task's
script file. Two independent defects combined:

1. **Source change detection ignored script content.** The taskset source — the
   production source behind `spec.entries` in `dicode.yaml` — detected per-task
   changes with `hashKinded`, a SHA-256 over the JSON of the *resolved spec*
   (`task.Spec`/`PipelineTask`). That covers `task.yaml`-derived fields but not
   the bytes of `task.js`/`task.ts` and sibling files. A script-only edit left
   the resolved spec identical, so the source emitted no `EventUpdated`, the
   reconciler never re-registered the task, and the gate's `Admit` never re-ran.
   The task stayed armed at its old approved hash and `dicode task approve`
   reported "not pending approval" — the cached hash the edit never invalidated.

2. **The fire guard trusted a stale pending set.** Even once (1) is fixed there
   is a window between the edit and the reconciler re-pending the task. The
   runtime imports script files fresh on every run, so in that window changed
   code ran under the old approval. `FireGuard` — the veto on every manual /
   chain / replay / resume fire — only consulted the in-memory pending set, which
   the async reconciler had not yet updated.

**Independent confirmation the bug was real:** the e2e test `file-change.spec.ts ›
editing task.js updates task behaviour` edited a task file and asserted the very
next run succeeded — it was only green *because* of defect (1). With the gate
re-arming correctly the task is now held pending and the run is refused until
re-approval, so the test was updated to approve the edit before running (its
intent and assertions unchanged).

## Approach

- `pkg/taskset/source.go` — fold `task.Hash` over the task directory into the
  change-detection hash (`snapHash`), so a script-only edit perturbs it, emits
  `EventUpdated`, and drives the gate to re-pend the changed task. Dir-less
  inline tasks keep hashing their spec alone.
- `pkg/approval/gate.go` — `FireGuard` re-hashes the live task dir at fire time
  and vetoes any fire whose current content is not approved in the lock. This is
  deterministic and independent of reconcile timing, closing the race window as
  a security backstop. Trusted / builtin tasks and a disabled gate skip the
  re-hash (their trust is not bound to a content hash), mirroring `Admit`. The
  same guard also covers `dicode task test`, which is consistent with the gate's
  intent.

### Performance note

The fire-time re-hash reads the task dir's files (code files in full; files over
1 MiB fold in only a size+mtime descriptor — see `task.Hash`) once per *gated*
fire; trusted/builtin/disabled skip it. It is the same hash the source already
computes per poll, now also computed once per fire of a gated task — a bounded
per-fire dir read, not an asymptotic regression. No mtime/size cache is added; a
dir-mtime cache would be a reasonable follow-up if profiling flags a hot path,
but it is out of scope here and would reintroduce a smaller staleness window.

## Test plan

- `TestFireGuardVetoesEditedApprovedTask` (pkg/approval): approve a task, edit
  `task.js` on disk without going through the reconciler (pending set stays
  empty), assert `FireGuard` returns `ErrPending` and the lock hash is unchanged.
  Verified FAILING on the unfixed tree (stashed the fix), passing with it.
- `TestFireGuardAllowsEditedTrustedTask` (pkg/approval): a trusted-source task
  still fires after an edit — the veto does not regress `trust: always`.
- `TestSource_ScriptEditEmitsUpdate` (pkg/taskset): editing only `task.js`
  emits exactly one `EventUpdated`. Verified FAILING without the source fix
  (0 events), passing with it.
- Updated `tests/e2e/file-change.spec.ts` to approve the edit before re-running,
  and to re-approve on restore so the shared e2e daemon is left clean.

## Gate results

- `make build` / `go build ./...`, `go vet ./...`, `gofmt -l` — clean
- `go test ./... -timeout 120s` — pass, except the pre-existing flake
  `TestGitSource_IdempotentPoll` (temp-dir cleanup "directory not empty",
  unrelated to this change — re-runs green)
- `go test ./pkg/approval/... ./pkg/taskset/... ./pkg/registry/... ./pkg/trigger/... -race` — pass
- `make test-e2e` — **could NOT run in the sandbox** (Deno download blocked);
  validated in CI's Playwright E2E job. Reported explicitly rather than claimed
  green.

## Bypasses considered

- **Rename** — new task ID: old ID `Forget` (drops lock + admitted handle), new
  ID `Admit` → pending. Must be re-approved.
- **Remove-and-readd** — `Forget` clears lock record and admitted handle; re-add
  goes through the gate from scratch.
- **Source re-clone** — changed files re-hash → `EventUpdated` → re-pend; the
  fire-time live re-hash is authoritative. A changed clone path hashes a missing
  dir → not approved → fail-closed veto.
- **Reconciler poll mid-run** — `FireGuard` runs before a run starts; an
  in-flight approved run completes, the next fire re-checks.
- **Hash collision / unchanged mtime** — code files (≤ 1 MiB) are hashed by full
  content, so a code edit always perturbs the hash; the size+mtime shortcut only
  applies to > 1 MiB assets (pre-existing, documented trusted-author trade-off).

Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)