### PR TITLE
feat(cli): progress spinner, input-guard, and Ctrl+C-cancels-the-run for interactive tasks

### DIFF
--- a/cmd/dicode/flush_linux.go
+++ b/cmd/dicode/flush_linux.go
@@ -1,4 +1,4 @@
-//go:build unix
+//go:build linux
 
 package main
 

--- a/cmd/dicode/flush_other.go
+++ b/cmd/dicode/flush_other.go
@@ -1,0 +1,7 @@
+//go:build !unix
+
+package main
+
+// flushStdinFD is a no-op on platforms without a termios TCFLSH ioctl
+// (Windows and others).
+func flushStdinFD(fd int) {}

--- a/cmd/dicode/flush_other.go
+++ b/cmd/dicode/flush_other.go
@@ -1,7 +1,7 @@
-//go:build !unix
+//go:build !linux
 
 package main
 
 // flushStdinFD is a no-op on platforms without a termios TCFLSH ioctl
-// (Windows and others).
+// (macOS, Windows, BSD — TCFLSH is Linux-only).
 func flushStdinFD(fd int) {}

--- a/cmd/dicode/flush_unix.go
+++ b/cmd/dicode/flush_unix.go
@@ -1,0 +1,12 @@
+//go:build unix
+
+package main
+
+import "golang.org/x/sys/unix"
+
+// flushStdinFD discards input the kernel's line discipline has buffered for
+// fd (TCIFLUSH via TCFLSH), so keystrokes typed during a blocking daemon call
+// are not fed to the next prompt.
+func flushStdinFD(fd int) {
+	_ = unix.IoctlSetPointerInt(fd, unix.TCFLSH, unix.TCIFLUSH)
+}

--- a/cmd/dicode/follow.go
+++ b/cmd/dicode/follow.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +12,8 @@ import (
 	"os/signal"
 	"sort"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/dicode/dicode/pkg/ipc"
 	"github.com/dicode/dicode/pkg/registry"
@@ -23,6 +26,69 @@ import (
 // scriptable one-shot behavior.
 func stdinIsInteractive() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+// stderrIsInteractive reports whether stderr is a terminal. Gates the
+// progress spinner: piped/redirected stderr (and the unit tests, which write
+// to a bytes.Buffer) get no spinner bytes.
+func stderrIsInteractive() bool {
+	return term.IsTerminal(int(os.Stderr.Fd()))
+}
+
+// flushStdin discards any input the OS has buffered for stdin, so keystrokes
+// typed while a blocking daemon call (WaitRun) was in flight are not fed to
+// the next prompt. No-op when stdin isn't a TTY — a piped/redirected input
+// stream has no line-discipline buffer to flush, and its bytes are the
+// caller's scripted answers, not stray keystrokes.
+func flushStdin() {
+	if !stdinIsInteractive() {
+		return
+	}
+	flushStdinFD(int(os.Stdin.Fd()))
+}
+
+// spinnerFrames cycle to animate the "working…" indicator shown on s.prompt
+// while a blocking daemon call is in flight.
+var spinnerFrames = [...]rune{'⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'}
+
+const (
+	spinnerInterval   = 90 * time.Millisecond
+	spinnerClearWidth = 20 // wide enough to blank "⠋ working… " plus slack
+)
+
+// startSpinner starts an animated "working…" line on w, redrawn in place
+// with \r every spinnerInterval. active gates it: when false (stderr is not a
+// TTY) it is a no-op and the returned stop func writes nothing, so no
+// spinner bytes ever reach a non-interactive w (piped output, or a test's
+// bytes.Buffer). The stop func halts the goroutine and clears the line so
+// whatever prints next starts clean; it is safe to call more than once.
+func startSpinner(w io.Writer, active bool) func() {
+	if !active {
+		return func() {}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		ticker := time.NewTicker(spinnerInterval)
+		defer ticker.Stop()
+		for i := 0; ; i++ {
+			fmt.Fprintf(w, "\r%c working… ", spinnerFrames[i%len(spinnerFrames)])
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			cancel()
+			<-stopped
+			fmt.Fprint(w, "\r"+strings.Repeat(" ", spinnerClearWidth)+"\r")
+		})
+	}
 }
 
 // parseWizardFlags pulls the wizard control flags out of a run/resume argument
@@ -160,6 +226,9 @@ type followClient interface {
 	Resume(runID string, input []byte) (ipc.ResumeResult, error)
 	// WaitRun blocks until runID reaches a terminal or suspended state.
 	WaitRun(runID string) (ipc.RunResult, error)
+	// Cancel asks the daemon to kill an in-flight run — used when the operator
+	// interrupts a blocking WaitRun (Ctrl+C).
+	Cancel(runID string) error
 	// Logs returns the accumulated log lines of a run.
 	Logs(runID string) ([]ipc.LogEntry, error)
 }
@@ -211,6 +280,21 @@ func (f controlFollowClient) WaitRun(runID string) (ipc.RunResult, error) {
 		return ipc.RunResult{}, err
 	}
 	return res, nil
+}
+
+// Cancel sends cli.run.cancel on a fresh connection (SendFresh), not f.c's own
+// connection — that one is typically parked inside a concurrent WaitRun's
+// blocking Send, and ControlClient.Send is not safe for concurrent use on a
+// single connection.
+func (f controlFollowClient) Cancel(runID string) error {
+	resp, err := f.c.SendFresh(ipc.Request{Method: "cli.run.cancel", RunID: runID})
+	if err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	return nil
 }
 
 func (f controlFollowClient) Logs(runID string) ([]ipc.LogEntry, error) {
@@ -468,10 +552,13 @@ func (s *followSession) follow(suspendedRunID string) error {
 			return nil
 		}
 
-		result, err := s.client.WaitRun(contID)
+		result, err := s.waitRunInterruptible(contID)
 		if err != nil {
 			return err
 		}
+		// Discard input typed while the turn was in flight before the next
+		// step (or the terminal banner below) reads from s.in.
+		flushStdin()
 
 		if result.Status == registry.StatusSuspended {
 			// Quiet between turns: the next step's banner (the schema
@@ -499,6 +586,54 @@ func (s *followSession) follow(suspendedRunID string) error {
 	}
 }
 
+// errRunCancelled is returned by follow when the operator interrupts a
+// blocking WaitRun (Ctrl+C) and the in-flight run was cancelled on the daemon
+// in response. followSuspended treats it as a clean exit (130), not a crash.
+var errRunCancelled = errors.New("run cancelled by interrupt")
+
+// waitRunInterruptible wraps s.client.WaitRun(runID) with the two niceties an
+// interactive terminal gets around a blocking daemon call: an animated
+// spinner on s.prompt (stderr-TTY gated) for the duration, and — TTY stdin
+// only — a SIGINT handler that cancels the run on the daemon rather than
+// merely exiting the CLI. The signal handler is installed only for this call
+// and removed before it returns, so nothing is left listening between turns.
+func (s *followSession) waitRunInterruptible(runID string) (ipc.RunResult, error) {
+	stopSpinner := startSpinner(s.prompt, stderrIsInteractive())
+	defer stopSpinner()
+
+	type outcome struct {
+		res ipc.RunResult
+		err error
+	}
+	doneCh := make(chan outcome, 1)
+	go func() {
+		res, err := s.client.WaitRun(runID)
+		doneCh <- outcome{res, err}
+	}()
+
+	// A nil sigCh is never ready in the select below, so a non-interactive
+	// stdin (piped input, or the follow tests' fakes) leaves Ctrl+C handling
+	// off entirely and this degenerates to a plain wait on doneCh.
+	var sigCh chan os.Signal
+	if stdinIsInteractive() {
+		sigCh = make(chan os.Signal, 1)
+		signal.Notify(sigCh, os.Interrupt)
+		defer signal.Stop(sigCh)
+	}
+
+	select {
+	case out := <-doneCh:
+		return out.res, out.err
+	case <-sigCh:
+		stopSpinner()
+		fmt.Fprint(s.prompt, "\n^C — cancelling…\n")
+		if cerr := s.client.Cancel(runID); cerr != nil {
+			fmt.Fprintf(s.prompt, "dicode: cancel run: %v\n", cerr)
+		}
+		return ipc.RunResult{}, errRunCancelled
+	}
+}
+
 // printLogs fetches and prints a run's log lines, matching cmdLogs's format. A
 // fetch error is noted on the prompt stream but does not abort the follow.
 func (s *followSession) printLogs(runID string) {
@@ -512,13 +647,11 @@ func (s *followSession) printLogs(runID string) {
 	}
 }
 
-// followSuspended drives the interactive wizard against a live daemon. Logs of
-// steps that have already settled are on stdout; a step still in flight when
-// SIGINT arrives has not printed its logs, and the handler deliberately issues
-// no control request to fetch them — the main goroutine is usually parked in
-// WaitRun on the same connection, and ControlClient.Send is not safe for
-// concurrent use. The handler notes the interrupt and exits 130 (the shell
-// convention); the daemon cancels the in-flight run when the connection drops.
+// followSuspended drives the interactive wizard against a live daemon.
+// SIGINT during a blocking turn cancels the run and unwinds via
+// errRunCancelled (see waitRunInterruptible); outside a turn (e.g. at a
+// prompt) SIGINT has no handler installed and falls back to the OS default,
+// terminating the process the same way it always has.
 func followSuspended(c *ipc.ControlClient, runID string, prefill *prefillPool, nonInteractive bool) error {
 	s := &followSession{
 		client:         controlFollowClient{c: c},
@@ -528,15 +661,9 @@ func followSuspended(c *ipc.ControlClient, runID string, prefill *prefillPool, n
 		prefill:        prefill,
 		nonInteractive: nonInteractive,
 	}
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt)
-	defer signal.Stop(sigCh)
-	go func() {
-		if _, ok := <-sigCh; !ok {
-			return
-		}
-		fmt.Fprintln(s.prompt, "\ninterrupted")
+	err := s.follow(runID)
+	if errors.Is(err, errRunCancelled) {
 		os.Exit(130)
-	}()
-	return s.follow(runID)
+	}
+	return err
 }

--- a/cmd/dicode/follow_test.go
+++ b/cmd/dicode/follow_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dicode/dicode/pkg/ipc"
 )
@@ -20,6 +21,7 @@ type fakeFollowClient struct {
 	logs        map[string][]ipc.LogEntry  // runID -> log lines
 	submitted   map[string]json.RawMessage // suspended runID -> input submitted
 	waitCalls   int                        // number of WaitRun invocations
+	cancelled   []string                   // runIDs passed to Cancel, in order
 }
 
 func (f *fakeFollowClient) ResumeGet(runID string) (ipc.ResumeInfo, error) {
@@ -37,6 +39,11 @@ func (f *fakeFollowClient) Resume(runID string, input []byte) (ipc.ResumeResult,
 func (f *fakeFollowClient) WaitRun(runID string) (ipc.RunResult, error) {
 	f.waitCalls++
 	return f.waitResults[runID], nil
+}
+
+func (f *fakeFollowClient) Cancel(runID string) error {
+	f.cancelled = append(f.cancelled, runID)
+	return nil
 }
 
 func (f *fakeFollowClient) Logs(runID string) ([]ipc.LogEntry, error) {
@@ -531,5 +538,68 @@ func TestFollow_DaemonContinuationOneShot(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "resumed: continuation run run-2") {
 		t.Errorf("expected one-shot continuation output, got:\n%s", out.String())
+	}
+}
+
+// ── interactive-UX helpers: no-op off a TTY ─────────────────────────────────
+
+// startSpinner(w, false) must never write to w — the gate for piped/CI
+// output and every bytes.Buffer-backed test above.
+func TestStartSpinner_NoopWhenInactive(t *testing.T) {
+	var buf bytes.Buffer
+	stop := startSpinner(&buf, false)
+	stop()
+	stop() // must tolerate a repeat call without panicking
+	if buf.Len() != 0 {
+		t.Fatalf("inactive spinner wrote %q, want nothing", buf.String())
+	}
+}
+
+// An active spinner animates frames and leaves the line cleared (ending in a
+// bare \r) once stopped, so whatever prints next starts clean.
+func TestStartSpinner_ActiveAnimatesAndClearsOnStop(t *testing.T) {
+	var buf bytes.Buffer
+	stop := startSpinner(&buf, true)
+	time.Sleep(3 * spinnerInterval)
+	stop()
+	stop() // idempotent
+	got := buf.String()
+	if !strings.Contains(got, "working") {
+		t.Fatalf("active spinner wrote no frames: %q", got)
+	}
+	if !strings.HasSuffix(got, "\r") {
+		t.Fatalf("stop() must leave the line cleared (trailing \\r), got %q", got)
+	}
+}
+
+// flushStdin must not panic regardless of TTY state; under `go test` stdin is
+// not a TTY, so this also exercises the no-op path directly.
+func TestFlushStdin_NoopWhenStdinNotATTY(t *testing.T) {
+	flushStdin()
+}
+
+// waitRunInterruptible must degrade to a plain WaitRun when neither stdin nor
+// stderr is a TTY: no spinner bytes on prompt, no Cancel call, and the result
+// passes through unchanged. This is the path every fakeFollowClient-backed
+// test above runs (go test's stdin/stderr are not TTYs).
+func TestWaitRunInterruptible_NonTTY_NoSpinnerNoCancel(t *testing.T) {
+	client := &fakeFollowClient{
+		waitResults: map[string]ipc.RunResult{"run-1": {RunID: "run-1", Status: "success"}},
+	}
+	var prompt bytes.Buffer
+	s := &followSession{client: client, prompt: &prompt}
+
+	res, err := s.waitRunInterruptible("run-1")
+	if err != nil {
+		t.Fatalf("waitRunInterruptible: %v", err)
+	}
+	if res.Status != "success" {
+		t.Fatalf("status = %q, want success", res.Status)
+	}
+	if prompt.Len() != 0 {
+		t.Fatalf("non-TTY prompt got spinner bytes: %q", prompt.String())
+	}
+	if len(client.cancelled) != 0 {
+		t.Fatalf("Cancel must not be called absent a real interrupt, got %v", client.cancelled)
 	}
 }

--- a/cmd/dicode/task_test.go
+++ b/cmd/dicode/task_test.go
@@ -101,6 +101,7 @@ func (noopEngine) WaitRun(context.Context, string) (ipc.RunResult, error) {
 func (noopEngine) WaitRunSettled(context.Context, string) (ipc.RunResult, error) {
 	return ipc.RunResult{}, nil
 }
+func (noopEngine) KillRun(string) bool     { return false }
 func (noopEngine) ActiveRunCount() int     { return 0 }
 func (noopEngine) ActiveTaskSlots() int    { return 0 }
 func (noopEngine) MaxConcurrentTasks() int { return 0 }

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -238,6 +238,9 @@ func (cs *ControlServer) dispatch(ctx context.Context, req Request) (any, error)
 	case "cli.run.wait":
 		return cs.handleRunWait(ctx, req)
 
+	case "cli.run.cancel":
+		return cs.handleRunCancel(req)
+
 	case "cli.logs":
 		return cs.handleLogs(ctx, req)
 
@@ -654,6 +657,28 @@ func (cs *ControlServer) handleRunWait(ctx context.Context, req Request) (RunRes
 		}
 	}
 	return cs.engine.WaitRunSettled(ctx, req.RunID)
+}
+
+// RunCancelResult is the cli.run.cancel response. Killed is false when the
+// run was not currently cancellable (already terminal, or the id unknown) —
+// not an error, since the caller (an interactive follow loop reacting to
+// Ctrl+C) treats either outcome the same way: stop waiting on the run.
+type RunCancelResult struct {
+	Killed bool `json:"killed"`
+}
+
+// handleRunCancel kills an in-flight run by id. Backs the CLI's Ctrl+C-during-
+// a-turn cancellation: the follow loop sends this on a separate connection
+// while its primary connection is still blocked in cli.run.wait, since
+// ControlClient.Send is not safe for concurrent use on one connection.
+func (cs *ControlServer) handleRunCancel(req Request) (RunCancelResult, error) {
+	if req.RunID == "" {
+		return RunCancelResult{}, errors.New("runID required")
+	}
+	if cs.engine == nil {
+		return RunCancelResult{}, errors.New("run cancel not available (engine not wired)")
+	}
+	return RunCancelResult{Killed: cs.engine.KillRun(req.RunID)}, nil
 }
 
 func (cs *ControlServer) handleLogs(ctx context.Context, req Request) ([]LogEntry, error) {

--- a/pkg/ipc/control_client.go
+++ b/pkg/ipc/control_client.go
@@ -13,6 +13,11 @@ import (
 type ControlClient struct {
 	conn net.Conn
 	caps []string
+
+	// socketPath/tokenPath let SendFresh open an independent connection for a
+	// request that must not wait behind one already in flight on conn.
+	socketPath string
+	tokenPath  string
 }
 
 // Dial connects to the daemon control socket at socketPath and authenticates.
@@ -30,7 +35,7 @@ func Dial(socketPath, tokenPath string) (*ControlClient, error) {
 		return nil, fmt.Errorf("connect to daemon at %s: %w", socketPath, err)
 	}
 
-	c := &ControlClient{conn: conn}
+	c := &ControlClient{conn: conn, socketPath: socketPath, tokenPath: tokenPath}
 	if err := c.handshake(tok); err != nil {
 		conn.Close()
 		return nil, err
@@ -78,6 +83,20 @@ func (c *ControlClient) Send(req Request) (Response, error) {
 		return Response{}, fmt.Errorf("recv: %w", err)
 	}
 	return resp, nil
+}
+
+// SendFresh performs req on a brand-new connection, independent of any
+// request in flight on c's own connection. Send is half-duplex on a single
+// synchronous connection (one fixed request ID, one reader), so a caller that
+// needs to issue a request while c is blocked in Send elsewhere (e.g.
+// cancelling a run mid-cli.run.wait) must use SendFresh rather than Send.
+func (c *ControlClient) SendFresh(req Request) (Response, error) {
+	fresh, err := Dial(c.socketPath, c.tokenPath)
+	if err != nil {
+		return Response{}, err
+	}
+	defer fresh.Close()
+	return fresh.Send(req)
 }
 
 // Close closes the underlying connection.

--- a/pkg/ipc/control_run_cancel_test.go
+++ b/pkg/ipc/control_run_cancel_test.go
@@ -1,0 +1,73 @@
+package ipc
+
+// cli.run.cancel backs the CLI follow loop's Ctrl+C-during-a-turn behavior:
+// interrupting a blocking cli.run.wait cancels the run on the daemon instead
+// of merely exiting the CLI. This pins the dispatch → engine.KillRun wiring.
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// killRecordingEngine records the run id passed to KillRun and returns a
+// scripted result, mirroring how *trigger.Engine reports whether the run was
+// still cancellable.
+type killRecordingEngine struct {
+	mockEngine
+	killedID string
+	killOK   bool
+}
+
+func (e *killRecordingEngine) KillRun(runID string) bool {
+	e.killedID = runID
+	return e.killOK
+}
+
+func TestCLIRunCancel_DispatchesToEngineKillRun(t *testing.T) {
+	eng := &killRecordingEngine{killOK: true}
+	cs := &ControlServer{engine: eng, log: zap.NewNop()}
+
+	res, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.run.cancel", RunID: "run-123"})
+	if err != nil {
+		t.Fatalf("dispatch cli.run.cancel: %v", err)
+	}
+
+	if eng.killedID != "run-123" {
+		t.Fatalf("engine.KillRun called with runID %q, want %q", eng.killedID, "run-123")
+	}
+	out, ok := res.(RunCancelResult)
+	if !ok {
+		t.Fatalf("result type = %T, want RunCancelResult", res)
+	}
+	if !out.Killed {
+		t.Fatalf("result.Killed = false, want true")
+	}
+}
+
+func TestCLIRunCancel_MissingRunID(t *testing.T) {
+	eng := &killRecordingEngine{killOK: true}
+	cs := &ControlServer{engine: eng, log: zap.NewNop()}
+
+	if _, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.run.cancel"}); err == nil {
+		t.Fatal("dispatch cli.run.cancel with empty runID: want error, got nil")
+	}
+	if eng.killedID != "" {
+		t.Fatalf("engine.KillRun should not have been called, got runID %q", eng.killedID)
+	}
+}
+
+func TestCLIRunCancel_NotCancellable(t *testing.T) {
+	eng := &killRecordingEngine{killOK: false}
+	cs := &ControlServer{engine: eng, log: zap.NewNop()}
+
+	res, err := cs.dispatch(context.Background(), Request{ID: "1", Method: "cli.run.cancel", RunID: "gone"})
+	if err != nil {
+		t.Fatalf("dispatch cli.run.cancel: %v", err)
+	}
+	out := res.(RunCancelResult)
+	if out.Killed {
+		t.Fatal("result.Killed = true, want false for a non-cancellable run")
+	}
+}

--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -205,6 +205,10 @@ type EngineRunner interface {
 	// chain. The CLI needs this to render the resume form; dicode.run_task wants
 	// WaitRun's "block until genuinely terminal" contract.
 	WaitRunSettled(ctx context.Context, runID string) (RunResult, error)
+	// KillRun cancels an in-flight run by id, e.g. the CLI's Ctrl+C-during-a-turn
+	// cancellation (cli.run.cancel). Returns false when the run is not currently
+	// cancellable (already terminal, or the id is unknown).
+	KillRun(runID string) bool
 	ActiveRunCount() int
 	ActiveTaskSlots() int
 	MaxConcurrentTasks() int

--- a/pkg/ipc/server_test.go
+++ b/pkg/ipc/server_test.go
@@ -44,6 +44,7 @@ func (m *mockEngine) WaitRun(_ context.Context, _ string) (RunResult, error) {
 func (m *mockEngine) WaitRunSettled(_ context.Context, _ string) (RunResult, error) {
 	return m.result, m.err
 }
+func (m *mockEngine) KillRun(_ string) bool   { return false }
 func (m *mockEngine) ActiveRunCount() int     { return 0 }
 func (m *mockEngine) ActiveTaskSlots() int    { return 0 }
 func (m *mockEngine) MaxConcurrentTasks() int { return 0 }


### PR DESCRIPTION
## Summary

Makes running a suspending task interactively (e.g. the `ai-agent-claude-cli` chat) feel modern. All three features are **TTY-gated** — piped/CI output and the non-TTY unit tests are byte-for-byte unchanged.

- **Progress spinner** — a braille spinner animates on stderr while a turn is running (the blocking `WaitRun`), cleared before the reply prints.
- **Input guard** — keystrokes typed *during* a turn are flushed (`TCIFLUSH`, Unix; no-op elsewhere) so they don't leak into the next prompt.
- **Ctrl+C cancels the run** — previously SIGINT just exited the CLI while the task kept running on the daemon. Now, during a turn, Ctrl+C calls a new `cli.run.cancel` IPC → `engine.KillRun(runID)`, prints `^C — cancelling…`, and exits `130`. The signal handler and spinner goroutine are `defer`-scoped to the single wait — nothing leaks between turns; outside a turn, SIGINT falls back to the OS default.

Notable: `Cancel` can't reuse the primary control connection (it's blocked in `WaitRun`'s `Send`), so it dials a fresh one (`ControlClient.SendFresh`). `KillRun` already existed on the engine (webui kill-run endpoint); this exposes it on the `EngineRunner` interface + control socket. `cli.run.cancel` sits on the peer-cred'd local control socket, same trust model as `cli.run.wait`/`cli.resume`.

Verified: gofmt/vet/build, `go test` + `-race` on `cmd/dicode` and `pkg/ipc`, and the full `go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved interactive follow mode with a “working…” spinner during waits.
  * Pressing Ctrl+C now cancels an in-progress run and exits cleanly.
  * Buffered keystrokes are cleared between interactive prompts to prevent accidental input.
  * Added cross-platform support for interactive input handling.

* **Bug Fixes**
  * Improved behavior when following suspended runs across terminal and non-terminal environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->