### PR TITLE
feat(notify): actionable error when no notification daemon is running + README

### DIFF
--- a/tasks/buildin/notify/README.md
+++ b/tasks/buildin/notify/README.md
@@ -1,0 +1,42 @@
+# buildin/notify — native desktop notification
+
+Delivers a native OS desktop notification. Manual trigger; params: `title`
+(required), `body` (required), `priority` (`min|low|default|high|urgent`),
+`tags` (comma-separated emoji shortcodes), `icon` (Linux freedesktop icon
+name). Replaces the browser Service Worker notification system
+([#60](https://github.com/dicode-ayo/dicode-core/issues/60)).
+
+Delivery per platform:
+
+- **Linux** — `notify-send` (libnotify). Install with `apt install libnotify-bin`
+  / `pacman -S libnotify`.
+- **macOS** — `osascript display notification`.
+- **Windows** — PowerShell `NotifyIcon.ShowBalloonTip`.
+
+## Nothing appears on Linux (i3, dwm, sway…)
+
+`notify-send` only hands the message to the **`org.freedesktop.Notifications`**
+DBus interface — it does not draw anything itself. A **notification daemon**
+must be running to display it. Full desktops (GNOME, KDE, XFCE) ship one, but
+**bare window managers don't**, so `notify-send` can be installed and still show
+nothing. When no daemon is running (and none is D-Bus-activatable), the call
+fails with a GDBus `ServiceUnknown` error; the task rewrites that into an
+actionable message (see `failure.ts`) instead of surfacing the raw stack.
+
+### Fix
+
+Run a notification daemon:
+
+- **dunst** — the common choice on X11 / i3. `sudo apt install dunst`, then start
+  it from your WM (`exec --no-startup-id dunst`).
+- **mako** — for Wayland (sway).
+
+Full desktop environments need no extra setup.
+
+## Tests
+
+```
+make test-tasks
+# or just this task:
+deno test --allow-all --config=tasks/deno.json tasks/buildin/notify/task.test.ts
+```

--- a/tasks/buildin/notify/failure.ts
+++ b/tasks/buildin/notify/failure.ts
@@ -1,0 +1,32 @@
+// failure.ts — turn a failed notification command into an actionable error.
+//
+// On Linux, notify-send delivers over the org.freedesktop.Notifications DBus
+// interface. The `notify-send` binary can be installed and still deliver
+// nothing if no notification daemon is running (and none is D-Bus-activatable)
+// — the default on bare window managers (i3/dwm/bspwm/sway). In that case the
+// call fails with a GDBus ServiceUnknown error; translate it into a fix rather
+// than surfacing the raw GDBus stack. Non-Linux failures pass through unchanged.
+
+/** Does this stderr indicate that no notification server exists on the bus? */
+export function isNoNotificationServer(stderr: string): boolean {
+  const s = stderr.toLowerCase();
+  return s.includes("org.freedesktop.notifications") && (
+    s.includes("serviceunknown") ||
+    s.includes("not provided by any") ||
+    s.includes("was not provided") ||
+    s.includes("not activatable")
+  );
+}
+
+/** Actionable message for a failed notification command (exit `code`). */
+export function notifyFailureMessage(code: number, stderr: string): string {
+  if (isNoNotificationServer(stderr)) {
+    return (
+      "no desktop notification daemon is running, so the notification was not " +
+      "shown. Bare window managers (i3/dwm/bspwm/sway) don't start one by " +
+      "default — run dunst (X11) or mako (Wayland). See " +
+      "tasks/buildin/notify/README.md. Original error: " + stderr
+    );
+  }
+  return `notification command failed (exit ${code}): ${stderr}`;
+}

--- a/tasks/buildin/notify/task.test.ts
+++ b/tasks/buildin/notify/task.test.ts
@@ -1,0 +1,41 @@
+/**
+ * task.test.ts — unit tests for the notify task's failure-message mapping.
+ *
+ * Run with:
+ *   deno test --allow-all --config=tasks/deno.json tasks/buildin/notify/task.test.ts
+ * or:
+ *   make test-tasks
+ */
+import { setupHarness } from "../../sdk-test.ts";
+await setupHarness(import.meta.url);
+
+import { isNoNotificationServer, notifyFailureMessage } from "./failure.ts";
+
+const SERVICE_UNKNOWN =
+  "GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name " +
+  "org.freedesktop.Notifications was not provided by any .service files";
+
+test("isNoNotificationServer: true for a GDBus ServiceUnknown on Notifications", () => {
+  assert.ok(isNoNotificationServer(SERVICE_UNKNOWN));
+});
+
+test("isNoNotificationServer: false for unrelated failures", () => {
+  assert.equal(isNoNotificationServer("some other error"), false);
+  assert.equal(
+    isNoNotificationServer("org.freedesktop.Notifications delivered ok"),
+    false,
+  );
+});
+
+test("notifyFailureMessage: missing server → hint names dunst/mako + README", () => {
+  const m = notifyFailureMessage(1, SERVICE_UNKNOWN);
+  assert.ok(m.includes("dunst"), "should mention dunst");
+  assert.ok(m.includes("mako"), "should mention mako");
+  assert.ok(m.includes("README.md"), "should point at the README");
+});
+
+test("notifyFailureMessage: other failures pass through with the exit code", () => {
+  const m = notifyFailureMessage(2, "boom");
+  assert.ok(m.includes("exit 2"));
+  assert.ok(m.includes("boom"));
+});

--- a/tasks/buildin/notify/task.ts
+++ b/tasks/buildin/notify/task.ts
@@ -1,3 +1,4 @@
+import { notifyFailureMessage } from "./failure.ts";
 
 export default async function main({ params }: DicodeSdk) {
 // ── params ────────────────────────────────────────────────────────────────────
@@ -108,7 +109,7 @@ if (os === "linux") {
 const result = await new Deno.Command(cmd[0], { args: cmd.slice(1) }).output();
 if (!result.success) {
   const stderr = new TextDecoder().decode(result.stderr).trim();
-  throw new Error(`notification command failed (exit ${result.code}): ${stderr}`);
+  throw new Error(notifyFailureMessage(result.code, stderr));
 }
 
 console.log("notification dispatched", { title, priority, urgency, tags });


### PR DESCRIPTION
## Summary

Companion to the tray fix (#557) — the same "bare WM lacks a DBus host daemon" trap, for desktop notifications.

`notify-send` doesn't draw anything itself; it hands the message to the **`org.freedesktop.Notifications`** DBus interface, which a **notification daemon** must implement to display it. Full desktops (GNOME/KDE/XFCE) ship one, but bare window managers (i3/dwm/bspwm/sway) don't — so `notify-send` can be installed (the task already checks that) and still show nothing, failing with a cryptic `GDBus.Error:...ServiceUnknown` that the task rethrew verbatim.

The task now recognizes that specific failure signature and rewrites it into an actionable message (run **dunst** on X11, **mako** on Wayland) pointing at the new `README.md`. Every other failure passes through with its original text and exit code, and the **success path is untouched** — deliberately no preflight probe, which could false-negative and break a working notification.

The recognizer (`isNoNotificationServer`) and message builder (`notifyFailureMessage`) are pure and unit-tested; the README documents the daemon requirement and fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
