### PR TITLE
feat(cli): surface tasks pending approval via `dicode task pending` and `list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1137,7 +1137,7 @@ The testing and validation system is designed with four layers. Not all are impl
 | Unit tests | `dicode task test` | Logic bugs, wrong HTTP calls, bad return values | ✅ Implemented (Deno; Python/Docker/Podman tracked as #159) |
 | Dry run | `dicode task run --dry-run` | Secret resolution, correct endpoints | Planned |
 
-> **Note**: E2E tests use Playwright and cover core UI flows, file changes, webhooks, config, and auth. Unit tests run via `dicode task test <task-id>` or `make test-tasks` — the CLI routes through the same executor as the MCP `test_task` tool so any caller (human, built-in agent, third-party AI) gets the same results. `task validate` and `task run --dry-run` are not yet implemented. Current CLI supports: `run`, `list`, `logs`, `status`, `ai`, `task test`, `secrets`, `relay`, `version`.
+> **Note**: E2E tests use Playwright and cover core UI flows, file changes, webhooks, config, and auth. Unit tests run via `dicode task test <task-id>` or `make test-tasks` — the CLI routes through the same executor as the MCP `test_task` tool so any caller (human, built-in agent, third-party AI) gets the same results. `task validate` and `task run --dry-run` are not yet implemented. Current CLI supports: `run`, `list`, `logs`, `status`, `ai`, `task test`, `task pending`, `task approve`, `secrets`, `relay`, `version`. When the trust-on-change approval gate is holding tasks, `dicode list` marks them `pending` in an APPROVAL column and `dicode task pending` lists each held task with its short content hash — copy an id straight into `dicode task approve <task-id>`.
 
 ---
 

--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -198,7 +198,7 @@ func dispatch(c *ipc.ControlClient, args []string) error {
 		return cmdAI(c, args[1:])
 	case "task":
 		if len(args) < 2 {
-			return fmt.Errorf("usage: dicode task <test|create|edit|save|cancel|delete> [args...]")
+			return fmt.Errorf("usage: dicode task <test|create|edit|save|cancel|delete|approve|pending> [args...]")
 		}
 		return cmdTask(c, args[1:])
 	case "auth":
@@ -571,9 +571,38 @@ func cmdTask(c *ipc.ControlClient, args []string) error {
 		return cmdTaskDelete(c, args[1:])
 	case "approve":
 		return cmdTaskApprove(c, args[1:])
+	case "pending":
+		return cmdTaskPending(c)
 	default:
-		return fmt.Errorf("unknown task subcommand %q — supported: test, create, edit, save, cancel, delete, approve", args[0])
+		return fmt.Errorf("unknown task subcommand %q — supported: test, create, edit, save, cancel, delete, approve, pending", args[0])
 	}
+}
+
+// cmdTaskPending implements `dicode task pending`: lists the tasks the
+// trust-on-change approval gate is holding, each with its short content hash, so
+// an operator can copy an id straight into `dicode task approve`.
+func cmdTaskPending(c *ipc.ControlClient) error {
+	resp, err := c.Send(ipc.Request{Method: "cli.task.pending"})
+	if err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	var tasks []ipc.PendingTask
+	if err := remarshal(resp.Result, &tasks); err != nil {
+		return err
+	}
+	if len(tasks) == 0 {
+		fmt.Println("no tasks pending approval")
+		return nil
+	}
+	fmt.Printf("%-40s %s\n", "TASK ID", "HASH")
+	for _, t := range tasks {
+		fmt.Printf("%-40s %s\n", t.TaskID, t.Hash)
+	}
+	fmt.Println("\napprove with: dicode task approve <task-id>")
+	return nil
 }
 
 // cmdTaskApprove implements `dicode task approve <task-id>`: approves a task
@@ -868,9 +897,18 @@ func cmdList(c *ipc.ControlClient) error {
 		fmt.Println("no tasks registered")
 		return nil
 	}
-	fmt.Printf("%-30s %-12s %-10s %s\n", "ID", "TRIGGER", "LAST STATUS", "NAME")
+	anyPending := false
+	fmt.Printf("%-30s %-12s %-10s %-8s %s\n", "ID", "TRIGGER", "LAST STATUS", "APPROVAL", "NAME")
 	for _, t := range tasks {
-		fmt.Printf("%-30s %-12s %-10s %s\n", t.ID, t.Trigger, orDash(t.LastStatus), t.Name)
+		approval := "-"
+		if t.Pending {
+			approval = "pending"
+			anyPending = true
+		}
+		fmt.Printf("%-30s %-12s %-10s %-8s %s\n", t.ID, t.Trigger, orDash(t.LastStatus), approval, t.Name)
+	}
+	if anyPending {
+		fmt.Println("\ntasks marked 'pending' await approval — see: dicode task pending")
 	}
 	return nil
 }
@@ -1577,6 +1615,7 @@ Commands:
                                   flags: --format=text|junit|gh-summary
   task delete <task-id> [flags]   remove a task from its source (local rm / git PR)
                                   flags: --source NAME, --force
+  task pending                    list tasks held pending by the approval gate, with their content hash
   task approve <task-id>          approve a task held pending by the approval gate
   relock [--check] [dir]          regenerate/verify all task locks (deno.lock + task.py.lock sidecars)
   deno relock [--check] [dir]     regenerate/verify a task tree's deno.lock via the pinned Deno

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -208,7 +208,7 @@ Unified IPC protocol replacing the old per-runtime `pkg/runtime/deno/server/`. T
 
 **Control socket** (persistent, daemon-lifetime):
 
-- `control.go` — **`ControlServer`**: listens at `~/.dicode/daemon.sock` (mode 0600). On startup writes a pre-issued CLI token to `~/.dicode/daemon.token` (mode 0600, atomic write). Handles `cli.ping`, `cli.list`, `cli.run`, `cli.logs`, `cli.status`, `cli.secrets.{list,set,delete}`. Context-aware: per-connection context cancels in-flight `cli.run` on client disconnect. CLI tokens use `tokenCLITTL` (~10 years) — daemon restart re-issues anyway
+- `control.go` — **`ControlServer`**: listens at `~/.dicode/daemon.sock` (mode 0600). On startup writes a pre-issued CLI token to `~/.dicode/daemon.token` (mode 0600, atomic write). Handles `cli.ping`, `cli.list`, `cli.run`, `cli.logs`, `cli.status`, `cli.secrets.{list,set,delete}`, `cli.task.{approve,pending}`. `cli.task.pending` lists tasks the approval gate is holding (each with a short content hash); `cli.list` also flags held tasks via `TaskSummary.Pending`. Both read the gate through `SetPendingApprovals`; a nil gate yields an empty list, not an error. Context-aware: per-connection context cancels in-flight `cli.run` on client disconnect. CLI tokens use `tokenCLITTL` (~10 years) — daemon restart re-issues anyway
 - `control_client.go` — **`ControlClient`**: `Dial(socketPath, tokenPath)` → `Send(req)` → `Close()`. Handshake decodes a union struct covering both success (`proto`) and error (`error`) envelopes
 
 - `pkg/runtime/deno/server/` **deleted** — both Deno and Python runtimes now import `pkg/ipc`
@@ -245,7 +245,7 @@ The daemon process logic, invoked via `dicode daemon`. Exported entry point: `da
 
 CLI dispatcher + daemon mode in one binary:
 
-- Subcommands: `daemon [-config dicode.yaml]`, `run <task-id> [key=value ...]`, `list`, `logs <run-id>`, `status [task-id]`, `secrets {list,set,delete}`, `version`
+- Subcommands: `daemon [-config dicode.yaml]`, `run <task-id> [key=value ...]`, `list`, `logs <run-id>`, `status [task-id]`, `task {test,create,edit,save,cancel,delete,approve,pending}`, `secrets {list,set,delete}`, `version` — `task pending` lists gate-held tasks with their content hash; `list` marks them in an APPROVAL column
 - `daemon` subcommand calls `pkg/daemon.Run()` — starts the full engine in-process
 - **Auto-start**: if `~/.dicode/daemon.sock` is not connectable, re-execs itself (`dicode daemon`) in the background, redirects stderr to `~/.dicode/daemon.log`, polls for the socket (8 second timeout)
 - Reads `~/.dicode/daemon.token` and calls `ipc.Dial()` to connect

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -757,6 +757,18 @@ func buildControlServer(cfg *config.Config, dataDir, version string, database db
 	// `dicode task approve` — the control socket is a trusted local channel.
 	ctrlSrv.SetTaskApprover(approvalGate.Approve)
 
+	// `dicode task pending` + `dicode list` annotation — surface the tasks the
+	// gate is holding so a headless operator can discover an id to approve.
+	ctrlSrv.SetPendingApprovals(func() []ipc.PendingTask {
+		ids := approvalGate.Pending()
+		out := make([]ipc.PendingTask, 0, len(ids))
+		for _, id := range ids {
+			hash, _ := approvalGate.PendingHash(id)
+			out = append(out, ipc.PendingTask{TaskID: id, Hash: hash})
+		}
+		return out
+	})
+
 	// Wire AI-first task authoring so `dicode task create|edit|save|cancel`
 	// reuses the same source manager and author_sessions store the REST
 	// handlers use.

--- a/pkg/ipc/capability.go
+++ b/pkg/ipc/capability.go
@@ -101,6 +101,11 @@ const (
 	CapCLIStatus  = "cli.status"  // daemon health and uptime
 	CapCLISecrets = "cli.secrets" // list / set / delete secrets
 	CapCLIAI      = "cli.ai"      // fire the configured ai task with a prompt
+	// CapCLITaskPending gates cli.task.pending — listing tasks the approval
+	// gate is holding. Read-only and strictly weaker than cli.task.approve
+	// (which cli clients already hold), but a distinct cap so a future policy
+	// could grant discovery without approval rights.
+	CapCLITaskPending = "cli.task.pending"
 )
 
 // cliCaps is the full capability set granted to every CLI client.
@@ -112,6 +117,7 @@ func cliCaps() []string {
 		CapCLIStatus,
 		CapCLISecrets,
 		CapCLIAI,
+		CapCLITaskPending,
 	}
 }
 

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -47,6 +47,11 @@ type ControlServer struct {
 	// Nil when the gate is not configured (tests).
 	taskApprover func(taskID string) error
 
+	// pendingApprovals reports the tasks the approval gate is holding (id +
+	// full content hash), wired via SetPendingApprovals. Nil when the gate is
+	// not configured (tests) — cli.task.pending then reports an empty list.
+	pendingApprovals func() []PendingTask
+
 	// defaultAITask is cfg.AI.Task — the task id that `dicode ai` fires when
 	// the client doesn't supply --task. Empty when the daemon was started
 	// without config (tests).
@@ -286,6 +291,9 @@ func (cs *ControlServer) dispatch(ctx context.Context, req Request) (any, error)
 
 	case "cli.task.approve":
 		return cs.handleTaskApprove(req)
+
+	case "cli.task.pending":
+		return cs.handleTaskPending()
 
 	case "cli.auth.reset_passphrase":
 		return cs.handleAuthResetPassphrase(ctx)
@@ -570,6 +578,7 @@ func (cs *ControlServer) handlePing() DaemonStatus {
 func (cs *ControlServer) handleList() ([]TaskSummary, error) {
 	ctx := context.Background()
 	specs := cs.reg.All()
+	pending := cs.pendingTaskIDs()
 	out := make([]TaskSummary, 0, len(specs))
 	for _, s := range specs {
 		summary := TaskSummary{
@@ -577,6 +586,9 @@ func (cs *ControlServer) handleList() ([]TaskSummary, error) {
 			Name:        s.Name,
 			Description: s.Description,
 			Trigger:     triggerLabel(s),
+		}
+		if _, ok := pending[s.ID]; ok {
+			summary.Pending = true
 		}
 		if runs, err := cs.reg.ListRuns(ctx, s.ID, 1); err == nil && len(runs) > 0 {
 			r := runs[0]

--- a/pkg/ipc/control_task_pending.go
+++ b/pkg/ipc/control_task_pending.go
@@ -1,0 +1,58 @@
+package ipc
+
+// PendingTask is one row in the cli.task.pending response: a task the approval
+// gate is holding, plus the short content hash observed when it was held — enough
+// to eyeball what changed without leaking the full digest.
+type PendingTask struct {
+	TaskID string `json:"taskID"`
+	Hash   string `json:"hash"`
+}
+
+// SetPendingApprovals wires the approval gate's pending set for cli.task.pending
+// and cli.list annotation. The callback returns each held task's id and full
+// content hash; the handler shortens the hash for display. Nil leaves
+// cli.task.pending returning an empty list and cli.list unannotated (tests /
+// gate disabled).
+func (cs *ControlServer) SetPendingApprovals(f func() []PendingTask) { cs.pendingApprovals = f }
+
+// handleTaskPending lists the tasks the approval gate is holding, each with its
+// short content hash, so a headless operator can discover an id to feed
+// `dicode task approve`. A nil gate (disabled / not wired) yields an empty list,
+// not an error — nothing pending and no gate are the same clear empty state.
+func (cs *ControlServer) handleTaskPending() ([]PendingTask, error) {
+	if cs.pendingApprovals == nil {
+		return []PendingTask{}, nil
+	}
+	pending := cs.pendingApprovals()
+	out := make([]PendingTask, 0, len(pending))
+	for _, p := range pending {
+		out = append(out, PendingTask{TaskID: p.TaskID, Hash: shortContentHash(p.Hash)})
+	}
+	return out, nil
+}
+
+// pendingTaskIDs returns the set of task ids the approval gate is holding, for
+// annotating cli.list. Empty when the gate is disabled or nothing is pending.
+func (cs *ControlServer) pendingTaskIDs() map[string]struct{} {
+	if cs.pendingApprovals == nil {
+		return nil
+	}
+	pending := cs.pendingApprovals()
+	if len(pending) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(pending))
+	for _, p := range pending {
+		set[p.TaskID] = struct{}{}
+	}
+	return set
+}
+
+// shortContentHash trims a content hash for display, matching the Web UI's
+// convention so the full digest never crosses the wire for a discovery listing.
+func shortContentHash(h string) string {
+	if len(h) > 12 {
+		return h[:12] + "…"
+	}
+	return h
+}

--- a/pkg/ipc/control_task_pending_test.go
+++ b/pkg/ipc/control_task_pending_test.go
@@ -1,0 +1,92 @@
+package ipc
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func newPendingTestServer(lister func() []PendingTask) *ControlServer {
+	return &ControlServer{
+		pendingApprovals: lister,
+		log:              zap.NewNop(),
+	}
+}
+
+func TestTaskPending_SeveralPending(t *testing.T) {
+	longHash := "0123456789abcdef0123456789abcdef" // > 12 chars → shortened
+	cs := newPendingTestServer(func() []PendingTask {
+		return []PendingTask{
+			{TaskID: "repo/deploy", Hash: longHash},
+			{TaskID: "repo/cleanup", Hash: "abc"}, // <= 12 chars → verbatim
+		}
+	})
+
+	res, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.task.pending"})
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	out, ok := res.([]PendingTask)
+	if !ok {
+		t.Fatalf("result type %T", res)
+	}
+	if len(out) != 2 {
+		t.Fatalf("len = %d, want 2 (%+v)", len(out), out)
+	}
+	if out[0].TaskID != "repo/deploy" || out[0].Hash != "0123456789ab"+"…" {
+		t.Fatalf("row 0 = %+v, want shortened hash", out[0])
+	}
+	if out[1].TaskID != "repo/cleanup" || out[1].Hash != "abc" {
+		t.Fatalf("row 1 = %+v, want short hash verbatim", out[1])
+	}
+}
+
+func TestTaskPending_NonePending(t *testing.T) {
+	cs := newPendingTestServer(func() []PendingTask { return nil })
+
+	res, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.task.pending"})
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	out, ok := res.([]PendingTask)
+	if !ok {
+		t.Fatalf("result type %T", res)
+	}
+	if out == nil || len(out) != 0 {
+		t.Fatalf("out = %#v, want non-nil empty slice", out)
+	}
+}
+
+func TestTaskPending_GateNotConfigured(t *testing.T) {
+	cs := newPendingTestServer(nil)
+
+	res, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.task.pending"})
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	out, ok := res.([]PendingTask)
+	if !ok {
+		t.Fatalf("result type %T", res)
+	}
+	if len(out) != 0 {
+		t.Fatalf("out = %+v, want empty list when gate is nil", out)
+	}
+}
+
+func TestTaskPending_AnnotatesPendingTaskIDs(t *testing.T) {
+	cs := newPendingTestServer(func() []PendingTask {
+		return []PendingTask{{TaskID: "repo/deploy", Hash: "deadbeef"}}
+	})
+	set := cs.pendingTaskIDs()
+	if _, ok := set["repo/deploy"]; !ok {
+		t.Fatalf("pendingTaskIDs = %v, want repo/deploy present", set)
+	}
+	if _, ok := set["repo/other"]; ok {
+		t.Fatal("pendingTaskIDs must not contain unlisted task")
+	}
+
+	if got := newPendingTestServer(nil).pendingTaskIDs(); got != nil {
+		t.Fatalf("nil gate pendingTaskIDs = %v, want nil", got)
+	}
+}

--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -248,6 +248,10 @@ type TaskSummary struct {
 	LastStatus  string `json:"lastStatus"` // "success" | "failure" | "running" | "crashlooping" | ""
 	LastRunID   string `json:"lastRunID"`  // "" if never run
 	LastRunAt   string `json:"lastRunAt"`  // RFC3339 or ""
+	// Pending is true when the approval gate is holding this task awaiting
+	// approval — a state distinct from any run status. cli.task.pending carries
+	// the detail (short content hash).
+	Pending bool `json:"pending,omitempty"`
 }
 
 // LogEntry is one log line returned by cli.logs.


### PR DESCRIPTION
## Summary

The trust-on-change approval gate (#392) holds new/changed tasks until an operator approves them, but the only CLI surface was `dicode task approve <task-id>` — which requires knowing the id up front. A headless / CLI-only operator had no way to *discover* what the gate was holding: `dicode list` reported run status only, so a task held by the gate was indistinguishable from one that had simply never run. The Web UI already surfaces this (pending page + `approval:pending` event); the CLI did not.

This adds two surfaces, both reading the gate's existing `Pending()` / `PendingHash()` API:

- **`dicode task pending`** — a new `cli.task.pending` IPC method listing each held task with its **short** content hash (matching the Web UI's `shortHash` truncation so the full digest never crosses the wire for a discovery listing) and a copy-pasteable id. Empty/disabled gate → a clear "no tasks pending approval" line, not an error.
- **`dicode list` annotation** — a distinct `APPROVAL` column marking held tasks `pending`, plus a footer hint. It is deliberately a *separate* column rather than an overload of the run-status column, since "pending approval" is not a run outcome.

### Rationale / scope notes

- **Capability model**: gated by a new `CapCLITaskPending` added to `cliCaps()` rather than widening `CapCLIList`. The listing is read-only and strictly weaker than `cli.task.approve`, which CLI clients already hold; a distinct cap lets a future policy grant discovery without approval rights.
- **Trust boundary**: `cli.task.pending` rides the same 0600 control socket (peer-UID / pre-shared-token handshake) as every other `cli.*` verb. It exposes only task ids and short hashes — a subset of what `cli.task.approve` already exposes and acts on — and does not widen who can reach the socket.
- The `dicode list` column widths reuse the existing fixed-width layout; long trigger labels already push columns on `main`, so this is unchanged behavior, not a regression introduced here.

## Test plan

- New `pkg/ipc/control_task_pending_test.go` mirrors `control_task_approve_test.go`: several pending (asserts hash shortening for >12-char digests and verbatim for short ones), none pending (non-nil empty slice), gate nil/disabled (empty list, no error), and `dicode list` annotation set membership.
- End-to-end against a live isolated daemon: started the gate holding all `examples/` tasks, confirmed `dicode task pending` listed them with short hashes and `dicode list` marked them in the `APPROVAL` column; approved `examples/hello-cron`, confirmed it left the pending list and ran successfully; then edited its script (exercising the #539 re-hash-on-change path), confirmed the reconciler re-held it under a *new* hash, re-approved, and confirmed it ran the edited code.

## Gate results

Run in the worktree sandbox:

- `make build` — pass
- `make lint` (`go fmt` + `go vet ./...`) — pass
- `go vet ./...` — pass
- `go test ./pkg/ipc/... ./pkg/approval/... ./cmd/... -race` — pass
- `make test` (full suite, `-timeout 60s`) — pass (all packages green, including the Deno/Python runtime tests, which ran here — egress was available in this sandbox, so the `TestControl_TaskTest_HappyPath` / e2e caveats did not apply)

CI is the source of truth; see the checks on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #536.
