### PR TITLE
fix(webui): send a suspended run's result page to the resume form

### DIFF
--- a/pkg/webui/run_result_suspended_test.go
+++ b/pkg/webui/run_result_suspended_test.go
@@ -1,0 +1,67 @@
+package webui
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// A suspended run has neither OutputContent nor a ReturnValue, so handleRunResult's
+// content checks fall through to 404. That is the page a browser lands on after a
+// webhook task's form POST suspends (fireWebhookTask redirects form submissions to
+// /runs/{id}/result), so the operator saw "not found" instead of the resume form.
+func TestRunResult_SuspendedRedirectsToResumeForm(t *testing.T) {
+	srv, reg := newTestServer(t)
+	ctx := context.Background()
+
+	runID, err := reg.StartRun(ctx, "examples/wizard", "")
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	schema := []byte(`{"type":"object","properties":{"ok":{"type":"boolean"}}}`)
+	ok, err := reg.SuspendRun(ctx, runID, []byte(`{}`), schema, "tok-1", 1, 0, nil)
+	if err != nil {
+		t.Fatalf("SuspendRun: %v", err)
+	}
+	if !ok {
+		t.Fatal("SuspendRun reported no change; the run was not suspended")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/runs/"+runID+"/result", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d (303 to the resume form)", w.Code, http.StatusSeeOther)
+	}
+	if got, want := w.Header().Get("Location"), "/hooks/webui/runs/"+runID; got != want {
+		t.Errorf("Location = %q, want %q", got, want)
+	}
+}
+
+// A finished run keeps returning its payload inline — the suspended branch must
+// not swallow the normal result path.
+func TestRunResult_FinishedStillServesReturnValue(t *testing.T) {
+	srv, reg := newTestServer(t)
+	ctx := context.Background()
+
+	runID, err := reg.StartRun(ctx, "examples/plain", "")
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	if err := reg.FinishRunWithResult(ctx, runID, "success", `{"count":2}`, "", ""); err != nil {
+		t.Fatalf("FinishRunWithResult: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/runs/"+runID+"/result", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got := w.Body.String(); got != `{"count":2}` {
+		t.Errorf("body = %q, want the run's return value", got)
+	}
+}

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -738,6 +738,14 @@ func (s *Server) handleRunResult(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	// A suspended run has produced neither output nor a return value, so the
+	// checks below would 404 it. It is not finished — it is waiting on input.
+	// Send the caller to the run page, which renders the resume form. This is
+	// where a browser lands after a webhook task's form POST suspends.
+	if run.Status == registry.StatusSuspended {
+		http.Redirect(w, r, "/hooks/webui/runs/"+runID, http.StatusSeeOther)
+		return
+	}
 	if run.OutputContentType != "" {
 		w.Header().Set("Content-Type", run.OutputContentType+"; charset=utf-8")
 		_, _ = w.Write([]byte(run.OutputContent))


### PR DESCRIPTION
## Summary

Trigger a webhook task from a browser form and let it suspend, and you get a **404** instead of the resume form.

`fireWebhookTask` redirects browser form submissions to `/runs/{id}/result` (`pkg/trigger/webhook.go`). `handleRunResult` serves `OutputContent`, else `ReturnValue`, else `http.NotFound`. A suspended run has produced neither — it hasn't finished, it's waiting on input — so it takes the 404 branch. The resume form exists and renders fine on the run page; there was simply no way to get there from the webhook flow.

A suspended run now redirects to `/hooks/webui/runs/{id}`, where `dc-run-detail.js` renders the schema-driven form. The finished-run paths are untouched.

Found while writing a webhook-triggered suspend-to-approve task: the approval form was unreachable from the trigger that was supposed to open it.

## Test plan

`pkg/webui/run_result_suspended_test.go`:

- `TestRunResult_SuspendedRedirectsToResumeForm` — suspends a run, GETs its result page, asserts 303 with `Location: /hooks/webui/runs/{id}`. **Verified it fails without the fix**: `status = 404, want 303`.
- `TestRunResult_FinishedStillServesReturnValue` — a finished run still serves its payload inline, so the new branch doesn't swallow the normal result path.

## Gate results

```
make build                      ✅
go vet ./pkg/webui/             ✅
gofmt -l pkg/webui/             ✅ (clean)
go test ./pkg/webui/ -count=1   ✅ (8.4s)
make test-e2e                   ⚠️ not runnable in this sandbox (blocked Deno
                                   download); CI's Playwright job covers it
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)