### PR TITLE
fix(ai-agent-claude-cli): actually mount the dicode MCP server

### DIFF
--- a/docs/design/ai-task-authoring.md
+++ b/docs/design/ai-task-authoring.md
@@ -127,7 +127,11 @@ Without it, a user who pauses to answer the agent's clarifying form loses the sa
 
 - **Single-session-per-source (#283)** becomes "one active suspended authoring run per
   source" — the concurrency rule must carry over.
-- **Provider posture:** default `task-create` to OpenAI (like `dicodai`) vs. Claude-via-MCP;
-  and whether a locked-down not-configured default is acceptable flagship UX.
+- **Provider posture — decided:** the flagship authoring backend is **Claude via
+  subscription** (`ai-agent-claude-cli`), reaching dicode through the MCP surface. The MCP
+  mount is now correct (`--strict-mcp-config --mcp-config`; the old reliance on auto-loading
+  `<cwd>/.claude/mcp.json` was a no-op). Remaining sub-question: an acceptable default when
+  no `CLAUDE_CODE_OAUTH_TOKEN` is configured. Tool-restriction + per-agent MCP scoping stay
+  in #560.
 - **Auto-wire `on_failure_chain: auto-fix`** as a default vs. keep opt-in — carries
   `git_commit_push` blast radius.

--- a/tasks/buildin/ai-agent-claude-cli/README.md
+++ b/tasks/buildin/ai-agent-claude-cli/README.md
@@ -152,11 +152,13 @@ curl -fsSL -X POST http://localhost:8080/hooks/ai-claude \
 
 ### Skills + MCP wiring
 
-On every invocation, the task creates `${DICODE_DATA_DIR}/tmp/claude-cli/<uuid>/.claude/`,
-populates it with skill markdowns + `mcp.json`, and runs `claude -p` with that
-as its CWD. Claude CLI honors `.claude/` for project-local config, so the
-skills become loadable instructions and the MCP server becomes a tool surface
-the agent can call.
+On every invocation the task creates a per-session `.claude/` workdir, populates
+it with the requested skill markdowns and an `mcp.json`, and runs `claude -p`
+from that directory. **Skills** are auto-loaded from `.claude/skills/`. **MCP is
+mounted explicitly** via `--mcp-config <path> --strict-mcp-config` — the CLI does
+*not* auto-load `<cwd>/.claude/mcp.json`, and `--strict-mcp-config` loads *only*
+dicode's server, ignoring any operator-level `~/.claude.json` / project
+`.mcp.json`.
 
 Cleanup is **out-of-band**: `buildin/temp-cleanup` sweeps any leaf directory
 under `${DICODE_DATA_DIR}/tmp/<task>/<uuid>/` that's older than 1 hour, every

--- a/tasks/buildin/ai-agent-claude-cli/task.test.ts
+++ b/tasks/buildin/ai-agent-claude-cli/task.test.ts
@@ -4,7 +4,7 @@
 // manipulation; tests don't need a real binary.
 
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
-import main from "./task.ts";
+import main, { buildClaudeArgs } from "./task.ts";
 
 const fakeDicode = {} as any;
 
@@ -340,4 +340,61 @@ JSON`,
     if (listed.includes("passwd")) {
         throw new Error(`path-traversal slipped through; .claude/skills lists: ${listed}`);
     }
+});
+
+Deno.test("buildClaudeArgs: base args are always present", () => {
+    assertEquals(
+        buildClaudeArgs({ prompt: "hi" }).join(" "),
+        "-p hi --output-format json",
+    );
+});
+
+Deno.test("buildClaudeArgs: resume/model/system_prompt appended when set", () => {
+    const a = buildClaudeArgs({
+        prompt: "hi", claudeSessionId: "s1", model: "sonnet", systemPrompt: "sp",
+    });
+    assertEquals(a[a.indexOf("--resume") + 1], "s1");
+    assertEquals(a[a.indexOf("--model") + 1], "sonnet");
+    assertEquals(a[a.indexOf("--append-system-prompt") + 1], "sp");
+});
+
+Deno.test("buildClaudeArgs: no MCP flags when no config path (mount skipped)", () => {
+    const a = buildClaudeArgs({ prompt: "hi" });
+    assertEquals(a.includes("--mcp-config"), false);
+    assertEquals(a.includes("--strict-mcp-config"), false);
+});
+
+Deno.test("buildClaudeArgs: mounts MCP strictly + explicitly with a config path", () => {
+    const a = buildClaudeArgs({ prompt: "hi", mcpConfigPath: "/w/.claude/mcp.json" });
+    assertEquals(a.includes("--strict-mcp-config"), true);
+    const i = a.indexOf("--mcp-config");
+    assertEquals(a[i + 1], "/w/.claude/mcp.json");
+});
+
+Deno.test("passes --strict-mcp-config --mcp-config to claude when MCP is wired", async () => {
+    // The bug this guards: previously the config was written to
+    // <cwd>/.claude/mcp.json with no flag, which the CLI never auto-loads, so
+    // Claude ran with zero dicode tools. Assert the flags reach the binary.
+    Deno.env.set("CLAUDE_CODE_OAUTH_TOKEN", "stub");
+    Deno.env.set("DICODE_MCP_API_KEY", "dck_test_mcp_key");
+    const sentinelDir = await Deno.makeTempDir();
+    const sentinel = `${sentinelDir}/args-recorded`;
+    const result: any = await withStubClaude(
+        `printf '%s\\n' "$@" > ${sentinel}
+cat <<'JSON'
+{"type":"result","is_error":false,"result":"ok","session_id":"s"}
+JSON`,
+        () => main({ params: makeParams([["prompt", "hi"]]), kv: makeKv(), dicode: fakeDicode }),
+    );
+    assertEquals(result.ok, true);
+    const recorded = await Deno.readTextFile(sentinel);
+    if (!recorded.includes("--strict-mcp-config")) {
+        throw new Error(`expected --strict-mcp-config in claude args, got:\n${recorded}`);
+    }
+    const lines = recorded.split("\n");
+    const i = lines.indexOf("--mcp-config");
+    if (i < 0 || !lines[i + 1]?.endsWith("/.claude/mcp.json")) {
+        throw new Error(`expected --mcp-config <…/.claude/mcp.json>, got:\n${recorded}`);
+    }
+    Deno.env.delete("DICODE_MCP_API_KEY");
 });

--- a/tasks/buildin/ai-agent-claude-cli/task.ts
+++ b/tasks/buildin/ai-agent-claude-cli/task.ts
@@ -60,6 +60,31 @@ function fail(error: string): { ok: false; error: string } {
 // paths. Mirrors the style of ValidateRunID elsewhere in the codebase.
 const SAFE_SKILL_NAME = /^[A-Za-z0-9_][A-Za-z0-9_.-]{0,63}$/;
 
+/**
+ * Build the `claude` CLI argument vector. Exported for unit testing.
+ *
+ * MCP: `<cwd>/.claude/mcp.json` is NOT an auto-load path for the Claude CLI
+ * (the auto-loaded project file is `.mcp.json` at the root, and even that hits a
+ * headless approval gate). So when a config was written we mount it explicitly
+ * with `--mcp-config`, and `--strict-mcp-config` loads ONLY that server —
+ * ignoring the operator's `~/.claude.json` / project `.mcp.json`. Passing
+ * neither flag (the prior behavior) meant Claude ran with zero dicode tools.
+ */
+export function buildClaudeArgs(opts: {
+    prompt: string;
+    claudeSessionId?: string;
+    model?: string;
+    systemPrompt?: string;
+    mcpConfigPath?: string;
+}): string[] {
+    const args = ["-p", opts.prompt, "--output-format", "json"];
+    if (opts.claudeSessionId) args.push("--resume", opts.claudeSessionId);
+    if (opts.model)           args.push("--model", opts.model);
+    if (opts.systemPrompt)    args.push("--append-system-prompt", opts.systemPrompt);
+    if (opts.mcpConfigPath)   args.push("--strict-mcp-config", "--mcp-config", opts.mcpConfigPath);
+    return args;
+}
+
 export default async function main({ params, kv }: SDK) {
     const prompt        = (await params.get("prompt"))        ?? "";
     const sessionIdIn   = (await params.get("session_id"))    ?? "";
@@ -117,19 +142,9 @@ export default async function main({ params, kv }: SDK) {
         console.warn("ai-agent-claude-cli: kv.get failed: " + (e instanceof Error ? e.message : String(e)));
     }
 
-    // Build args. The -p / --print mode runs one-shot and emits JSON on
-    // stdout, no interactive shell. --output-format json gives us the
-    // structured response (vs. plain text).
-    const args = ["-p", prompt, "--output-format", "json"];
-    if (claudeSessionId) {
-        args.push("--resume", claudeSessionId);
-    }
-    if (model) {
-        args.push("--model", model);
-    }
-    if (systemPrompt) {
-        args.push("--append-system-prompt", systemPrompt);
-    }
+    // Args are assembled by buildClaudeArgs() just before spawn (below), after
+    // MCP setup, so the --mcp-config flags reflect whether the config was
+    // actually written.
 
     // Per-invocation working directory. Claude CLI honors a project-local
     // `.claude/` dir at the invocation cwd: `.claude/mcp.json` configures
@@ -212,6 +227,16 @@ export default async function main({ params, kv }: SDK) {
     }
 
     console.log(`ai-agent-claude-cli: invoking ${cliPath} (resume=${claudeSessionId ? claudeSessionId.slice(0, 8) + "…" : "no"}, model=${model || "default"}, dicode_session=${dicodeSessionId.slice(0, 8)}…, mcp=${mcpWired ? "on" : "off"}, skills=${skillsWired})`);
+
+    const args = buildClaudeArgs({
+        prompt,
+        claudeSessionId,
+        model,
+        systemPrompt,
+        // <cwd>/.claude/mcp.json is not auto-loaded; mount it explicitly and
+        // strictly so only dicode's server reaches Claude.
+        mcpConfigPath: mcpWired ? `${claudeDir}/mcp.json` : undefined,
+    });
 
     const cmd = new Deno.Command(cliPath, {
         args,


### PR DESCRIPTION
## Summary

The Claude-CLI agent task's MCP wiring was a silent no-op. It wrote the server config to `<cwd>/.claude/mcp.json` and passed no flag — but the Claude CLI does **not** auto-load that path (the auto-loaded project file is `.mcp.json` at the root, and even that hits a headless approval gate in `-p` mode). So Claude ran with **zero dicode tools** despite the task logging `mcp=on`. Verified against the Claude Code docs.

The fix mounts the config **explicitly**: `--mcp-config <path> --strict-mcp-config`. The `--strict-mcp-config` flag also loads **only** dicode's server, ignoring the operator's `~/.claude.json` / project `.mcp.json` — the per-invocation isolation the hardening work wants anyway. The argument vector is extracted into a pure, tested `buildClaudeArgs()`; an integration test asserts the stubbed `claude` binary actually receives the flags when MCP is wired.

Also records the flagship authoring backend decision (**Claude via subscription**) in `docs/design/ai-task-authoring.md` and corrects the README's stale "CLI honors `.claude/` for config" claim.

First concrete step of the hardening tracked in #560 (tool-restriction, per-agent MCP capability scoping, and growing the MCP surface remain there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)