### PR TITLE
test(trigger,webui): make shutdown-drain waits load-tolerant

### DIFF
--- a/pkg/trigger/drainslot_test.go
+++ b/pkg/trigger/drainslot_test.go
@@ -68,7 +68,7 @@ func TestDrainSlotOuterHeldInnerFireRefusedIsClean(t *testing.T) {
 	go func() { eng.runWG.Wait(); close(drained) }()
 	select {
 	case <-drained:
-	case <-time.After(2 * time.Second):
+	case <-time.After(drainWait):
 		t.Fatal("runWG never drained after outer release — a slot leaked")
 	}
 

--- a/pkg/trigger/shutdown_drain_test.go
+++ b/pkg/trigger/shutdown_drain_test.go
@@ -21,6 +21,14 @@ import (
 	"go.uber.org/zap"
 )
 
+// drainWait bounds every "did this happen" wait in the shutdown-drain tests.
+// These waits gate on a mock executor's goroutine being scheduled, so a value
+// tight enough to look like a timing assertion (2s) fails on a loaded CI runner
+// while passing on an idle machine. Only the negative assertions ("Start must
+// NOT return yet") use a short window, where a brief wait is the conservative
+// direction.
+const drainWait = 30 * time.Second
+
 // drainExec is a daemon body whose termination behaviour the test controls.
 // It signals when the body begins so the test can find the run's ID before
 // triggering shutdown.
@@ -98,7 +106,7 @@ func runningDaemonRunID(t *testing.T, eng *Engine, exec *drainExec, taskID strin
 	t.Helper()
 	select {
 	case <-exec.started:
-	case <-time.After(2 * time.Second):
+	case <-time.After(drainWait):
 		t.Fatal("daemon body never started")
 	}
 	var runID string
@@ -135,7 +143,7 @@ func TestShutdownDrainsInFlightRunFinalization(t *testing.T) {
 
 	select {
 	case <-startDone:
-	case <-time.After(5 * time.Second):
+	case <-time.After(drainWait):
 		t.Fatal("Start did not return after shutdown")
 	}
 
@@ -172,7 +180,7 @@ func TestShutdownDrainBoundedByGrace(t *testing.T) {
 
 	select {
 	case <-startDone:
-	case <-time.After(5 * time.Second):
+	case <-time.After(drainWait):
 		t.Fatal("Start hung past the drain grace on a wedged run")
 	}
 	elapsed := time.Since(start)
@@ -222,7 +230,7 @@ func TestShutdownGatesChainDispatch(t *testing.T) {
 
 	select {
 	case <-startDone:
-	case <-time.After(5 * time.Second):
+	case <-time.After(drainWait):
 		t.Fatal("Start did not return after shutdown")
 	}
 
@@ -272,7 +280,7 @@ func TestTrackRunGateRaceWithShutdown(t *testing.T) {
 
 	select {
 	case <-drained:
-	case <-time.After(5 * time.Second):
+	case <-time.After(drainWait):
 		t.Fatal("drain did not complete")
 	}
 	fires.Wait()

--- a/pkg/trigger/webhook_shutdown_drain_test.go
+++ b/pkg/trigger/webhook_shutdown_drain_test.go
@@ -57,7 +57,7 @@ func TestShutdownDrainsInFlightSyncWebhookRun(t *testing.T) {
 
 	select {
 	case <-exec.started:
-	case <-time.After(2 * time.Second):
+	case <-time.After(drainWait):
 		t.Fatal("sync webhook task body never started")
 	}
 
@@ -76,14 +76,14 @@ func TestShutdownDrainsInFlightSyncWebhookRun(t *testing.T) {
 
 	select {
 	case <-startDone:
-	case <-time.After(5 * time.Second):
+	case <-time.After(drainWait):
 		t.Fatal("Start did not return after the sync-webhook run finished")
 	}
 
 	var w *httptest.ResponseRecorder
 	select {
 	case w = <-webhookDone:
-	case <-time.After(2 * time.Second):
+	case <-time.After(drainWait):
 		t.Fatal("webhook handler never returned")
 	}
 	if w.Code >= 400 {

--- a/pkg/webui/replay_shutdown_drain_test.go
+++ b/pkg/webui/replay_shutdown_drain_test.go
@@ -24,6 +24,14 @@ import (
 	"go.uber.org/zap"
 )
 
+// drainWait bounds every "did this happen" wait in the shutdown-drain tests.
+// These waits gate on a mock executor's goroutine being scheduled, so a value
+// tight enough to look like a timing assertion (2s) fails on a loaded CI runner
+// while passing on an idle machine. Only the negative assertions ("Start must
+// NOT return yet") use a short window, where a brief wait is the conservative
+// direction.
+const drainWait = 30 * time.Second
+
 type noopExecutor struct{}
 
 func (noopExecutor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
@@ -121,7 +129,7 @@ func TestShutdownDrainsInFlightReplayFetch(t *testing.T) {
 
 	select {
 	case <-fetcher.started:
-	case <-time.After(2 * time.Second):
+	case <-time.After(drainWait):
 		t.Fatal("replay fetch never started")
 	}
 
@@ -140,7 +148,7 @@ func TestShutdownDrainsInFlightReplayFetch(t *testing.T) {
 
 	select {
 	case <-startDone:
-	case <-time.After(5 * time.Second):
+	case <-time.After(drainWait):
 		t.Fatal("Start did not return after the replay fetch finished")
 	}
 
@@ -149,7 +157,7 @@ func TestShutdownDrainsInFlightReplayFetch(t *testing.T) {
 		if w.Code != http.StatusOK {
 			t.Fatalf("replay = %d, want 200; body=%s", w.Code, w.Body.String())
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(drainWait):
 		t.Fatal("replay handler never returned")
 	}
 }
@@ -168,7 +176,7 @@ func TestShutdownRefusesReplayAfterShutdownLatched(t *testing.T) {
 	cancel()
 	select {
 	case <-startDone:
-	case <-time.After(5 * time.Second):
+	case <-time.After(drainWait):
 		t.Fatal("Start did not return after ctx cancel")
 	}
 


### PR DESCRIPTION
## Summary

`TestShutdownDrainsInFlightSyncWebhookRun` fails intermittently on CI with `sync webhook task body never started`, and has now blocked two unrelated PRs (#539, #541) that merely branched off a `main` containing it. It is a false negative: it reports a shutdown-drain bug where none exists.

The test blocks on a mock executor's goroutine signalling that it started, and bounds that wait at 2s. That reads like a timing assertion but isn't one — nothing about the drain contract depends on the body starting within 2s. On an idle machine it passes; on a loaded CI runner the goroutine misses the deadline. Reproduced deterministically: idle, 6/6 passes; under six busy cores, it fails at 2.015s, exactly the deadline.

The same shape is present across the whole drain-test family that grew with #520 → #525 → #529 → #533, so this fixes all four files rather than just the one that happened to fail.

## Approach

Every wait that asserts something *did* happen now uses a named `drainWait` (30s) constant. A generous bound is free here: a timeout caps only the failure path — a passing test still returns as soon as the channel fires, so the suite does not get slower (the drain tests still complete in under a second).

The negative assertions — "`Start` must **not** return while a run is in flight" — deliberately keep their short 300ms window. For those, a brief wait is the conservative direction, and lengthening it would only slow the suite.

## Test plan

- Reproduced the failure on unmodified `origin/main` (`2ae0dec`) under six-way CPU load: fails at 2.015s. Idle: 6/6 pass. Confirms load sensitivity rather than a logic defect, and confirms `main` — not #539 or #541 — is the source.
- Bisected `2fa5d51`, `8d312df`, `8f7e8f9`, `801c37f`, `2ae0dec` with full-package runs: all pass. No commit *introduced* a deterministic break; the test has been flaky since it landed in #532.
- With this change, under the same six-way load: `pkg/trigger` and `pkg/webui` drain tests pass with `-count=3`.
- Full `go test ./pkg/trigger/` (42.8s) and `./pkg/webui/` (8.5s) pass. `gofmt -l` clean, `go vet` clean.

## Note

Test-only; no production code touched. The drain behaviour verified by these tests is unchanged — this makes them actually verify it on a busy machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized shutdown-related wait times across several regression tests to improve consistency.
  * Reduced the risk of timing-related test flakiness by using a shared, longer timeout for slower scenarios.
  * Kept test behavior unchanged while making asynchronous shutdown checks more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->