### PR TITLE
fix(trigger): stop Register from deleting the webhook path it re-claims

### DIFF
--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -464,7 +464,16 @@ func (e *Engine) Register(k task.Kinded) error {
 		// holds pipelines), but the delete is a cheap no-op safeguard if a
 		// pipeline is ever replaced in-place by a Task of the same ID.
 		delete(e.deferredPipelines, s.ID)
-		e.unregisterTriggers(s.ID)
+		// Keep the webhook path this registration is about to re-claim, so a
+		// request in flight during a reload never sees it missing. Only when the
+		// path will actually be re-added below: a disabled task arms no triggers,
+		// and registerWebhookPath refuses the reserved OAuth path.
+		keep := ""
+		if s.Enabled && s.Trigger.Webhook != "" &&
+			!(s.Trigger.Webhook == reservedOAuthCompletePath && s.ID != oauthRelayBuiltinID) {
+			keep = s.Trigger.Webhook
+		}
+		e.unregisterTriggersKeeping(s.ID, keep)
 
 		// Disabled tasks are kept in the registry for API visibility but must not
 		// be scheduled, spawned as daemons, or registered as webhook endpoints.
@@ -542,6 +551,18 @@ func (e *Engine) Unregister(id string) {
 // while already holding registerMu without deadlocking on a re-entrant lock.
 // Does NOT touch deferredPipelines (the caller handles that under registerMu).
 func (e *Engine) unregisterTriggers(id string) {
+	e.unregisterTriggersKeeping(id, "")
+}
+
+// unregisterTriggersKeeping is unregisterTriggers, except that a webhook path
+// the caller is about to re-claim for the same task is left in place.
+//
+// registerMu serialises registrations but webhook lookups only take e.mu, so a
+// request racing a re-registration would otherwise find the path gone between
+// the delete here and the re-add in registerWebhookPath, and 404. Every
+// Register re-registers (Engine.Start at boot, the reconciler on every content
+// change), so a live webhook could 404 for no reason the caller could see.
+func (e *Engine) unregisterTriggersKeeping(id, keepWebhookPath string) {
 	e.mu.Lock()
 	hadCron := false
 	if entryID, ok := e.cronEntries[id]; ok {
@@ -550,7 +571,7 @@ func (e *Engine) unregisterTriggers(id string) {
 		hadCron = true
 	}
 	for path, tid := range e.webhooks {
-		if tid == id {
+		if tid == id && path != keepWebhookPath {
 			delete(e.webhooks, path)
 		}
 	}

--- a/pkg/trigger/webhook_register_race_test.go
+++ b/pkg/trigger/webhook_register_race_test.go
@@ -1,0 +1,156 @@
+package trigger
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
+)
+
+type immediateExec struct{}
+
+func (immediateExec) Execute(_ context.Context, _ *task.Spec, opts pkgruntime.RunOptions) (*pkgruntime.RunResult, error) {
+	return &pkgruntime.RunResult{RunID: opts.RunID}, nil
+}
+
+func raceEnv(t *testing.T) (*Engine, *registry.Registry) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+	eng := New(reg, immediateExec{}, zap.NewNop())
+	eng.RegisterExecutor(task.RuntimeDocker, immediateExec{})
+	return eng, reg
+}
+
+func webhookSpec(id, path string, enabled bool) *task.Spec {
+	return &task.Spec{
+		ID: id, Name: id, Runtime: task.RuntimeDocker,
+		Docker:  &task.DockerConfig{Image: "alpine"},
+		Trigger: task.TriggerConfig{Webhook: path},
+		Enabled: enabled,
+	}
+}
+
+// The invariant behind the fix: re-registering a task must never take its own
+// webhook path out of the routing map, even transiently. Registration is
+// serialised by registerMu but lookups only take e.mu, so a path deleted here
+// and re-added a moment later is a live 404 for any request in between.
+func TestUnregisterTriggersKeeping_RetainsReclaimedPath(t *testing.T) {
+	eng, _ := raceEnv(t)
+	spec := webhookSpec("keep", "/hooks/keep", true)
+	if err := eng.Register(spec); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	eng.unregisterTriggersKeeping(spec.ID, spec.Trigger.Webhook)
+
+	eng.mu.Lock()
+	got, ok := eng.webhooks["/hooks/keep"]
+	eng.mu.Unlock()
+	if !ok || got != "keep" {
+		t.Fatalf("webhooks[/hooks/keep] = %q,%v; the re-claimed path must never be removed", got, ok)
+	}
+}
+
+// The complement: a path that is NOT being re-claimed is still torn down, so a
+// renamed, disabled, or removed task frees its route.
+func TestUnregisterTriggersKeeping_DropsUnclaimedPath(t *testing.T) {
+	eng, _ := raceEnv(t)
+	spec := webhookSpec("drop", "/hooks/old", true)
+	if err := eng.Register(spec); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	eng.unregisterTriggersKeeping(spec.ID, "/hooks/new")
+
+	eng.mu.Lock()
+	_, stillThere := eng.webhooks["/hooks/old"]
+	eng.mu.Unlock()
+	if stillThere {
+		t.Fatal("webhooks[/hooks/old] survived; a path not being re-claimed must be dropped")
+	}
+}
+
+// A disabled task arms no triggers, so re-registering it must free the route
+// rather than keep it (Register passes keep="" when !Enabled).
+func TestRegister_DisabledTaskReleasesWebhookPath(t *testing.T) {
+	eng, _ := raceEnv(t)
+	if err := eng.Register(webhookSpec("toggle", "/hooks/toggle", true)); err != nil {
+		t.Fatalf("Register enabled: %v", err)
+	}
+	if err := eng.Register(webhookSpec("toggle", "/hooks/toggle", false)); err != nil {
+		t.Fatalf("Register disabled: %v", err)
+	}
+
+	eng.mu.Lock()
+	_, stillThere := eng.webhooks["/hooks/toggle"]
+	eng.mu.Unlock()
+	if stillThere {
+		t.Fatal("a disabled task kept its webhook route")
+	}
+}
+
+// End-to-end: hammer the endpoint while the task is re-registered underneath it.
+// Every fire must be served. Before the fix this 404s intermittently, which is
+// what made TestShutdownDrainsInFlightSyncWebhookRun flake — its body never ran.
+func TestWebhookNeverFourOhFoursDuringReRegister(t *testing.T) {
+	eng, reg := raceEnv(t)
+	spec := webhookSpec("hot", "/hooks/hot", true)
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("reg.Register: %v", err)
+	}
+	if err := eng.Register(spec); err != nil {
+		t.Fatalf("eng.Register: %v", err)
+	}
+
+	handler := eng.WebhookHandler()
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	notFound := 0
+
+	stop := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				eng.Register(spec) //nolint:errcheck
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 300; i++ {
+			req := httptest.NewRequest(http.MethodPost, "/hooks/hot", nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			if w.Code == http.StatusNotFound {
+				mu.Lock()
+				notFound++
+				mu.Unlock()
+			}
+		}
+		close(stop)
+	}()
+	wg.Wait()
+
+	if notFound > 0 {
+		t.Errorf("%d/300 fires 404'd while the task stayed registered throughout", notFound)
+	}
+}


### PR DESCRIPTION
## Summary

A webhook POST that arrives while its task is being re-registered gets a **404**, even though the task is registered the whole time.

`Engine.Register` calls `unregisterTriggers` and then re-arms the triggers. Registration is serialised by `registerMu`, but webhook lookups take only `e.mu` — so `unregisterTriggers` deletes the path under `e.mu`, `registerWebhookPath` re-adds it under `e.mu`, and any request landing between those two critical sections finds no route. `registerWebhookPath` already tolerates a task re-claiming its own path, so the delete was never necessary in the first place.

This is not rare. `Engine.Start` re-registers every spec at boot, and the reconciler re-registers a task on every content change — the documented "no restart needed after git push" path. A regression test that hammers the endpoint while re-registering measured **177/300 fires 404'ing** before this change, and 0/300 after.

`Register` now keeps a webhook path it is about to re-claim. A path that is *not* re-claimed — the task was renamed, disabled, or removed — is still torn down, and the reserved OAuth path stays refused.

## How it was found

It is the root cause of `TestShutdownDrainsInFlightSyncWebhookRun`, which has been flaking since #532 and blocked two unrelated PRs today. Its webhook fire raced `Start`'s re-registration and 404'd, so the task body never ran and the test timed out waiting on it.

I misdiagnosed this once already. #542 read the fixed 2s wait as a tight timeout and raised it to 30s. The test then failed at **30.1s** instead of 2.0s — the wait was never the problem, and the higher bound only made the failure slower. #542 is still correct on its own terms (a scheduling wait should not masquerade as a timing assertion) but it fixed a symptom, not this.

## Test plan

`pkg/trigger/webhook_register_race_test.go`:

- `TestUnregisterTriggersKeeping_RetainsReclaimedPath` — the invariant: a re-claimed path is never removed, even transiently.
- `TestUnregisterTriggersKeeping_DropsUnclaimedPath` — the complement: a path not being re-claimed is still freed, so a rename releases its route.
- `TestRegister_DisabledTaskReleasesWebhookPath` — a disabled task arms no triggers and must give up its route.
- `TestWebhookNeverFourOhFoursDuringReRegister` — hammers the endpoint while re-registering. **177/300 fires 404'd with the fix neutered; 0/300 with it.**

Verified the originally-flaky test is stable: `-run TestShutdownDrainsInFlightSyncWebhookRun -count=20` under 8-way CPU load passes in 6s (it previously failed at the 30s bound under the same load).

## Gate results

```
make build                          ✅
go vet ./pkg/trigger/               ✅
gofmt -l pkg/trigger/               ✅ (clean)
go test ./pkg/trigger/ -race        ✅ (64s)
new tests, -count=5 -race           ✅
make test-e2e                       ⚠️ not runnable in this sandbox (blocked Deno
                                       download); CI's Playwright job covers it
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)