### PR TITLE
docs: fix stale deployment claims in business-model.md

### DIFF
--- a/docs/concepts/business-model.md
+++ b/docs/concepts/business-model.md
@@ -70,13 +70,12 @@ AGPL-3.0 license — copyleft that protects the project:
 ## Deployment profiles
 
 **Desktop** — default for laptops:
-- Tray icon with status
-- OS desktop notifications
+- Tray icon with status (`buildin/tray`)
+- OS desktop notifications (`buildin/notify`)
 - Relay client (laptop behind NAT -> public URLs)
-- Starts on login via `dicode service install`
 
 **Headless** — for servers and Docker:
-- `--headless` flag or `DICODE_HEADLESS=true`
+- `DICODE_ONBOARDING=silent` (or any environment without a TTY/display, which auto-selects the non-interactive surface)
 - No tray, no desktop notifications
 - Relay optional (skip if server has public IP)
 


### PR DESCRIPTION
## Summary

Follow-up to the docs reconciliation in #555, which missed `docs/concepts/business-model.md`. Its "Deployment profiles" section carried two claims that don't match the code:

- **`Starts on login via dicode service install`** — there is no `dicode service` command. The `pkg/service` stub (a `Manager` interface with no platform implementations and no CLI wiring) was deleted as dead code in the #388 architecture audit (PR #453), and the current docs mark run-on-login as "not currently planned." Dropped the bullet.
- **`--headless` flag or `DICODE_HEADLESS=true`** — neither exists. The onboarding surface is chosen by `DICODE_ONBOARDING` (`silent`/`cli`/`browser`) plus TTY/display auto-detection (`pkg/onboarding/surface.go`). Replaced with the real mechanism.

The rest of the section is accurate (tray, `buildin/notify` desktop notifications, relay client) and I annotated the tray/notify bullets with their backing buildin tasks. The pricing/strategy content is untouched.

Surfaced while answering a question about the tray and `dicode service` after #555 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment profile guidance for Desktop and Headless environments.
  * Documented Desktop tray status, OS notifications, and relay behavior behind NAT.
  * Updated Headless setup instructions to use `DICODE_ONBOARDING=silent` for non-interactive environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->