### PR TITLE
fix(dev-clones-cleanup): protect suspended runs' clones from sweep

### DIFF
--- a/tasks/buildin/dev-clones-cleanup/task.test.ts
+++ b/tasks/buildin/dev-clones-cleanup/task.test.ts
@@ -77,6 +77,39 @@ test("removes orphan clones, keeps active run", async () => {
   }
 });
 
+test("protects a suspended run's clone, sweeps a terminal run's clone", async () => {
+  // A suspended run is an AI chat/authoring session paused awaiting user input;
+  // its sandbox must survive the sweep. A terminal run's clone is fair game.
+  const dataDir = await Deno.makeTempDir({ prefix: "dc-cleanup-susp-" });
+  try {
+    await makeCloneTree(dataDir, [
+      { source: "buildin", runID: "run-suspended-1" },
+      { source: "buildin", runID: "run-failed-1" },
+    ]);
+
+    env.set("DICODE_DATADIR", dataDir);
+
+    dicode.list_tasks = async () => [{ id: "my-task" }];
+    dicode.get_runs = async (_id: string) => {
+      return [
+        { ID: "run-suspended-1", Status: "suspended" },
+        { ID: "run-failed-1",    Status: "failed" },
+      ];
+    };
+
+    const result = await runTask() as { ok: boolean; removed: number; kept: number };
+
+    assert.equal(result.ok, true);
+    assert.equal(result.removed, 1);
+    assert.equal(result.kept, 1);
+
+    const remaining = await listCloneDirs(dataDir);
+    assert.equal(JSON.stringify(remaining), JSON.stringify(["run-suspended-1"]));
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+  }
+});
+
 test("returns early with note when dev-clones dir does not exist", async () => {
   const dataDir = await Deno.makeTempDir({ prefix: "dc-cleanup-ne-" });
   // Do NOT create dev-clones under it — task should detect NotFound.

--- a/tasks/buildin/dev-clones-cleanup/task.ts
+++ b/tasks/buildin/dev-clones-cleanup/task.ts
@@ -1,7 +1,7 @@
 // Sweeps orphaned dev-mode clone directories.
 //
 // Layout: ${DATADIR}/dev-clones/<sourceName>/<runID>/
-// A clone is orphan iff its <runID> is not in the set of currently-running
+// A clone is orphan iff its <runID> is not in the set of non-terminal
 // run IDs (across all registered tasks). Files/dirs that do not fit the
 // layout are left alone.
 //
@@ -26,7 +26,9 @@ async function collectActiveRunIDs(dicode: Dicode): Promise<Set<string>> {
       continue; // task may have been deregistered between list_tasks and get_runs
     }
     for (const r of runs) {
-      if (r.Status === "running") active.add(r.ID);
+      // A suspended run is paused awaiting user input (an AI chat/authoring
+      // session), so its dev-clone is still live — protect any non-terminal run.
+      if (r.Status === "running" || r.Status === "suspended") active.add(r.ID);
     }
   }
   return active;


### PR DESCRIPTION
## Summary

The dev-clones-cleanup sweep deletes any dev-mode clone whose run is not currently `running`. A **suspended** run — an AI chat/authoring session paused waiting for the user's next message — is not `running`, so its dev-clone was classed an orphan and reaped within ≤15 minutes, destroying the user's sandbox mid-conversation.

`collectActiveRunIDs` now treats a run as active when its status is `running` **or** `suspended`, protecting every non-terminal run. This mirrors the registry's own stale-run sweep, which already deliberately skips suspended runs (`TestCleanupStaleRuns_SkipsSuspended`). Terminal runs (`success`/`failed`/etc.) remain eligible for cleanup.

The status strings match `pkg/registry`'s `StatusRunning`/`StatusSuspended` constants.

Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)