### PR TITLE
fix(cli): stop `dicode run` hanging on a task that suspends

### DIFF
--- a/cmd/dicode/task_test.go
+++ b/cmd/dicode/task_test.go
@@ -98,6 +98,9 @@ func (noopEngine) FireFromTask(context.Context, string, string, map[string]strin
 func (noopEngine) WaitRun(context.Context, string) (ipc.RunResult, error) {
 	return ipc.RunResult{}, nil
 }
+func (noopEngine) WaitRunSettled(context.Context, string) (ipc.RunResult, error) {
+	return ipc.RunResult{}, nil
+}
 func (noopEngine) ActiveRunCount() int     { return 0 }
 func (noopEngine) ActiveTaskSlots() int    { return 0 }
 func (noopEngine) MaxConcurrentTasks() int { return 0 }

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -624,7 +624,10 @@ func (cs *ControlServer) handleRun(ctx context.Context, req Request) (RunResult,
 	if err != nil {
 		return RunResult{}, err
 	}
-	return cs.engine.WaitRun(ctx, runID)
+	// Settled, not WaitRun: a task that suspends must surface as `suspended` so
+	// the CLI can render its resume form. WaitRun follows the resume chain and
+	// would block until someone else answers the wizard.
+	return cs.engine.WaitRunSettled(ctx, runID)
 }
 
 // handleRunWait blocks until an existing run reaches a terminal or suspended
@@ -650,7 +653,7 @@ func (cs *ControlServer) handleRunWait(ctx context.Context, req Request) (RunRes
 			return RunResult{RunID: run.ID, Status: run.Status}, nil
 		}
 	}
-	return cs.engine.WaitRun(ctx, req.RunID)
+	return cs.engine.WaitRunSettled(ctx, req.RunID)
 }
 
 func (cs *ControlServer) handleLogs(ctx context.Context, req Request) ([]LogEntry, error) {

--- a/pkg/ipc/control_run_suspend_test.go
+++ b/pkg/ipc/control_run_suspend_test.go
@@ -1,0 +1,74 @@
+package ipc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	"go.uber.org/zap"
+)
+
+// waiterProbeEngine reports which waiter the control server chose. cli.run and
+// cli.run.wait must use WaitRunSettled: WaitRun follows a suspended run's resume
+// chain, so the CLI would block instead of rendering the wizard.
+type waiterProbeEngine struct {
+	mockEngine
+	usedWaitRun    bool
+	usedWaitSettle bool
+}
+
+func (r *waiterProbeEngine) WaitRun(_ context.Context, _ string) (RunResult, error) {
+	r.usedWaitRun = true
+	return RunResult{Status: "success"}, nil
+}
+
+func (r *waiterProbeEngine) WaitRunSettled(_ context.Context, runID string) (RunResult, error) {
+	r.usedWaitSettle = true
+	return RunResult{RunID: runID, Status: "suspended"}, nil
+}
+
+func TestCLIRun_UsesSettledWaiterSoSuspendedSurfaces(t *testing.T) {
+	eng := &waiterProbeEngine{}
+	cs := &ControlServer{engine: eng, log: zap.NewNop()}
+
+	res, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.run", TaskID: "wizard"})
+	if err != nil {
+		t.Fatalf("dispatch cli.run: %v", err)
+	}
+
+	if eng.usedWaitRun {
+		t.Error("cli.run used WaitRun; a suspending task would hang the CLI instead of showing its resume form")
+	}
+	if !eng.usedWaitSettle {
+		t.Fatal("cli.run did not use WaitRunSettled")
+	}
+	rr, ok := res.(RunResult)
+	if !ok {
+		t.Fatalf("result type = %T, want RunResult", res)
+	}
+	if rr.Status != "suspended" {
+		t.Errorf("status = %q, want the suspended status passed through to the CLI", rr.Status)
+	}
+}
+
+func TestCLIRunWait_UsesSettledWaiter(t *testing.T) {
+	eng := &waiterProbeEngine{}
+	// handleRunWait consults the registry to short-circuit daemon runs.
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	cs := &ControlServer{engine: eng, reg: registry.New(d), log: zap.NewNop()}
+
+	if _, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.run.wait", RunID: "run-1"}); err != nil {
+		t.Fatalf("dispatch cli.run.wait: %v", err)
+	}
+	if eng.usedWaitRun {
+		t.Error("cli.run.wait used WaitRun; the follow loop would block past a suspended continuation")
+	}
+	if !eng.usedWaitSettle {
+		t.Fatal("cli.run.wait did not use WaitRunSettled")
+	}
+}

--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -201,6 +201,10 @@ type EngineRunner interface {
 	// so the IPC server can stamp the caller's run ID on the new run (#116).
 	FireFromTask(ctx context.Context, taskID, parentRunID string, params map[string]string) (string, error)
 	WaitRun(ctx context.Context, runID string) (RunResult, error)
+	// WaitRunSettled stops at a suspended run instead of following its resume
+	// chain. The CLI needs this to render the resume form; dicode.run_task wants
+	// WaitRun's "block until genuinely terminal" contract.
+	WaitRunSettled(ctx context.Context, runID string) (RunResult, error)
 	ActiveRunCount() int
 	ActiveTaskSlots() int
 	MaxConcurrentTasks() int

--- a/pkg/ipc/server_test.go
+++ b/pkg/ipc/server_test.go
@@ -41,6 +41,9 @@ func (m *mockEngine) FireFromTask(_ context.Context, _ string, parentRunID strin
 func (m *mockEngine) WaitRun(_ context.Context, _ string) (RunResult, error) {
 	return m.result, m.err
 }
+func (m *mockEngine) WaitRunSettled(_ context.Context, _ string) (RunResult, error) {
+	return m.result, m.err
+}
 func (m *mockEngine) ActiveRunCount() int     { return 0 }
 func (m *mockEngine) ActiveTaskSlots() int    { return 0 }
 func (m *mockEngine) MaxConcurrentTasks() int { return 0 }

--- a/pkg/trigger/run.go
+++ b/pkg/trigger/run.go
@@ -142,6 +142,14 @@ func (e *Engine) WaitRun(ctx context.Context, runID string) (ipc.RunResult, erro
 	}
 }
 
+// WaitRunSettled is waitRunSettled for callers outside pkg/trigger. The CLI's
+// run/resume follow mode needs to observe `suspended` to render the resume form;
+// WaitRun would block past it, through the whole resume chain, and the wizard
+// would never be shown.
+func (e *Engine) WaitRunSettled(ctx context.Context, runID string) (ipc.RunResult, error) {
+	return e.waitRunSettled(ctx, runID)
+}
+
 // waitRunSettled blocks until the run's goroutine finishes (or is already done)
 // and returns its current record, including a non-terminal `suspended`. It does
 // not follow the resume chain — callers that must observe `suspended` directly

--- a/pkg/trigger/waitrun_settled_test.go
+++ b/pkg/trigger/waitrun_settled_test.go
@@ -1,0 +1,95 @@
+package trigger
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	"go.uber.org/zap"
+)
+
+// WaitRun and WaitRunSettled deliberately disagree about a suspended run:
+// dicode.run_task wants "block until genuinely terminal" (#516), while the CLI
+// must observe `suspended` to render the resume form. Collapsing the two hangs
+// `dicode run` on any task that suspends.
+func waitEnv(t *testing.T) (*Engine, *registry.Registry) {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+	return New(reg, immediateExec{}, zap.NewNop()), reg
+}
+
+func suspendedRun(t *testing.T, reg *registry.Registry) string {
+	t.Helper()
+	ctx := context.Background()
+	runID, err := reg.StartRun(ctx, "wizard", "")
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	schema := []byte(`{"type":"object","properties":{"a":{"type":"string"}}}`)
+	ok, err := reg.SuspendRun(ctx, runID, []byte(`{}`), schema, "tok", 1, 0, nil)
+	if err != nil || !ok {
+		t.Fatalf("SuspendRun: ok=%v err=%v", ok, err)
+	}
+	return runID
+}
+
+func TestWaitRunSettled_ReturnsSuspendedImmediately(t *testing.T) {
+	eng, reg := waitEnv(t)
+	runID := suspendedRun(t, reg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+	var got string
+	go func() {
+		res, err := eng.WaitRunSettled(ctx, runID)
+		if err == nil {
+			got = res.Status
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitRunSettled blocked on a suspended run; the CLI would never render the resume form")
+	}
+	if got != string(registry.StatusSuspended) {
+		t.Fatalf("status = %q, want %q", got, registry.StatusSuspended)
+	}
+}
+
+// The complement: WaitRun must NOT settle on `suspended` — it follows the resume
+// chain. A caller that wants the pause has to ask for it.
+func TestWaitRun_DoesNotReturnWhileSuspended(t *testing.T) {
+	eng, reg := waitEnv(t)
+	runID := suspendedRun(t, reg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 700*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		eng.WaitRun(ctx, runID) //nolint:errcheck
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Returned only because ctx expired, which is the contract: bounded by the
+		// caller's timeout, not by the run reaching `suspended`.
+		if ctx.Err() == nil {
+			t.Fatal("WaitRun returned on a suspended run; it must follow the resume chain")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("WaitRun ignored its context deadline")
+	}
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -59,6 +59,7 @@ export default defineConfig({
         '**/run-input-persistence.spec.ts',
         '**/task-toggle.spec.ts',
         '**/suspend-resume.spec.ts',
+        '**/cli-suspend.spec.ts',
       ],
       use: {
         ...devices['Desktop Chrome'],

--- a/tests/e2e/cli-suspend.spec.ts
+++ b/tests/e2e/cli-suspend.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * cli-suspend.spec.ts
+ *
+ * End-to-end coverage for the `dicode` CLI against a suspending task.
+ *
+ * The webui surface is covered by suspend-resume.spec.ts. This drives the real
+ * binary, because the CLI and the engine disagreed about what a suspended run
+ * means and nothing caught it: `WaitRun` was changed to follow the resume chain
+ * (right for dicode.run_task), the CLI's follow loop shares that waiter and
+ * needs to observe `suspended` instead, and `dicode run` hung forever on any
+ * task that suspends. Every unit test stayed green.
+ *
+ * Only non-TTY paths are exercised here. With no TTY, `dicode run` takes the
+ * one-shot path unless --field answers can auto-advance the wizard — both of
+ * which are exactly the behaviours that broke.
+ */
+
+import { test, expect } from '@playwright/test';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { BINARY } from './helpers/dicode-server';
+
+const execFileAsync = promisify(execFile);
+
+const TASK_ID = 'e2e-tests/suspend-wizard';
+// Well under Playwright's per-test timeout: a hang must fail as a hang, not as
+// a suite timeout with no output.
+const CLI_TIMEOUT_MS = 20_000;
+
+/** Run the CLI against the e2e daemon, with stdin closed so no TTY is detected. */
+async function dicode(args: string[]): Promise<{ stdout: string; stderr: string }> {
+  const dataDir = process.env.DICODE_E2E_TEMP_DIR;
+  expect(dataDir, 'DICODE_E2E_TEMP_DIR must be set by the e2e daemon helper').toBeTruthy();
+
+  return execFileAsync(BINARY, args, {
+    env: { ...process.env, DICODE_DATA_DIR: dataDir! },
+    timeout: CLI_TIMEOUT_MS,
+    // The CLI aborts the daemon-autostart path when it cannot reach a terminal.
+    windowsHide: true,
+  });
+}
+
+test.describe('suspend/resume cli', () => {
+  test.setTimeout(90_000);
+
+  // The regression: `dicode run` blocked forever instead of printing the
+  // suspended run id, because it waited on a run that was waiting on it.
+  test('run --non-interactive prints the suspended run id and exits', async () => {
+    const { stdout } = await dicode(['run', TASK_ID, '--non-interactive']);
+
+    expect(stdout).toContain('suspended');
+    // The id is what makes the one-shot path scriptable — `dicode resume <id>`.
+    const runId = stdout.match(/[0-9a-f-]{36}/)?.[0];
+    expect(runId, `no run id in CLI output:\n${stdout}`).toBeTruthy();
+
+    // And it is genuinely resumable from that id.
+    const { stdout: resumed } = await dicode(['resume', runId!, 'project_name=cli-e2e']);
+    expect(resumed).toContain('resumed');
+  });
+
+  // Pre-supplied answers must auto-advance the wizard with no TTY and no prompt.
+  test('run --field auto-advances the wizard to success', async () => {
+    const { stdout } = await dicode([
+      'run',
+      TASK_ID,
+      '--field',
+      'project_name=cli-prefill',
+      '--non-interactive',
+    ]);
+
+    expect(stdout).toContain('success');
+    // The fixture's resume handler echoes the submitted value back as the result.
+    expect(stdout).toContain('cli-prefill');
+  });
+
+  // `dicode resume` with no args lists suspended runs — the discovery surface a
+  // headless operator uses after the one-shot path prints an id.
+  test('resume with no args lists the suspended run', async () => {
+    const { stdout: runOut } = await dicode(['run', TASK_ID, '--non-interactive']);
+    const runId = runOut.match(/[0-9a-f-]{36}/)?.[0];
+    expect(runId).toBeTruthy();
+
+    const { stdout: list } = await dicode(['resume']);
+    expect(list).toContain(runId!);
+    expect(list).toContain(TASK_ID);
+    // The field the run is waiting on is surfaced so the operator knows what to send.
+    expect(list).toContain('project_name');
+  });
+});

--- a/tests/e2e/suspend-resume.spec.ts
+++ b/tests/e2e/suspend-resume.spec.ts
@@ -102,4 +102,27 @@ test.describe('suspend/resume webui', () => {
     });
     expect(replay.status()).toBe(409);
   });
+
+  // A browser POSTing a webhook task's form is redirected to /runs/<id>/result.
+  // A suspended run has neither output nor a return value, so that page used to
+  // 404 — the operator saw "not found" where the resume form belongs (#547).
+  test('a suspended run\'s result page redirects to the resume form', async ({ request }) => {
+    const taskRes = await request.get(`/api/tasks/${encodeURIComponent(TASK_ID)}`);
+    if (!taskRes.ok()) {
+      test.skip(true, `${TASK_ID} not registered — fixture taskset missing it?`);
+      return;
+    }
+
+    const fireRes = await request.post(
+      `/api/tasks/${encodeURIComponent(TASK_ID)}/run`,
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+    expect(fireRes.ok()).toBe(true);
+    const { runId } = (await fireRes.json()) as { runId: string };
+    await waitForStatus(request, runId, 'suspended');
+
+    const res = await request.get(`/runs/${runId}/result`, { maxRedirects: 0 });
+    expect(res.status()).toBe(303);
+    expect(res.headers()['location']).toBe(`/hooks/webui/runs/${runId}`);
+  });
 });


### PR DESCRIPTION
## Summary

`dicode run examples/suspend-wizard` hangs forever and prints nothing. So does the `--field`/`--non-interactive` form, which is supposed to auto-advance the whole wizard. The run itself suspends correctly — the CLI just never hears about it.

`WaitRun` and the CLI's follow loop want opposite things from a suspended run:

- `dicode.run_task` (`pkg/ipc/server.go`) wants "block until genuinely terminal". #516 asked for exactly this, and #543 delivered it by making `WaitRun` follow the resume chain past `suspended`.
- The CLI (`cli.run`, `cli.run.wait`) must **observe** `suspended` — that is the signal to fetch the schema and render the wizard. `follow.go`'s own comment states the contract it relies on: *"WaitRun blocks until runID reaches a terminal or suspended state."*

Both went through `WaitRun`. After #543 the CLI waits for a resume that only it could have triggered.

The engine already had `waitRunSettled`, which stops at `suspended` and is used by the pipeline runner and provider resolution for the same reason. This exports it as `WaitRunSettled` and routes the two CLI entry points through it. `dicode.run_task`, `cli.ai`, and the git-pr builtin keep `WaitRun`.

## How it was found

Verifying the suspendable-tasks epic end-to-end after its last follow-up merged. Every issue was closed and every unit test green, but the headline command hung. The epic's own CLI surface was broken by a fix to the epic's own engine semantics, and nothing pinned the boundary between them.

## Test plan

Regression tests at both layers, each verified to fail without the fix.

`pkg/trigger/waitrun_settled_test.go` — the semantic split:
- `TestWaitRunSettled_ReturnsSuspendedImmediately` — settles on `suspended` rather than blocking.
- `TestWaitRun_DoesNotReturnWhileSuspended` — the complement: `WaitRun` follows the chain and is bounded only by the caller's context.

`pkg/ipc/control_run_suspend_test.go` — the wiring, so a refactor cannot silently reintroduce the hang:
- `TestCLIRun_UsesSettledWaiterSoSuspendedSurfaces`
- `TestCLIRunWait_UsesSettledWaiter`

Both fail with the call sites reverted (`cli.run used WaitRun; a suspending task would hang the CLI`).

Manually verified against a live daemon: the command that hung for 180s now auto-advances all three wizard steps and returns `{project: acme, framework: deno, confirmed: true}`.

## Gate results

```
make build                                ✅
go vet ./pkg/ipc/ ./pkg/trigger/           ✅
gofmt -l                                   ✅ (clean)
go test ./pkg/ipc/ ./pkg/trigger/          ✅
manual: dicode run --field … --non-interactive  ✅ completes
make test-e2e                              ⚠️ not runnable in this sandbox
                                              (blocked Deno download); CI covers it
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)