### PR TITLE
fix(ai-agent-claude-cli): make the Claude MCP path work end-to-end

### DIFF
--- a/tasks/buildin/ai-agent-claude-cli/task.test.ts
+++ b/tasks/buildin/ai-agent-claude-cli/task.test.ts
@@ -386,6 +386,18 @@ Deno.test("buildClaudeArgs: mounts MCP strictly + explicitly with a config path"
     assertEquals(a[i + 1], "/w/.claude/mcp.json");
 });
 
+Deno.test("buildClaudeArgs: allowlists the dicode MCP tools when MCP is wired", () => {
+    // Without this, `claude -p` refuses un-allowlisted tools (can't prompt),
+    // so it sees the dicode tools but never calls them. Scoped to `mcp__dicode`
+    // so the agent gets dicode's surface, not raw Bash/Write host access.
+    const a = buildClaudeArgs({ prompt: "hi", mcpConfigPath: "/w/.claude/mcp.json" });
+    const i = a.indexOf("--allowedTools");
+    assertEquals(i >= 0, true);
+    assertEquals(a[i + 1], "mcp__dicode");
+    // No allowlist flag when MCP isn't mounted.
+    assertEquals(buildClaudeArgs({ prompt: "hi" }).includes("--allowedTools"), false);
+});
+
 Deno.test("passes --strict-mcp-config --mcp-config to claude when MCP is wired", async () => {
     // The bug this guards: previously the config was written to
     // <cwd>/.claude/mcp.json with no flag, which the CLI never auto-loads, so

--- a/tasks/buildin/ai-agent-claude-cli/task.ts
+++ b/tasks/buildin/ai-agent-claude-cli/task.ts
@@ -81,7 +81,14 @@ export function buildClaudeArgs(opts: {
     if (opts.claudeSessionId) args.push("--resume", opts.claudeSessionId);
     if (opts.model)           args.push("--model", opts.model);
     if (opts.systemPrompt)    args.push("--append-system-prompt", opts.systemPrompt);
-    if (opts.mcpConfigPath)   args.push("--strict-mcp-config", "--mcp-config", opts.mcpConfigPath);
+    if (opts.mcpConfigPath) {
+        args.push("--strict-mcp-config", "--mcp-config", opts.mcpConfigPath);
+        // Auto-approve the dicode MCP tools so the agent can call them
+        // non-interactively — `claude -p` refuses un-allowlisted tools rather
+        // than prompting. Scoped to the `dicode` server only, so the agent gets
+        // dicode's governed tool surface and NOT raw Bash/Write/Read host access.
+        args.push("--allowedTools", "mcp__dicode");
+    }
     return args;
 }
 

--- a/tasks/buildin/ai-agent-claude-cli/task.yaml
+++ b/tasks/buildin/ai-agent-claude-cli/task.yaml
@@ -89,6 +89,10 @@ permissions:
     # who stored the token via `dicode secrets set` or the WebUI.
     - name: CLAUDE_CODE_OAUTH_TOKEN
       secret: CLAUDE_CODE_OAUTH_TOKEN
+      # Dual-mode auth: when the secret is unset the task falls back to the
+      # logged-in $HOME/.claude credentials, so a missing secret must resolve to
+      # empty rather than failing the run before task.ts can fall back.
+      optional: true
     # HOME is required so the CLI can read/write its credential cache
     # at $HOME/.claude/.credentials.json. Without HOME set, it falls
     # back to '/' and refuses to persist state.
@@ -106,6 +110,10 @@ permissions:
     # dicode-task tool access).
     - name: DICODE_MCP_API_KEY
       secret: DICODE_MCP_API_KEY
+      # The daemon mints an ephemeral per-run MCP token and injects it over this
+      # entry (#564), so `dicode mcp install` isn't required; a missing secret
+      # must resolve to empty rather than failing the run before that injection.
+      optional: true
 
   fs:
     # Credential + session state cache. The CLI re-reads the OAuth token


### PR DESCRIPTION
## Summary

Found by driving `dicode ai --task buildin/ai-agent-claude-cli` live — two gaps the unit tests missed (they set env directly and stubbed the CLI, bypassing both the daemon's env resolver and claude's permission gate):

1. **Required-secret trap.** `CLAUDE_CODE_OAUTH_TOKEN` and `DICODE_MCP_API_KEY` were declared as required `secret:` env entries, so the daemon failed env-resolution **before the task ran** — silently defeating *both* the dual-mode login fallback (#563) and the ephemeral-token "no `dicode mcp install`" path (#564). Marking both `optional: true` (missing secret → empty string) lets the login fallback and the per-run ephemeral MCP token injection take over.
2. **`claude -p` refuses un-allowlisted tools** (it can't prompt headlessly), so Claude *saw* the dicode MCP tools but never called them. Pass `--allowedTools mcp__dicode` when MCP is wired — which also confines Claude to dicode's governed tool surface, not raw Bash/Write/Read host access (part of the #560 hardening).

## Verified live
On a real machine: `dicode ai --task buildin/ai-agent-claude-cli "list my tasks"` now authenticates via the logged-in `~/.claude` (no token), gets a per-run ephemeral MCP token (no `dicode mcp install`), and **actually calls `mcp__dicode__list_tasks`** and returns the registry.

Adds a `buildClaudeArgs` test for the `--allowedTools` wiring. Completes the end-to-end story behind #562/#563/#564.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Claude CLI MCP configuration handling by restricting enabled tools to the supported MCP tool when an MCP configuration is provided.
  - Tasks can now proceed when optional OAuth or MCP credentials are unavailable, allowing available local credentials and fallback handling to work as expected.

- **Tests**
  - Added coverage verifying MCP tool allowlisting with and without an MCP configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->