### PR TITLE
feat(mcp): ephemeral per-run dicode MCP API tokens

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -221,6 +221,14 @@ func run(ctx context.Context, cancel context.CancelFunc, cfg *config.Config, con
 		return err
 	}
 
+	// 8.6. Ephemeral per-run MCP token minter: sweep tokens orphaned by a
+	// previous daemon session, then wire the minter into both runtimes so
+	// `permissions.env: [DICODE_MCP_API_KEY]` tasks get one auto-revoked
+	// per-run key instead of `dicode mcp install`'s operator-managed key.
+	if err := wireMCPTokenMinter(ctx, srv, denoRT, pythonRT, log); err != nil {
+		return err
+	}
+
 	// 9. Control socket for CLI clients.
 	ctrlSrv, err := buildControlServer(cfg, dataDir, version, database, reg, rec, eng, localSecrets, srv, sourceMgr, approvalGate, log)
 	if err != nil {
@@ -830,6 +838,27 @@ func wireCryptoIPC(secretsChain secrets.Chain, denoRT *denoruntime.Runtime, log 
 	} else {
 		denoRT.SetCryptoHandler(cryptoDeriver)
 	}
+}
+
+// wireMCPTokenMinter sweeps ephemeral per-run MCP API keys orphaned by a
+// previous daemon session (a run in flight when the daemon last stopped
+// leaves its token behind — nothing will ever call Revoke for it) and then
+// wires the minter into both runtimes so a run whose spec declares
+// permissions.env DICODE_MCP_API_KEY gets a fresh key at start and has it
+// revoked at end, instead of relying on a static `dicode mcp install` key.
+// srv.MCPTokenMinter() is nil when no database is configured (tests); the
+// static-secret path then still works unchanged.
+func wireMCPTokenMinter(ctx context.Context, srv *webui.Server, denoRT *denoruntime.Runtime, pythonRT *pythonruntime.Runtime, log *zap.Logger) error {
+	if err := srv.SweepEphemeralMCPTokens(ctx); err != nil {
+		return fmt.Errorf("sweep orphaned ephemeral MCP tokens: %w", err)
+	}
+	if minter := srv.MCPTokenMinter(); minter != nil {
+		denoRT.SetMCPTokenMinter(minter)
+		pythonRT.SetMCPTokenMinter(minter)
+	} else {
+		log.Debug("ephemeral MCP token minter not wired (no database) — DICODE_MCP_API_KEY falls back to the secrets chain")
+	}
+	return nil
 }
 
 // initAuditPruning builds the audit store and runs the startup prune pass

--- a/pkg/runtime/bridgedeps.go
+++ b/pkg/runtime/bridgedeps.go
@@ -66,6 +66,11 @@ type BridgeDeps struct {
 	// TestGuard is the approval gate's veto for dicode.tasks.test, forwarded
 	// to every per-run IPC server. Nil means allow.
 	TestGuard func(taskID string) error
+	// MCPTokenMinter mints/revokes ephemeral per-run dicode MCP API keys
+	// (SetMCPTokenMinter). Nil disables the ephemeral path: a task declaring
+	// MCPTokenEnvName then gets whatever the secrets chain resolves for that
+	// name, same as before this feature existed.
+	MCPTokenMinter MCPTokenMinter
 	// ProtectedPaths are files (dicode.lock, dicode.yaml) that hold approval
 	// state and must never be writable by a task, even when a broad write
 	// grant covers their directory. Deno emits them as --deny-write flags;
@@ -198,4 +203,13 @@ func (d *BridgeDeps) SetProviderRunner(p envresolve.ProviderRunner) {
 // of constructing a fresh instance each time.
 func (d *BridgeDeps) SetEnvResolver(r *envresolve.Resolver) {
 	d.SharedResolver = r
+}
+
+// SetMCPTokenMinter wires the ephemeral per-run MCP token minter: on a run
+// whose spec declares permissions.env MCPTokenEnvName, ApplyMCPToken mints a
+// token through it and revokes on every exit path. Nil (the default)
+// disables the ephemeral path. Mirrors the SetReplayer / SetTestGuard
+// late-wiring pattern — call after New and before Start.
+func (d *BridgeDeps) SetMCPTokenMinter(m MCPTokenMinter) {
+	d.MCPTokenMinter = m
 }

--- a/pkg/runtime/deno/mcp_token_test.go
+++ b/pkg/runtime/deno/mcp_token_test.go
@@ -1,0 +1,128 @@
+package deno
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// fakeMCPTokenMinter is a test double for pkgruntime.MCPTokenMinter that
+// records Mint/Revoke calls without touching any real key store.
+type fakeMCPTokenMinter struct {
+	mu      sync.Mutex
+	minted  map[string]string
+	revoked map[string]bool
+	nextTok int
+}
+
+func newFakeMCPTokenMinter() *fakeMCPTokenMinter {
+	return &fakeMCPTokenMinter{minted: map[string]string{}, revoked: map[string]bool{}}
+}
+
+func (f *fakeMCPTokenMinter) Mint(_ context.Context, runID string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nextTok++
+	tok := fmt.Sprintf("fake-mcp-token-%d", f.nextTok)
+	f.minted[runID] = tok
+	return tok, nil
+}
+
+func (f *fakeMCPTokenMinter) Revoke(_ context.Context, runID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.revoked[runID] = true
+	return nil
+}
+
+func (f *fakeMCPTokenMinter) wasRevoked(runID string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.revoked[runID]
+}
+
+func (f *fakeMCPTokenMinter) mintCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.minted)
+}
+
+// TestRuntime_MCPToken_MintedWhenDeclared covers the opt-in path: a spec
+// that declares permissions.env DICODE_MCP_API_KEY gets a freshly minted
+// token injected, and it is revoked once the run completes.
+func TestRuntime_MCPToken_MintedWhenDeclared(t *testing.T) {
+	e := newTestEnv(t)
+	minter := newFakeMCPTokenMinter()
+	e.rt.SetMCPTokenMinter(minter)
+
+	spec := &task.Spec{
+		ID: "mcp-token-declared", Name: "mcp-token-declared", Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true}, Timeout: 30 * time.Second,
+		Permissions: task.Permissions{
+			Env: []task.EnvEntry{{Name: pkgruntime.MCPTokenEnvName}},
+		},
+	}
+	r := e.runSpec(t, `export default async function main() { return Deno.env.get("DICODE_MCP_API_KEY") ?? null }`, spec)
+	if r.Error != nil {
+		t.Fatalf("unexpected error: %v", r.Error)
+	}
+	tok, _ := r.ReturnValue.(string)
+	if tok == "" {
+		t.Fatalf("task did not see a minted token, got %v", r.ReturnValue)
+	}
+	if minter.mintCount() != 1 {
+		t.Fatalf("expected exactly one mint, got %d", minter.mintCount())
+	}
+	if !minter.wasRevoked(r.RunID) {
+		t.Errorf("expected run %s to be revoked after completion", r.RunID)
+	}
+}
+
+// TestRuntime_MCPToken_NotMintedWhenNotDeclared covers the gate: a spec
+// that does not declare DICODE_MCP_API_KEY must never trigger a mint, even
+// when a minter is wired.
+func TestRuntime_MCPToken_NotMintedWhenNotDeclared(t *testing.T) {
+	e := newTestEnv(t)
+	minter := newFakeMCPTokenMinter()
+	e.rt.SetMCPTokenMinter(minter)
+
+	r := e.run(t, `return "ok"`)
+	if r.Error != nil {
+		t.Fatalf("unexpected error: %v", r.Error)
+	}
+	if minter.mintCount() != 0 {
+		t.Fatalf("expected no mint for a spec that doesn't declare DICODE_MCP_API_KEY, got %d", minter.mintCount())
+	}
+}
+
+// TestRuntime_MCPToken_RevokedOnScriptError covers the revoke-on-every-path
+// requirement: a task that throws must still have its ephemeral token
+// revoked.
+func TestRuntime_MCPToken_RevokedOnScriptError(t *testing.T) {
+	e := newTestEnv(t)
+	minter := newFakeMCPTokenMinter()
+	e.rt.SetMCPTokenMinter(minter)
+
+	spec := &task.Spec{
+		ID: "mcp-token-error", Name: "mcp-token-error", Runtime: task.RuntimeDeno,
+		Trigger: task.TriggerConfig{Manual: true}, Timeout: 30 * time.Second,
+		Permissions: task.Permissions{
+			Env: []task.EnvEntry{{Name: pkgruntime.MCPTokenEnvName}},
+		},
+	}
+	r := e.runSpec(t, `export default async function main() { throw new Error("boom") }`, spec)
+	if r.Error == nil {
+		t.Fatal("expected the run to fail")
+	}
+	if minter.mintCount() != 1 {
+		t.Fatalf("expected exactly one mint even though the run errored, got %d", minter.mintCount())
+	}
+	if !minter.wasRevoked(r.RunID) {
+		t.Errorf("expected run %s to be revoked on the error path", r.RunID)
+	}
+}

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -231,6 +231,16 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 		return result, nil
 	}
 
+	// Ephemeral per-run MCP token (opt-in via permissions.env
+	// DICODE_MCP_API_KEY): mint before anything else touches resolved, and
+	// defer the revoke unconditionally so it fires on every exit path below.
+	mcpRevoke, err := pkgruntime.ApplyMCPToken(ctx, rt.live(), rt.Log, spec, runID, resolved)
+	if err != nil {
+		result.Error = err
+		return result, nil
+	}
+	defer mcpRevoke()
+
 	taskPath := spec.ScriptPath()
 	if taskPath == "" {
 		result.Error = fmt.Errorf("script not found for task %s", spec.ID)

--- a/pkg/runtime/mcp_token.go
+++ b/pkg/runtime/mcp_token.go
@@ -1,0 +1,75 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
+)
+
+// MCPTokenEnvName is the permissions.env name a task declares to opt into
+// receiving an ephemeral per-run dicode MCP API key in place of a static
+// secret under the same name.
+const MCPTokenEnvName = "DICODE_MCP_API_KEY"
+
+// MCPTokenMinter mints and revokes a short-lived dicode MCP API key scoped
+// to a single run, removing the need for `dicode mcp install`'s
+// operator-managed key for internal agent tasks. Implemented by pkg/webui
+// over its API-key store; the interface lives here so pkg/runtime does not
+// need to import pkg/webui.
+//
+// MVP scope: the minted token is full-surface — the same permissions as an
+// operator-managed key — not yet scoped to the task's declared capabilities.
+// Per-capability scoping is a follow-on.
+type MCPTokenMinter interface {
+	Mint(ctx context.Context, runID string) (token string, err error)
+	Revoke(ctx context.Context, runID string) error
+}
+
+// WantsMCPToken reports whether spec declares a permissions.env entry named
+// MCPTokenEnvName — the signal a task uses to opt into an ephemeral per-run
+// MCP token.
+func WantsMCPToken(spec *task.Spec) bool {
+	if spec == nil {
+		return false
+	}
+	for _, e := range spec.Permissions.Env {
+		if e.Name == MCPTokenEnvName {
+			return true
+		}
+	}
+	return false
+}
+
+// ApplyMCPToken mints an ephemeral MCP token and stores it into
+// resolved[MCPTokenEnvName] when spec opts in (WantsMCPToken) and a minter
+// is wired (live.MCPTokenMinter). The mint overrides any secret-store value
+// already present under that name — the ephemeral per-run token always
+// wins. Nothing is minted, and the no-op revoke is returned, when the spec
+// doesn't declare the env entry or no minter is wired (legacy/test path:
+// the static-secret env value, if any, is left untouched).
+//
+// Callers MUST defer the returned revoke unconditionally, immediately after
+// this call returns, so the token is revoked on every exit path (success,
+// error, timeout, panic). Revoke runs against context.Background() rather
+// than the run's ctx: a timed-out or canceled run is exactly the case where
+// revocation matters most, and it must not be defeated by the same
+// cancellation that ended the run.
+func ApplyMCPToken(ctx context.Context, live *BridgeDeps, log *zap.Logger, spec *task.Spec, runID string, resolved map[string]string) (revoke func(), err error) {
+	noop := func() {}
+	minter := live.MCPTokenMinter
+	if minter == nil || !WantsMCPToken(spec) {
+		return noop, nil
+	}
+	token, err := minter.Mint(ctx, runID)
+	if err != nil {
+		return noop, fmt.Errorf("mint mcp token: %w", err)
+	}
+	resolved[MCPTokenEnvName] = token
+	return func() {
+		if rerr := minter.Revoke(context.Background(), runID); rerr != nil && log != nil {
+			log.Warn("revoke ephemeral mcp token failed", zap.String("run", runID), zap.Error(rerr))
+		}
+	}, nil
+}

--- a/pkg/runtime/python/mcp_token_test.go
+++ b/pkg/runtime/python/mcp_token_test.go
@@ -1,0 +1,189 @@
+//go:build !windows
+
+package python
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dicode/dicode/pkg/registry"
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+	"github.com/dicode/dicode/pkg/task"
+	uvpkg "github.com/dicode/dicode/pkg/uv"
+)
+
+// fakeMCPTokenMinter is a test double for pkgruntime.MCPTokenMinter that
+// records Mint/Revoke calls without touching any real key store.
+type fakeMCPTokenMinter struct {
+	mu      sync.Mutex
+	minted  map[string]string
+	revoked map[string]bool
+	nextTok int
+}
+
+func newFakeMCPTokenMinter() *fakeMCPTokenMinter {
+	return &fakeMCPTokenMinter{minted: map[string]string{}, revoked: map[string]bool{}}
+}
+
+func (f *fakeMCPTokenMinter) Mint(_ context.Context, runID string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nextTok++
+	tok := fmt.Sprintf("fake-mcp-token-%d", f.nextTok)
+	f.minted[runID] = tok
+	return tok, nil
+}
+
+func (f *fakeMCPTokenMinter) Revoke(_ context.Context, runID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.revoked[runID] = true
+	return nil
+}
+
+func (f *fakeMCPTokenMinter) wasRevoked(runID string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.revoked[runID]
+}
+
+func (f *fakeMCPTokenMinter) mintCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.minted)
+}
+
+// newMCPTokenExecutor provisions uv the way the runtime does and returns a
+// registry + runtime + executor, skipping when uv cannot be provisioned
+// (offline CI) — mirrors newSuspendExecutor in suspend_test.go.
+func newMCPTokenExecutor(t *testing.T) (*Runtime, *registry.Registry, pkgruntime.Executor) {
+	t.Helper()
+	uv, err := uvpkg.EnsureUv("")
+	if err != nil {
+		t.Skipf("uv provisioning failed (offline?): %v", err)
+	}
+	rt, reg := newTestRuntime(t)
+	return rt, reg, rt.NewExecutor(uv)
+}
+
+// dumpRunLogs logs the run's log lines via t.Logf, for debugging a failed
+// Execute call.
+func dumpRunLogs(t *testing.T, reg *registry.Registry, runID string) {
+	t.Helper()
+	logs, err := reg.GetRunLogs(context.Background(), runID)
+	if err != nil {
+		t.Logf("GetRunLogs: %v", err)
+		return
+	}
+	for _, l := range logs {
+		t.Logf("[%s] %s", l.Level, l.Message)
+	}
+}
+
+// TestExecute_MCPToken_MintedWhenDeclared covers the opt-in path: a spec
+// that declares permissions.env DICODE_MCP_API_KEY gets a freshly minted
+// token injected, and it is revoked once the run completes.
+func TestExecute_MCPToken_MintedWhenDeclared(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires uv subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	rt, reg, ex := newMCPTokenExecutor(t)
+	minter := newFakeMCPTokenMinter()
+	rt.SetMCPTokenMinter(minter)
+
+	spec := writePythonTask(t, "mcp-token-declared", `
+result = env.get("DICODE_MCP_API_KEY")
+`)
+	spec.Permissions = task.Permissions{Env: []task.EnvEntry{{Name: pkgruntime.MCPTokenEnvName}}}
+
+	runID := "test-run-mcp-declared"
+	res, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{RunID: runID})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Error != nil {
+		dumpRunLogs(t, reg, runID)
+		t.Fatalf("unexpected run error: %v", res.Error)
+	}
+	tok, _ := res.ChainInput.(string)
+	if tok == "" {
+		dumpRunLogs(t, reg, runID)
+		t.Fatalf("task did not see a minted token, got %v", res.ChainInput)
+	}
+	if minter.mintCount() != 1 {
+		t.Fatalf("expected exactly one mint, got %d", minter.mintCount())
+	}
+	if !minter.wasRevoked(runID) {
+		t.Errorf("expected run %s to be revoked after completion", runID)
+	}
+}
+
+// TestExecute_MCPToken_NotMintedWhenNotDeclared covers the gate: a spec
+// that does not declare DICODE_MCP_API_KEY must never trigger a mint, even
+// when a minter is wired.
+func TestExecute_MCPToken_NotMintedWhenNotDeclared(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires uv subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	rt, reg, ex := newMCPTokenExecutor(t)
+	minter := newFakeMCPTokenMinter()
+	rt.SetMCPTokenMinter(minter)
+
+	spec := writePythonTask(t, "mcp-token-not-declared", `result = "ok"`)
+
+	runID := "test-run-mcp-not-declared"
+	res, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{RunID: runID})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Error != nil {
+		dumpRunLogs(t, reg, runID)
+		t.Fatalf("unexpected run error: %v", res.Error)
+	}
+	if minter.mintCount() != 0 {
+		t.Fatalf("expected no mint for a spec that doesn't declare DICODE_MCP_API_KEY, got %d", minter.mintCount())
+	}
+}
+
+// TestExecute_MCPToken_RevokedOnScriptError covers the revoke-on-every-path
+// requirement: a task that raises must still have its ephemeral token
+// revoked.
+func TestExecute_MCPToken_RevokedOnScriptError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires uv subprocess")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	rt, reg, ex := newMCPTokenExecutor(t)
+	minter := newFakeMCPTokenMinter()
+	rt.SetMCPTokenMinter(minter)
+
+	spec := writePythonTask(t, "mcp-token-error", `raise RuntimeError("boom")`)
+	spec.Permissions = task.Permissions{Env: []task.EnvEntry{{Name: pkgruntime.MCPTokenEnvName}}}
+
+	runID := "test-run-mcp-error"
+	res, err := ex.Execute(ctx, spec, pkgruntime.RunOptions{RunID: runID})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Error == nil {
+		dumpRunLogs(t, reg, runID)
+		t.Fatal("expected the run to fail")
+	}
+	if minter.mintCount() != 1 {
+		t.Fatalf("expected exactly one mint even though the run errored, got %d", minter.mintCount())
+	}
+	if !minter.wasRevoked(runID) {
+		t.Errorf("expected run %s to be revoked on the error path", runID)
+	}
+}

--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -197,6 +197,16 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 		return result, nil
 	}
 
+	// Ephemeral per-run MCP token (opt-in via permissions.env
+	// DICODE_MCP_API_KEY): mint before anything else touches resolved, and
+	// defer the revoke unconditionally so it fires on every exit path below.
+	mcpRevoke, err := pkgruntime.ApplyMCPToken(ctx, &e.parent.BridgeDeps, e.Log, spec, runID, resolved)
+	if err != nil {
+		result.Error = err
+		return result, nil
+	}
+	defer mcpRevoke()
+
 	// Read the user's task.py.
 	scriptPath := spec.ScriptPath()
 	if scriptPath == "" {

--- a/pkg/webui/apikeys.go
+++ b/pkg/webui/apikeys.go
@@ -131,15 +131,36 @@ func (s *apiKeyStore) revoke(ctx context.Context, id string) error {
 // shape, so the chance of collision is vanishingly small.
 const cliManagedKeyPrefix = "dicode-cli/"
 
-// revokeByName deletes API keys with the given exact name. Restricted
-// to the CLI-managed namespace (`dicode-cli/...`) so a CLI install
-// flow can't accidentally sweep dashboard-created keys that happen to
-// share a friendly name. Returns nil when no rows matched (idempotent).
+// ephemeralKeyPrefix scopes API-key names minted for ephemeral per-run MCP
+// tokens (see mcpTokenMinter) — one key per run, minted at run start and
+// revoked when the run ends. Distinct from cliManagedKeyPrefix so the two
+// tool-managed namespaces, and operator-created (dashboard) keys, never
+// collide.
+const ephemeralKeyPrefix = "ephemeral/run/"
+
+// revokeByName deletes API keys with the given exact name. Restricted to
+// the CLI-managed (`dicode-cli/...`) and ephemeral per-run MCP token
+// (`ephemeral/run/...`) namespaces so a tool-driven revoke can't
+// accidentally sweep dashboard-created keys that happen to share a friendly
+// name. Returns nil when no rows matched (idempotent).
 func (s *apiKeyStore) revokeByName(ctx context.Context, name string) error {
-	if !strings.HasPrefix(name, cliManagedKeyPrefix) {
-		return fmt.Errorf("revokeByName refused: name %q is not in the CLI-managed namespace %q", name, cliManagedKeyPrefix)
+	if !strings.HasPrefix(name, cliManagedKeyPrefix) && !strings.HasPrefix(name, ephemeralKeyPrefix) {
+		return fmt.Errorf("revokeByName refused: name %q is not in a tool-managed namespace (%q, %q)", name, cliManagedKeyPrefix, ephemeralKeyPrefix)
 	}
 	return s.db.Exec(ctx, `DELETE FROM api_keys WHERE name = ?`, name)
+}
+
+// revokeByNamePrefix deletes every API key whose name begins with prefix.
+// Restricted to the ephemeral per-run MCP token namespace so it can't be
+// repurposed to bulk-delete CLI-managed or operator (dashboard) keys. Used
+// at daemon startup to sweep tokens orphaned by a run that was in flight
+// when the daemon last stopped — nothing will ever call Revoke for it.
+// Returns nil when no rows matched (idempotent).
+func (s *apiKeyStore) revokeByNamePrefix(ctx context.Context, prefix string) error {
+	if prefix != ephemeralKeyPrefix {
+		return fmt.Errorf("revokeByNamePrefix refused: prefix %q is not the ephemeral MCP token namespace %q", prefix, ephemeralKeyPrefix)
+	}
+	return s.db.Exec(ctx, `DELETE FROM api_keys WHERE name LIKE ?`, prefix+"%")
 }
 
 // APIKeyInfo is the public representation of an API key.

--- a/pkg/webui/mcp_token_minter.go
+++ b/pkg/webui/mcp_token_minter.go
@@ -1,0 +1,35 @@
+package webui
+
+import (
+	"context"
+
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+)
+
+var _ pkgruntime.MCPTokenMinter = (*mcpTokenMinter)(nil)
+
+// mcpTokenMinter implements pkgruntime.MCPTokenMinter over apiKeyStore: one
+// dck_-prefixed API key per run, named under ephemeralKeyPrefix so
+// revokeByName / revokeByNamePrefix can find and delete it without touching
+// operator- or CLI-managed keys.
+type mcpTokenMinter struct {
+	keys *apiKeyStore
+}
+
+func newMCPTokenMinter(keys *apiKeyStore) *mcpTokenMinter {
+	return &mcpTokenMinter{keys: keys}
+}
+
+// Mint generates a fresh API key named for this run and returns the raw
+// value. The token is full-surface — the same permissions as an
+// operator-managed key — not yet scoped to the task's declared
+// capabilities; per-capability scoping is a follow-on.
+func (m *mcpTokenMinter) Mint(ctx context.Context, runID string) (string, error) {
+	raw, _, err := m.keys.generate(ctx, ephemeralKeyPrefix+runID)
+	return raw, err
+}
+
+// Revoke deletes the run's key.
+func (m *mcpTokenMinter) Revoke(ctx context.Context, runID string) error {
+	return m.keys.revokeByName(ctx, ephemeralKeyPrefix+runID)
+}

--- a/pkg/webui/mcp_token_minter_test.go
+++ b/pkg/webui/mcp_token_minter_test.go
@@ -1,0 +1,111 @@
+package webui
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/db"
+)
+
+// newTestAPIKeyStore builds an apiKeyStore over a fresh in-memory SQLite DB.
+func newTestAPIKeyStore(t *testing.T) *apiKeyStore {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return newAPIKeyStore(d)
+}
+
+// TestMCPTokenMinter_MintValidateRevoke covers the full lifecycle: a minted
+// token validates, and after Revoke it no longer does.
+func TestMCPTokenMinter_MintValidateRevoke(t *testing.T) {
+	ctx := context.Background()
+	keys := newTestAPIKeyStore(t)
+	minter := newMCPTokenMinter(keys)
+
+	token, err := minter.Mint(ctx, "run-123")
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	if token == "" {
+		t.Fatal("Mint returned empty token")
+	}
+	if !keys.validate(ctx, token) {
+		t.Fatal("minted token does not validate")
+	}
+
+	if err := minter.Revoke(ctx, "run-123"); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if keys.validate(ctx, token) {
+		t.Fatal("token still validates after Revoke")
+	}
+}
+
+// TestMCPTokenMinter_RevokeIdempotent covers revoking a run ID that was
+// never minted (e.g. Mint failed before Revoke ran) or already revoked.
+func TestMCPTokenMinter_RevokeIdempotent(t *testing.T) {
+	ctx := context.Background()
+	minter := newMCPTokenMinter(newTestAPIKeyStore(t))
+	if err := minter.Revoke(ctx, "never-minted"); err != nil {
+		t.Fatalf("Revoke on unminted run ID should be a no-op, got: %v", err)
+	}
+}
+
+// TestRevokeByNamePrefix_SweepsEphemeralOnly covers the startup-sweep
+// primitive: it must revoke every ephemeral/run/* key and leave CLI-managed
+// and operator (dashboard) keys untouched.
+func TestRevokeByNamePrefix_SweepsEphemeralOnly(t *testing.T) {
+	ctx := context.Background()
+	keys := newTestAPIKeyStore(t)
+
+	ephemeralA, _, err := keys.generate(ctx, ephemeralKeyPrefix+"run-a")
+	if err != nil {
+		t.Fatalf("generate ephemeral A: %v", err)
+	}
+	ephemeralB, _, err := keys.generate(ctx, ephemeralKeyPrefix+"run-b")
+	if err != nil {
+		t.Fatalf("generate ephemeral B: %v", err)
+	}
+	cliKey, _, err := keys.generate(ctx, cliManagedKeyPrefix+"laptop")
+	if err != nil {
+		t.Fatalf("generate cli key: %v", err)
+	}
+	dashKey, _, err := keys.generate(ctx, "my dashboard key")
+	if err != nil {
+		t.Fatalf("generate dashboard key: %v", err)
+	}
+
+	if err := keys.revokeByNamePrefix(ctx, ephemeralKeyPrefix); err != nil {
+		t.Fatalf("revokeByNamePrefix: %v", err)
+	}
+
+	if keys.validate(ctx, ephemeralA) {
+		t.Error("ephemeral key A still validates after sweep")
+	}
+	if keys.validate(ctx, ephemeralB) {
+		t.Error("ephemeral key B still validates after sweep")
+	}
+	if !keys.validate(ctx, cliKey) {
+		t.Error("CLI-managed key was swept but should survive")
+	}
+	if !keys.validate(ctx, dashKey) {
+		t.Error("dashboard key was swept but should survive")
+	}
+}
+
+// TestRevokeByNamePrefix_RefusesOtherPrefixes guards against the sweep
+// primitive being repurposed to bulk-delete keys outside the ephemeral
+// namespace.
+func TestRevokeByNamePrefix_RefusesOtherPrefixes(t *testing.T) {
+	ctx := context.Background()
+	keys := newTestAPIKeyStore(t)
+	if err := keys.revokeByNamePrefix(ctx, cliManagedKeyPrefix); err == nil {
+		t.Fatal("expected revokeByNamePrefix to refuse a non-ephemeral prefix")
+	}
+	if err := keys.revokeByNamePrefix(ctx, ""); err == nil {
+		t.Fatal("expected revokeByNamePrefix to refuse an empty prefix")
+	}
+}

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -143,6 +143,7 @@ type Server struct {
 	scsStore           *scsStore              // underlying SQLite store for sm; nil in DB-less tests
 	dbSessions         *dbSessionStore        // persistent trusted-device tokens
 	apiKeys            *apiKeyStore           // MCP / programmatic API keys
+	mcpTokenMinter     *mcpTokenMinter        // ephemeral per-run MCP token minter over apiKeys; nil in tests (no database)
 	authoringSessions  *authoringSessionStore // AI-first authoring sessions
 	passphraseStore    *passphraseStore       // auth passphrase persisted in DB
 	cachedPassphrase   string                 // in-memory cache of stored DB value (bcrypt hash, or legacy plaintext during migration); invalidated on change
@@ -215,6 +216,28 @@ func (s *Server) RevokeAPIKeyByName(ctx context.Context, name string) error {
 	return s.apiKeys.revokeByName(ctx, name)
 }
 
+// MCPTokenMinter returns the ephemeral per-run MCP token minter for wiring
+// into the Deno/Python runtimes via their SetMCPTokenMinter. Returns a true
+// nil pkgruntime.MCPTokenMinter (not a nil-valued non-nil interface) when no
+// database is configured (tests) — callers can compare directly against nil.
+func (s *Server) MCPTokenMinter() pkgruntime.MCPTokenMinter {
+	if s.mcpTokenMinter == nil {
+		return nil
+	}
+	return s.mcpTokenMinter
+}
+
+// SweepEphemeralMCPTokens revokes every ephemeral per-run MCP API key left
+// over from a previous daemon session. Call once at startup before any new
+// run can mint one: a run that was in flight when the daemon last stopped
+// leaves its token orphaned, since nothing will ever call Revoke for it.
+func (s *Server) SweepEphemeralMCPTokens(ctx context.Context) error {
+	if s.apiKeys == nil {
+		return nil
+	}
+	return s.apiKeys.revokeByNamePrefix(ctx, ephemeralKeyPrefix)
+}
+
 // SetManagedRuntimes registers the list of managed runtimes (Deno, Python, …)
 // that will appear in the Config UI. Call this after New and before Start.
 func (s *Server) SetManagedRuntimes(runtimes []pkgruntime.ManagedRuntime) {
@@ -233,12 +256,14 @@ func New(port int, r *registry.Registry, eng *trigger.Engine, cfg *config.Config
 
 	var dbs *dbSessionStore
 	var aks *apiKeyStore
+	var mtm *mcpTokenMinter
 	var ps *passphraseStore
 	var store *scsStore
 	var as *authoringSessionStore
 	if database != nil {
 		dbs = newDBSessionStore(database, log)
 		aks = newAPIKeyStore(database)
+		mtm = newMCPTokenMinter(aks)
 		ps = newPassphraseStore(database)
 		store = sm.Store.(*scsStore)
 		as = newAuthoringSessionStore(database)
@@ -257,6 +282,7 @@ func New(port int, r *registry.Registry, eng *trigger.Engine, cfg *config.Config
 		scsStore:          store,
 		dbSessions:        dbs,
 		apiKeys:           aks,
+		mcpTokenMinter:    mtm,
 		authoringSessions: as,
 		passphraseStore:   ps,
 		logs:              logs,


### PR DESCRIPTION
## Summary

The first building block of the governed-agent story (#560): instead of an operator running `dicode mcp install` and persisting a shared, daemon-wide `DICODE_MCP_API_KEY`, the daemon **mints a short-lived MCP API key per run, injects it, and revokes it when the run ends.**

Since dicode both spawns the agent and serves `/mcp`, it is caller and server — so it provisions the credential itself. No operator dance for internal agents, and the shared key stops being load-bearing.

## How it works

- **Gated to opt-in tasks only.** A run mints a token only when its spec declares a `permissions.env` entry named `DICODE_MCP_API_KEY` (`WantsMCPToken`) and a minter is wired.
- **Injection reuses the existing per-run env path.** The minted token is written into the resolved env map (overriding any static secret-store value), so it reaches the subprocess via the same mechanism that already threads `DICODE_SOCKET`/`DICODE_TOKEN`. `DICODE_MCP_API_KEY` stays on the `neverForwardEnv` denylist — the only way in is the mint.
- **Revoked on every exit path.** `defer mcpRevoke()` is registered immediately after mint, before any early return; the revoke runs on `context.Background()` so a timed-out/canceled run can't defeat its own cleanup. A startup sweep (`revokeByNamePrefix "ephemeral/run/"`) reaps tokens orphaned by a run in flight when the daemon last stopped.
- **Layering.** The `MCPTokenMinter` interface lives in `pkg/runtime` (no `runtime→webui` import); `pkg/webui` implements it over the existing `apiKeyStore`; the daemon wires it into both the Deno and Python runtimes.

## Scope boundary

MVP is **per-run + auto-revoke**. The token is still full-surface (same permissions as an operator key) — **not yet capability-scoped to the task's declared `dicode.*` caps**. That scoping is the next block in #560 and is called out as a TODO in the interface doc.

Validated: `go build`/`vet`/`gofmt`/`test` and `-race` on the changed packages, including error-path revoke tests for both runtimes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)