### PR TITLE
fix(suspend): #516 low-priority hardening follow-ups

### DIFF
--- a/pkg/db/resume_index_test.go
+++ b/pkg/db/resume_index_test.go
@@ -1,0 +1,59 @@
+package db
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// The resume-token lookup and the deadline sweep must be index-backed, not
+// full-table scans, since `runs` grows unbounded with history. Assert the
+// query planner uses the resume indexes for both hot paths.
+func TestResumeIndexes_UsedByPlanner(t *testing.T) {
+	d := newTestDB(t).(*SQLiteDB)
+	ctx := context.Background()
+
+	cases := []struct {
+		name  string
+		query string
+		index string
+	}{
+		{
+			name:  "resume-token lookup",
+			query: `SELECT id FROM runs WHERE resume_token = 'tok'`,
+			index: "idx_runs_resume_token",
+		},
+		{
+			name: "deadline sweep",
+			query: `SELECT id FROM runs WHERE status = 'suspended' AND resume_deadline IS NOT NULL ` +
+				`AND resume_deadline > 0 AND resume_deadline < 123`,
+			index: "idx_runs_status_resume_deadline",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows, err := d.db.QueryContext(ctx, "EXPLAIN QUERY PLAN "+tc.query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer rows.Close()
+			var plan strings.Builder
+			for rows.Next() {
+				var a, b, c int
+				var detail string
+				if err := rows.Scan(&a, &b, &c, &detail); err != nil {
+					t.Fatal(err)
+				}
+				plan.WriteString(detail)
+				plan.WriteString("\n")
+			}
+			got := plan.String()
+			if !strings.Contains(got, tc.index) {
+				t.Errorf("query plan does not use %s:\n%s", tc.index, got)
+			}
+			if strings.Contains(got, "SCAN runs") {
+				t.Errorf("query plan full-scans runs instead of using %s:\n%s", tc.index, got)
+			}
+		})
+	}
+}

--- a/pkg/db/sqlite.go
+++ b/pkg/db/sqlite.go
@@ -245,6 +245,19 @@ func (s *SQLiteDB) migrate() error {
 		return fmt.Errorf("migrate run-grouping indexes: %w", err)
 	}
 
+	// Suspend/resume lookup indexes (#95). Without them the resume-token lookup
+	// (GetRunByResumeToken) and the per-minute deadline sweep (SweepExpiredSuspensions)
+	// full-scan `runs`, which grows unbounded with run history. The token index
+	// is partial: only suspended/resumed rows carry a token, so it stays tiny
+	// against a table that is overwhelmingly terminal runs.
+	_, err = s.db.Exec(`
+		CREATE INDEX IF NOT EXISTS idx_runs_resume_token ON runs(resume_token) WHERE resume_token IS NOT NULL;
+		CREATE INDEX IF NOT EXISTS idx_runs_status_resume_deadline ON runs(status, resume_deadline);
+	`)
+	if err != nil {
+		return fmt.Errorf("migrate resume indexes: %w", err)
+	}
+
 	// author_sessions — AI-first task authoring sessions (#288).
 	_, err = s.db.Exec(`
 		CREATE TABLE IF NOT EXISTS author_sessions (

--- a/pkg/ipc/control_resume_test.go
+++ b/pkg/ipc/control_resume_test.go
@@ -48,7 +48,7 @@ func suspendRun(t *testing.T, reg *registry.Registry, runID, token string, schem
 		t.Fatalf("StartRunWithID: %v", err)
 	}
 	deadline := time.Now().Add(time.Hour).UnixMilli()
-	if err := reg.SuspendRun(ctx, runID, []byte(`{"step":1}`), schema, token, time.Now().UnixMilli(), deadline, nil); err != nil {
+	if _, err := reg.SuspendRun(ctx, runID, []byte(`{"step":1}`), schema, token, time.Now().UnixMilli(), deadline, nil); err != nil {
 		t.Fatalf("SuspendRun: %v", err)
 	}
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -262,15 +262,24 @@ func (r *Registry) FinishRunWithResult(ctx context.Context, runID, status, retur
 // A deadline of 0 stores NULL (no TTL). state, schema, and resumeParams may be
 // nil. The schema is persisted in the legacy resume_form BLOB column (reused
 // as-is to avoid a migration).
-func (r *Registry) SuspendRun(ctx context.Context, runID string, state, schema []byte, token string, suspendedAt, deadline int64, resumeParams []byte) error {
+//
+// The UPDATE is guarded on status = running so a concurrent finalize (a kill or
+// shutdown drain that already moved the run to cancelled/failure) is not
+// clobbered back to suspended. Reports whether the row changed: false means the
+// run left `running` before the suspend landed, so no resume state was written.
+func (r *Registry) SuspendRun(ctx context.Context, runID string, state, schema []byte, token string, suspendedAt, deadline int64, resumeParams []byte) (bool, error) {
 	var deadlineArg any
 	if deadline > 0 {
 		deadlineArg = deadline
 	}
-	return r.db.Exec(ctx,
-		`UPDATE runs SET status = ?, resume_state = ?, resume_form = ?, resume_token = ?, suspended_at = ?, resume_deadline = ?, resume_params = ? WHERE id = ?`,
-		StatusSuspended, state, schema, token, suspendedAt, deadlineArg, resumeParams, runID,
+	affected, err := r.db.ExecResult(ctx,
+		`UPDATE runs SET status = ?, resume_state = ?, resume_form = ?, resume_token = ?, suspended_at = ?, resume_deadline = ?, resume_params = ? WHERE id = ? AND status = ?`,
+		StatusSuspended, state, schema, token, suspendedAt, deadlineArg, resumeParams, runID, StatusRunning,
 	)
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
 }
 
 // SetLogHook registers a function called after each log entry is written.

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -488,7 +488,7 @@ func TestSuspendRun_RoundTrip(t *testing.T) {
 	suspendedAt := time.Now().UnixMilli()
 	deadline := suspendedAt + 86_400_000
 
-	if err := r.SuspendRun(ctx, runID, state, schema, token, suspendedAt, deadline, nil); err != nil {
+	if _, err := r.SuspendRun(ctx, runID, state, schema, token, suspendedAt, deadline, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -531,7 +531,7 @@ func TestSuspendRun_NoDeadlineNilBlobs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := r.SuspendRun(ctx, runID, nil, nil, "tok", time.Now().UnixMilli(), 0, nil); err != nil {
+	if _, err := r.SuspendRun(ctx, runID, nil, nil, "tok", time.Now().UnixMilli(), 0, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -564,7 +564,7 @@ func TestCleanupStaleRuns_SkipsSuspended(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := r.SuspendRun(ctx, suspended, []byte(`{}`), nil, "tok", time.Now().UnixMilli(), 0, nil); err != nil {
+	if _, err := r.SuspendRun(ctx, suspended, []byte(`{}`), nil, "tok", time.Now().UnixMilli(), 0, nil); err != nil {
 		t.Fatal(err)
 	}
 	running, err := r.StartRun(ctx, "task-b", "")
@@ -589,5 +589,41 @@ func TestCleanupStaleRuns_SkipsSuspended(t *testing.T) {
 	}
 	if rRun.Status != StatusCancelled {
 		t.Errorf("running run status = %q, want %q", rRun.Status, StatusCancelled)
+	}
+}
+
+// A finalize that already moved a run out of `running` (e.g. a kill or shutdown
+// drain writing cancelled) must not be resurrected to suspended by a suspend
+// persist landing afterward. SuspendRun is status-guarded and reports no change.
+func TestSuspendRun_DoesNotResurrectCancelled(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := newTestRegistry(t)
+
+	runID, err := r.StartRun(ctx, "task-race", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.FinishRun(ctx, runID, StatusCancelled); err != nil {
+		t.Fatal(err)
+	}
+
+	suspended, err := r.SuspendRun(ctx, runID, []byte(`{"step":1}`), nil, "tok", time.Now().UnixMilli(), 0, nil)
+	if err != nil {
+		t.Fatalf("SuspendRun: %v", err)
+	}
+	if suspended {
+		t.Fatal("SuspendRun reported a change on a cancelled run; want no-op")
+	}
+
+	run, err := r.GetRun(ctx, runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != StatusCancelled {
+		t.Errorf("status = %q, want %q (must not be resurrected)", run.Status, StatusCancelled)
+	}
+	if run.ResumeToken != "" {
+		t.Errorf("resume_token = %q, want empty (no resume state should be written)", run.ResumeToken)
 	}
 }

--- a/pkg/registry/replay.go
+++ b/pkg/registry/replay.go
@@ -11,6 +11,13 @@ import (
 // allow it. See ownership policy in Replay's doc comment.
 var ErrReplayNotPermitted = errors.New("replay: caller task may not replay this run")
 
+// ErrRunNotReplayable is returned by Replay when the target run is suspended.
+// A suspended run is mid-flight awaiting input and must be resumed (which
+// consumes its single-use token), not replayed — replaying would spawn a
+// duplicate fresh execution alongside a run that still holds a live resume
+// token, bypassing the resume flow.
+var ErrRunNotReplayable = errors.New("replay: run is suspended and must be resumed, not replayed")
+
 // ReplayRunner abstracts the trigger engine's ability to fire a task with a
 // given input as a "replay" source. Decoupled from pkg/trigger via this
 // interface to keep pkg/registry import-cycle-free. The trigger engine's
@@ -65,6 +72,9 @@ func (r *Replayer) Replay(ctx context.Context, runID, taskName, callerTaskID, ca
 	run, err := r.registry.GetRun(ctx, runID)
 	if err != nil {
 		return "", fmt.Errorf("get run: %w", err)
+	}
+	if run.Status == StatusSuspended {
+		return "", ErrRunNotReplayable
 	}
 	if run.InputStorageKey == "" {
 		return "", ErrInputUnavailable

--- a/pkg/registry/replay_test.go
+++ b/pkg/registry/replay_test.go
@@ -150,3 +150,39 @@ func TestReplay_RunNotFound(t *testing.T) {
 		t.Error("expected error for unknown run ID")
 	}
 }
+
+// A suspended run must not be replayable server-side: replay would spawn a
+// duplicate execution while the original still holds a live resume token.
+// The guard fires before the input check and never invokes the runner.
+func TestReplay_SuspendedRunRejected(t *testing.T) {
+	r := newTestRegistry(t)
+	ctx := context.Background()
+
+	is := NewInputStore(newTestInputCrypto(t), &mockRunner{store: map[string]string{}}, "fake-storage")
+
+	runID := uuid.New().String()
+	if _, err := r.StartRunWithID(ctx, runID, "user-task", "", "manual", "task"); err != nil {
+		t.Fatal(err)
+	}
+	key, size, storedAt, err := is.Persist(ctx, runID, PersistedInput{Source: "webhook"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.SetRunInput(ctx, runID, key, size, storedAt, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.SuspendRun(ctx, runID, []byte(`{"step":1}`), nil, "tok", time.Now().UnixMilli(), 0, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeReplayRunner{}
+	replayer := NewReplayer(r, is, runner)
+
+	_, err = replayer.Replay(ctx, runID, "", "", "")
+	if !errors.Is(err, ErrRunNotReplayable) {
+		t.Errorf("got %v, want ErrRunNotReplayable", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("runner fired %d times on a suspended run; want 0", len(runner.calls))
+	}
+}

--- a/pkg/registry/resume_test.go
+++ b/pkg/registry/resume_test.go
@@ -26,7 +26,7 @@ func seedSuspendedRun(t *testing.T, r *Registry, runID, token string, deadline i
 	if _, err := r.StartRunWithID(ctx, runID, "task-x", "", string(TriggerManual), RunKindTask); err != nil {
 		t.Fatalf("StartRunWithID: %v", err)
 	}
-	if err := r.SuspendRun(ctx, runID, []byte(`{"step":1}`), []byte(`{"type":"object","properties":{}}`), token, time.Now().UnixMilli(), deadline, nil); err != nil {
+	if _, err := r.SuspendRun(ctx, runID, []byte(`{"step":1}`), []byte(`{"type":"object","properties":{}}`), token, time.Now().UnixMilli(), deadline, nil); err != nil {
 		t.Fatalf("SuspendRun: %v", err)
 	}
 }

--- a/pkg/trigger/engine_waitrun_test.go
+++ b/pkg/trigger/engine_waitrun_test.go
@@ -182,8 +182,8 @@ func TestEngine_WaitRun_FollowsResumeChain(t *testing.T) {
 		done <- waitOut{status: r.Status, runID: r.RunID, ret: r.ReturnValue, err: err}
 	}()
 
-	// WaitRun must NOT return while the run is still suspended (the old bug
-	// returned {status: suspended} immediately).
+	// WaitRun must NOT return while the run is still suspended; suspended is
+	// non-terminal.
 	select {
 	case out := <-done:
 		t.Fatalf("WaitRun returned while suspended: status=%q err=%v", out.status, out.err)

--- a/pkg/trigger/engine_waitrun_test.go
+++ b/pkg/trigger/engine_waitrun_test.go
@@ -151,3 +151,77 @@ func TestEngine_WaitRun_ContextCanceled(t *testing.T) {
 	e.engine.KillRun(runID)
 	waitForTerminal(t, e.engine, runID, 30*time.Second)
 }
+
+// A run that suspends is not terminal: WaitRun must keep blocking and follow
+// the resume chain, returning the continuation run's terminal result rather
+// than an intermediate {status: suspended}. Drives the suspend/resume state
+// transitions at the registry level so no live runtime is needed.
+func TestEngine_WaitRun_FollowsResumeChain(t *testing.T) {
+	e := newTestEnv(t)
+	ctx := context.Background()
+
+	const origID = "orig-run"
+	if _, err := e.reg.StartRunWithID(ctx, origID, "wizard", "", string(registry.TriggerManual), registry.RunKindTask); err != nil {
+		t.Fatalf("StartRunWithID: %v", err)
+	}
+	if _, err := e.reg.SuspendRun(ctx, origID, []byte(`{"step":1}`), nil, "tok", time.Now().UnixMilli(), 0, nil); err != nil {
+		t.Fatalf("SuspendRun: %v", err)
+	}
+
+	type waitOut struct {
+		status string
+		runID  string
+		ret    interface{}
+		err    error
+	}
+	done := make(chan waitOut, 1)
+	go func() {
+		wctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		r, err := e.engine.WaitRun(wctx, origID)
+		done <- waitOut{status: r.Status, runID: r.RunID, ret: r.ReturnValue, err: err}
+	}()
+
+	// WaitRun must NOT return while the run is still suspended (the old bug
+	// returned {status: suspended} immediately).
+	select {
+	case out := <-done:
+		t.Fatalf("WaitRun returned while suspended: status=%q err=%v", out.status, out.err)
+	case <-time.After(600 * time.Millisecond):
+	}
+
+	// Resume: mark the original resumed and spawn the continuation run that
+	// carries the real result.
+	if err := e.reg.MarkRunResumed(ctx, origID); err != nil {
+		t.Fatalf("MarkRunResumed: %v", err)
+	}
+	const contID = "cont-run"
+	if _, err := e.reg.StartRunWithID(ctx, contID, "wizard", origID, string(registry.TriggerResume), registry.RunKindTask); err != nil {
+		t.Fatalf("StartRunWithID continuation: %v", err)
+	}
+	if err := e.reg.FinishRunWithResult(ctx, contID, registry.StatusSuccess, `{"answer":42}`, "", ""); err != nil {
+		t.Fatalf("FinishRunWithResult: %v", err)
+	}
+
+	select {
+	case out := <-done:
+		if out.err != nil {
+			t.Fatalf("WaitRun err: %v", out.err)
+		}
+		if out.status != registry.StatusSuccess {
+			t.Errorf("status = %q, want success", out.status)
+		}
+		if out.runID != contID {
+			t.Errorf("runID = %q, want continuation %q", out.runID, contID)
+		}
+		m, ok := out.ret.(map[string]interface{})
+		if !ok {
+			t.Fatalf("return value %T, want map", out.ret)
+		}
+		if m["answer"].(float64) != 42 {
+			t.Errorf("answer = %v, want 42", m["answer"])
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitRun did not return after resume+continuation finished")
+	}
+}

--- a/pkg/trigger/pipeline_runner.go
+++ b/pkg/trigger/pipeline_runner.go
@@ -506,7 +506,7 @@ func (r *PipelineRunner) runTerminalDaemon(stageIdx int, stage task.Stage, upstr
 		current := r.daemonRunID
 		r.mu.Unlock()
 
-		res, werr := e.WaitRun(context.Background(), current)
+		res, werr := e.waitRunSettled(context.Background(), current)
 		status := res.Status
 		ret := res.ReturnValue
 		if werr != nil {
@@ -660,7 +660,7 @@ func (e *Engine) fireStageRaw(ctx context.Context, st task.Stage, upstream task.
 // cancellation) is an error; on ctx cancellation it kills the orphaned stage
 // subprocess rather than leaving it running detached.
 func (e *Engine) awaitStageSuccess(ctx context.Context, runID string) (task.InputContext, error) {
-	res, werr := e.WaitRun(ctx, runID)
+	res, werr := e.waitRunSettled(ctx, runID)
 	if werr != nil {
 		// ctx cancelled (pipeline timeout or KillRun on the parent) — stop the
 		// orphaned stage subprocess rather than leaving it running detached.
@@ -977,7 +977,7 @@ func (e *Engine) runPipelineStageRerun(runner *PipelineRunner, reranTaskID strin
 	if oldDaemonRunID != "" {
 		e.KillRun(oldDaemonRunID)
 		waitCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		_, _ = e.WaitRun(waitCtx, oldDaemonRunID)
+		_, _ = e.waitRunSettled(waitCtx, oldDaemonRunID)
 		cancel()
 	}
 

--- a/pkg/trigger/provider.go
+++ b/pkg/trigger/provider.go
@@ -101,7 +101,7 @@ func (e *Engine) Run(ctx context.Context, providerID string, reqs []envresolve.P
 	if err != nil {
 		return nil, fmt.Errorf("fire provider %q: %w", providerID, err)
 	}
-	res, werr := e.WaitRun(ctx, runID)
+	res, werr := e.waitRunSettled(ctx, runID)
 	if werr != nil {
 		return nil, fmt.Errorf("wait provider %q: %w", providerID, werr)
 	}

--- a/pkg/trigger/resume.go
+++ b/pkg/trigger/resume.go
@@ -52,10 +52,13 @@ var (
 // an unguessable single-use resume token and records the state/form blobs plus
 // the deadline. The deadline comes from the task (result.ResumeDeadline) or
 // defaults to defaultResumeTTL from now.
-func (e *Engine) suspendRun(opts *pkgruntime.RunOptions, result *pkgruntime.RunResult) error {
+// Reports whether the run was actually suspended: false (with nil error) means
+// a concurrent finalize already moved it out of `running`, so no resume state
+// was persisted and the caller must not report it as suspended.
+func (e *Engine) suspendRun(opts *pkgruntime.RunOptions, result *pkgruntime.RunResult) (bool, error) {
 	token, err := newResumeToken()
 	if err != nil {
-		return fmt.Errorf("mint resume token: %w", err)
+		return false, fmt.Errorf("mint resume token: %w", err)
 	}
 	nowMs := time.Now().UnixMilli()
 	deadlineMs := result.ResumeDeadline
@@ -68,7 +71,7 @@ func (e *Engine) suspendRun(opts *pkgruntime.RunOptions, result *pkgruntime.RunR
 	carry := resumeCarry{Params: opts.Params, ChainDepth: e.chainDepth(opts.RunID)}
 	if len(carry.Params) > 0 || carry.ChainDepth > 0 {
 		if carryJSON, err = json.Marshal(carry); err != nil {
-			return fmt.Errorf("marshal resume params: %w", err)
+			return false, fmt.Errorf("marshal resume params: %w", err)
 		}
 	}
 	return e.registry.SuspendRun(context.Background(), opts.RunID,

--- a/pkg/trigger/resume_test.go
+++ b/pkg/trigger/resume_test.go
@@ -422,7 +422,7 @@ func TestSuspendedDaemonRun_KeepsSlotAndReportsSuspended(t *testing.T) {
 	if _, err := reg.StartRunWithID(ctx, runID, spec.ID, "", string(registry.TriggerDaemon), registry.RunKindTask); err != nil {
 		t.Fatalf("StartRunWithID: %v", err)
 	}
-	if err := reg.SuspendRun(ctx, runID, []byte(`{}`), nil, "tok-daemon", time.Now().UnixMilli(), 0, nil); err != nil {
+	if _, err := reg.SuspendRun(ctx, runID, []byte(`{}`), nil, "tok-daemon", time.Now().UnixMilli(), 0, nil); err != nil {
 		t.Fatalf("SuspendRun: %v", err)
 	}
 

--- a/pkg/trigger/run.go
+++ b/pkg/trigger/run.go
@@ -68,30 +68,95 @@ func (e *Engine) FireFromTask(ctx context.Context, taskID, parentRunID string, p
 		registry.TriggerManual)
 }
 
-// WaitRun blocks until the run identified by runID reaches a terminal state,
-// then returns a RunResult. Implements ipc.EngineRunner.
+// waitRunPollInterval bounds the busy-wait for the two run transitions that
+// have no completion channel to select on: suspended→(resumed|cancelled), and
+// the sub-millisecond window in which a freshly-discovered continuation run
+// exists in the DB but has not yet registered its runDone channel.
+const waitRunPollInterval = 200 * time.Millisecond
+
+// maxEmptyResumedPolls bounds how long WaitRun waits for the continuation of a
+// `resumed` run to appear before giving up and returning the resumed status.
+// The continuation is recorded microseconds after the resume flips the status,
+// so any real gap this long means the continuation failed to spawn (e.g. the
+// fire guard vetoed it or the engine is shutting down) and will never arrive.
+const maxEmptyResumedPolls = 25
+
+// WaitRun blocks until the run identified by runID reaches a state terminal for
+// the caller, then returns a RunResult. Implements ipc.EngineRunner.
 //
-// Channel lifecycle: startRun() registers a chan struct{} in runDone keyed by
-// runID. The cleanup func (deferred in fireAsync/fireSync via startRun) closes
-// that channel once the run goroutine finishes. WaitRun selects on the channel
-// so it is woken up immediately rather than polling.
+// suspended is NOT terminal: a run that called dicode.suspend() is paused
+// awaiting input and will either resume (spawning a continuation run that
+// carries the real outcome) or be cancelled at its deadline. WaitRun follows
+// that chain — on `resumed` it continues waiting on the continuation run, so a
+// `dicode.run_task` caller receives the logical task's final result rather than
+// an intermediate `suspended`. The suspend→resume hop has no completion channel
+// (the continuation is a distinct run), so it is polled; the wait is bounded
+// entirely by ctx (the caller's task context / timeout).
 //
-// Race: if WaitRun is called after the channel has already been closed and
-// deleted (i.e. the run finished before the caller reached this function), the
-// Load will return ok==false. In that case we fall through to a single DB read
-// to return the final status.
+// Engine-internal callers for which a suspended run is an error rather than a
+// pause (the pipeline runner, provider resolution) must use waitRunSettled,
+// which returns the `suspended` status directly instead of following it.
 func (e *Engine) WaitRun(ctx context.Context, runID string) (ipc.RunResult, error) {
+	emptyResumedPolls := 0
+	for {
+		res, err := e.waitRunSettled(ctx, runID)
+		if err != nil {
+			return ipc.RunResult{}, err
+		}
+		switch res.Status {
+		case registry.StatusResumed:
+			// Token consumed; the continuation run carries the real outcome.
+			// Follow it. There is a brief window where the original is `resumed`
+			// but the continuation row is not yet recorded — re-poll until it is.
+			next, err := e.resumeContinuationID(ctx, runID)
+			if err != nil {
+				return ipc.RunResult{}, err
+			}
+			if next != "" {
+				runID = next
+				emptyResumedPolls = 0
+				continue
+			}
+			emptyResumedPolls++
+			if emptyResumedPolls > maxEmptyResumedPolls {
+				// The continuation never materialized; return the resumed status
+				// rather than polling until ctx expires.
+				return res, nil
+			}
+			if err := waitRunSleep(ctx); err != nil {
+				return ipc.RunResult{}, err
+			}
+		case registry.StatusSuspended, registry.StatusRunning:
+			// Non-terminal with no channel to wait on: `suspended` has no
+			// completion channel (the resume is a separate run), and a
+			// continuation just discovered via the DB may not have registered
+			// its runDone yet. Poll until the state advances.
+			emptyResumedPolls = 0
+			if err := waitRunSleep(ctx); err != nil {
+				return ipc.RunResult{}, err
+			}
+		default:
+			// success / failure / cancelled — terminal for the caller.
+			return res, nil
+		}
+	}
+}
+
+// waitRunSettled blocks until the run's goroutine finishes (or is already done)
+// and returns its current record, including a non-terminal `suspended`. It does
+// not follow the resume chain — callers that must observe `suspended` directly
+// (the pipeline runner, provider resolution) use this; WaitRun layers
+// resume-chain following on top.
+func (e *Engine) waitRunSettled(ctx context.Context, runID string) (ipc.RunResult, error) {
 	if v, ok := e.runDone.Load(runID); ok {
 		// Run is in progress — wait for the completion channel to be closed.
 		select {
 		case <-v.(chan struct{}):
-			// Channel closed: run has finished. Fall through to DB read below.
+			// Channel closed: the run goroutine finished. Read its record.
 		case <-ctx.Done():
 			return ipc.RunResult{}, ctx.Err()
 		}
 	}
-	// Either the channel was never present (run already finished before we
-	// arrived) or it was just closed. Either way, fetch the final record.
 	run, err := e.registry.GetRun(ctx, runID)
 	if err != nil {
 		if errors.Is(err, registry.ErrRunNotFound) {
@@ -99,12 +164,43 @@ func (e *Engine) WaitRun(ctx context.Context, runID string) (ipc.RunResult, erro
 		}
 		return ipc.RunResult{}, err
 	}
-	// Prefer the persisted return_value when present. Fall back to the
-	// in-memory runReturnValue cache for tasks that opted out of
-	// persistence via `run_result.enabled: false` — without this fallback,
-	// `dicode.run_task` callers would receive nil for those tasks even
-	// though the value is available in process. The cache entry survives
-	// for runReturnValueTTL after run completion (see startRun cleanup).
+	return e.buildRunResult(runID, run), nil
+}
+
+// waitRunSleep blocks for waitRunPollInterval or until ctx is done, returning
+// ctx.Err() in the latter case.
+func waitRunSleep(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(waitRunPollInterval):
+		return nil
+	}
+}
+
+// resumeContinuationID returns the ID of the continuation run spawned when the
+// suspended run parentRunID was resumed, or "" if none is recorded yet. The
+// single-use resume token guarantees at most one such continuation.
+func (e *Engine) resumeContinuationID(ctx context.Context, parentRunID string) (string, error) {
+	children, err := e.registry.ListChildren(ctx, parentRunID, 50)
+	if err != nil {
+		return "", err
+	}
+	for _, c := range children {
+		if c.TriggerSource == registry.TriggerResume {
+			return c.ID, nil
+		}
+	}
+	return "", nil
+}
+
+// buildRunResult assembles the ipc.RunResult for a terminal run. It prefers the
+// persisted return_value, falling back to the in-memory runReturnValue cache
+// for tasks that opted out of persistence via `run_result.enabled: false` —
+// without this fallback, `dicode.run_task` callers would receive nil for those
+// tasks even though the value is available in process. The cache entry survives
+// for runReturnValueTTL after run completion (see startRun cleanup).
+func (e *Engine) buildRunResult(runID string, run *registry.Run) ipc.RunResult {
 	returnJSON := run.ReturnValue
 	if returnJSON == "" {
 		if v, ok := e.runReturnValue.Load(runID); ok {
@@ -119,7 +215,7 @@ func (e *Engine) WaitRun(ctx context.Context, runID string) (ipc.RunResult, erro
 		RunID:       runID,
 		Status:      run.Status,
 		ReturnValue: returnValue,
-	}, nil
+	}
 }
 
 // KillRun cancels a running task by its run ID.

--- a/pkg/trigger/run.go
+++ b/pkg/trigger/run.go
@@ -724,12 +724,23 @@ func (e *Engine) dispatch(ctx context.Context, spec *task.Spec, opts pkgruntime.
 	// chain — suspended is non-terminal, so success/failure chains must not
 	// fire until the continuation run reaches a real terminal state.
 	if result.Suspended {
-		if serr := e.suspendRun(&opts, result); serr != nil {
+		suspended, serr := e.suspendRun(&opts, result)
+		if serr != nil {
 			e.log.Warn("suspend run persist failed", zap.String("run", opts.RunID), zap.Error(serr))
 			if ferr := e.registry.FinishRun(context.Background(), opts.RunID, registry.StatusFailure); ferr != nil {
 				e.log.Warn("FinishRun: suspend fallback", zap.String("run", opts.RunID), zap.Error(ferr))
 			}
 			return registry.StatusFailure, &pkgruntime.RunResult{Error: serr}
+		}
+		if !suspended {
+			// A concurrent finalize (kill / shutdown drain) moved the run out of
+			// running before the suspend landed. The status guard left the row
+			// untouched; report its persisted terminal status rather than
+			// resurrecting it as suspended.
+			if run, gerr := e.registry.GetRun(context.Background(), opts.RunID); gerr == nil {
+				return run.Status, result
+			}
+			return registry.StatusCancelled, result
 		}
 		return registry.StatusSuspended, result
 	}

--- a/pkg/webui/replay_test.go
+++ b/pkg/webui/replay_test.go
@@ -2,12 +2,34 @@ package webui
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
 )
+
+// suspendGuardFetcher satisfies the (unexported) fetcher the Replayer depends
+// on. The suspended-run guard fires before any fetch, so Fetch must never be
+// called.
+type suspendGuardFetcher struct{ t *testing.T }
+
+func (s suspendGuardFetcher) Fetch(context.Context, string, string, int64) (registry.PersistedInput, error) {
+	s.t.Fatal("Fetch called; suspended-run guard should short-circuit before input fetch")
+	return registry.PersistedInput{}, nil
+}
+
+// suspendGuardRunner records whether a replay was ever fired.
+type suspendGuardRunner struct{ fired bool }
+
+func (s *suspendGuardRunner) FireForReplay(context.Context, string, string, any) (string, error) {
+	s.fired = true
+	return "new-run", nil
+}
 
 // apiReplayRun's failure paths can be exercised without a fully-wired
 // Replayer: when the server's Replayer is nil, the handler should return
@@ -73,5 +95,33 @@ func TestApiReplayRun_RejectsUnknownFields(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400; body = %s", w.Code, w.Body.String())
+	}
+}
+
+// A suspended run must be resumed, not replayed. The server rejects the replay
+// with 409 Conflict and never fires the runner.
+func TestApiReplayRun_409OnSuspendedRun(t *testing.T) {
+	srv, reg := newTestServer(t)
+	ctx := context.Background()
+
+	if _, err := reg.StartRunWithID(ctx, "susp-run", "user-task", "", "manual", "task"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reg.SuspendRun(ctx, "susp-run", []byte(`{"step":1}`), nil, "tok", time.Now().UnixMilli(), 0, nil); err != nil {
+		t.Fatal(err)
+	}
+	runner := &suspendGuardRunner{}
+	srv.SetReplayer(registry.NewReplayer(reg, suspendGuardFetcher{t}, runner))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/runs/susp-run/replay", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want 409; body = %s", w.Code, w.Body.String())
+	}
+	if runner.fired {
+		t.Error("runner fired on a suspended run; replay must be blocked")
 	}
 }

--- a/pkg/webui/resume_test.go
+++ b/pkg/webui/resume_test.go
@@ -40,7 +40,7 @@ func seedSuspendedRun(t *testing.T, reg *registry.Registry, schema []byte, token
 	if err != nil {
 		t.Fatalf("StartRunWithID: %v", err)
 	}
-	if err := reg.SuspendRun(ctx, id, []byte(`{"step":"x"}`), schema, token, 1, 0, nil); err != nil {
+	if _, err := reg.SuspendRun(ctx, id, []byte(`{"step":"x"}`), schema, token, 1, 0, nil); err != nil {
 		t.Fatalf("SuspendRun: %v", err)
 	}
 	return id

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -2255,6 +2255,8 @@ func (s *Server) apiReplayRun(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var taskNotFound *trigger.TaskNotFoundError
 		switch {
+		case errors.Is(err, registry.ErrRunNotReplayable):
+			jsonErr(w, "run is suspended; resume it instead of replaying: "+runID, http.StatusConflict)
 		case errors.Is(err, registry.ErrInputUnavailable):
 			jsonErr(w, "no persisted input for run: "+runID, http.StatusBadRequest)
 		case errors.Is(err, registry.ErrRunNotFound):


### PR DESCRIPTION
## Summary

Issue #516 collected five LOW-severity hardening seams left behind after the suspendable-tasks epic (#95). Each was re-verified against current `main`; four were still present and are fixed here, and one was already resolved upstream. The fixes are independent and land as one commit per seam.

**`WaitRun` treated `suspended` as terminal** (still present). `dicode.run_task`'s synchronous wait returned `{status: suspended}` the instant a child paused via `dicode.suspend()`, contradicting its "blocks until terminal" contract. `suspended` is non-terminal: the run either resumes — spawning a continuation run that carries the real result — or is cancelled at its deadline. `WaitRun` now follows that chain, polling the suspend window (there is no completion channel for the suspend→resume hop) and, on `resumed`, waiting on the continuation run (recursively, for multi-step wizards). Engine-internal callers for which a suspended run is an *error* rather than a pause (the pipeline runner and provider resolution) keep the settle-on-suspended behavior via a new `waitRunSettled`, so pipeline stage-suspend detection is preserved. The whole wait stays bounded by the caller's ctx, and a `resumed`-with-no-continuation edge (fire failed after the token was consumed) is bounded rather than polling until ctx expires.

**Replay of a suspended run was not blocked server-side** (still present). `apiReplayRun`/the `Replayer` had no status check, so a suspended run could be replayed via the API even though the UI hides the button — spawning a duplicate fresh execution while the original still holds a live resume token. The `Replayer` now rejects a suspended run with `ErrRunNotReplayable` before any input fetch or runner fire; the webui maps it to 409 Conflict.

**Missing resume indexes** (still present). `GetRunByResumeToken` and the per-minute `SweepExpiredSuspensions` both filtered `runs` with no supporting index, so each was a full-table scan that degrades with run history. `EXPLAIN QUERY PLAN` against the migrated schema confirmed the scans and that the two added indexes eliminate them; the resume-token index is partial (`WHERE resume_token IS NOT NULL`) so it stays small against a table dominated by terminal runs. The `ListSuspendedRuns` ORDER-BY path was left unindexed on purpose — it is a rare interactive `dicode resume` listing, not a hot path, and an unused/low-value index is write overhead on every run.

**`SuspendRun`'s UPDATE was unconditional on status** (still present). Unlike `MarkRunResumed`/the sweep, it wrote `suspended` regardless of current status, so a finalize that had already moved the run out of `running` (a kill or shutdown drain writing `cancelled` via `finalizeCancelled`) could be clobbered back to `suspended`, stranding a live resume token on an otherwise-terminal run. The UPDATE is now gated on `status = running` and reports whether the row changed; the engine reports the run's real terminal status when the guard skips the write.

**Webui didn't refetch on a live `run:finished`→suspended** — already resolved. `dc-run-detail.js`'s `run:finished` handler refetches `/api/runs/{id}` and updates `this._run` (introduced by #527, commit 5cabaee), so a just-suspended run renders its resume form without a manual reload. No change needed.

## Test plan

Each behavioral fix has a regression test that fails without it (verified by reverting the fix):

- `TestEngine_WaitRun_FollowsResumeChain` (pkg/trigger) — asserts `WaitRun` on a suspended run does not return while suspended, then returns the *continuation* run's `success` + return value once resumed. Without the fix it returns `suspended` immediately.
- `TestReplay_SuspendedRunRejected` (pkg/registry) + `TestApiReplayRun_409OnSuspendedRun` (pkg/webui) — replaying a suspended run returns `ErrRunNotReplayable` / HTTP 409 and never fires the runner.
- `TestResumeIndexes_UsedByPlanner` (pkg/db) — `EXPLAIN QUERY PLAN` for the token lookup and the sweep uses the new indexes and does not `SCAN runs`.
- `TestSuspendRun_DoesNotResurrectCancelled` (pkg/registry) — suspending a run already `cancelled` is a no-op (reports no change, status stays `cancelled`, no token written).

Existing suspend/resume/pipeline tests updated for the `SuspendRun` `(bool, error)` signature and re-run green.

## Gate results

- `make build` — OK
- `go vet ./...` / `make lint` — OK
- `go test ./pkg/registry/... ./pkg/trigger/... ./pkg/ipc/... -race` — OK
- `make test` (timeout 60s) — all packages OK, 0 failures

`TestShutdownDrainsInFlightSyncWebhookRun` flaked once under `-race` load and passed on isolated re-run (a startup-timing test unrelated to these changes).

Closes #516. Part of #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
