### PR TITLE
feat(examples): repo-prune — webhook-triggered, suspend-to-approve git pruning

### DIFF
--- a/tasks/examples/repo-prune/prune-stale-refs.sh
+++ b/tasks/examples/repo-prune/prune-stale-refs.sh
@@ -153,8 +153,9 @@ analyse() {
 
   jq -n --argjson wd "$wt_del" --argjson wk "$wt_keep" \
         --argjson ld "$loc_del" --argjson lk "$loc_keep" --argjson rd "$rem_del" \
-        --arg d "$DEFAULT_BRANCH" '{
+        --arg d "$DEFAULT_BRANCH" --argjson il "$INCLUDE_LOCKED" '{
      default_branch:$d,
+     include_locked:($il == 1),
      worktrees:{delete:$wd, keep:$wk},
      local_branches:{delete:$ld, keep:$lk},
      remote_branches:{delete:$rd},
@@ -188,17 +189,44 @@ if [ -n "$open_heads" ]; then
   [ -z "$clash" ] || { echo "refusing: plan targets an open PR's branch: $clash" >&2; exit 1; }
 fi
 
-jq -r '.worktrees.delete[]? | .path' <<<"$plan" | while IFS= read -r p; do
+# The branch guards above have no worktree counterpart in the plan, so re-derive
+# each worktree's real state here rather than trusting the plan's classification.
+# `git worktree remove` already refuses a path that is not a registered worktree,
+# but it will happily force-remove a dirty or locked one.
+plan_include_locked=$(jq -r '.include_locked // false' <<<"$plan")
+wt_state() { # path -> "missing" | "dirty" | "locked" | "ok"
+  git worktree list --porcelain | grep -qxF "worktree $1" || { echo missing; return; }
+  if [ -n "$(git -C "$1" status --porcelain 2>/dev/null | grep -vE " ($(echo "$IGNORE_DIRTY" | tr ' ' '|'))$")" ]; then
+    echo dirty; return
+  fi
+  if git worktree list --porcelain | grep -A3 -xF "worktree $1" | grep -q '^locked'; then
+    echo locked; return
+  fi
+  echo ok
+}
+
+while IFS= read -r p; do
   [ -n "$p" ] || continue
-  git worktree unlock "$p" 2>/dev/null || true
-  git worktree remove --force "$p" && echo "worktree removed: $p"
-done
+  case "$(wt_state "$p")" in
+    missing) echo "refusing: plan names a path that is not a worktree of this repo: $p" >&2; exit 1 ;;
+    dirty)   echo "refusing: plan targets a worktree with uncommitted work: $p" >&2; exit 1 ;;
+    locked)
+      [ "$plan_include_locked" = "true" ] || {
+        echo "refusing: plan targets a locked worktree without --include-locked: $p" >&2; exit 1; }
+      git worktree unlock "$p" 2>/dev/null || true
+      ;;
+  esac
+  git worktree remove --force -- "$p" && echo "worktree removed: $p"
+done < <(jq -r '.worktrees.delete[]? | .path' <<<"$plan")
 git worktree prune
 
+# `--` terminates options on every destructive command: a ref may legally be
+# named `-D` or `--all` (git check-ref-format accepts both), and without the
+# terminator git parses it as a flag instead of a ref.
 mapfile -t locals < <(jq -r '.local_branches.delete[]?' <<<"$plan")
 if [ "${#locals[@]}" -gt 0 ]; then
   # -D not -d: squash-merged branches are not ancestors of main, so -d refuses them.
-  git branch -D "${locals[@]}" >/dev/null && echo "local branches deleted: ${#locals[@]}"
+  git branch -D -- "${locals[@]}" >/dev/null && echo "local branches deleted: ${#locals[@]}"
 fi
 
 mapfile -t remotes < <(jq -r '.remote_branches.delete[]?' <<<"$plan")
@@ -207,9 +235,12 @@ if [ "${#remotes[@]}" -gt 0 ]; then
   i=0
   while [ "$i" -lt "${#remotes[@]}" ]; do
     chunk=("${remotes[@]:$i:50}")
-    git push origin --delete "${chunk[@]}" >/dev/null 2>&1 \
-      && echo "remote branches deleted: ${#chunk[@]}" \
-      || echo "warning: a remote chunk failed (already gone?)" >&2
+    # stderr is kept: "already deleted" and "auth failed" must not look alike.
+    if git push origin --delete -- "${chunk[@]}" >/dev/null; then
+      echo "remote branches deleted: ${#chunk[@]}"
+    else
+      echo "warning: a remote chunk failed; see the git error above" >&2
+    fi
     i=$((i + 50))
   done
 fi

--- a/tasks/examples/repo-prune/prune-stale-refs.sh
+++ b/tasks/examples/repo-prune/prune-stale-refs.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+#
+# Analyse and prune stale git worktrees and branches (local + remote).
+#
+#   prune-stale-refs.sh                 # analyse only, emit a JSON plan on stdout
+#   prune-stale-refs.sh --apply         # execute the plan
+#   prune-stale-refs.sh --apply --plan FILE
+#                                       # execute a previously emitted plan verbatim
+#
+# Analysis and execution are separate phases on purpose: the plan is a value you
+# can review, approve, and hand back. `--apply --plan FILE` never re-derives
+# anything, so what a human approved is exactly what runs.
+#
+# A ref is safe to delete when its content is already on the default branch:
+#   - its PR is MERGED (covers squash-merges, which rewrite commit ids and so
+#     defeat `git branch --merged` and `git cherry` alike), or
+#   - it carries zero commits beyond origin/<default>.
+#
+# Never deleted, regardless of the above:
+#   - the default branch
+#   - any branch that is the head of an OPEN PR
+#   - the release-please branch (reused across releases, so old merged release
+#     PRs make it look safe while the current release PR still needs it)
+#   - a worktree with uncommitted work, or a branch holding unmerged commits
+#
+# Requires: git, gh (authenticated), jq.
+
+set -euo pipefail
+
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+RELEASE_BRANCH="${RELEASE_BRANCH:-release-please--branches--main}"
+# Files git leaves dirty that never represent real work. Space-separated.
+IGNORE_DIRTY="${IGNORE_DIRTY:-dicode.lock}"
+
+APPLY=0
+PLAN_FILE=""
+INCLUDE_LOCKED=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply)          APPLY=1 ;;
+    --plan)           PLAN_FILE="${2:?--plan needs a file}"; shift ;;
+    --include-locked) INCLUDE_LOCKED=1 ;;
+    -h|--help)        sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+for bin in git gh jq; do
+  command -v "$bin" >/dev/null || { echo "missing dependency: $bin" >&2; exit 1; }
+done
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+# ---------------------------------------------------------------- apply-a-plan
+
+if [ -n "$PLAN_FILE" ]; then
+  [ "$APPLY" -eq 1 ] || { echo "--plan is only meaningful with --apply" >&2; exit 2; }
+  [ -r "$PLAN_FILE" ] || { echo "cannot read plan: $PLAN_FILE" >&2; exit 1; }
+  plan=$(cat "$PLAN_FILE")
+else
+  plan=""
+fi
+
+# ------------------------------------------------------------------- analysis
+
+analyse() {
+  git fetch origin "$DEFAULT_BRANCH" --quiet
+  git remote prune origin >/dev/null 2>&1 || true
+
+  local prs protected
+  prs=$(gh pr list --state all --limit 1000 --json headRefName,state,number)
+
+  # Protected = default + release branch + every OPEN PR's head branch.
+  protected=$(jq -r --arg d "$DEFAULT_BRANCH" --arg r "$RELEASE_BRANCH" '
+    [ $d, $r ] + [ .[] | select(.state=="OPEN") | .headRefName ] | unique | .[]' <<<"$prs")
+
+  is_protected() { printf '%s\n' "$protected" | grep -qxF "$1"; }
+
+  # branch -> newest PR state
+  pr_state() {
+    jq -r --arg b "$1" 'map(select(.headRefName==$b)) | sort_by(.number) | last | .state // "NONE"' <<<"$prs"
+  }
+
+  ahead_of_main() { git rev-list --count "origin/$DEFAULT_BRANCH..$1" 2>/dev/null || echo 999; }
+
+  # ---- worktrees
+  local wt_del="[]" wt_keep="[]"
+  local wt br locked dirty state reason
+  while IFS= read -r line; do
+    case "$line" in
+      worktree\ *) wt=${line#worktree }; br=""; locked=0 ;;
+      branch\ *)   br=${line#branch refs/heads/} ;;
+      locked*)     locked=1 ;;
+      "")
+        [ -n "${wt:-}" ] || continue
+        [ "$wt" = "$REPO_ROOT" ] && { wt=""; continue; }
+
+        dirty=$(git -C "$wt" status --porcelain 2>/dev/null \
+                 | grep -vE " ($(echo "$IGNORE_DIRTY" | tr ' ' '|'))$" | wc -l | tr -d ' ')
+        state=$( [ -n "$br" ] && pr_state "$br" || echo NONE )
+        reason=""
+
+        if [ -n "$br" ] && is_protected "$br"; then reason="protected branch"
+        elif [ "$dirty" -gt 0 ];                then reason="$dirty uncommitted file(s)"
+        elif [ "$locked" -eq 1 ] && [ "$INCLUDE_LOCKED" -eq 0 ]; then reason="locked (pass --include-locked)"
+        elif [ "$state" = "MERGED" ];           then reason=""
+        elif [ -z "$br" ];                      then reason=""            # detached, clean
+        elif [ "$(ahead_of_main "$br")" -eq 0 ]; then reason=""
+        else reason="$(ahead_of_main "$br") unmerged commit(s), PR=$state"
+        fi
+
+        if [ -z "$reason" ]; then
+          wt_del=$(jq --arg p "$wt" --arg b "$br" '. + [{path:$p,branch:$b}]' <<<"$wt_del")
+        else
+          wt_keep=$(jq --arg p "$wt" --arg b "$br" --arg r "$reason" '. + [{path:$p,branch:$b,reason:$r}]' <<<"$wt_keep")
+        fi
+        wt=""
+        ;;
+    esac
+  done < <(git worktree list --porcelain; echo)
+
+  # ---- local branches
+  local loc_del="[]" loc_keep="[]" n
+  while IFS= read -r br; do
+    [ "$br" = "$DEFAULT_BRANCH" ] && continue
+    if is_protected "$br"; then
+      loc_keep=$(jq --arg b "$br" '. + [{branch:$b,reason:"protected"}]' <<<"$loc_keep"); continue
+    fi
+    # A branch checked out in a surviving worktree cannot be deleted.
+    if git worktree list --porcelain | grep -qxF "branch refs/heads/$br"; then
+      if ! jq -e --arg b "$br" 'any(.[]; .branch==$b)' >/dev/null <<<"$wt_del"; then
+        loc_keep=$(jq --arg b "$br" '. + [{branch:$b,reason:"checked out in a retained worktree"}]' <<<"$loc_keep"); continue
+      fi
+    fi
+    state=$(pr_state "$br"); n=$(ahead_of_main "$br")
+    if [ "$state" = "MERGED" ] || [ "$n" -eq 0 ]; then
+      loc_del=$(jq --arg b "$br" '. + [$b]' <<<"$loc_del")
+    else
+      loc_keep=$(jq --arg b "$br" --arg r "$n unmerged commit(s), PR=$state" '. + [{branch:$b,reason:$r}]' <<<"$loc_keep")
+    fi
+  done < <(git for-each-ref --format='%(refname:short)' refs/heads/)
+
+  # ---- remote branches: MERGED PR only. A no-PR remote branch may be someone
+  # else's in-flight work, so "0 commits ahead" is not sufficient there.
+  local rem_del="[]"
+  while IFS= read -r br; do
+    is_protected "$br" && continue
+    [ "$(pr_state "$br")" = "MERGED" ] && rem_del=$(jq --arg b "$br" '. + [$b]' <<<"$rem_del")
+  done < <(git ls-remote --heads origin | sed 's#.*refs/heads/##')
+
+  jq -n --argjson wd "$wt_del" --argjson wk "$wt_keep" \
+        --argjson ld "$loc_del" --argjson lk "$loc_keep" --argjson rd "$rem_del" \
+        --arg d "$DEFAULT_BRANCH" '{
+     default_branch:$d,
+     worktrees:{delete:$wd, keep:$wk},
+     local_branches:{delete:$ld, keep:$lk},
+     remote_branches:{delete:$rd},
+     summary:{worktrees_delete:($wd|length), worktrees_keep:($wk|length),
+              local_delete:($ld|length),   local_keep:($lk|length),
+              remote_delete:($rd|length)}
+   }'
+}
+
+[ -n "$plan" ] || plan=$(analyse)
+
+if [ "$APPLY" -eq 0 ]; then
+  printf '%s\n' "$plan"
+  exit 0
+fi
+
+# -------------------------------------------------------------------- execute
+
+# Re-assert the invariants against the plan we are about to run. A plan handed
+# back after an approval pause may have been authored anywhere; the guards below
+# are the last thing standing between it and `git push --delete`.
+guard=$(jq -r --arg d "$DEFAULT_BRANCH" --arg r "$RELEASE_BRANCH" '
+  [ (.local_branches.delete // [])[], (.remote_branches.delete // [])[] ]
+  | map(select(. == $d or . == $r)) | .[]' <<<"$plan")
+[ -z "$guard" ] || { echo "refusing: plan targets a protected branch: $guard" >&2; exit 1; }
+
+open_heads=$(gh pr list --state open --limit 200 --json headRefName --jq '.[].headRefName')
+if [ -n "$open_heads" ]; then
+  clash=$(jq -r '[ (.local_branches.delete // [])[], (.remote_branches.delete // [])[] ] | .[]' <<<"$plan" \
+          | grep -xF -f <(printf '%s\n' "$open_heads") || true)
+  [ -z "$clash" ] || { echo "refusing: plan targets an open PR's branch: $clash" >&2; exit 1; }
+fi
+
+jq -r '.worktrees.delete[]? | .path' <<<"$plan" | while IFS= read -r p; do
+  [ -n "$p" ] || continue
+  git worktree unlock "$p" 2>/dev/null || true
+  git worktree remove --force "$p" && echo "worktree removed: $p"
+done
+git worktree prune
+
+mapfile -t locals < <(jq -r '.local_branches.delete[]?' <<<"$plan")
+if [ "${#locals[@]}" -gt 0 ]; then
+  # -D not -d: squash-merged branches are not ancestors of main, so -d refuses them.
+  git branch -D "${locals[@]}" >/dev/null && echo "local branches deleted: ${#locals[@]}"
+fi
+
+mapfile -t remotes < <(jq -r '.remote_branches.delete[]?' <<<"$plan")
+if [ "${#remotes[@]}" -gt 0 ]; then
+  # Chunked: one push per ~50 refs keeps the request small and a failure local.
+  i=0
+  while [ "$i" -lt "${#remotes[@]}" ]; do
+    chunk=("${remotes[@]:$i:50}")
+    git push origin --delete "${chunk[@]}" >/dev/null 2>&1 \
+      && echo "remote branches deleted: ${#chunk[@]}" \
+      || echo "warning: a remote chunk failed (already gone?)" >&2
+    i=$((i + 50))
+  done
+fi
+
+git remote prune origin >/dev/null 2>&1 || true
+echo "done"

--- a/tasks/examples/repo-prune/prune-stale-refs.test.sh
+++ b/tasks/examples/repo-prune/prune-stale-refs.test.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# Shell-level tests for prune-stale-refs.sh's guards, run against a throwaway
+# repo. The task's task.test.ts stubs Deno.Command, so nothing there exercises
+# the script itself — and the script is what does the deleting.
+#
+#   ./prune-stale-refs.test.sh
+#
+# `gh` is stubbed on PATH so no network call is made and the open-PR guard is
+# driven from a fixture.
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/prune-stale-refs.sh"
+PASS=0
+FAIL=0
+
+ok()   { PASS=$((PASS + 1)); printf '  ok   %s\n' "$1"; }
+bad()  { FAIL=$((FAIL + 1)); printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; }
+
+# A repo with a default branch and a `gh` stub that reports no PRs.
+new_repo() {
+  local d
+  d=$(mktemp -d)
+  git -C "$d" init -q -b main
+  git -C "$d" config user.email t@t.t
+  git -C "$d" config user.name t
+  git -C "$d" commit -q --allow-empty -m init
+  # `origin/main` must resolve: point the repo at itself.
+  git -C "$d" remote add origin "$d"
+  git -C "$d" fetch -q origin 2>/dev/null || true
+  git -C "$d" update-ref refs/remotes/origin/main refs/heads/main
+
+  mkdir -p "$d/.bin"
+  cat > "$d/.bin/gh" <<'STUB'
+#!/usr/bin/env bash
+# `gh pr list ... --json ...` → empty array; nothing else is called.
+echo '[]'
+STUB
+  chmod +x "$d/.bin/gh"
+  printf '%s' "$d"
+}
+
+run_apply() { # repo, plan-json -> output; never exits the harness
+  local d="$1" plan="$2"
+  printf '%s' "$plan" > "$d/plan.json"
+  ( cd "$d" && PATH="$d/.bin:$PATH" bash "$SCRIPT" --apply --plan "$d/plan.json" 2>&1 )
+}
+
+# ---------------------------------------------------------------- guard tests
+
+t_refuses_default_branch() {
+  local d out; d=$(new_repo)
+  out=$(run_apply "$d" '{"local_branches":{"delete":["main"]},"remote_branches":{"delete":[]},"worktrees":{"delete":[]}}')
+  if grep -q "protected branch: main" <<<"$out" && git -C "$d" show-ref -q refs/heads/main; then
+    ok "refuses a plan targeting the default branch"
+  else
+    bad "refuses a plan targeting the default branch" "$out"
+  fi
+  rm -rf "$d"
+}
+
+t_refuses_release_branch() {
+  local d out; d=$(new_repo)
+  git -C "$d" branch "release-please--branches--main"
+  out=$(run_apply "$d" '{"local_branches":{"delete":["release-please--branches--main"]},"remote_branches":{"delete":[]},"worktrees":{"delete":[]}}')
+  if grep -q "protected branch" <<<"$out" && git -C "$d" show-ref -q refs/heads/release-please--branches--main; then
+    ok "refuses a plan targeting the release branch"
+  else
+    bad "refuses a plan targeting the release branch" "$out"
+  fi
+  rm -rf "$d"
+}
+
+# A ref may legally be named `-D`. Without `--`, git parses it as a flag: the
+# branch survives and, worse, the flag changes what the command does.
+t_dash_named_branch_is_deleted_not_parsed_as_flag() {
+  local d out; d=$(new_repo)
+  git -C "$d" commit -q --allow-empty -m keep
+  git -C "$d" update-ref refs/heads/-D HEAD
+  git -C "$d" branch victim
+  out=$(run_apply "$d" '{"local_branches":{"delete":["victim","-D"]},"remote_branches":{"delete":[]},"worktrees":{"delete":[]}}')
+  if ! git -C "$d" show-ref -q "refs/heads/-D" && ! git -C "$d" show-ref -q refs/heads/victim; then
+    ok "a branch named -D is deleted as a ref, not swallowed as a flag"
+  else
+    bad "a branch named -D is deleted as a ref, not swallowed as a flag" "$out"
+  fi
+  rm -rf "$d"
+}
+
+t_refuses_unregistered_worktree_path() {
+  local d out victim; d=$(new_repo)
+  victim=$(mktemp -d); touch "$victim/precious"
+  out=$(run_apply "$d" "{\"local_branches\":{\"delete\":[]},\"remote_branches\":{\"delete\":[]},\"worktrees\":{\"delete\":[{\"path\":\"$victim\"}]}}")
+  if grep -q "not a worktree of this repo" <<<"$out" && [ -f "$victim/precious" ]; then
+    ok "refuses a worktree path that is not registered to this repo"
+  else
+    bad "refuses a worktree path that is not registered to this repo" "$out"
+  fi
+  rm -rf "$d" "$victim"
+}
+
+t_refuses_dirty_worktree() {
+  local d out; d=$(new_repo)
+  git -C "$d" worktree add -q -b wt "$d/../wt-$$" 2>/dev/null
+  local wt="$d/../wt-$$"
+  echo "uncommitted" > "$wt/scratch.txt"
+  out=$(run_apply "$d" "{\"local_branches\":{\"delete\":[]},\"remote_branches\":{\"delete\":[]},\"worktrees\":{\"delete\":[{\"path\":\"$(cd "$wt" && pwd)\"}]}}")
+  if grep -q "uncommitted work" <<<"$out" && [ -f "$wt/scratch.txt" ]; then
+    ok "refuses a worktree holding uncommitted work"
+  else
+    bad "refuses a worktree holding uncommitted work" "$out"
+  fi
+  git -C "$d" worktree remove --force "$wt" 2>/dev/null
+  rm -rf "$d" "$wt"
+}
+
+t_refuses_locked_worktree_without_flag() {
+  local d out; d=$(new_repo)
+  local wt="$d/../wtl-$$"
+  git -C "$d" worktree add -q -b wtl "$wt" 2>/dev/null
+  git -C "$d" worktree lock "$wt"
+  out=$(run_apply "$d" "{\"include_locked\":false,\"local_branches\":{\"delete\":[]},\"remote_branches\":{\"delete\":[]},\"worktrees\":{\"delete\":[{\"path\":\"$(cd "$wt" && pwd)\"}]}}")
+  if grep -q "locked worktree" <<<"$out" && [ -d "$wt" ]; then
+    ok "refuses a locked worktree unless include_locked was set"
+  else
+    bad "refuses a locked worktree unless include_locked was set" "$out"
+  fi
+  git -C "$d" worktree unlock "$wt" 2>/dev/null
+  git -C "$d" worktree remove --force "$wt" 2>/dev/null
+  rm -rf "$d" "$wt"
+}
+
+t_analysis_keeps_default_branch() {
+  local d out; d=$(new_repo)
+  git -C "$d" branch stale
+  out=$( cd "$d" && PATH="$d/.bin:$PATH" bash "$SCRIPT" 2>/dev/null )
+  if [ "$(jq -r '[.local_branches.delete[]] | index("main") // "absent"' <<<"$out")" = "absent" ]; then
+    ok "analysis never puts the default branch in the delete list"
+  else
+    bad "analysis never puts the default branch in the delete list" "$out"
+  fi
+  rm -rf "$d"
+}
+
+echo "prune-stale-refs.sh guards:"
+t_refuses_default_branch
+t_refuses_release_branch
+t_dash_named_branch_is_deleted_not_parsed_as_flag
+t_refuses_unregistered_worktree_path
+t_refuses_dirty_worktree
+t_refuses_locked_worktree_without_flag
+t_analysis_keeps_default_branch
+
+echo
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tasks/examples/repo-prune/task.test.ts
+++ b/tasks/examples/repo-prune/task.test.ts
@@ -1,0 +1,173 @@
+import { setupHarness } from "../../sdk-test.ts";
+import { resume } from "./task.ts";
+await setupHarness(import.meta.url);
+
+// suspend isn't part of the default mock surface; capture the request and throw
+// so the handler under test stops where the real runtime would exit.
+function captureSuspend() {
+  const calls: Record<string, unknown>[] = [];
+  const suspend = (req: Record<string, unknown>) => {
+    calls.push(req);
+    throw new Error("__suspended__");
+  };
+  return { calls, suspend };
+}
+
+const EMPTY_PLAN = {
+  summary: { worktrees_delete: 0, worktrees_keep: 0, local_delete: 0, local_keep: 3, remote_delete: 0 },
+  worktrees: { delete: [] },
+  local_branches: { delete: [] },
+  remote_branches: { delete: [] },
+};
+
+const FULL_PLAN = {
+  summary: { worktrees_delete: 1, worktrees_keep: 2, local_delete: 2, local_keep: 5, remote_delete: 1 },
+  worktrees: { delete: [{ path: "/repo/.wt/a", branch: "feat/a" }] },
+  local_branches: { delete: ["feat/a", "feat/b"] },
+  remote_branches: { delete: ["feat/a"] },
+};
+
+const origCommand = Deno.Command;
+
+/** Replace Deno.Command so no subprocess ever runs; record each argv. */
+function stubCommand(stdout: string, code = 0): string[][] {
+  const seen: string[][] = [];
+  const enc = new TextEncoder();
+  (Deno as unknown as Record<string, unknown>).Command = class {
+    #args: string[];
+    constructor(_bin: string, opts: { args: string[] }) {
+      this.#args = opts.args;
+    }
+    output() {
+      seen.push(this.#args);
+      return Promise.resolve({ code, stdout: enc.encode(stdout), stderr: enc.encode("") });
+    }
+  };
+  return seen;
+}
+
+function restore() {
+  (Deno as unknown as Record<string, unknown>).Command = origCommand;
+}
+
+test("nothing stale: returns early and never suspends", async () => {
+  const { calls, suspend } = captureSuspend();
+  (dicode as Record<string, unknown>).suspend = suspend;
+  stubCommand(JSON.stringify(EMPTY_PLAN));
+  params.set("repo_path", "/repo");
+  params.set("include_locked", "false");
+
+  const result = await runTask() as { applied: boolean; reason: string };
+
+  assert.equal(calls.length, 0);
+  assert.equal(result.applied, false);
+  assert.equal(result.reason, "nothing to prune");
+  restore();
+});
+
+test("a non-empty plan suspends for approval and carries the plan in state", async () => {
+  const { calls, suspend } = captureSuspend();
+  (dicode as Record<string, unknown>).suspend = suspend;
+  stubCommand(JSON.stringify(FULL_PLAN));
+  params.set("repo_path", "/repo");
+  params.set("include_locked", "false");
+
+  let threw = false;
+  try {
+    await runTask();
+  } catch {
+    threw = true;
+  }
+
+  assert.ok(threw);
+  assert.equal(calls.length, 1);
+  const req = calls[0] as {
+    schema: { required: string[]; title: string };
+    state: { plan: typeof FULL_PLAN };
+  };
+  assert.equal(req.schema.required[0], "approve");
+  // The plan the operator approves is the plan resume replays.
+  assert.equal(req.state.plan.local_branches.delete.length, 2);
+  // 1 worktree + 2 local + 1 remote.
+  assert.ok(req.schema.title.includes("4"), `want total 4 in title, got: ${req.schema.title}`);
+  restore();
+});
+
+test("include_locked is forwarded to the script", async () => {
+  const { suspend } = captureSuspend();
+  (dicode as Record<string, unknown>).suspend = suspend;
+  const seen = stubCommand(JSON.stringify(EMPTY_PLAN));
+  params.set("repo_path", "/repo");
+  params.set("include_locked", "true");
+
+  await runTask();
+
+  assert.ok(seen[0].includes("--include-locked"));
+  restore();
+});
+
+test("declining the plan applies nothing", async () => {
+  const seen = stubCommand("");
+
+  const result = await resume({
+    input: { approve: false, note: "not now" },
+    state: { plan: FULL_PLAN, repo: "/repo" },
+  } as never) as { applied: boolean; reason: string };
+
+  assert.equal(result.applied, false);
+  assert.equal(result.reason, "declined by operator");
+  assert.equal(seen.length, 0);
+  restore();
+});
+
+test("approving replays the approved plan verbatim via --apply --plan", async () => {
+  const seen = stubCommand("worktree removed: /repo/.wt/a\ndone");
+  const writes: Record<string, string> = {};
+  const origWrite = Deno.writeTextFile;
+  const origRemove = Deno.remove;
+  (Deno as unknown as Record<string, unknown>).writeTextFile = (p: string, c: string) => {
+    writes[p] = c;
+    return Promise.resolve();
+  };
+  (Deno as unknown as Record<string, unknown>).remove = () => Promise.resolve();
+
+  const result = await resume({
+    input: { approve: true },
+    state: { plan: FULL_PLAN, repo: "/repo" },
+  } as never) as { applied: boolean };
+
+  assert.equal(result.applied, true);
+  assert.ok(seen[0].includes("--apply"));
+  assert.ok(seen[0].includes("--plan"), "replays a plan file rather than re-analysing");
+  assert.equal(JSON.parse(writes["/repo/.git/prune-plan.json"]).local_branches.delete.length, 2);
+
+  (Deno as unknown as Record<string, unknown>).writeTextFile = origWrite;
+  (Deno as unknown as Record<string, unknown>).remove = origRemove;
+  restore();
+});
+
+test("a failing script surfaces its stderr rather than a bare exit code", async () => {
+  const { suspend } = captureSuspend();
+  (dicode as Record<string, unknown>).suspend = suspend;
+  (Deno as unknown as Record<string, unknown>).Command = class {
+    constructor(_bin: string, _opts: unknown) {}
+    output() {
+      return Promise.resolve({
+        code: 1,
+        stdout: new TextEncoder().encode(""),
+        stderr: new TextEncoder().encode("refusing: plan targets a protected branch: main"),
+      });
+    }
+  };
+  params.set("repo_path", "/repo");
+  params.set("include_locked", "false");
+
+  let msg = "";
+  try {
+    await runTask();
+  } catch (e) {
+    msg = (e as Error).message;
+  }
+  assert.ok(msg.includes("protected branch"), `want stderr in the error, got: ${msg}`);
+  restore();
+});

--- a/tasks/examples/repo-prune/task.ts
+++ b/tasks/examples/repo-prune/task.ts
@@ -1,0 +1,109 @@
+import type { DicodeSdk } from "../../sdk.ts";
+
+/**
+ * Analyse → approve → prune stale git worktrees and branches.
+ *
+ * main() runs the script read-only and suspends with the plan. resume() feeds
+ * that same plan back with --apply --plan, so the approved bytes are the
+ * executed bytes.
+ */
+
+const SCRIPT = new URL("./prune-stale-refs.sh", import.meta.url).pathname;
+
+interface Plan {
+  summary: {
+    worktrees_delete: number;
+    worktrees_keep: number;
+    local_delete: number;
+    local_keep: number;
+    remote_delete: number;
+  };
+  worktrees: { delete: { path: string; branch: string }[] };
+  local_branches: { delete: string[] };
+  remote_branches: { delete: string[] };
+}
+
+async function sh(args: string[], cwd: string): Promise<string> {
+  const cmd = new Deno.Command("bash", { args: [SCRIPT, ...args], cwd, stdout: "piped", stderr: "piped" });
+  const { code, stdout, stderr } = await cmd.output();
+  const out = new TextDecoder().decode(stdout);
+  const err = new TextDecoder().decode(stderr).trim();
+  if (code !== 0) {
+    throw new Error(`prune-stale-refs.sh ${args.join(" ")} exited ${code}: ${err || "(no stderr)"}`);
+  }
+  if (err) console.warn(`prune script stderr: ${err}`);
+  return out;
+}
+
+/** A one-line-per-ref preview, capped: a 250-branch list in a form is unreadable. */
+function preview(names: string[], cap = 12): string {
+  if (names.length === 0) return "(none)";
+  const head = names.slice(0, cap).join("\n");
+  return names.length > cap ? `${head}\n… and ${names.length - cap} more` : head;
+}
+
+export default async function main({ params, dicode }: DicodeSdk) {
+  const repo = (await params.get("repo_path")) ?? "";
+  const includeLocked = (await params.get("include_locked")) === "true";
+
+  console.log(`repo-prune: analysing ${repo} (include_locked=${includeLocked})`);
+  const plan: Plan = JSON.parse(await sh(includeLocked ? ["--include-locked"] : [], repo));
+  const s = plan.summary;
+
+  const total = s.worktrees_delete + s.local_delete + s.remote_delete;
+  if (total === 0) {
+    console.log("repo-prune: nothing stale");
+    return { applied: false, reason: "nothing to prune", summary: s };
+  }
+
+  const worktrees = plan.worktrees.delete.map((w) => w.path);
+  console.log(`repo-prune: ${total} stale ref(s) — pausing for approval`);
+
+  await dicode.suspend({
+    state: { plan, repo },
+    // A destructive plan should not wait forever for a human.
+    deadline: Date.now() + 24 * 60 * 60 * 1000,
+    schema: {
+      type: "object",
+      title: `Prune ${total} stale ref(s) from ${repo}?`,
+      description:
+        `Worktrees: ${s.worktrees_delete} delete / ${s.worktrees_keep} keep\n` +
+        `Local branches: ${s.local_delete} delete / ${s.local_keep} keep\n` +
+        `Remote branches: ${s.remote_delete} delete\n\n` +
+        `Worktrees:\n${preview(worktrees)}\n\n` +
+        `Local:\n${preview(plan.local_branches.delete)}\n\n` +
+        `Remote:\n${preview(plan.remote_branches.delete)}\n\n` +
+        `Remote deletions are restorable from each merged PR's page on GitHub.`,
+      properties: {
+        approve: { type: "boolean", title: "Execute this plan", default: false },
+        note: { type: "string", title: "Note (recorded in the run log)", default: "" },
+      },
+      required: ["approve"],
+    },
+  });
+  // Unreachable — suspend() never returns.
+}
+
+export async function resume({ input, state }: DicodeSdk) {
+  const { approve, note = "" } = input as { approve: boolean; note?: string };
+  const { plan, repo } = state as { plan: Plan; repo: string };
+
+  if (!approve) {
+    console.log(`repo-prune: declined${note ? ` — ${note}` : ""}`);
+    return { applied: false, reason: "declined by operator", note };
+  }
+
+  // Hand the approved plan back on disk rather than re-analysing: between the
+  // suspend and the resume the repo may have moved, and re-deriving would widen
+  // the blast radius past what was shown. Lives under .git/ so it is covered by
+  // the task's fs grant and never lands in a working tree.
+  const planPath = `${repo}/.git/prune-plan.json`;
+  await Deno.writeTextFile(planPath, JSON.stringify(plan));
+  try {
+    const out = await sh(["--apply", "--plan", planPath], repo);
+    console.log(`repo-prune: applied${note ? ` — ${note}` : ""}`);
+    return { applied: true, note, summary: plan.summary, output: out.trim().split("\n") };
+  } finally {
+    await Deno.remove(planPath).catch(() => {});
+  }
+}

--- a/tasks/examples/repo-prune/task.yaml
+++ b/tasks/examples/repo-prune/task.yaml
@@ -1,0 +1,48 @@
+apiVersion: dicode/v1
+kind: Task
+name: Repo Prune (example)
+description: |
+  Analyse a git repo for stale worktrees and branches (local + remote), pause for
+  a human to approve the exact deletion plan, then execute it.
+
+  The analysis phase is read-only and its output is a plan. The run suspends with
+  that plan carried in its state; on resume the plan is executed verbatim via
+  `--apply --plan`, so nothing is re-derived after approval — what a human read is
+  what runs. The script re-asserts its own guards (never the default branch, the
+  release branch, or an open PR's head) before deleting anything, so a tampered
+  plan is refused rather than trusted.
+
+  Triggered by an authenticated webhook: POST /hooks/repo-prune. A destructive
+  operation should not sit behind an unauthenticated URL.
+runtime: deno
+
+trigger:
+  webhook: /hooks/repo-prune
+  # Require a dicode session. The alternative, webhook_secret HMAC, is fine for a
+  # machine caller; a session is the right gate when a human approves the suspend.
+  auth: true
+
+permissions:
+  run: ["bash", "git", "gh", "jq"]
+  env:
+    # git/gh/jq resolution and gh's credential lookup.
+    - PATH
+    - HOME
+    # gh auth in a headless daemon; omit to fall back to ~/.config/gh.
+    - { name: GH_TOKEN, secret: gh_token }
+  fs:
+    - path: "${HOME}/dicode/dicode-core"
+      permission: rw
+
+params:
+  repo_path:
+    type: string
+    default: "${HOME}/dicode/dicode-core"
+  # Locked worktrees are locked on purpose. Opt in explicitly.
+  include_locked:
+    type: boolean
+    default: false
+
+# The analysis phase shells out to `gh pr list` once and `git rev-list` per
+# branch; a few hundred branches takes well over the 60s default.
+timeout: 600s

--- a/tasks/examples/taskset.yaml
+++ b/tasks/examples/taskset.yaml
@@ -172,3 +172,7 @@ spec:
               task: auth/openrouter-oauth
         net:
           - openrouter.ai
+
+    repo-prune:
+      ref:
+        path: ./repo-prune/task.yaml


### PR DESCRIPTION
## Summary

An example task that puts the suspend primitive in front of a genuinely destructive operation: pruning stale git worktrees and branches, local and remote.

The shape is the point. `main()` runs `prune-stale-refs.sh` read-only and gets back a **plan** — a JSON value listing exactly what would be deleted and what is kept, with a reason for each exclusion. It suspends with that plan carried in `state` and a summary rendered in the form. `resume()` replays the approved plan via `--apply --plan` rather than re-analysing, so the bytes a human read are the bytes that execute. Between approval and execution the repo can move; re-deriving would silently widen the blast radius past what was shown.

Approval is not the only guard. The script re-asserts its invariants against whatever plan it is handed, so a tampered or stale plan is refused rather than trusted:

- never the default branch
- never the release-please branch — it is reused across releases, so old merged release PRs make it *look* safe while the current release PR still needs it
- never an open PR's head branch
- never a worktree with uncommitted work, or a branch holding unmerged commits

A ref counts as safe only when its content is already on the default branch: its PR is **MERGED**, or it carries zero commits beyond `origin/main`. Checking the PR state matters — squash-merges rewrite commit ids, so `git branch --merged` and `git cherry` both report a squash-merged branch as unmerged and would strand hundreds of dead refs.

Triggered by an authenticated webhook (`auth: true`). A destructive operation should not sit behind an unauthenticated URL, and a session is the right gate when a human approves the pause.

## Test plan

`dicode task test examples/repo-prune` — 6 passed, 0 failed. `Deno.Command` is stubbed so no subprocess runs:

- empty plan returns early and never suspends
- a non-empty plan suspends, and the plan lands in `state` intact
- `include_locked` reaches the script's argv
- declining spawns no subprocess at all
- approving invokes `--apply --plan`, and the JSON written is the JSON approved
- a failing script surfaces its stderr, not a bare exit code

The script's guards were exercised directly against this repo: a hand-authored plan targeting `main` is refused (`refusing: plan targets a protected branch: main`), as is one targeting an open PR's branch, with nothing deleted in either case.

## Note

Depends on nothing, but pairs with #547: a webhook task that suspends currently 404s instead of showing its resume form, which is how that bug was found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)