### PR TITLE
feat(registry): collapse a run's descendant tree under its root (#569)

### DIFF
--- a/pkg/db/sqlite.go
+++ b/pkg/db/sqlite.go
@@ -201,11 +201,22 @@ func (s *SQLiteDB) migrate() error {
 		// ctx.params and honors the same chain-depth ceiling. NULL when the
 		// suspended run carried neither.
 		{"resume_params", "BLOB"},
+		// root_run_id (#569) — the topmost ancestor of a run's parent chain
+		// (chain / pipeline stage / replay / suspend-resume continuation). A
+		// parentless run is its own root. Denormalized at insert time
+		// (Registry.StartRunWithID) so grouping a run's whole descendant tree
+		// under one collapsible unit (ListRunGroup) is a single indexed WHERE
+		// instead of a recursive walk. NULL only for rows written before this
+		// migration, until backfillRootRunID runs.
+		{"root_run_id", "TEXT"},
 	}
 	for _, m := range runsMigrations {
 		if err := addColumnIfMissing(ctx, s.db, "runs", m.name, m.ddl); err != nil {
 			return fmt.Errorf("migrate runs.%s: %w", m.name, err)
 		}
+	}
+	if err := backfillRootRunID(ctx, s.db); err != nil {
+		return fmt.Errorf("backfill root_run_id: %w", err)
 	}
 
 	// ua_family on trusted-device rows. Nullable on purpose: rows issued
@@ -243,6 +254,13 @@ func (s *SQLiteDB) migrate() error {
 	`)
 	if err != nil {
 		return fmt.Errorf("migrate run-grouping indexes: %w", err)
+	}
+
+	// root_run_id index (#569) — ListRunGroup and GetRunGroupLogs both filter
+	// on it; without an index they'd full-scan runs/run_logs as history grows.
+	_, err = s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_runs_root_run_id ON runs(root_run_id);`)
+	if err != nil {
+		return fmt.Errorf("migrate root_run_id index: %w", err)
 	}
 
 	// Suspend/resume lookup indexes (#95). Without them the resume-token lookup
@@ -327,6 +345,57 @@ func (s *SQLiteDB) migrate() error {
 		return fmt.Errorf("migrate audit_log: %w", err)
 	}
 
+	return nil
+}
+
+// backfillRootRunID fills root_run_id on rows written before the #569
+// migration. It only ever touches rows where root_run_id IS NULL, so on every
+// startup after the first it's a cheap no-op (new rows always insert with
+// root_run_id set by Registry.StartRunWithID).
+//
+// Parentless rows get root_run_id = id directly. Child rows resolve by
+// walking the parent_run_id chain one hop per pass — bounded to
+// maxRootBackfillPasses so a pathological chain can't loop forever — until no
+// more rows can be resolved. Any row still NULL afterwards (its parent chain
+// bottoms out at a missing/deleted row, or the chain is deeper than the pass
+// bound) falls back to root_run_id = id: it renders as its own top-level
+// group rather than joining its ancestor's, which is the safe degradation.
+func backfillRootRunID(ctx context.Context, db *sql.DB) error {
+	if _, err := db.ExecContext(ctx,
+		`UPDATE runs SET root_run_id = id
+		 WHERE root_run_id IS NULL AND (parent_run_id IS NULL OR parent_run_id = '')`,
+	); err != nil {
+		return fmt.Errorf("backfill root rows: %w", err)
+	}
+	const maxRootBackfillPasses = 100
+	for i := 0; i < maxRootBackfillPasses; i++ {
+		res, err := db.ExecContext(ctx,
+			`UPDATE runs SET root_run_id = (
+			     SELECT p.root_run_id FROM runs p WHERE p.id = runs.parent_run_id
+			 )
+			 WHERE root_run_id IS NULL
+			   AND parent_run_id IS NOT NULL AND parent_run_id != ''
+			   AND EXISTS (
+			       SELECT 1 FROM runs p
+			       WHERE p.id = runs.parent_run_id AND p.root_run_id IS NOT NULL
+			   )`,
+		)
+		if err != nil {
+			return fmt.Errorf("backfill child rows (pass %d): %w", i, err)
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("backfill child rows (pass %d): rows affected: %w", i, err)
+		}
+		if n == 0 {
+			break
+		}
+	}
+	// Stragglers: orphaned parent_run_id (parent row missing/deleted) or a
+	// chain deeper than maxRootBackfillPasses. Self-root them.
+	if _, err := db.ExecContext(ctx, `UPDATE runs SET root_run_id = id WHERE root_run_id IS NULL`); err != nil {
+		return fmt.Errorf("backfill straggler rows: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -61,6 +61,13 @@ type Run struct {
 	StartedAt   time.Time
 	FinishedAt  *time.Time
 	ParentRunID string
+	// RootRunID is the topmost ancestor of this run's parent chain (chain /
+	// pipeline stage / replay / suspend-resume continuation) — the run's own
+	// ID when it has no parent. Set once at insert time by StartRunWithID and
+	// never updated; used to collapse a whole descendant tree (a suspend/
+	// resume conversation, a pipeline and its stages, a chain) into one
+	// group via ListRunGroup (#569).
+	RootRunID string
 	// Group is a free-text label set by the task itself via dicode.set_group().
 	// Used by the WebUI to collapse same-group siblings in the run list (#114).
 	// Column name on disk is `run_group` because GROUP is a SQL keyword.
@@ -198,19 +205,59 @@ func (r *Registry) StartRun(ctx context.Context, taskID, parentRunID string) (st
 // StartRunWithID records a new run using a caller-supplied ID.
 // Use this when the run ID must be known before execution begins (e.g. async fire).
 // kind may be "task" or "pipeline"; empty defaults to "task".
+//
+// root_run_id is computed here and never revisited: a parentless run is its
+// own root; a child inherits its parent's root_run_id. Every path that
+// threads parentRunID — chains, pipeline stages, replay, and suspend/resume
+// continuations (trigger.ResumeRun sets ParentRunID to the suspended run) —
+// goes through this one write path, so they all inherit the correct root
+// automatically.
 func (r *Registry) StartRunWithID(ctx context.Context, id, taskID, parentRunID, triggerSource, kind string) (string, error) {
 	if kind == "" {
 		kind = RunKindTask
 	}
+	rootRunID := id
+	if parentRunID != "" {
+		parentRoot, err := r.getRootRunID(ctx, parentRunID)
+		if err != nil {
+			return "", fmt.Errorf("start run: resolve parent root: %w", err)
+		}
+		if parentRoot != "" {
+			rootRunID = parentRoot
+		} else {
+			// Parent row missing (or, defensively, has no root of its own) —
+			// fall back to the parent ID itself rather than self-rooting, so
+			// the run still groups under its immediate parent if that row
+			// shows up later (e.g. a write-order race).
+			rootRunID = parentRunID
+		}
+	}
 	now := time.Now().UnixMilli()
 	err := r.db.Exec(ctx,
-		`INSERT INTO runs (id, task_id, status, started_at, parent_run_id, trigger_source, kind) VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		id, taskID, StatusRunning, now, parentRunID, triggerSource, kind,
+		`INSERT INTO runs (id, task_id, status, started_at, parent_run_id, trigger_source, kind, root_run_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, taskID, StatusRunning, now, parentRunID, triggerSource, kind, rootRunID,
 	)
 	if err != nil {
 		return "", fmt.Errorf("start run: %w", err)
 	}
 	return id, nil
+}
+
+// getRootRunID returns the root_run_id of the given run, or "" if the run row
+// doesn't exist (or, defensively, if its root_run_id is somehow empty).
+func (r *Registry) getRootRunID(ctx context.Context, runID string) (string, error) {
+	var root string
+	err := r.db.Query(ctx,
+		`SELECT COALESCE(root_run_id, '') FROM runs WHERE id = ?`,
+		[]any{runID},
+		func(rows db.Scanner) error {
+			if rows.Next() {
+				return rows.Scan(&root)
+			}
+			return nil
+		},
+	)
+	return root, err
 }
 
 // SetRunResult stores a JSON-encoded return value and optional structured output for a finished run.
@@ -361,7 +408,7 @@ func (r *Registry) BulkAppendLogs(ctx context.Context, entries []PendingLogEntry
 // means extending this list plus scanRun — nothing else.
 const runColumns = `id, task_id, COALESCE(kind, 'task'), status, started_at, finished_at, parent_run_id, trigger_source,
         COALESCE(return_value, ''), COALESCE(output_content_type, ''), COALESCE(output_content, ''),
-        COALESCE(fail_reason, ''), COALESCE(run_group, '')`
+        COALESCE(fail_reason, ''), COALESCE(run_group, ''), COALESCE(root_run_id, id)`
 
 // runInputColumns are the input-persistence columns GetRun additionally
 // selects (appended after runColumns). queryRuns deliberately omits them:
@@ -396,7 +443,7 @@ func scanRun(rows db.Scanner, withInput, withResume bool) (*Run, error) {
 	dest := []any{
 		&run.ID, &run.TaskID, &run.Kind, &run.Status, &startedMs, &finishedMs, &parentID,
 		&tsStr, &run.ReturnValue, &run.OutputContentType, &run.OutputContent,
-		&run.FailureReason, &run.Group,
+		&run.FailureReason, &run.Group, &run.RootRunID,
 	}
 	if withInput {
 		dest = append(dest,
@@ -499,6 +546,46 @@ func (r *Registry) ListByGroup(ctx context.Context, taskID, group string, limit 
 	return r.queryRuns(ctx,
 		`WHERE task_id = ? AND run_group = ? ORDER BY started_at DESC LIMIT ?`,
 		[]any{taskID, group, limit})
+}
+
+// ListRunGroup returns every run sharing the given root_run_id — a run's
+// whole descendant tree (chain, pipeline + stages, or a suspend/resume
+// conversation), oldest first so the group reads top-to-bottom as a
+// conversation/timeline (#569). rootRunID is typically a run's own ID (a run
+// is always a member of its own group).
+func (r *Registry) ListRunGroup(ctx context.Context, rootRunID string, limit int) ([]*Run, error) {
+	return r.queryRuns(ctx,
+		`WHERE COALESCE(root_run_id, id) = ? ORDER BY started_at ASC LIMIT ?`,
+		[]any{rootRunID, limit})
+}
+
+// GetRunGroupLogs returns log entries for every run in rootRunID's group
+// (see ListRunGroup), ordered by timestamp then log ID so entries from
+// different member runs interleave chronologically rather than being grouped
+// per-run (#569).
+func (r *Registry) GetRunGroupLogs(ctx context.Context, rootRunID string) ([]*LogEntry, error) {
+	var logs []*LogEntry
+	err := r.db.Query(ctx,
+		`SELECT l.id, l.run_id, l.ts, l.level, l.message
+		 FROM run_logs l
+		 JOIN runs r ON r.id = l.run_id
+		 WHERE COALESCE(r.root_run_id, r.id) = ?
+		 ORDER BY l.ts ASC, l.id ASC`,
+		[]any{rootRunID},
+		func(rows db.Scanner) error {
+			for rows.Next() {
+				e := &LogEntry{}
+				var tsMs int64
+				if err := rows.Scan(&e.ID, &e.RunID, &tsMs, &e.Level, &e.Message); err != nil {
+					return err
+				}
+				e.Ts = time.UnixMilli(tsMs)
+				logs = append(logs, e)
+			}
+			return nil
+		},
+	)
+	return logs, err
 }
 
 // queryRuns runs a `SELECT … FROM runs <whereAndLimitClause>` and decodes rows

--- a/pkg/registry/root_run_test.go
+++ b/pkg/registry/root_run_test.go
@@ -1,0 +1,240 @@
+package registry
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/db"
+)
+
+// ── #569 root_run_id computation ────────────────────────────────────────────
+
+func TestStartRun_RootRunID_ParentlessIsSelfRoot(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+	ctx := context.Background()
+
+	runID, err := r.StartRun(ctx, "task-a", "")
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	run, err := r.GetRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if run.RootRunID != runID {
+		t.Errorf("RootRunID = %q, want self %q", run.RootRunID, runID)
+	}
+}
+
+func TestStartRun_RootRunID_ChildInheritsParentRoot(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+	ctx := context.Background()
+
+	parentID, _ := r.StartRun(ctx, "parent-task", "")
+	childID, _ := r.StartRun(ctx, "child-task", parentID)
+
+	child, err := r.GetRun(ctx, childID)
+	if err != nil {
+		t.Fatalf("GetRun child: %v", err)
+	}
+	if child.RootRunID != parentID {
+		t.Errorf("child RootRunID = %q, want parent %q", child.RootRunID, parentID)
+	}
+}
+
+func TestStartRun_RootRunID_GrandchildSharesRootWithGrandparent(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+	ctx := context.Background()
+
+	rootID, _ := r.StartRun(ctx, "root-task", "")
+	midID, _ := r.StartRun(ctx, "mid-task", rootID)
+	leafID, _ := r.StartRun(ctx, "leaf-task", midID)
+
+	mid, err := r.GetRun(ctx, midID)
+	if err != nil {
+		t.Fatalf("GetRun mid: %v", err)
+	}
+	leaf, err := r.GetRun(ctx, leafID)
+	if err != nil {
+		t.Fatalf("GetRun leaf: %v", err)
+	}
+	if mid.RootRunID != rootID {
+		t.Errorf("mid RootRunID = %q, want %q", mid.RootRunID, rootID)
+	}
+	if leaf.RootRunID != rootID {
+		t.Errorf("leaf RootRunID = %q, want %q (3 levels must share one root)", leaf.RootRunID, rootID)
+	}
+}
+
+func TestStartRun_RootRunID_MissingParentFallsBackToParentID(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+	ctx := context.Background()
+
+	// parentRunID references a row that was never created (e.g. a caller
+	// passed a stale/foreign ID). StartRunWithID must not error — it falls
+	// back to the parent ID itself as the root rather than failing the run.
+	childID, err := r.StartRun(ctx, "child-task", "does-not-exist")
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	child, err := r.GetRun(ctx, childID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if child.RootRunID != "does-not-exist" {
+		t.Errorf("RootRunID = %q, want fallback %q", child.RootRunID, "does-not-exist")
+	}
+}
+
+// ── ListRunGroup / GetRunGroupLogs ──────────────────────────────────────────
+
+func TestListRunGroup_ReturnsWholeTree(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+	ctx := context.Background()
+
+	rootID, _ := r.StartRun(ctx, "root-task", "")
+	childID, _ := r.StartRun(ctx, "child-task", rootID)
+	grandchildID, _ := r.StartRun(ctx, "grandchild-task", childID)
+	// Unrelated tree — must not appear.
+	otherRoot, _ := r.StartRun(ctx, "other-task", "")
+
+	group, err := r.ListRunGroup(ctx, rootID, 50)
+	if err != nil {
+		t.Fatalf("ListRunGroup: %v", err)
+	}
+	if len(group) != 3 {
+		t.Fatalf("len(group) = %d, want 3: %+v", len(group), group)
+	}
+	got := map[string]bool{}
+	for _, run := range group {
+		got[run.ID] = true
+		if run.RootRunID != rootID {
+			t.Errorf("member %s RootRunID = %q, want %q", run.ID, run.RootRunID, rootID)
+		}
+	}
+	if !got[rootID] || !got[childID] || !got[grandchildID] {
+		t.Errorf("group missing expected members: %+v", got)
+	}
+	if got[otherRoot] {
+		t.Errorf("group leaked unrelated run %s", otherRoot)
+	}
+}
+
+func TestGetRunGroupLogs_AggregatesAllMembersInOrder(t *testing.T) {
+	t.Parallel()
+	r := newTestRegistry(t)
+	ctx := context.Background()
+
+	rootID, _ := r.StartRun(ctx, "root-task", "")
+	childID, _ := r.StartRun(ctx, "child-task", rootID)
+
+	if err := r.AppendLog(ctx, rootID, "info", "root line 1"); err != nil {
+		t.Fatalf("AppendLog: %v", err)
+	}
+	if err := r.AppendLog(ctx, childID, "info", "child line 1"); err != nil {
+		t.Fatalf("AppendLog: %v", err)
+	}
+	if err := r.AppendLog(ctx, rootID, "info", "root line 2"); err != nil {
+		t.Fatalf("AppendLog: %v", err)
+	}
+
+	// Unrelated run's logs must not leak into the group.
+	otherID, _ := r.StartRun(ctx, "other-task", "")
+	if err := r.AppendLog(ctx, otherID, "info", "should not appear"); err != nil {
+		t.Fatalf("AppendLog: %v", err)
+	}
+
+	logs, err := r.GetRunGroupLogs(ctx, rootID)
+	if err != nil {
+		t.Fatalf("GetRunGroupLogs: %v", err)
+	}
+	if len(logs) != 3 {
+		t.Fatalf("len(logs) = %d, want 3: %+v", len(logs), logs)
+	}
+	for _, l := range logs {
+		if l.RunID != rootID && l.RunID != childID {
+			t.Errorf("unexpected run_id %q in group logs", l.RunID)
+		}
+	}
+	// Insertion order preserved (ts then id tie-break).
+	if logs[0].Message != "root line 1" || logs[1].Message != "child line 1" || logs[2].Message != "root line 2" {
+		t.Errorf("logs not in insertion order: %+v", logs)
+	}
+}
+
+// ── backfill (pkg/db migration) ─────────────────────────────────────────────
+
+// TestBackfillRootRunID_OnReopen writes rows directly (simulating a
+// pre-#569 database with root_run_id left NULL) and then reopens the DB,
+// which re-runs migrate() and its backfill pass. Requires a real file (not
+// ":memory:") since a fresh in-memory DB has no persisted rows to reopen.
+func TestBackfillRootRunID_OnReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "backfill.db")
+
+	d, err := db.Open(db.Config{Type: "sqlite", Path: path})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	ctx := context.Background()
+
+	// Insert a 3-level chain the way pre-#569 code would have (no
+	// root_run_id column value — StartRunWithID would have set it, so
+	// instead write directly to simulate rows that predate the migration).
+	if err := d.Exec(ctx,
+		`INSERT INTO runs (id, task_id, status, started_at, parent_run_id) VALUES (?, ?, ?, ?, ?)`,
+		"root-1", "t", "success", 1000, "",
+	); err != nil {
+		t.Fatalf("insert root: %v", err)
+	}
+	if err := d.Exec(ctx,
+		`INSERT INTO runs (id, task_id, status, started_at, parent_run_id) VALUES (?, ?, ?, ?, ?)`,
+		"mid-1", "t", "success", 2000, "root-1",
+	); err != nil {
+		t.Fatalf("insert mid: %v", err)
+	}
+	if err := d.Exec(ctx,
+		`INSERT INTO runs (id, task_id, status, started_at, parent_run_id) VALUES (?, ?, ?, ?, ?)`,
+		"leaf-1", "t", "success", 3000, "mid-1",
+	); err != nil {
+		t.Fatalf("insert leaf: %v", err)
+	}
+	// An orphan: parent_run_id points at a row that doesn't exist.
+	if err := d.Exec(ctx,
+		`INSERT INTO runs (id, task_id, status, started_at, parent_run_id) VALUES (?, ?, ?, ?, ?)`,
+		"orphan-1", "t", "success", 4000, "ghost-parent",
+	); err != nil {
+		t.Fatalf("insert orphan: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Reopen — migrate() runs again, including backfillRootRunID.
+	d2, err := db.Open(db.Config{Type: "sqlite", Path: path})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer d2.Close()
+	r := New(d2)
+
+	for id, want := range map[string]string{
+		"root-1":   "root-1",
+		"mid-1":    "root-1",
+		"leaf-1":   "root-1",
+		"orphan-1": "orphan-1", // straggler: self-rooted since its parent row is missing
+	} {
+		run, err := r.GetRun(ctx, id)
+		if err != nil {
+			t.Fatalf("GetRun %s: %v", id, err)
+		}
+		if run.RootRunID != want {
+			t.Errorf("%s: RootRunID = %q, want %q", id, run.RootRunID, want)
+		}
+	}
+}

--- a/pkg/trigger/resume_test.go
+++ b/pkg/trigger/resume_test.go
@@ -187,6 +187,46 @@ func TestResumeRun_SeedsContinuationAndConsumesToken(t *testing.T) {
 	}
 }
 
+// TestResumeRun_ContinuationSharesRoot verifies #569: a resume continuation's
+// root_run_id is the ORIGINAL suspended run's ID (which is its own root,
+// since it has no parent), not the continuation's own ID. This is what lets
+// the WebUI collapse a whole suspend/resume conversation into one group.
+func TestResumeRun_ContinuationSharesRoot(t *testing.T) {
+	exec := &suspendExec{}
+	eng, reg := newSuspendEnv(t, exec)
+
+	spec := &task.Spec{ID: "wiz", Name: "wiz", Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}, Enabled: true}
+	if err := reg.Register(spec); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	origID, err := eng.FireManual(context.Background(), "wiz", nil)
+	if err != nil {
+		t.Fatalf("FireManual: %v", err)
+	}
+	orig := waitStatus(t, reg, origID, registry.StatusSuspended)
+	if orig.RootRunID != origID {
+		t.Fatalf("suspended run RootRunID = %q, want self %q", orig.RootRunID, origID)
+	}
+
+	newID, err := eng.ResumeRun(context.Background(), orig.ResumeToken, []byte(`{"project_name":"acme"}`))
+	if err != nil {
+		t.Fatalf("ResumeRun: %v", err)
+	}
+	cont := waitStatus(t, reg, newID, registry.StatusSuccess)
+	if cont.RootRunID != origID {
+		t.Errorf("continuation RootRunID = %q, want original run %q", cont.RootRunID, origID)
+	}
+
+	group, err := reg.ListRunGroup(context.Background(), origID, 50)
+	if err != nil {
+		t.Fatalf("ListRunGroup: %v", err)
+	}
+	if len(group) != 2 {
+		t.Fatalf("len(group) = %d, want 2 (original + continuation): %+v", len(group), group)
+	}
+}
+
 func TestResumeRun_TokenIsSingleUse(t *testing.T) {
 	eng, reg := newSuspendEnv(t, &suspendExec{})
 	spec := &task.Spec{ID: "wiz", Name: "wiz", Runtime: task.RuntimeDeno, Trigger: task.TriggerConfig{Manual: true}, Enabled: true}

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -495,6 +495,9 @@ func (s *Server) Handler() http.Handler {
 			r.Get("/audit", s.apiQueryAudit)
 			r.Get("/runs/{runID}", s.apiGetRun)
 			r.Get("/runs/{runID}/logs", s.apiGetLogs)
+			// Aggregated logs across a run's whole root_run_id group (#569) —
+			// e.g. every turn of a suspend/resume conversation, interleaved by ts.
+			r.Get("/runs/{runID}/group-logs", s.apiGetGroupLogs)
 			r.Post("/runs/{runID}/kill", s.apiKillRun)
 
 			// Secrets management (protected by main session via requireAuth above).
@@ -2072,12 +2075,15 @@ func (s *Server) handleMCP(w http.ResponseWriter, r *http.Request) {
 	s.gateway.ServeHTTP(w, r)
 }
 
-// apiQueryRuns handles GET /api/runs with one of two filter modes (#116):
-//   - ?parent=<runID>          → list child runs of <runID>
-//   - ?group=<label>&task=<id> → list same-group siblings for a task
+// apiQueryRuns handles GET /api/runs with one of three filter modes:
+//   - ?parent=<runID>          → list immediate child runs of <runID> (#116)
+//   - ?group=<label>&task=<id> → list same-group siblings for a task (#116)
+//   - ?root=<runID>            → list <runID>'s whole descendant tree —
+//     chain / pipeline stages / suspend-resume continuations — collapsed
+//     under their shared root_run_id, oldest first (#569)
 //
-// Either filter is required; group requires task to scope the lookup since
-// labels are task-local.
+// Exactly one filter is required; group additionally requires task to scope
+// the lookup since labels are task-local.
 func (s *Server) apiQueryRuns(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	limit := 50
@@ -2086,9 +2092,10 @@ func (s *Server) apiQueryRuns(w http.ResponseWriter, r *http.Request) {
 	}
 	parent := q.Get("parent")
 	group := q.Get("group")
+	root := q.Get("root")
 	taskID := q.Get("task")
-	if parent == "" && group == "" {
-		jsonErr(w, "missing filter: provide ?parent=<id> or ?group=<label>&task=<id>", http.StatusBadRequest)
+	if parent == "" && group == "" && root == "" {
+		jsonErr(w, "missing filter: provide ?parent=<id>, ?root=<id>, or ?group=<label>&task=<id>", http.StatusBadRequest)
 		return
 	}
 	if group != "" && taskID == "" {
@@ -2099,9 +2106,12 @@ func (s *Server) apiQueryRuns(w http.ResponseWriter, r *http.Request) {
 		runs []*registry.Run
 		err  error
 	)
-	if parent != "" {
+	switch {
+	case root != "":
+		runs, err = s.registry.ListRunGroup(r.Context(), root, limit)
+	case parent != "":
 		runs, err = s.registry.ListChildren(r.Context(), parent, limit)
-	} else {
+	default:
 		runs, err = s.registry.ListByGroup(r.Context(), taskID, group, limit)
 	}
 	if err != nil {
@@ -2197,6 +2207,48 @@ func (s *Server) apiGetLogs(w http.ResponseWriter, r *http.Request) {
 	for i, l := range logs {
 		out[i] = LogEntryJSON{
 			ID:      l.ID,
+			Level:   l.Level,
+			Message: l.Message,
+			Ts:      l.Ts.UnixMilli(),
+		}
+	}
+	jsonOK(w, out)
+}
+
+// GroupLogEntryJSON is the JSON shape returned by GET
+// /api/runs/{runID}/group-logs — LogEntryJSON plus RunID, since entries in an
+// aggregated view span multiple runs and the caller needs to attribute each
+// line to its run (#569).
+type GroupLogEntryJSON struct {
+	ID      int64  `json:"id"`
+	RunID   string `json:"run_id"`
+	Level   string `json:"level"`
+	Message string `json:"message"`
+	Ts      int64  `json:"ts"` // Unix milliseconds
+}
+
+// apiGetGroupLogs handles GET /api/runs/{runID}/group-logs: the union of log
+// entries for every run sharing {runID}'s root_run_id (its whole descendant
+// tree), interleaved chronologically. {runID} need not itself be the root —
+// GetRunGroupLogs resolves its group membership via COALESCE(root_run_id, id).
+func (s *Server) apiGetGroupLogs(w http.ResponseWriter, r *http.Request) {
+	runID := chi.URLParam(r, "runID")
+	run, err := s.registry.GetRun(r.Context(), runID)
+	if err != nil {
+		jsonErr(w, "run not found", http.StatusNotFound)
+		return
+	}
+	logs, err := s.registry.GetRunGroupLogs(r.Context(), run.RootRunID)
+	if err != nil {
+		s.log.Error("get run group logs", zap.String("run", runID), zap.Error(err))
+		jsonErr(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	out := make([]GroupLogEntryJSON, len(logs))
+	for i, l := range logs {
+		out[i] = GroupLogEntryJSON{
+			ID:      l.ID,
+			RunID:   l.RunID,
 			Level:   l.Level,
 			Message: l.Message,
 			Ts:      l.Ts.UnixMilli(),

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -623,6 +623,72 @@ func TestAPI_QueryRuns_ByParentAndGroup(t *testing.T) {
 	}
 }
 
+// #569: GET /api/runs?root=<id> collapses a run's whole descendant tree
+// (chain / pipeline stages / suspend-resume continuations), and
+// GET /api/runs/{id}/group-logs aggregates every member's log lines.
+func TestAPI_QueryRuns_ByRoot_And_GroupLogs(t *testing.T) {
+	srv, reg := newTestServer(t)
+	ctx := context.Background()
+
+	rootID, err := reg.StartRun(ctx, "task-a", "")
+	if err != nil {
+		t.Fatalf("StartRun root: %v", err)
+	}
+	childID, _ := reg.StartRun(ctx, "child-task", rootID)
+	grandchildID, _ := reg.StartRun(ctx, "grandchild-task", childID)
+	// Unrelated tree — must not appear.
+	_, _ = reg.StartRun(ctx, "other-task", "")
+
+	if err := reg.AppendLog(ctx, rootID, "info", "root said hi"); err != nil {
+		t.Fatalf("AppendLog: %v", err)
+	}
+	if err := reg.AppendLog(ctx, grandchildID, "info", "grandchild said bye"); err != nil {
+		t.Fatalf("AppendLog: %v", err)
+	}
+
+	// ── root filter ───────────────────────────────────────────────────────
+	req := httptest.NewRequest(http.MethodGet, "/api/runs?root="+rootID, nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("root query: status %d body=%s", w.Code, w.Body.String())
+	}
+	var group []map[string]any
+	_ = json.NewDecoder(w.Body).Decode(&group)
+	if len(group) != 3 {
+		t.Fatalf("expected 3 runs in group, got %d (%v)", len(group), group)
+	}
+	got := map[string]bool{}
+	for _, r := range group {
+		got[r["ID"].(string)] = true
+		if r["RootRunID"] != rootID {
+			t.Errorf("member %v RootRunID = %v, want %q", r["ID"], r["RootRunID"], rootID)
+		}
+	}
+	if !got[rootID] || !got[childID] || !got[grandchildID] {
+		t.Errorf("group missing expected members: %v", got)
+	}
+
+	// ── group-logs aggregation, addressed via a non-root member ─────────────
+	req = httptest.NewRequest(http.MethodGet, "/api/runs/"+grandchildID+"/group-logs", nil)
+	w = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("group-logs: status %d body=%s", w.Code, w.Body.String())
+	}
+	var logs []map[string]any
+	_ = json.NewDecoder(w.Body).Decode(&logs)
+	if len(logs) != 2 {
+		t.Fatalf("expected 2 aggregated log lines, got %d (%v)", len(logs), logs)
+	}
+	if logs[0]["message"] != "root said hi" || logs[0]["run_id"] != rootID {
+		t.Errorf("first log entry = %v, want root's line", logs[0])
+	}
+	if logs[1]["message"] != "grandchild said bye" || logs[1]["run_id"] != grandchildID {
+		t.Errorf("second log entry = %v, want grandchild's line", logs[1])
+	}
+}
+
 func TestAPI_GetRun_and_Logs(t *testing.T) {
 	srv, reg := newTestServer(t)
 	registerTask(t, reg, "log-task", `log.info("hello"); return 1`)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -60,6 +60,7 @@ export default defineConfig({
         '**/task-toggle.spec.ts',
         '**/suspend-resume.spec.ts',
         '**/cli-suspend.spec.ts',
+        '**/run-tree-collapse.spec.ts',
       ],
       use: {
         ...devices['Desktop Chrome'],

--- a/tasks/buildin/webui/app/components/dc-task-detail.js
+++ b/tasks/buildin/webui/app/components/dc-task-detail.js
@@ -246,16 +246,20 @@ class DcTaskDetail extends LitElement {
     });
   }
 
-  // ── Run-list grouping (#114) ────────────────────────────────────────────
+  // ── Run-list grouping (#114 / #569) ─────────────────────────────────────
   // The flat list of runs returned by /api/tasks/{id}/runs is collapsed by
   // two rules so the user sees one row per logical event:
   //
-  //   1. Hide rows whose ParentRunID is set — those are stage runs (a
-  //      pipeline stage, or a sub-task fired via dicode.run_task). A toggle
-  //      restores the flat view for debugging.
+  //   1. Hide rows that aren't their own root_run_id — those are members of
+  //      some other row's descendant tree (a pipeline stage, a chain hop, a
+  //      suspend/resume continuation, a sub-task fired via dicode.run_task).
+  //      A toggle restores the flat view for debugging.
   //   2. Collapse consecutive top-level rows with the same non-empty Group
   //      into one row ("N runs in this session, last 3m ago"). Tasks tag
   //      themselves via dicode.set_group() — see the ai-agent buildin (#112).
+  //      This is orthogonal to root_run_id grouping: Group is a free-text
+  //      label the task applies to itself; root_run_id is the structural
+  //      parent/child tree. A root-level run can carry both.
   //
   // The result is a list of "items" where each item is either:
   //   { kind: 'single', run }              — one row
@@ -264,7 +268,14 @@ class DcTaskDetail extends LitElement {
     const all = this._runs || [];
     if (this._showStages) return all.map(run => ({ kind: 'single', run }));
 
-    const top = all.filter(r => !(r.ParentRunID || r.parent_run_id));
+    // A run pushed live via the run:started/run:finished websocket events
+    // (see _load) carries only {ID, Status, StartedAt, ...} — no RootRunID.
+    // Treat a missing RootRunID as "top-level" (same as the pre-#569
+    // ParentRunID-absence check) rather than hiding it until the next poll.
+    const top = all.filter(r => {
+      const root = r.RootRunID || r.root_run_id;
+      return root ? root === r.ID : !(r.ParentRunID || r.parent_run_id);
+    });
     const items = [];
     for (const run of top) {
       const group = run.Group || run.group;
@@ -282,9 +293,12 @@ class DcTaskDetail extends LitElement {
     return items;
   }
 
-  // _toggleExpand expands or collapses an inline children panel. On first
-  // expand it lazily fetches /api/runs?parent=<id>; subsequent toggles flip
-  // the visibility without re-fetching.
+  // _toggleExpand expands or collapses a run's whole descendant tree. On
+  // first expand it lazily fetches /api/runs?root=<id> — the run's entire
+  // root_run_id group (every chain hop, pipeline stage, and suspend/resume
+  // continuation), not just its immediate children — so a multi-hop tree
+  // renders fully nested from one click (#569). Subsequent toggles flip
+  // visibility without re-fetching.
   async _toggleExpand(runID) {
     const next = new Set(this._expanded);
     if (next.has(runID)) {
@@ -296,9 +310,9 @@ class DcTaskDetail extends LitElement {
     this._expanded = next;
     if (!this._children.has(runID)) {
       try {
-        const kids = await get(`/api/runs?parent=${encodeURIComponent(runID)}&limit=50`);
+        const group = await get(`/api/runs?root=${encodeURIComponent(runID)}&limit=200`);
         const cm = new Map(this._children);
-        cm.set(runID, kids || []);
+        cm.set(runID, group || []);
         this._children = cm;
       } catch (e) {
         const cm = new Map(this._children);
@@ -308,14 +322,28 @@ class DcTaskDetail extends LitElement {
     }
   }
 
+  // _renderDescendants recursively renders every member of `group` (the full
+  // root_run_id group fetched once by _toggleExpand) whose parent is
+  // parentID, then that member's own children, and so on — the whole tree
+  // renders from the one top-level expand toggle rather than requiring a
+  // click per level (#569).
+  _renderDescendants(parentID, group, indent) {
+    const kids = group.filter(r => (r.ParentRunID || r.parent_run_id) === parentID && r.ID !== parentID);
+    if (!kids.length) return '';
+    return kids.map(kid => html`
+      ${this._renderRunRow(kid, { indent, isChild: true })}
+      ${this._renderDescendants(kid.ID, group, indent + 1)}
+    `);
+  }
+
   _renderRunRow(r, opts) {
     const indent = opts?.indent || 0;
     const hint   = opts?.hint;
-    const expandedKid = !!opts?.isChild;
+    const isChild = !!opts?.isChild;
     const padding = indent ? `padding-left:${indent * 1.5}rem` : '';
     const expanded = this._expanded.has(r.ID);
     const kids = this._children.get(r.ID) || [];
-    const showExpand = !expandedKid; // sub-rows don't recurse further by default
+    const showExpand = !isChild; // the whole tree expands from the top-level toggle; sub-rows don't get their own
     // registry.Run has no JSON tags, so the kind serializes as `Kind`
     // ("task" | "pipeline"); badge pipeline parents so operators can tell a
     // pipeline run (whose stage children expand below) from a plain task run.
@@ -325,7 +353,7 @@ class DcTaskDetail extends LitElement {
         <td style=${padding}>
           ${showExpand ? html`<button class="btn btn-sm secondary"
             style="padding:0 .35rem;margin-right:.35rem;font-family:monospace"
-            title="Show stage runs"
+            title="Show descendant runs"
             @click=${() => this._toggleExpand(r.ID)}>${expanded ? '▾' : '▸'}</button>` : ''}
           <a href="runs/${r.ID}">${r.ID.slice(0,8)}</a>
           ${isPipeline ? html`<span class="badge" title="Pipeline run"
@@ -341,7 +369,7 @@ class DcTaskDetail extends LitElement {
           <a href="/runs/${r.ID}/result" target="_blank"
              class="btn btn-sm secondary">Result</a>` : ''}</td>
       </tr>
-      ${expanded ? (kids.length ? kids.map(kid => this._renderRunRow(kid, { indent: indent + 1, isChild: true })) : html`
+      ${!isChild && expanded ? (kids.length ? this._renderDescendants(r.ID, kids, indent + 1) : html`
         <tr><td colspan="5" class="meta" style="padding-left:${(indent + 1) * 1.5}rem">No sub-runs.</td></tr>
       `) : ''}`;
   }

--- a/tests/e2e/run-tree-collapse.spec.ts
+++ b/tests/e2e/run-tree-collapse.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * run-tree-collapse.spec.ts
+ *
+ * E2E coverage for #573: a run's descendant tree collapses under its root
+ * run. A suspend/resume conversation (original run + its resume
+ * continuation) shares one root_run_id (#569); the WebUI run list shows it
+ * as a single top-level row, and the expand toggle (`▸`/`▾` →
+ * GET /api/runs?root=<id>` → `_renderDescendants`) reveals the
+ * continuation nested underneath.
+ */
+
+import { test, expect } from '@playwright/test';
+import type { APIRequestContext } from '@playwright/test';
+import { gotoWebui, navigateInSpa, waitForTaskDetail } from './helpers/webui';
+
+const TASK_ID = 'e2e-tests/suspend-wizard';
+
+function runStatus(run: Record<string, unknown>): string {
+  return (run.Status ?? run.status) as string;
+}
+
+function rootRunID(run: Record<string, unknown>): string {
+  return (run.RootRunID ?? run.root_run_id) as string;
+}
+
+function runID(run: Record<string, unknown>): string {
+  return (run.ID ?? run.id) as string;
+}
+
+async function getRun(
+  request: APIRequestContext,
+  id: string,
+): Promise<Record<string, unknown>> {
+  const res = await request.get(`/api/runs/${id}`);
+  expect(res.ok()).toBe(true);
+  return (await res.json()) as Record<string, unknown>;
+}
+
+async function waitForStatus(
+  request: APIRequestContext,
+  id: string,
+  want: string,
+  timeoutMs = 30_000,
+): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + timeoutMs;
+  let last = '';
+  while (Date.now() < deadline) {
+    const run = await getRun(request, id);
+    last = runStatus(run);
+    if (last === want) return run;
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  throw new Error(`Run ${id} did not reach ${want} within ${timeoutMs}ms (last=${last})`);
+}
+
+/** Fire the suspend-wizard, resume it, and wait for the continuation to finish. */
+async function spawnConversation(
+  request: APIRequestContext,
+): Promise<{ rootId: string; continuationId: string }> {
+  const fireRes = await request.post(
+    `/api/tasks/${encodeURIComponent(TASK_ID)}/run`,
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+  expect(fireRes.ok()).toBe(true);
+  const { runId } = (await fireRes.json()) as { runId: string };
+  await waitForStatus(request, runId, 'suspended');
+
+  const resumeRes = await request.post(`/api/runs/${runId}/resume`, {
+    headers: { 'Content-Type': 'application/json' },
+    data: { project_name: 'run-tree-collapse-e2e' },
+  });
+  expect(resumeRes.ok()).toBe(true);
+  const { run_id: continuationId } = (await resumeRes.json()) as { run_id: string };
+  await waitForStatus(request, continuationId, 'success');
+
+  return { rootId: runId, continuationId };
+}
+
+test.describe('run-tree collapse (#573)', () => {
+  test.setTimeout(60_000);
+
+  test('root and continuation share a root_run_id, queryable via /api/runs?root=', async ({ request }) => {
+    const taskRes = await request.get(`/api/tasks/${encodeURIComponent(TASK_ID)}`);
+    if (!taskRes.ok()) {
+      test.skip(true, `${TASK_ID} not registered — fixture taskset missing it?`);
+      return;
+    }
+
+    const { rootId, continuationId } = await spawnConversation(request);
+
+    const root = await getRun(request, rootId);
+    expect(rootRunID(root)).toBe(rootId);
+
+    const continuation = await getRun(request, continuationId);
+    expect(rootRunID(continuation)).toBe(rootId);
+
+    const groupRes = await request.get(`/api/runs?root=${rootId}`);
+    expect(groupRes.ok()).toBe(true);
+    const group = (await groupRes.json()) as Array<Record<string, unknown>>;
+    const ids = group.map(runID);
+    expect(ids).toContain(rootId);
+    expect(ids).toContain(continuationId);
+  });
+
+  test('the conversation renders as one row that expands to reveal the continuation', async ({ page, request }) => {
+    const taskRes = await request.get(`/api/tasks/${encodeURIComponent(TASK_ID)}`);
+    if (!taskRes.ok()) {
+      test.skip(true, `${TASK_ID} not registered — fixture taskset missing it?`);
+      return;
+    }
+
+    const { rootId, continuationId } = await spawnConversation(request);
+
+    await gotoWebui(page);
+    // Client-side navigate (not page.goto) — the task ID contains a "/" and
+    // the SPA router matches the literal pushState path, not a URL-decoded
+    // one, so a full page load of an encoded URL would hand the component a
+    // still-percent-encoded taskid.
+    await navigateInSpa(page, '/tasks/' + TASK_ID);
+    await waitForTaskDetail(page);
+
+    // The conversation is exactly one top-level row (filtered by
+    // RootRunID === ID), not two flat rows.
+    const rootLink = page.locator(`a[href="runs/${rootId}"]`);
+    await expect(rootLink).toBeVisible({ timeout: 15_000 });
+    await expect(rootLink).toHaveCount(1);
+    await expect(rootLink).toContainText(rootId.slice(0, 8));
+
+    // The continuation is folded under the root, not rendered as its own row.
+    const continuationLink = page.locator(`a[href="runs/${continuationId}"]`);
+    await expect(continuationLink).toHaveCount(0);
+
+    const rootRow = page.locator('tr', { has: rootLink });
+    const expandBtn = rootRow.locator('button[title="Show descendant runs"]');
+    await expect(expandBtn).toBeVisible();
+    await expandBtn.click();
+
+    // Expanding reveals the continuation nested underneath.
+    await expect(continuationLink).toBeVisible({ timeout: 10_000 });
+    await expect(continuationLink).toContainText(continuationId.slice(0, 8));
+  });
+});


### PR DESCRIPTION
## Summary

Closes #569. The foundational block for AI-tasks-as-conversations (`docs/design/ai-task-authoring.md`): so a suspend/resume conversation, a pipeline, or a chain reads as **one collapsible unit** instead of N polluting run rows.

Denormalizes a **`root_run_id`** on `runs`, computed once at insert in `StartRunWithID` (parentless → self; child → inherits the parent's root). Because chains, pipeline stages, replay, and suspend/resume continuations all create runs through that one write path, they inherit the correct root automatically — so grouping a whole descendant tree is a single indexed `WHERE` (`ListRunGroup`) instead of a recursive walk.

- **Migration:** `root_run_id` via `addColumnIfMissing` + `idx_runs_root_run_id` + a `backfillRootRunID` pass that only ever touches `NULL` rows (idempotent no-op after first boot): self-root parentless rows → iteratively propagate parent→child → self-root any straggler.
- **Additive, no regression:** the existing free-text `run_group` collapse (#114/#116) is left untouched; `root_run_id` is structural grouping alongside it. All existing pipeline-stage grouping tests pass unmodified.
- **API:** `GET /api/runs?root=<id>` (whole tree) and `GET /api/runs/{id}/group-logs` (aggregated timeline; resolves the member's root first so any run id works).
- **WebUI:** the run list collapses top-level by `RootRunID === ID` and expands the full nested tree via `?root=`.

## Scope / caveats
- The **WebUI change (`dc-task-detail.js`) has no automated coverage** — it's a Lit component; logic was reviewed and `node --check`'d, but **a manual smoke test of the run-list collapse/expand is worth doing** before relying on it.
- `group-logs` is implemented but **not yet wired into a log viewer** — only the run-list tree collapse is surfaced. The combined-log-timeline UI comes with the migration (#571).
- Backfill walks the parent chain up to 100 passes; a >100-hop chain self-roots at the break (documented; not realistic for chains).

Verified: gofmt / vet / build / `go test ./...` / `-race` (registry, db, trigger) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)