### PR TITLE
docs: correct claude-cli tool claim + adopt capability-scoped MCP as the agent surface

### DIFF
--- a/docs/design/ai-task-authoring.md
+++ b/docs/design/ai-task-authoring.md
@@ -60,6 +60,17 @@ suspendable task run.**
    every changed task (AI-authored included) pending operator approval. Save just lands the
    task; the gate reviews it. No bespoke AI review queue — #213 collapses to the autonomy
    dial.
+5. **Agents reach dicode capabilities through one governed surface: MCP.** Every backend
+   (`ai-agent`, `ai-agent-claude-cli`, future) authors by calling dicode's MCP tools, on the
+   same skills + prompts — not each model's raw tools and not the SDK. **This only closes
+   the privilege hole if MCP carries the capability model** (see #560): (a) restrict the raw
+   model tools so the agent can't bypass MCP (`claude --allowedTools` = the dicode tools
+   only, `--permission-mode`, confined cwd); (b) add **per-agent capability scoping** to
+   `/mcp` — today it is a single daemon-wide Bearer key with no per-caller scoping, so a
+   naive "give it MCP" would hand every agent full access; (c) grow the MCP surface to the
+   governed authoring tools (write-into-clone, test, commit/PR), lifting existing REST
+   (`/api/sources/{name}/commit-push`, `/api/tasks/{id}/test`) into it. The capability-gated
+   IPC control plane stays the enforcement point; MCP is its model-agnostic front door.
 
 ### Rejected alternatives
 
@@ -72,14 +83,16 @@ suspendable task run.**
 ## Backend matrix
 
 The authoring loop needs a **tool-using** agent (write files, call `tasks.test`, `git-pr`).
+Both backends are tool-capable; they differ in **how governed** those tools are.
 
-| Backend | Chat | Tool-using authoring loop |
-|---|---|---|
-| `buildin/ai-agent` (OpenAI-compatible, `OPENAI_API_KEY`) | ✅ | ✅ — the tool-calling loop + dicode SDK via the shim. Drives `auto-fix`/`task-create` today. |
-| `buildin/ai-agent-claude-cli` (Claude Pro/Max, `CLAUDE_CODE_OAUTH_TOKEN`) | ✅ | ⚠️ Not directly — runs `claude -p` (print mode), no filesystem tools, no dicode SDK. Tool-use for Claude requires wiring dicode's `/mcp` in (`dicode mcp install` + `enable_mcp`). |
+| Backend | Chat | Authoring | Governance today |
+|---|---|---|---|
+| `buildin/ai-agent` (OpenAI-compatible, `OPENAI_API_KEY`) | ✅ | ✅ | Governed — edits go through the capability-gated dicode SDK (dev-clone, `tasks.test`, `git-pr`). Drives `auto-fix` today. |
+| `buildin/ai-agent-claude-cli` (Claude Pro/Max, `CLAUDE_CODE_OAUTH_TOKEN`) | ✅ | ✅ | **Ungoverned.** `claude -p` runs with its full default tools (Read/Write/Edit/Bash) — the task passes no `--allowedTools`/`--permission-mode`, so as a subprocess it has host-wide fs/bash as the daemon user. A privilege hole; **must be restricted + routed through MCP** (#560). |
 
-So: Claude enables chat immediately on subscription; the flagship authoring loop runs on
-OpenAI `ai-agent` today, or Claude-via-MCP as a deliberate design choice.
+The end state (decision 5): both backends run the **same governed MCP path** on the same
+prompts. Claude-via-subscription becomes a first-class authoring backend *once* its raw
+tools are restricted and MCP is capability-scoped — not before.
 
 ## Phased plan
 

--- a/tasks/buildin/ai-agent-claude-cli/README.md
+++ b/tasks/buildin/ai-agent-claude-cli/README.md
@@ -224,10 +224,14 @@ follow-up to the auto-fix override.)
 
 ## Limitations
 
-- **No tool-use beyond what `claude -p` supports.** This wrapper invokes the
-  CLI in print mode, which doesn't enable Claude's filesystem / bash tools.
-  For tool-using agentic loops, drive Claude's own session machinery from
-  outside dicode (or wait for an SDK that exposes it cleanly).
+- **Unsandboxed tool access (security).** `claude -p` runs with its full
+  default toolset (Read/Write/Edit/Bash) — this wrapper passes no
+  `--allowedTools`/`--disallowedTools`/`--permission-mode`. As a subprocess the
+  `claude` binary is not confined by dicode's Deno sandbox, so a turn has
+  host-wide filesystem + bash access as the daemon user, non-interactively.
+  The `run: ["claude"]` permission understates this. Hardening — restrict the
+  tools and route dicode capabilities through MCP — is tracked in
+  [#560](https://github.com/dicode-ayo/dicode-core/issues/560).
 - **No streaming today.** The wrapper waits for the full response before
   returning. Claude's `--output-format stream-json` is supported by the CLI;
   follow-up could plumb that through `dicode.output()` for live tokens.


### PR DESCRIPTION
## Summary

Corrects a wrong claim and records the resulting architecture decision.

An empirical test (`claude -p "create a file…"` wrote to `$HOME`) showed the Claude CLI runs with its **full default toolset** (Read/Write/Edit/Bash). The `ai-agent-claude-cli` task invokes `claude -p … --output-format json` with **no** `--allowedTools`/`--disallowedTools`/`--permission-mode` (`task.ts:123`), so as a subprocess it has host-wide filesystem + bash access as the daemon user — `run: ["claude"]` badly understates it. The "print mode has no filesystem tools" claim in `docs/design/ai-task-authoring.md` and the task README was stale; both are corrected here.

The decision this drives: all agent backends should reach dicode capabilities through **one governed surface (MCP)** on the same prompts/skills, rather than each model's raw tools or the SDK. That only *closes* the privilege hole (rather than relocating it) if MCP also gains **per-agent capability scoping** (today `/mcp` is a single daemon-wide key), the raw model tools are **restricted**, and the surface **grows** to the governed authoring tools.

Documents the direction for the hardening tracked in #560 (implementation stays open there — this PR does not close it).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)