### PR TITLE
fix(security): close ephemeral MCP token redactor leak and self-approval inversion

### DIFF
--- a/pkg/ipc/server.go
+++ b/pkg/ipc/server.go
@@ -579,17 +579,19 @@ func (s *Server) handleConn(conn net.Conn) {
 					)
 					continue
 				}
-				// Replace the run's redactor with a new one carrying
-				// these values. Prior redactor values (from secrets
-				// resolved at consumer-launch time) are NOT preserved
-				// here — the existing redactor doesn't expose its
-				// inner values. This is acceptable because a provider
-				// task is itself a CHILD run; its redactor only needs
-				// to scrub the values the provider just returned.
+				// Fold these values into the run's redactor, preserving
+				// what it already scrubs — the secrets resolved at launch
+				// and any ephemeral per-run MCP token. Replacing it wholesale
+				// would drop those and re-expose them on later log lines from
+				// this same run.
 				//
 				// atomic.Store synchronises with the atomic.Load on the
 				// "log" hot path; no mutex needed here.
-				s.redactor.Store(secrets.NewRedactor(sm))
+				extra := make([]string, 0, len(sm))
+				for _, v := range sm {
+					extra = append(extra, v)
+				}
+				s.redactor.Store(s.redactor.Load().WithExtra(extra...))
 
 				// Persist key names + [redacted] placeholders to the run
 				// log so operators can audit which secrets the provider

--- a/pkg/ipc/server_test.go
+++ b/pkg/ipc/server_test.go
@@ -1565,6 +1565,66 @@ func TestServer_SecretOutputRoutedAndRedacted(t *testing.T) {
 	}
 }
 
+// TestServer_SecretOutput_PreservesExistingRedaction is the regression for
+// the leak reopening on the output.secret path: a value the run's redactor
+// already scrubs (e.g. the ephemeral per-run MCP token folded in at launch)
+// must stay redacted after the task emits a secret output — the redactor is
+// extended, not replaced.
+func TestServer_SecretOutput_PreservesExistingRedaction(t *testing.T) {
+	const priorSecret = "mcp-token-abc123"
+	const newSecret = "postgres://x"
+
+	e := newTestEnv(t)
+	runID := fmt.Sprintf("test-%d", time.Now().UnixNano())
+	srv := New(runID, "test-task", e.secret, e.reg, e.db, nil, nil, zap.NewNop(), nil, nil)
+	srv.SetRedactor(secrets.NewRedactor(map[string]string{"DICODE_MCP_API_KEY": priorSecret}))
+
+	socketPath, token, err := srv.Start(context.Background())
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(srv.Stop)
+	conn := dial(t, socketPath)
+	t.Cleanup(func() { conn.Close() })
+	doHandshake(t, conn, token)
+
+	// The task emits a secret output — this rebuilds the run redactor.
+	sendMsg(t, conn, map[string]any{
+		"method":    "output",
+		"secret":    true,
+		"secretMap": map[string]string{"PG_URL": newSecret},
+	})
+	// Then logs a line containing both the prior token and the new secret.
+	sendMsg(t, conn, map[string]any{
+		"method":  "log",
+		"level":   "info",
+		"message": "dump: " + priorSecret + " and " + newSecret,
+	})
+	time.Sleep(50 * time.Millisecond)
+	conn.Close()
+	srv.Stop()
+
+	logs, err := e.reg.GetRunLogs(context.Background(), srv.runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var line string
+	for _, l := range logs {
+		if strings.HasPrefix(l.Message, "dump: ") {
+			line = l.Message
+		}
+	}
+	if line == "" {
+		t.Fatalf("dump log line not found in %d entries", len(logs))
+	}
+	if strings.Contains(line, priorSecret) {
+		t.Errorf("prior redactor value leaked after secret output: %q", line)
+	}
+	if strings.Contains(line, newSecret) {
+		t.Errorf("newly-output secret leaked: %q", line)
+	}
+}
+
 // TestServer_SecretOutputRejectsNestedMap verifies that a SecretMap whose
 // values are objects (rather than strings) is logged-and-dropped: nothing
 // arrives on the SetSecretOutput channel.

--- a/pkg/runtime/deno/runtime.go
+++ b/pkg/runtime/deno/runtime.go
@@ -234,12 +234,17 @@ func (rt *Runtime) Run(ctx context.Context, spec *task.Spec, opts RunOptions) (*
 	// Ephemeral per-run MCP token (opt-in via permissions.env
 	// DICODE_MCP_API_KEY): mint before anything else touches resolved, and
 	// defer the revoke unconditionally so it fires on every exit path below.
-	mcpRevoke, err := pkgruntime.ApplyMCPToken(ctx, rt.live(), rt.Log, spec, runID, resolved)
+	mcpToken, mcpRevoke, err := pkgruntime.ApplyMCPToken(ctx, rt.live(), rt.Log, spec, runID, resolved)
 	if err != nil {
 		result.Error = err
 		return result, nil
 	}
 	defer mcpRevoke()
+	// The redactor was snapshot before the mint; fold the token in so it is
+	// scrubbed from run logs like any other secret.
+	if mcpToken != "" {
+		redactor = redactor.WithExtra(mcpToken)
+	}
 
 	taskPath := spec.ScriptPath()
 	if taskPath == "" {

--- a/pkg/runtime/mcp_token.go
+++ b/pkg/runtime/mcp_token.go
@@ -50,24 +50,31 @@ func WantsMCPToken(spec *task.Spec) bool {
 // doesn't declare the env entry or no minter is wired (legacy/test path:
 // the static-secret env value, if any, is left untouched).
 //
+// The minted token value is returned so the caller can fold it into the
+// run-log redactor (secrets.Redactor.WithExtra) before any log stream or IPC
+// server is wired: the redactor is snapshot from the secrets resolved for the
+// run, which do not include a token minted after resolution, so without this
+// the ephemeral key would pass through run logs unredacted. token is "" when
+// nothing was minted.
+//
 // Callers MUST defer the returned revoke unconditionally, immediately after
 // this call returns, so the token is revoked on every exit path (success,
 // error, timeout, panic). Revoke runs against context.Background() rather
 // than the run's ctx: a timed-out or canceled run is exactly the case where
 // revocation matters most, and it must not be defeated by the same
 // cancellation that ended the run.
-func ApplyMCPToken(ctx context.Context, live *BridgeDeps, log *zap.Logger, spec *task.Spec, runID string, resolved map[string]string) (revoke func(), err error) {
+func ApplyMCPToken(ctx context.Context, live *BridgeDeps, log *zap.Logger, spec *task.Spec, runID string, resolved map[string]string) (token string, revoke func(), err error) {
 	noop := func() {}
 	minter := live.MCPTokenMinter
 	if minter == nil || !WantsMCPToken(spec) {
-		return noop, nil
+		return "", noop, nil
 	}
-	token, err := minter.Mint(ctx, runID)
+	token, err = minter.Mint(ctx, runID)
 	if err != nil {
-		return noop, fmt.Errorf("mint mcp token: %w", err)
+		return "", noop, fmt.Errorf("mint mcp token: %w", err)
 	}
 	resolved[MCPTokenEnvName] = token
-	return func() {
+	return token, func() {
 		if rerr := minter.Revoke(context.Background(), runID); rerr != nil && log != nil {
 			log.Warn("revoke ephemeral mcp token failed", zap.String("run", runID), zap.Error(rerr))
 		}

--- a/pkg/runtime/python/runtime.go
+++ b/pkg/runtime/python/runtime.go
@@ -200,12 +200,17 @@ func (e *executor) Execute(ctx context.Context, spec *task.Spec, opts pkgruntime
 	// Ephemeral per-run MCP token (opt-in via permissions.env
 	// DICODE_MCP_API_KEY): mint before anything else touches resolved, and
 	// defer the revoke unconditionally so it fires on every exit path below.
-	mcpRevoke, err := pkgruntime.ApplyMCPToken(ctx, &e.parent.BridgeDeps, e.Log, spec, runID, resolved)
+	mcpToken, mcpRevoke, err := pkgruntime.ApplyMCPToken(ctx, &e.parent.BridgeDeps, e.Log, spec, runID, resolved)
 	if err != nil {
 		result.Error = err
 		return result, nil
 	}
 	defer mcpRevoke()
+	// The redactor was snapshot before the mint; fold the token in so it is
+	// scrubbed from run logs like any other secret.
+	if mcpToken != "" {
+		redactor = redactor.WithExtra(mcpToken)
+	}
 
 	// Read the user's task.py.
 	scriptPath := spec.ScriptPath()

--- a/pkg/secrets/redactor.go
+++ b/pkg/secrets/redactor.go
@@ -21,6 +21,10 @@ const RedactionMarker = "<REDACTED>"
 type Redactor struct {
 	// nil when there are no values to redact — the hot path bails early.
 	replacer *strings.Replacer
+	// The deduped, non-empty values this redactor was built from, retained
+	// so WithExtra can rebuild rather than compose (a strings.Replacer is
+	// opaque and cannot be extended in place).
+	values []string
 }
 
 // NewRedactor returns a Redactor that replaces every distinct non-empty
@@ -33,6 +37,26 @@ type Redactor struct {
 // Duplicates are dropped so repeated secret registration doesn't produce
 // a duplicate-key argument to strings.NewReplacer (which would panic).
 func NewRedactor(values map[string]string) *Redactor {
+	vals := make([]string, 0, len(values))
+	for _, v := range values {
+		vals = append(vals, v)
+	}
+	return redactorFromValues(vals)
+}
+
+// WithExtra returns a new Redactor that redacts everything r does plus each
+// non-empty value in extra. Safe on a nil or zero-value receiver. Used to
+// fold in a value that only becomes known after the run's secrets were
+// resolved — e.g. an ephemeral per-run token minted after ResolveRunEnv.
+func (r *Redactor) WithExtra(extra ...string) *Redactor {
+	var base []string
+	if r != nil {
+		base = r.values
+	}
+	return redactorFromValues(append(append([]string(nil), base...), extra...))
+}
+
+func redactorFromValues(values []string) *Redactor {
 	if len(values) == 0 {
 		return &Redactor{}
 	}
@@ -62,7 +86,7 @@ func NewRedactor(values map[string]string) *Redactor {
 	for _, v := range uniq {
 		pairs = append(pairs, v, RedactionMarker)
 	}
-	return &Redactor{replacer: strings.NewReplacer(pairs...)}
+	return &Redactor{replacer: strings.NewReplacer(pairs...), values: uniq}
 }
 
 // RedactString returns s with every occurrence of a known secret value

--- a/pkg/secrets/redactor_test.go
+++ b/pkg/secrets/redactor_test.go
@@ -34,6 +34,29 @@ func TestRedactor_EmptyValueMap(t *testing.T) {
 	}
 }
 
+func TestRedactor_WithExtra(t *testing.T) {
+	t.Parallel()
+
+	// Extra value folds in on top of the base secrets.
+	base := NewRedactor(map[string]string{"A": "alpha"})
+	r := base.WithExtra("bravo")
+	if got := r.RedactString("alpha bravo"); got != RedactionMarker+" "+RedactionMarker {
+		t.Errorf("WithExtra redaction = %q", got)
+	}
+	// The original is untouched — WithExtra returns a new Redactor.
+	if got := base.RedactString("alpha bravo"); got != RedactionMarker+" bravo" {
+		t.Errorf("base mutated by WithExtra: %q", got)
+	}
+	// Safe on nil and zero receivers, and empty extras are dropped.
+	var nilR *Redactor
+	if got := nilR.WithExtra("token").RedactString("token"); got != RedactionMarker {
+		t.Errorf("nil.WithExtra = %q", got)
+	}
+	if got := base.WithExtra("").RedactString("alpha"); got != RedactionMarker {
+		t.Errorf("empty extra should be a no-op add: %q", got)
+	}
+}
+
 func TestRedactor_SingleValue(t *testing.T) {
 	t.Parallel()
 	r := NewRedactor(map[string]string{"MY_TOKEN": "s3cr3t"})

--- a/pkg/webui/apikeys.go
+++ b/pkg/webui/apikeys.go
@@ -98,7 +98,7 @@ func (s *apiKeyStore) validate(ctx context.Context, raw string) bool {
 // the ephemeral per-run MCP token namespace. Governance endpoints (approve,
 // commit-push) gate on this so a prompt-injected agent holding its own run's
 // ephemeral token can't approve or push the very task it just authored —
-// which would invert the trust-on-change approval gate (#392).
+// which would invert the trust-on-change approval gate.
 func (s *apiKeyStore) validateNonEphemeral(ctx context.Context, raw string) bool {
 	name, ok := s.lookup(ctx, raw)
 	return ok && !strings.HasPrefix(name, ephemeralKeyPrefix)
@@ -257,6 +257,14 @@ func (s *Server) apiCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Name == "" {
 		jsonErr(w, "name is required", http.StatusBadRequest)
+		return
+	}
+	// The tool-managed namespaces are reserved: a dashboard key named into
+	// them would be denied at governance endpoints (validateNonEphemeral) and
+	// swept by the startup revoke — surprising data loss. Keep them off-limits
+	// to operator-chosen names.
+	if strings.HasPrefix(body.Name, ephemeralKeyPrefix) || strings.HasPrefix(body.Name, cliManagedKeyPrefix) {
+		jsonErr(w, "name uses a reserved prefix", http.StatusBadRequest)
 		return
 	}
 	raw, info, err := s.apiKeys.generate(r.Context(), body.Name)

--- a/pkg/webui/apikeys.go
+++ b/pkg/webui/apikeys.go
@@ -60,32 +60,48 @@ func (s *apiKeyStore) generate(ctx context.Context, name string) (raw string, in
 	return raw, info, nil
 }
 
-// Validate checks a raw key against stored hashes, updates last_used, and
-// returns true if valid and not expired.
-func (s *apiKeyStore) validate(ctx context.Context, raw string) bool {
+// lookup checks a raw key against stored hashes, updates last_used, and
+// returns the key's name when valid and not expired.
+func (s *apiKeyStore) lookup(ctx context.Context, raw string) (name string, ok bool) {
 	if !strings.HasPrefix(raw, apiKeyPrefix) {
-		return false
+		return "", false
 	}
 	hash := hashAPIKey(raw)
 	now := time.Now().Unix()
-	found := false
 
 	var id string
 	_ = s.db.Query(ctx,
-		`SELECT id FROM api_keys WHERE key_hash = ? AND (expires_at IS NULL OR expires_at > ?)`,
+		`SELECT id, name FROM api_keys WHERE key_hash = ? AND (expires_at IS NULL OR expires_at > ?)`,
 		[]any{hash, now},
 		func(rows db.Scanner) error {
 			if rows.Next() {
-				found = true
-				return rows.Scan(&id)
+				ok = true
+				return rows.Scan(&id, &name)
 			}
 			return nil
 		},
 	)
-	if found && id != "" {
+	if ok && id != "" {
 		_ = s.db.Exec(ctx, `UPDATE api_keys SET last_used = ? WHERE id = ?`, now, id)
+		return name, true
 	}
-	return found
+	return "", false
+}
+
+// validate reports whether raw is a valid, unexpired API key.
+func (s *apiKeyStore) validate(ctx context.Context, raw string) bool {
+	_, ok := s.lookup(ctx, raw)
+	return ok
+}
+
+// validateNonEphemeral is validate that additionally rejects keys minted in
+// the ephemeral per-run MCP token namespace. Governance endpoints (approve,
+// commit-push) gate on this so a prompt-injected agent holding its own run's
+// ephemeral token can't approve or push the very task it just authored —
+// which would invert the trust-on-change approval gate (#392).
+func (s *apiKeyStore) validateNonEphemeral(ctx context.Context, raw string) bool {
+	name, ok := s.lookup(ctx, raw)
+	return ok && !strings.HasPrefix(name, ephemeralKeyPrefix)
 }
 
 // List returns all API keys (without hashes).
@@ -184,20 +200,33 @@ func hashAPIKey(raw string) string {
 // requireAPIKey is a middleware that checks for a valid Bearer API key.
 // Only active when server.auth is true.
 func (s *Server) requireAPIKey(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !s.cfg.Server.Auth {
+	return s.apiKeyMiddleware(s.apiKeys.validate)(next)
+}
+
+// requireNonEphemeralAPIKey is requireAPIKey that additionally rejects
+// ephemeral per-run MCP tokens, for governance endpoints an agent must not
+// reach with its own run's token (see validateNonEphemeral).
+func (s *Server) requireNonEphemeralAPIKey(next http.Handler) http.Handler {
+	return s.apiKeyMiddleware(s.apiKeys.validateNonEphemeral)(next)
+}
+
+func (s *Server) apiKeyMiddleware(validate func(context.Context, string) bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !s.cfg.Server.Auth {
+				next.ServeHTTP(w, r)
+				return
+			}
+			raw := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+			if raw == "" || !validate(r.Context(), raw) {
+				s.auditDenied(r, "invalid or missing API key")
+				w.Header().Set("WWW-Authenticate", `Bearer realm="dicode"`)
+				jsonErr(w, "invalid or missing API key", http.StatusUnauthorized)
+				return
+			}
 			next.ServeHTTP(w, r)
-			return
-		}
-		raw := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
-		if raw == "" || !s.apiKeys.validate(r.Context(), raw) {
-			s.auditDenied(r, "invalid or missing API key")
-			w.Header().Set("WWW-Authenticate", `Bearer realm="dicode"`)
-			jsonErr(w, "invalid or missing API key", http.StatusUnauthorized)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
+		})
+	}
 }
 
 // apiListAPIKeys lists all API keys (no raw values).

--- a/pkg/webui/approval_test.go
+++ b/pkg/webui/approval_test.go
@@ -291,6 +291,29 @@ func TestAPI_ApproveTask_RejectsEphemeralToken(t *testing.T) {
 	}
 }
 
+// TestAPI_ResumeReplay_RejectEphemeralToken pins that an agent's ephemeral
+// per-run token cannot drive resume/replay of arbitrary runs. A 401 at the
+// auth layer is enough — the handler is never reached, so the target run need
+// not exist.
+func TestAPI_ResumeReplay_RejectEphemeralToken(t *testing.T) {
+	srv, _, _ := newApprovalTestServer(t, true)
+	ephemeral, err := newMCPTokenMinter(srv.apiKeys).Mint(context.Background(), "run-self")
+	if err != nil {
+		t.Fatalf("mint ephemeral: %v", err)
+	}
+	h := srv.Handler()
+
+	for _, path := range []string{"/api/runs/other-run/resume", "/api/runs/other-run/replay"} {
+		req := httptest.NewRequest(http.MethodPost, path, nil)
+		req.Header.Set("Authorization", "Bearer "+ephemeral)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("%s with ephemeral token: status = %d, want 401: %s", path, w.Code, w.Body.String())
+		}
+	}
+}
+
 func TestAPI_ApproveTask_SessionCookieWorks(t *testing.T) {
 	srv, reg, _ := newApprovalTestServer(t, true)
 	registerMinimalTask(t, reg, "repo/pending-task")

--- a/pkg/webui/approval_test.go
+++ b/pkg/webui/approval_test.go
@@ -259,6 +259,38 @@ func TestAPI_ApproveTask_RequiresAuth(t *testing.T) {
 	}
 }
 
+// TestAPI_ApproveTask_RejectsEphemeralToken is the regression for the
+// self-approval inversion: an agent's own ephemeral per-run MCP token is a
+// valid API key, but it must not let that agent approve the task it just
+// authored. The gate must stay pending.
+func TestAPI_ApproveTask_RejectsEphemeralToken(t *testing.T) {
+	srv, reg, _ := newApprovalTestServer(t, true)
+	registerMinimalTask(t, reg, "repo/pending-task")
+	gate := newFakeGate()
+	gate.pending["repo/pending-task"] = "hash-1"
+	srv.SetApprovalGate(gate)
+
+	ephemeral, err := newMCPTokenMinter(srv.apiKeys).Mint(context.Background(), "run-self")
+	if err != nil {
+		t.Fatalf("mint ephemeral: %v", err)
+	}
+	// Sanity: it really is a valid key, just not one allowed here.
+	if !srv.apiKeys.validate(context.Background(), ephemeral) {
+		t.Fatal("precondition: ephemeral token should validate as a key")
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/repo%2Fpending-task/approve", nil)
+	req.Header.Set("Authorization", "Bearer "+ephemeral)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("ephemeral token: status = %d, want 401: %s", w.Code, w.Body.String())
+	}
+	if !gate.IsPending("repo/pending-task") {
+		t.Fatal("ephemeral token must not approve the task")
+	}
+}
+
 func TestAPI_ApproveTask_SessionCookieWorks(t *testing.T) {
 	srv, reg, _ := newApprovalTestServer(t, true)
 	registerMinimalTask(t, reg, "repo/pending-task")

--- a/pkg/webui/auth.go
+++ b/pkg/webui/auth.go
@@ -145,23 +145,37 @@ func (s *Server) hasValidSession(w http.ResponseWriter, r *http.Request) bool {
 // Used by endpoints that need to be reachable from both the WebUI (cookies)
 // and CLI/CI tooling (Bearer). When server.auth is disabled this is a no-op.
 func (s *Server) requireSessionOrAPIKey(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !s.cfg.Server.Auth {
-			next.ServeHTTP(w, r)
-			return
-		}
-		if raw := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "); raw != "" && s.apiKeys.validate(r.Context(), raw) {
-			next.ServeHTTP(w, r)
-			return
-		}
-		if s.hasValidSession(w, r) {
-			next.ServeHTTP(w, r)
-			return
-		}
-		s.auditDenied(r, "no valid session or API key")
-		w.Header().Set("WWW-Authenticate", `Bearer realm="dicode"`)
-		jsonErr(w, "unauthorized", http.StatusUnauthorized)
-	})
+	return s.sessionOrAPIKeyMiddleware(s.apiKeys.validate)(next)
+}
+
+// requireSessionOrNonEphemeralAPIKey is requireSessionOrAPIKey that rejects
+// ephemeral per-run MCP tokens on the Bearer path (a session cookie is still
+// accepted). Governance endpoints an agent must not self-serve — task
+// approval above all — gate on this (see validateNonEphemeral).
+func (s *Server) requireSessionOrNonEphemeralAPIKey(next http.Handler) http.Handler {
+	return s.sessionOrAPIKeyMiddleware(s.apiKeys.validateNonEphemeral)(next)
+}
+
+func (s *Server) sessionOrAPIKeyMiddleware(validate func(context.Context, string) bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !s.cfg.Server.Auth {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if raw := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "); raw != "" && validate(r.Context(), raw) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if s.hasValidSession(w, r) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			s.auditDenied(r, "no valid session or API key")
+			w.Header().Set("WWW-Authenticate", `Bearer realm="dicode"`)
+			jsonErr(w, "unauthorized", http.StatusUnauthorized)
+		})
+	}
 }
 
 // requireAuth is a middleware that enforces authentication when server.auth is

--- a/pkg/webui/mcp_token_minter_test.go
+++ b/pkg/webui/mcp_token_minter_test.go
@@ -96,6 +96,45 @@ func TestRevokeByNamePrefix_SweepsEphemeralOnly(t *testing.T) {
 	}
 }
 
+// TestValidateNonEphemeral covers the governance-endpoint guard: a valid
+// ephemeral per-run token is rejected while operator, CLI-managed, and
+// dashboard keys still pass. This is what stops a prompt-injected agent from
+// approving or pushing the task it just authored with its own run token.
+func TestValidateNonEphemeral(t *testing.T) {
+	ctx := context.Background()
+	keys := newTestAPIKeyStore(t)
+
+	ephemeral, err := newMCPTokenMinter(keys).Mint(ctx, "run-x")
+	if err != nil {
+		t.Fatalf("mint ephemeral: %v", err)
+	}
+	cliKey, _, err := keys.generate(ctx, cliManagedKeyPrefix+"laptop")
+	if err != nil {
+		t.Fatalf("generate cli key: %v", err)
+	}
+	dashKey, _, err := keys.generate(ctx, "my dashboard key")
+	if err != nil {
+		t.Fatalf("generate dashboard key: %v", err)
+	}
+
+	// Ephemeral token is a valid key but must fail the governance check.
+	if !keys.validate(ctx, ephemeral) {
+		t.Fatal("precondition: ephemeral token should be a valid key")
+	}
+	if keys.validateNonEphemeral(ctx, ephemeral) {
+		t.Error("ephemeral token passed validateNonEphemeral")
+	}
+	if !keys.validateNonEphemeral(ctx, cliKey) {
+		t.Error("CLI-managed key rejected by validateNonEphemeral")
+	}
+	if !keys.validateNonEphemeral(ctx, dashKey) {
+		t.Error("dashboard key rejected by validateNonEphemeral")
+	}
+	if keys.validateNonEphemeral(ctx, "dck_not-a-real-key") {
+		t.Error("bogus key passed validateNonEphemeral")
+	}
+}
+
 // TestRevokeByNamePrefix_RefusesOtherPrefixes guards against the sweep
 // primitive being repurposed to bulk-delete keys outside the ephemeral
 // namespace.

--- a/pkg/webui/mcp_token_minter_test.go
+++ b/pkg/webui/mcp_token_minter_test.go
@@ -2,6 +2,9 @@ package webui
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/dicode/dicode/pkg/db"
@@ -132,6 +135,37 @@ func TestValidateNonEphemeral(t *testing.T) {
 	}
 	if keys.validateNonEphemeral(ctx, "dck_not-a-real-key") {
 		t.Error("bogus key passed validateNonEphemeral")
+	}
+}
+
+// TestCreateAPIKey_RejectsReservedPrefix covers the dashboard-create guard:
+// operator-chosen names must not land in a tool-managed namespace, where they
+// would be denied at governance endpoints and swept at startup.
+func TestCreateAPIKey_RejectsReservedPrefix(t *testing.T) {
+	srv, _, _ := newApprovalTestServer(t, true)
+	h := srv.Handler()
+	cookie := login(t, h, "hunter2", false)
+	if cookie == nil {
+		t.Fatal("login failed")
+	}
+
+	for _, name := range []string{ephemeralKeyPrefix + "foo", cliManagedKeyPrefix + "bar"} {
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/keys", strings.NewReader(`{"name":"`+name+`"}`))
+		req.AddCookie(cookie)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("name %q: status = %d, want 400: %s", name, w.Code, w.Body.String())
+		}
+	}
+
+	// A normal name still succeeds.
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/keys", strings.NewReader(`{"name":"my key"}`))
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("normal name: status = %d, want 200: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -604,7 +604,9 @@ func (s *Server) Handler() http.Handler {
 
 	// Commit-push endpoint — API-key gated, mounted outside the session-auth
 	// group so IPC tasks and CI scripts can call it with a Bearer token.
-	r.With(s.requireAPIKey).Post("/api/sources/{name}/commit-push", s.apiCommitPush)
+	// Ephemeral per-run tokens are denied: an agent must not push the source
+	// changes it just authored (see requireNonEphemeralAPIKey).
+	r.With(s.requireNonEphemeralAPIKey).Post("/api/sources/{name}/commit-push", s.apiCommitPush)
 
 	// Replay endpoint — accepts either a session cookie (WebUI replay button)
 	// or a Bearer API key (CLI / auto-fix scripts). Mounted outside the
@@ -617,9 +619,11 @@ func (s *Server) Handler() http.Handler {
 	// from the client.
 	r.With(s.requireSessionOrAPIKey).Post("/api/runs/{runID}/resume", s.apiResumeRun)
 
-	// Approval-gate approve endpoint (#398) — same auth posture as replay:
-	// session cookie (WebUI approve button) or Bearer API key.
-	r.With(s.requireSessionOrAPIKey).Post("/api/tasks/{id}/approve", s.apiApproveTask)
+	// Approval-gate approve endpoint (#398) — session cookie (WebUI approve
+	// button) or Bearer API key, but NOT an ephemeral per-run token: the
+	// approval gate's whole purpose is that a human, not the authoring agent,
+	// clears a changed task (see requireSessionOrNonEphemeralAPIKey).
+	r.With(s.requireSessionOrNonEphemeralAPIKey).Post("/api/tasks/{id}/approve", s.apiApproveTask)
 
 	// Tokenized approve link (#398) — the single-use token in the URL is the
 	// auth, so these stay outside the session groups. GET renders a confirm

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -608,16 +608,19 @@ func (s *Server) Handler() http.Handler {
 	// changes it just authored (see requireNonEphemeralAPIKey).
 	r.With(s.requireNonEphemeralAPIKey).Post("/api/sources/{name}/commit-push", s.apiCommitPush)
 
-	// Replay endpoint — accepts either a session cookie (WebUI replay button)
-	// or a Bearer API key (CLI / auto-fix scripts). Mounted outside the
-	// session-only group so machine callers without cookies still work.
-	r.With(s.requireSessionOrAPIKey).Post("/api/runs/{runID}/replay", s.apiReplayRun)
+	// Replay endpoint — session cookie (WebUI replay button) or Bearer API key
+	// (CLI / auto-fix scripts). Mounted outside the session-only group so
+	// machine callers without cookies still work. An ephemeral per-run token
+	// is denied: it must not re-drive arbitrary runs across the fleet.
+	r.With(s.requireSessionOrNonEphemeralAPIKey).Post("/api/runs/{runID}/replay", s.apiReplayRun)
 
 	// Resume endpoint (#95) — a suspended run's form submission. Same auth
-	// posture as replay: session cookie (WebUI form) or Bearer API key. The
-	// raw resume_token is resolved server-side from the run, never trusted
-	// from the client.
-	r.With(s.requireSessionOrAPIKey).Post("/api/runs/{runID}/resume", s.apiResumeRun)
+	// posture as replay: session cookie (WebUI form) or non-ephemeral Bearer
+	// key; the driving CLI uses its own managed key, so denying the ephemeral
+	// per-run token here costs nothing and walls agents off from resuming
+	// other runs with attacker-chosen input. The raw resume_token is resolved
+	// server-side from the run, never trusted from the client.
+	r.With(s.requireSessionOrNonEphemeralAPIKey).Post("/api/runs/{runID}/resume", s.apiResumeRun)
 
 	// Approval-gate approve endpoint (#398) — session cookie (WebUI approve
 	// button) or Bearer API key, but NOT an ephemeral per-run token: the


### PR DESCRIPTION
## Summary

The Fable-led session retrospective found two governance holes in the per-run ephemeral MCP token (#564) that CI and the merge-time reviews missed. Both are exploitable only by prompt-injected agent content under dicode's trust model, but both undermine the "governed agent" design directly. This closes them.

**Redactor leak (#580).** `ApplyMCPToken` mints the token *after* `ResolveRunEnv` has already frozen the run-log redactor, so the minted key was never scrubbed from run logs. A task declaring `permissions.env: [DICODE_MCP_API_KEY]` that dumps its env on a crash persisted a live, full-surface key to SQLite, the WebUI, `dicode logs`, and group-logs. The fix returns the minted token from `ApplyMCPToken` and folds it into the redactor (`secrets.Redactor.WithExtra`) in both runtimes before any IPC server or log stream is wired.

**Self-approval inversion (#581).** The minted key is full-surface, so it satisfied the Bearer path on `POST /api/tasks/{id}/approve` and `/api/sources/{name}/commit-push` — letting a prompt-injected agent approve and push the very task it just authored, inverting the keystone of the #392 trust-on-change gate. Governance endpoints now gate on `validateNonEphemeral`, which rejects the `ephemeral/run/` namespace on the Bearer path; a session cookie or any operator/CLI-managed key still passes unchanged.

## Deliberately left behind

Capability-scoping the token (so its permissions derive from the task's declared surface rather than being all-or-nothing) and a short `expires_at` TTL on mints remain tracked in #567 — this PR is the cheap must-fix slice, not the full scoping work. The claude-cli deny-posture hardening stays in #560.

Closes #580
Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Ephemeral per-run tokens can no longer approve tasks or commit and push changes.
  * Durable API keys and authenticated sessions continue to support these actions.

* **Bug Fixes**
  * Per-run MCP tokens are now automatically removed from runtime and Python execution logs.
  * API key validation and authentication handling are more consistent across protected actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->