### PR TITLE
feat(ai-agent-claude-cli): dual-mode auth — token optional, fall back to login

### DIFF
--- a/tasks/buildin/ai-agent-claude-cli/README.md
+++ b/tasks/buildin/ai-agent-claude-cli/README.md
@@ -25,16 +25,19 @@ passphrase to exist, which is why you still want `server.auth: true` in
 yourself) and gates the rest of the HTTP surface (WebUI, REST API) behind
 the same session-cookie + API-key auth chain.
 
-### 1. Mint a Claude OAuth token
+### 1. Authenticate — token, or reuse a local login
 
-On any machine where you've signed into Claude Code with your Pro/Max account:
+Auth is **dual-mode**:
 
-```sh
-claude setup-token
-```
-
-This emits a one-year token. Store it in dicode's secrets store under the key
-`CLAUDE_CODE_OAUTH_TOKEN` (via the WebUI or `dicode secrets set`).
+- **Explicit token (recommended for servers / containers).** On any machine
+  signed into Claude Code with your Pro/Max account, run `claude setup-token`
+  (emits a one-year token) and store it in dicode's secrets store under
+  `CLAUDE_CODE_OAUTH_TOKEN` (via the WebUI or `dicode secrets set`).
+- **Reuse an existing login (local, single-user).** If the daemon runs as a
+  user whose `claude` is already logged in, you can skip the token entirely —
+  the task falls back to the credentials at `$HOME/.claude/.credentials.json`.
+  Less portable and less auditable than an explicit secret, so prefer the token
+  for shared or headless deployments.
 
 ### 2. Install the `claude` binary on the daemon host
 

--- a/tasks/buildin/ai-agent-claude-cli/task.test.ts
+++ b/tasks/buildin/ai-agent-claude-cli/task.test.ts
@@ -76,16 +76,31 @@ Deno.test("rejects empty prompt", async () => {
     assertEquals(r.ok, false);
 });
 
-Deno.test("rejects missing OAuth token", async () => {
+Deno.test("no token: falls back to logged-in credentials (does not hard-fail)", async () => {
     Deno.env.delete("CLAUDE_CODE_OAUTH_TOKEN");
-    const r: any = await main({
-        params: makeParams([["prompt", "hi"]]),
-        kv: makeKv(), dicode: fakeDicode,
-    });
-    assertEquals(r.ok, false);
-    if (!String(r.error ?? "").includes("CLAUDE_CODE_OAUTH_TOKEN")) {
-        throw new Error(`expected OAuth-token error, got ${r.error}`);
-    }
+    const result: any = await withStubClaude(
+        `cat <<'JSON'
+{"type":"result","is_error":false,"result":"ok","session_id":"s"}
+JSON`,
+        () => main({ params: makeParams([["prompt", "hi"]]), kv: makeKv(), dicode: fakeDicode }),
+    );
+    assertEquals(result.ok, true);
+});
+
+Deno.test("no token: does not inject an empty CLAUDE_CODE_OAUTH_TOKEN into claude env", async () => {
+    // Setting the var to "" would override the $HOME/.claude credential-file
+    // fallback with an invalid empty token — it must be absent, not empty.
+    Deno.env.delete("CLAUDE_CODE_OAUTH_TOKEN");
+    const sentinelDir = await Deno.makeTempDir();
+    const sentinel = `${sentinelDir}/token-seen`;
+    await withStubClaude(
+        `printf '[%s]' "\${CLAUDE_CODE_OAUTH_TOKEN-UNSET}" > ${sentinel}
+cat <<'JSON'
+{"type":"result","is_error":false,"result":"ok","session_id":"s"}
+JSON`,
+        () => main({ params: makeParams([["prompt", "hi"]]), kv: makeKv(), dicode: fakeDicode }),
+    );
+    assertEquals((await Deno.readTextFile(sentinel)).trim(), "[UNSET]");
 });
 
 Deno.test("rejects malformed session_id", async () => {

--- a/tasks/buildin/ai-agent-claude-cli/task.ts
+++ b/tasks/buildin/ai-agent-claude-cli/task.ts
@@ -107,10 +107,15 @@ export default async function main({ params, kv }: SDK) {
         return fail(`session_id ${JSON.stringify(sessionIdIn)} contains invalid characters; expected ^[a-zA-Z0-9_-]{1,64}$`);
     }
 
+    // Dual-mode auth: prefer an explicit CLAUDE_CODE_OAUTH_TOKEN secret
+    // (portable for headless / containerized daemons where no interactive login
+    // exists), but if it is unset fall back to the logged-in credentials at
+    // $HOME/.claude/.credentials.json — so a local daemon running as an
+    // already-logged-in user needs no token. We can't see the credential file
+    // from inside the Deno sandbox (the claude subprocess reads it, not us), so
+    // we don't hard-fail here; a genuine no-auth situation surfaces as claude's
+    // own auth error downstream.
     const oauthToken = Deno.env.get("CLAUDE_CODE_OAUTH_TOKEN") ?? "";
-    if (!oauthToken) {
-        return fail("CLAUDE_CODE_OAUTH_TOKEN is not set. Mint one via `claude setup-token` and store it as a dicode secret named CLAUDE_CODE_OAUTH_TOKEN. See tasks/buildin/ai-agent-claude-cli/README.md.");
-    }
 
     const cliPath = resolveCliPath(cliPathParam);
     if (!cliPath) {
@@ -238,13 +243,17 @@ export default async function main({ params, kv }: SDK) {
         mcpConfigPath: mcpWired ? `${claudeDir}/mcp.json` : undefined,
     });
 
+    const claudeEnv: Record<string, string> = {
+        HOME: Deno.env.get("HOME") ?? "/root",
+        PATH: Deno.env.get("PATH") ?? "/usr/local/bin:/usr/bin:/bin",
+    };
+    // Inject the token only when present. Setting it to "" would override the
+    // $HOME/.claude credential-file fallback with an empty, invalid token.
+    if (oauthToken) claudeEnv.CLAUDE_CODE_OAUTH_TOKEN = oauthToken;
+
     const cmd = new Deno.Command(cliPath, {
         args,
-        env: {
-            CLAUDE_CODE_OAUTH_TOKEN: oauthToken,
-            HOME: Deno.env.get("HOME") ?? "/root",
-            PATH: Deno.env.get("PATH") ?? "/usr/local/bin:/usr/bin:/bin",
-        },
+        env: claudeEnv,
         cwd: workdir,
         stdin: "null",
         stdout: "piped",


### PR DESCRIPTION
## Summary

The Claude-CLI task hard-required `CLAUDE_CODE_OAUTH_TOKEN` and errored before spawning `claude` if it was unset. But `claude` also authenticates from the logged-in credentials at `$HOME/.claude/.credentials.json` — so a local daemon running as an already-logged-in user needed no token at all (as the operator's own `claude -p` test showed).

Makes the token **optional**: prefer it when set (portable for headless / containerized daemons where no interactive login exists), otherwise let `claude` fall back to the credential file. The token is injected into `claude`'s env **only when non-empty** — setting it to `""` would override the credential fallback with an invalid token. Redaction already guards the empty case.

Answers "do I need a token if my `claude` is already logged in?" → on a local single-user daemon, no.

Tests: replaced the old "rejects missing token" test with fallback coverage + an assertion that no empty token is injected into the child env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)