### PR TITLE
feat(tray): warn when no SNI host will show the icon + README

### DIFF
--- a/tasks/buildin/tray/README.md
+++ b/tasks/buildin/tray/README.md
@@ -1,0 +1,66 @@
+# buildin/tray — system tray icon
+
+A daemon task that shows dicode's status-bar icon with **Open Dashboard** and
+**Quit dicode** menu items. It drives a pre-compiled native helper
+(`systray-portable`) over stdin/stdout — no CGO, no GTK, no build dependency on
+the dicode binary (replaces the old `pkg/tray/` Go package; see
+[#59](https://github.com/dicode-ayo/dicode-core/issues/59)).
+
+Runtime: Deno. Trigger: `daemon: true`, `restart: always` — dicoded keeps it
+alive and relaunches it if the helper crashes. The dashboard port comes from
+`DICODE_PORT` (falls back to `8080`).
+
+## The icon doesn't show up (i3, dwm, bspwm, sway…)
+
+On Linux the tray uses the **StatusNotifierItem (SNI / AppIndicator)** DBus
+protocol. The icon only appears if a **StatusNotifierHost** — a compatible bar
+or tray — is running on your session bus. Full desktops (GNOME, KDE, XFCE)
+ship one; **bare window managers don't**, so the icon is silently invisible
+even though the task is running fine.
+
+Two things confuse people here:
+
+- **i3bar only supports the legacy XEmbed protocol, not SNI.** So even with
+  i3bar's `tray_output` enabled, an SNI icon won't show.
+- There's no error — the item registers into the void.
+
+The task logs a one-line hint at startup when it detects no SNI host (see
+"Startup hint" below).
+
+### Fixes
+
+- **polybar ≥ 3.6** has a native SNI tray. Add a tray module and use polybar as
+  your bar:
+  ```ini
+  [module/tray]
+  type = internal/tray
+  tray-size = 66%
+  ```
+- **waybar** (Wayland) supports SNI via its `tray` module.
+- **Stay on i3bar** by running an SNI→XEmbed bridge, then i3bar renders it:
+  ```
+  # ~/.config/i3/config
+  exec --no-startup-id snixembed        # or: xembedsniproxy (from KDE)
+  # in the bar { } block:
+  tray_output primary
+  ```
+  On Debian/Ubuntu: `sudo apt install snixembed`.
+
+macOS and Windows render the tray natively and are unaffected.
+
+## Startup hint
+
+At startup (on Linux, after a short grace period for the bar to come up) the
+task probes the session bus via `gdbus` for a registered SNI host
+(`IsStatusNotifierHostRegistered`). If none is found it logs an actionable hint
+pointing here. The probe is best-effort: if `gdbus` isn't available or the
+reply can't be read, it stays quiet rather than warning on a guess. See
+`sni.ts`.
+
+## Tests
+
+```
+make test-tasks
+# or just this task:
+deno test --allow-all --config=tasks/deno.json tasks/buildin/tray/task.test.ts
+```

--- a/tasks/buildin/tray/sni.ts
+++ b/tasks/buildin/tray/sni.ts
@@ -1,0 +1,87 @@
+// sni.ts — detect whether a Linux system-tray host will actually display the
+// icon.
+//
+// Linux tray icons use the StatusNotifierItem (SNI) DBus protocol. The icon is
+// only shown if a StatusNotifierHost (a compatible bar/tray) is registered on
+// the session bus. On bare window managers (i3/dwm/bspwm/sway) none runs by
+// default, so the icon is silently invisible with no error. macOS (Cocoa) and
+// Windows (Win32) render the tray natively and never hit this path.
+
+const WATCHERS = [
+  "org.kde.StatusNotifierWatcher",
+  "org.freedesktop.StatusNotifierWatcher",
+];
+
+/** Interpret a `gdbus call … IsStatusNotifierHostRegistered` reply
+ *  (e.g. `(<true>,)`). Returns null when the reply can't be interpreted. */
+export function parseHostRegistered(stdout: string): boolean | null {
+  if (/\btrue\b/.test(stdout)) return true;
+  if (/\bfalse\b/.test(stdout)) return false;
+  return null;
+}
+
+/** Query one watcher's IsStatusNotifierHostRegistered via gdbus. Returns the
+ *  raw stdout, or null if that watcher name is not registered. */
+async function gdbusRunner(dest: string): Promise<string | null> {
+  const { code, stdout } = await new Deno.Command("gdbus", {
+    args: [
+      "call", "--session", "--dest", dest,
+      "--object-path", "/StatusNotifierWatcher",
+      "--method", "org.freedesktop.DBus.Properties.Get",
+      dest, "IsStatusNotifierHostRegistered",
+    ],
+    stdout: "piped",
+    stderr: "null",
+  }).output();
+  return code === 0 ? new TextDecoder().decode(stdout) : null;
+}
+
+/** Best-effort: is an SNI host registered on the session bus?
+ *  - true/false when a watcher answers definitively,
+ *  - false when no watcher exists at all (a host is then impossible),
+ *  - null when we can't tell (gdbus missing/erroring, or an unreadable reply),
+ *    so callers can stay quiet instead of warning on a guess. */
+export async function probeSNIHost(
+  runner: (dest: string) => Promise<string | null> = gdbusRunner,
+): Promise<boolean | null> {
+  let sawWatcher = false;
+  for (const dest of WATCHERS) {
+    let out: string | null;
+    try {
+      out = await runner(dest);
+    } catch {
+      return null; // tooling unusable — don't nag
+    }
+    if (out === null) continue; // this watcher name absent, try the next
+    sawWatcher = true;
+    const registered = parseHostRegistered(out);
+    if (registered !== null) return registered;
+  }
+  return sawWatcher ? null : false;
+}
+
+/** An actionable hint when the tray icon will likely be invisible, else null.
+ *  Pure and synchronous so the decision is unit-testable. */
+export function trayVisibilityHint(
+  os: string,
+  hostRegistered: boolean | null,
+): string | null {
+  if (os !== "linux") return null; // macOS/Windows render natively
+  if (hostRegistered !== false) return null; // true = shown; null = unknown
+  return (
+    "tray: no StatusNotifierItem host is running on the session bus, so the " +
+    "icon will not appear. Bare window managers (i3/dwm/bspwm/sway) don't host " +
+    "SNI by default. Run an SNI-capable bar (polybar ≥3.6 `internal/tray`, " +
+    "waybar), or bridge to i3bar with `snixembed` / `xembedsniproxy`. " +
+    "See tasks/buildin/tray/README.md."
+  );
+}
+
+/** Probe the bus and, on Linux with no host, log a single actionable hint. */
+export async function warnIfTrayInvisible(
+  log: (msg: string) => void = console.warn,
+): Promise<void> {
+  if (Deno.build.os !== "linux") return;
+  const hint = trayVisibilityHint("linux", await probeSNIHost());
+  if (hint) log(hint);
+}

--- a/tasks/buildin/tray/task.test.ts
+++ b/tasks/buildin/tray/task.test.ts
@@ -1,0 +1,53 @@
+/**
+ * task.test.ts — unit tests for the tray task's SNI visibility hint.
+ *
+ * Run with:
+ *   deno test --allow-all --config=tasks/deno.json tasks/buildin/tray/task.test.ts
+ * or:
+ *   make test-tasks
+ */
+import { setupHarness } from "../../sdk-test.ts";
+await setupHarness(import.meta.url);
+
+import { parseHostRegistered, probeSNIHost, trayVisibilityHint } from "./sni.ts";
+
+test("trayVisibilityHint: no hint on macOS/Windows (native tray)", () => {
+  assert.equal(trayVisibilityHint("darwin", false), null);
+  assert.equal(trayVisibilityHint("windows", false), null);
+});
+
+test("trayVisibilityHint: no hint on Linux when a host is registered", () => {
+  assert.equal(trayVisibilityHint("linux", true), null);
+});
+
+test("trayVisibilityHint: no hint on Linux when the probe was inconclusive", () => {
+  assert.equal(trayVisibilityHint("linux", null), null);
+});
+
+test("trayVisibilityHint: Linux + no host → actionable hint", () => {
+  const h = trayVisibilityHint("linux", false);
+  assert.ok(h, "expected a hint string");
+  assert.ok(h!.includes("snixembed"), "hint should name a bridge");
+  assert.ok(h!.includes("README.md"), "hint should point at the README");
+});
+
+test("parseHostRegistered: reads gdbus true/false, null on garbage", () => {
+  assert.equal(parseHostRegistered("(<true>,)\n"), true);
+  assert.equal(parseHostRegistered("(<false>,)\n"), false);
+  assert.equal(parseHostRegistered("unexpected reply"), null);
+});
+
+test("probeSNIHost: false when no watcher name is registered", async () => {
+  assert.equal(await probeSNIHost(() => Promise.resolve(null)), false);
+});
+
+test("probeSNIHost: true when a watcher reports a host", async () => {
+  assert.equal(await probeSNIHost(() => Promise.resolve("(<true>,)")), true);
+});
+
+test("probeSNIHost: null when the runner throws (tooling missing)", async () => {
+  assert.equal(
+    await probeSNIHost(() => Promise.reject(new Error("no gdbus"))),
+    null,
+  );
+});

--- a/tasks/buildin/tray/task.ts
+++ b/tasks/buildin/tray/task.ts
@@ -5,6 +5,7 @@
 // No CGO, no GTK, no fyne dependency.
 
 import Systray, { type MenuItem } from "./systray/mod.ts";
+import { warnIfTrayInvisible } from "./sni.ts";
 
 // ── icon ─────────────────────────────────────────────────────────────────────
 //
@@ -98,6 +99,12 @@ export default async function main({ params }: DicodeSdk) {
 
   // Wait for the binary to be downloaded, started, and ready.
   await systray.ready();
+
+  // On bare WMs the SNI icon can be silently invisible; probe after a short
+  // grace period so the bar has a chance to register a host first.
+  setTimeout(() => {
+    warnIfTrayInvisible().catch(() => {});
+  }, 3000);
 
   systray.onClick((action) => {
     switch (action.item.title) {

--- a/tasks/buildin/tray/task.yaml
+++ b/tasks/buildin/tray/task.yaml
@@ -12,6 +12,9 @@ runtime: deno
 permissions:
   env:
     - DICODE_PORT
+  # Unrestricted because the systray helper binary runs from a dynamic temp
+  # path; the task also spawns xdg-open (Open Dashboard) and gdbus (SNI-host
+  # probe, see sni.ts). A future least-privilege pass must keep those covered.
   run:
     - "*"
   fs:


### PR DESCRIPTION
## Summary

The `buildin/tray` icon uses the **StatusNotifierItem (SNI / AppIndicator)** DBus protocol on Linux. The icon only renders if a **StatusNotifierHost** (a compatible bar/tray) is running on the session bus — full desktops ship one, but bare window managers (i3/dwm/bspwm/sway) don't, and i3bar speaks only the legacy **XEmbed** protocol. The result is a tray icon that is **silently invisible with no error**, which reads as a broken feature.

This makes the failure legible:

- **Startup hint** — shortly after the tray starts, on Linux, the task probes the session bus (best-effort, via `gdbus`) for `IsStatusNotifierHostRegistered`. When no host is found, it logs one actionable line pointing at the new README. The probe returns "unknown" (and stays quiet) when it can't tell — missing `gdbus`, an unreadable reply — rather than warning on a guess.
- **README** (`tasks/buildin/tray/README.md`) — documents the SNI-vs-XEmbed situation and the fixes: polybar ≥3.6 `internal/tray`, waybar, or `snixembed`/`xembedsniproxy` bridging to i3bar.

The decision logic (`trayVisibilityHint`) and the gdbus reply parser (`parseHostRegistered`) are pure and unit-tested; `probeSNIHost` takes an injectable runner so it's tested without spawning a subprocess. Verified end-to-end on a real i3 machine with no SNI host: the probe returns `false` and the hint fires as intended.

No behavior change on macOS/Windows (native tray) or on desktops that host SNI — the hint only appears when the icon genuinely won't show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
