### PR TITLE
test(trigger): reap orphaned Deno subprocesses on testEnv teardown

### DIFF
--- a/pkg/trigger/daemon_reap_test.go
+++ b/pkg/trigger/daemon_reap_test.go
@@ -19,9 +19,11 @@ import (
 //
 // The test drives a real newTestEnv teardown in a subtest (the exact structure
 // of TestPipelineDaemonTerminalStage) and then asserts no Deno subprocess
-// survives. denoruntime.ActivePIDs tracks only subprocesses this test binary
-// spawned, so the assertion is unaffected by unrelated Deno processes on the
-// host.
+// survives. denoruntime.ActivePIDs counts subprocesses this test binary spawned
+// (unaffected by unrelated Deno processes on the host) but is not scoped to a
+// single engine, so the zero-survivor assertion is only valid while pkg/trigger
+// tests run serially — a concurrent t.Parallel() test's subprocess would read
+// as a false leak here.
 func TestDaemonSubprocessReapedOnTeardown(t *testing.T) {
 	if testing.Short() {
 		t.Skip("requires Deno subprocess")

--- a/pkg/trigger/daemon_reap_test.go
+++ b/pkg/trigger/daemon_reap_test.go
@@ -1,0 +1,93 @@
+package trigger
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	denoruntime "github.com/dicode/dicode/pkg/runtime/deno"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// TestDaemonSubprocessReapedOnTeardown guards #526. Registering a Daemon:true
+// spec auto-starts a standalone daemon body; a pipeline whose terminal stage is
+// that daemon spins up a second, stage-owned daemon run. The pipeline tests kill
+// the stage run but never stop the auto-started standalone daemon, so before the
+// fix its Deno subprocess was orphaned (reparented to init) when the test
+// process exited. newTestEnv's teardown must now reap it.
+//
+// The test drives a real newTestEnv teardown in a subtest (the exact structure
+// of TestPipelineDaemonTerminalStage) and then asserts no Deno subprocess
+// survives. denoruntime.ActivePIDs tracks only subprocesses this test binary
+// spawned, so the assertion is unaffected by unrelated Deno processes on the
+// host.
+func TestDaemonSubprocessReapedOnTeardown(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Deno subprocess")
+	}
+	if n := len(denoruntime.ActivePIDs()); n != 0 {
+		t.Skipf("%d Deno subprocess(es) already active from another test; cannot isolate", n)
+	}
+
+	t.Run("pipeline-with-daemon-terminal-stage", func(t *testing.T) {
+		env := newTestEnv(t)
+		dir := t.TempDir()
+
+		stageA := writeTask(t, dir, "reap-a",
+			`export default async function main() { return "a" }`,
+			task.TriggerConfig{Manual: true})
+		stageB := writeTask(t, dir, "reap-b",
+			`export default async function main() { while (true) { await new Promise(r => setTimeout(r, 200)); } }`,
+			task.TriggerConfig{Daemon: true, Restart: "never"})
+		for _, s := range []*task.Spec{stageA, stageB} {
+			if err := env.reg.Register(s); err != nil {
+				t.Fatalf("reg.Register %s: %v", s.ID, err)
+			}
+			// Registering reap-b (Daemon:true) auto-starts a standalone daemon.
+			if err := env.engine.Register(s); err != nil {
+				t.Fatalf("eng.Register %s: %v", s.ID, err)
+			}
+		}
+
+		pipe := &task.PipelineTask{
+			APIVersion: "dicode/v1", Kind: task.KindPipelineTask,
+			ID: "reap-pipe", Name: "RP", Subtype: "sequential", Enabled: true,
+			Trigger: task.PipelineTrigger{Manual: true},
+			Stages:  []task.Stage{{Task: "reap-a"}, {Task: "reap-b"}},
+		}
+		if err := env.reg.Register(pipe); err != nil {
+			t.Fatalf("reg.Register pipe: %v", err)
+		}
+		if err := env.engine.Register(pipe); err != nil {
+			t.Fatalf("eng.Register pipe: %v", err)
+		}
+
+		parentRunID, err := env.engine.FireManual(context.Background(), "reap-pipe", nil)
+		if err != nil {
+			t.Fatalf("FireManual: %v", err)
+		}
+
+		daemonChild := findStageChild(t, env, parentRunID, "reap-b", registry.StatusRunning, 20*time.Second)
+		// Standalone daemon + pipeline-stage daemon are both live now.
+		if n := len(denoruntime.ActivePIDs()); n < 2 {
+			t.Fatalf("expected >=2 live Deno subprocesses (standalone + stage), got %d", n)
+		}
+		// Kill only the pipeline stage run, exactly as the pipeline tests do. The
+		// standalone daemon is left running — it is what leaked before the fix.
+		if !env.engine.KillRun(daemonChild.ID) {
+			t.Fatal("KillRun(daemonChild) returned false")
+		}
+		waitForTerminal(t, env.engine, parentRunID, 20*time.Second)
+	})
+
+	// The subtest's newTestEnv t.Cleanup runs on return and must have reaped the
+	// orphaned standalone daemon subprocess.
+	deadline := time.Now().Add(10 * time.Second)
+	for len(denoruntime.ActivePIDs()) > 0 && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if n := len(denoruntime.ActivePIDs()); n != 0 {
+		t.Fatalf("%d Deno subprocess(es) survived testEnv teardown; daemon runs not reaped", n)
+	}
+}

--- a/pkg/trigger/engine_test.go
+++ b/pkg/trigger/engine_test.go
@@ -43,7 +43,37 @@ func newTestEnv(t *testing.T) *testEnv {
 		t.Skipf("deno not available: %v", err)
 	}
 	eng := New(reg, rt, zap.NewNop())
+	// A testEnv never runs Engine.Start, so its shutdown drain never fires.
+	// Registering a Daemon:true spec auto-starts a standalone daemon body, and
+	// tests may leave other runs in flight; without reaping, those Deno
+	// subprocesses are orphaned (reparented to init) when the test process
+	// exits (#526). Reap them on teardown, before the LIFO-earlier db.Close.
+	t.Cleanup(func() { reapEngineRuns(eng, 10*time.Second) })
 	return &testEnv{engine: eng, reg: reg, denoRT: rt}
+}
+
+// reapEngineRuns cancels every in-flight run the engine tracks — standalone
+// daemons auto-started on Register, pipeline parents, and stage runs — and
+// waits up to grace for their Deno subprocesses to exit. It latches the
+// shutdown flag first so a restart:always daemon's kill does not immediately
+// respawn. Returns the count of Deno subprocesses still alive when it returns
+// (0 = fully reaped).
+func reapEngineRuns(eng *Engine, grace time.Duration) int {
+	eng.beginShutdown()
+	eng.runCancels.Range(func(_, v any) bool {
+		if c, ok := v.(context.CancelFunc); ok {
+			c()
+		}
+		return true
+	})
+	deadline := time.Now().Add(grace)
+	for {
+		n := len(denoruntime.ActivePIDs())
+		if n == 0 || time.Now().After(deadline) {
+			return n
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 }
 
 func writeTask(t *testing.T, dir, id, script string, trigger task.TriggerConfig) *task.Spec {

--- a/pkg/trigger/engine_test.go
+++ b/pkg/trigger/engine_test.go
@@ -58,6 +58,11 @@ func newTestEnv(t *testing.T) *testEnv {
 // shutdown flag first so a restart:always daemon's kill does not immediately
 // respawn. Returns the count of Deno subprocesses still alive when it returns
 // (0 = fully reaped).
+//
+// denoruntime.ActivePIDs is process-global, not scoped to eng, so the drain
+// condition is only meaningful while pkg/trigger tests run serially — a
+// t.Parallel() test elsewhere in the package would make this block on (or
+// observe) subprocesses eng never spawned.
 func reapEngineRuns(eng *Engine, grace time.Duration) int {
 	eng.beginShutdown()
 	eng.runCancels.Range(func(_, v any) bool {


### PR DESCRIPTION
## Summary

A session of `go test ./pkg/trigger/...` accumulated orphaned `deno run` processes (PPID=1, reparented to init, some observed alive for hours), all traced to three pipeline daemon tests via their temp-dir paths: `TestPipelineDaemonTerminalStage`, `TestPipelineStageRerun`, `TestPipelineParentKillDuringRestart`.

Root cause is test hygiene, not a runtime/daemon defect. Registering a `Daemon:true` spec via `Engine.Register` auto-starts a *standalone* daemon body (`registerDaemon` → `startDaemon` → `fireAsync`). A pipeline whose terminal stage is that same daemon spins up a *second*, stage-owned daemon run. The tests kill the stage run (which correctly reaps its subprocess and drives the pipeline to `cancelled`), but nothing ever stops the auto-started standalone daemon. In production this is handled: `Engine.Start`'s shutdown path kills every `daemonRuns` entry plus live pipeline-daemon runs and drains `runWG` on context cancellation. But `newTestEnv` never calls `Start`, so it has no shutdown drain, and the standalone daemon's Deno subprocess is orphaned when the test process exits.

The kill machinery itself is sound — `KillRun` → runCtx cancel → execCtx cancel → `exec.CommandContext` SIGKILL correctly reaps a subprocess. The gap is purely that the test harness never issues those cancellations for runs it leaves in flight.

The fix reaps on teardown: `newTestEnv` now registers a `t.Cleanup` that cancels every engine-tracked run (latching the shutdown flag first so a `restart:always` daemon does not respawn) and waits, bounded, for the Deno subprocess count to drain to zero. Because it cancels all tracked runs rather than the three named ones, it closes the leak for the whole package, and it runs before the LIFO-earlier `db.Close` so no run finalizes past DB close either.

### What was deliberately left behind

No production code changed — the daemon/pipeline shutdown drain (#520/#525) already reaps these runs correctly on a real `Start`/shutdown cycle. This is a test-harness-only fix.

## Test plan

- Reproduced the leak on `main`: a clean, **passing** `go test` run of the three tests left exactly one orphaned `deno` process per test (PPID=1); isolated re-runs accumulated one orphan each (2 → 3 → 4). Instrumented the pipeline scenario to confirm the survivor is the auto-started standalone daemon (ActivePIDs = 2 while live → 1 after the stage kill + pipeline `cancelled` → 1 after teardown).
- Added `TestDaemonSubprocessReapedOnTeardown`, which drives a real `newTestEnv` teardown (pipeline + daemon terminal stage, killing only the stage) inside a subtest and asserts no Deno subprocess survives. It **fails without the fix** (`1 Deno subprocess(es) survived testEnv teardown`) and passes with it. It keys off `denoruntime.ActivePIDs`, which counts only subprocesses this test binary spawned, so it is unaffected by unrelated host processes.
- After the fix, the full `go test ./pkg/trigger/... -race` run leaves zero test-spawned `deno` orphans.

## Gate results

- `make build` — pass
- `go vet ./...` — pass
- `go test ./pkg/trigger/... -race -timeout 360s` — pass (63.5s), 0 orphaned `deno` processes after
- `make test` (`go test ./... -timeout 60s`) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #526.
