### PR TITLE
feat(mcp): capability-scope the ephemeral per-run MCP token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Run a single test package: `go test ./pkg/registry/... -timeout 60s -run TestNam
 5. Create registry (`pkg/registry`) — in-memory task state + SQLite run log
 6. Init runtimes (`pkg/runtime/deno`, `pkg/runtime/python`, `pkg/runtime/docker`, `pkg/runtime/podman`)
 7. Start trigger engine (`pkg/trigger`) — cron, webhook, manual, daemon, chaining
-8. Start web UI + REST API (`pkg/webui`) — serves an API-key-gated `/mcp` URL that forwards to the buildin/mcp task. The buildin task uses `trigger.auth: true` so direct `/hooks/mcp` posts require a session — only the forwarder (which bypasses `webhookAuthGuard`) lets API-key callers through.
+8. Start web UI + REST API (`pkg/webui`) — serves an API-key-gated `/mcp` URL that forwards to the buildin/mcp task. The buildin task uses `trigger.auth: true` so direct `/hooks/mcp` posts require a session — only the forwarder (which bypasses `webhookAuthGuard`) lets API-key callers through. A scoped ephemeral per-run MCP token additionally gets its `tools/call` requests checked against its minting task's declared `permissions.dicode` before the forwarder proxies the call — see `docs/concepts/mcp-server.md`.
 9. Start reconciler loop (`pkg/registry/reconciler`) — syncs sources every 30s
 
 **Reconciler loop**: polls sources, computes per-task content hash, diffs against registry. New task → register. Removed → deregister. Changed hash → reload. No restart needed after git push.

--- a/docs/concepts/mcp-server.md
+++ b/docs/concepts/mcp-server.md
@@ -189,3 +189,15 @@ Hint-style tool: returns a text pointer telling the MCP client to call `POST /ap
 ## Security
 
 The `/mcp` endpoint requires a `dck_` API key (Bearer) when `server.auth: true` (`pkg/webui/apikeys.go` `requireAPIKey`, wired via `requireSessionOrAPIKey`). Without auth it is open on localhost. See [security.md](security.md) Phase 4 for the full authentication model.
+
+### Ephemeral per-run tokens are capability-scoped
+
+A task that declares `permissions.env: [{name: DICODE_MCP_API_KEY}]` gets a fresh Bearer key minted at run start and revoked at run end, instead of a static secret — see `tasks/buildin/ai-agent-claude-cli` for an example consumer. That key's MCP tool surface is scoped 1:1 to the task's own declared `permissions.dicode`:
+
+- `list_tasks` / `get_task` require `permissions.dicode.list_tasks: true`.
+- `run_task` requires the target task ID to appear in `permissions.dicode.tasks` (or `["*"]` for any task).
+- `list_sources`, `switch_dev_mode`, and `test_task` are always allowed — they're hint-only tools that exercise no dicode capability.
+
+A task with no `permissions.dicode` block at all gets a token that can call none of the scoped tools. Enforcement happens in `pkg/webui`'s `/mcp` handler, before the request ever reaches the `buildin/mcp` task — the task itself always runs with full `list_tasks`/`run_task` permissions and isn't relied on to self-restrict. A denied call gets a JSON-RPC error back (HTTP 200, `error.code: -32001`) rather than being forwarded.
+
+Operator-, CLI-, and dashboard-created API keys (`dicode mcp install`, the dashboard's Create API Key) are **unscoped** — full access, exactly as before this feature — since they aren't tied to a single task's declared permissions.

--- a/pkg/db/sqlite.go
+++ b/pkg/db/sqlite.go
@@ -232,6 +232,15 @@ func (s *SQLiteDB) migrate() error {
 		return fmt.Errorf("migrate sessions.drift_reason: %w", err)
 	}
 
+	// scopes (#567) — JSON-encoded runtime.MCPScope for ephemeral per-run MCP
+	// API keys, restricting the MCP tool surface a key may call to the
+	// owning task's own declared permissions.dicode. NULL/empty means
+	// unscoped (full access) — the default, so every existing dashboard- or
+	// CLI-managed key keeps working unchanged.
+	if err := addColumnIfMissing(ctx, s.db, "api_keys", "scopes", "TEXT"); err != nil {
+		return fmt.Errorf("migrate api_keys.scopes: %w", err)
+	}
+
 	// scs_sessions — SQLite-backed store for alexedwards/scs/v2 session
 	// manager. Replaces the former in-memory sessionStore.
 	_, err = s.db.Exec(`

--- a/pkg/runtime/deno/mcp_token_test.go
+++ b/pkg/runtime/deno/mcp_token_test.go
@@ -24,7 +24,7 @@ func newFakeMCPTokenMinter() *fakeMCPTokenMinter {
 	return &fakeMCPTokenMinter{minted: map[string]string{}, revoked: map[string]bool{}}
 }
 
-func (f *fakeMCPTokenMinter) Mint(_ context.Context, runID string) (string, error) {
+func (f *fakeMCPTokenMinter) Mint(_ context.Context, runID string, _ pkgruntime.MCPScope) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.nextTok++

--- a/pkg/runtime/mcp_token.go
+++ b/pkg/runtime/mcp_token.go
@@ -19,12 +19,38 @@ const MCPTokenEnvName = "DICODE_MCP_API_KEY"
 // over its API-key store; the interface lives here so pkg/runtime does not
 // need to import pkg/webui.
 //
-// MVP scope: the minted token is full-surface — the same permissions as an
-// operator-managed key — not yet scoped to the task's declared capabilities.
-// Per-capability scoping is a follow-on.
+// The minted token carries the MCPScope passed to Mint, so it authorizes
+// only the MCP capabilities the calling task's own permissions.dicode
+// already grants it — never more than the task could already do directly.
 type MCPTokenMinter interface {
-	Mint(ctx context.Context, runID string) (token string, err error)
+	Mint(ctx context.Context, runID string, scope MCPScope) (token string, err error)
 	Revoke(ctx context.Context, runID string) error
+}
+
+// MCPScope is the set of MCP-server capabilities an ephemeral per-run token
+// authorizes, derived from the owning task's declared dicode permissions.
+// A zero-value MCPScope (used when the calling spec declares no dicode
+// permissions at all) authorizes nothing.
+type MCPScope struct {
+	ListTasks  bool     `json:"list_tasks,omitempty"`
+	RunTaskIDs []string `json:"run_task_ids,omitempty"` // nil = deny run_task; "*" = any task
+}
+
+// MCPScopeFor derives the MCP capability scope an ephemeral token minted for
+// spec should carry, from spec's own declared permissions.dicode. Mirrors
+// exactly what the task itself is allowed to do via the dicode SDK — the
+// token must not grant the MCP caller anything the task couldn't already do
+// directly.
+func MCPScopeFor(spec *task.Spec) MCPScope {
+	if spec == nil || spec.Permissions.Dicode == nil {
+		return MCPScope{}
+	}
+	d := spec.Permissions.Dicode
+	scope := MCPScope{ListTasks: d.ListTasks}
+	if len(d.Tasks) > 0 {
+		scope.RunTaskIDs = append([]string(nil), d.Tasks...)
+	}
+	return scope
 }
 
 // WantsMCPToken reports whether spec declares a permissions.env entry named
@@ -69,7 +95,7 @@ func ApplyMCPToken(ctx context.Context, live *BridgeDeps, log *zap.Logger, spec 
 	if minter == nil || !WantsMCPToken(spec) {
 		return "", noop, nil
 	}
-	token, err = minter.Mint(ctx, runID)
+	token, err = minter.Mint(ctx, runID, MCPScopeFor(spec))
 	if err != nil {
 		return "", noop, fmt.Errorf("mint mcp token: %w", err)
 	}

--- a/pkg/runtime/mcp_token_test.go
+++ b/pkg/runtime/mcp_token_test.go
@@ -1,0 +1,163 @@
+package runtime
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// TestMCPScopeFor covers the derivation of an ephemeral token's MCP
+// capability scope from a spec's own declared permissions.dicode — the
+// scope must mirror exactly what the task itself is allowed to do, never
+// more.
+func TestMCPScopeFor(t *testing.T) {
+	tests := []struct {
+		name string
+		spec *task.Spec
+		want MCPScope
+	}{
+		{
+			name: "nil spec yields zero scope",
+			spec: nil,
+			want: MCPScope{},
+		},
+		{
+			name: "spec with nil Permissions.Dicode yields zero scope",
+			spec: &task.Spec{},
+			want: MCPScope{},
+		},
+		{
+			name: "ListTasks true is carried through",
+			spec: &task.Spec{Permissions: task.Permissions{
+				Dicode: &task.DicodePermissions{ListTasks: true},
+			}},
+			want: MCPScope{ListTasks: true},
+		},
+		{
+			name: "Tasks wildcard is carried through as RunTaskIDs",
+			spec: &task.Spec{Permissions: task.Permissions{
+				Dicode: &task.DicodePermissions{Tasks: []string{"*"}},
+			}},
+			want: MCPScope{RunTaskIDs: []string{"*"}},
+		},
+		{
+			name: "Tasks explicit list is carried through as RunTaskIDs",
+			spec: &task.Spec{Permissions: task.Permissions{
+				Dicode: &task.DicodePermissions{Tasks: []string{"a", "b"}},
+			}},
+			want: MCPScope{RunTaskIDs: []string{"a", "b"}},
+		},
+		{
+			name: "ListTasks and Tasks together",
+			spec: &task.Spec{Permissions: task.Permissions{
+				Dicode: &task.DicodePermissions{ListTasks: true, Tasks: []string{"a"}},
+			}},
+			want: MCPScope{ListTasks: true, RunTaskIDs: []string{"a"}},
+		},
+		{
+			name: "Dicode declared but no MCP-relevant fields set yields zero scope",
+			spec: &task.Spec{Permissions: task.Permissions{
+				Dicode: &task.DicodePermissions{GetRuns: true},
+			}},
+			want: MCPScope{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MCPScopeFor(tt.spec)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MCPScopeFor() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// fakeMCPTokenMinter is a test double for MCPTokenMinter that records the
+// scope it was minted with, so ApplyMCPToken's derivation can be asserted
+// without a real key store.
+type fakeMCPTokenMinter struct {
+	mintedScope MCPScope
+	mintCalls   int
+	revoked     map[string]bool
+}
+
+func newFakeMCPTokenMinter() *fakeMCPTokenMinter {
+	return &fakeMCPTokenMinter{revoked: map[string]bool{}}
+}
+
+func (f *fakeMCPTokenMinter) Mint(_ context.Context, _ string, scope MCPScope) (string, error) {
+	f.mintCalls++
+	f.mintedScope = scope
+	return "fake-mcp-token", nil
+}
+
+func (f *fakeMCPTokenMinter) Revoke(_ context.Context, runID string) error {
+	f.revoked[runID] = true
+	return nil
+}
+
+// TestApplyMCPToken_PassesDerivedScope covers the wiring between
+// ApplyMCPToken and MCPScopeFor: the scope handed to the minter's Mint call
+// must be exactly what MCPScopeFor computes for the run's spec.
+func TestApplyMCPToken_PassesDerivedScope(t *testing.T) {
+	spec := &task.Spec{
+		Permissions: task.Permissions{
+			Env:    []task.EnvEntry{{Name: MCPTokenEnvName}},
+			Dicode: &task.DicodePermissions{ListTasks: true, Tasks: []string{"repo/a", "repo/b"}},
+		},
+	}
+	minter := newFakeMCPTokenMinter()
+	live := &BridgeDeps{MCPTokenMinter: minter}
+	resolved := map[string]string{}
+
+	token, revoke, err := ApplyMCPToken(context.Background(), live, nil, spec, "run-1", resolved)
+	if err != nil {
+		t.Fatalf("ApplyMCPToken: %v", err)
+	}
+	defer revoke()
+
+	if minter.mintCalls != 1 {
+		t.Fatalf("expected exactly one Mint call, got %d", minter.mintCalls)
+	}
+	want := MCPScopeFor(spec)
+	if !reflect.DeepEqual(minter.mintedScope, want) {
+		t.Errorf("scope passed to Mint = %+v, want %+v", minter.mintedScope, want)
+	}
+	if token == "" {
+		t.Fatal("expected a non-empty minted token")
+	}
+	if resolved[MCPTokenEnvName] != token {
+		t.Errorf("resolved[%s] = %q, want %q", MCPTokenEnvName, resolved[MCPTokenEnvName], token)
+	}
+}
+
+// TestApplyMCPToken_ZeroScopeWhenNoDicodePermissions covers the
+// deny-by-default case: a spec that opts into the ephemeral token but
+// declares no permissions.dicode at all must still get a token minted (the
+// env opt-in and the dicode capability grant are independent), but with a
+// zero-value scope that authorizes nothing at the MCP layer.
+func TestApplyMCPToken_ZeroScopeWhenNoDicodePermissions(t *testing.T) {
+	spec := &task.Spec{
+		Permissions: task.Permissions{
+			Env: []task.EnvEntry{{Name: MCPTokenEnvName}},
+		},
+	}
+	minter := newFakeMCPTokenMinter()
+	live := &BridgeDeps{MCPTokenMinter: minter}
+	resolved := map[string]string{}
+
+	_, revoke, err := ApplyMCPToken(context.Background(), live, nil, spec, "run-2", resolved)
+	if err != nil {
+		t.Fatalf("ApplyMCPToken: %v", err)
+	}
+	defer revoke()
+
+	if minter.mintCalls != 1 {
+		t.Fatalf("expected exactly one Mint call, got %d", minter.mintCalls)
+	}
+	if !reflect.DeepEqual(minter.mintedScope, MCPScope{}) {
+		t.Errorf("scope passed to Mint = %+v, want zero value", minter.mintedScope)
+	}
+}

--- a/pkg/runtime/python/mcp_token_test.go
+++ b/pkg/runtime/python/mcp_token_test.go
@@ -28,7 +28,7 @@ func newFakeMCPTokenMinter() *fakeMCPTokenMinter {
 	return &fakeMCPTokenMinter{minted: map[string]string{}, revoked: map[string]bool{}}
 }
 
-func (f *fakeMCPTokenMinter) Mint(_ context.Context, runID string) (string, error) {
+func (f *fakeMCPTokenMinter) Mint(_ context.Context, runID string, _ pkgruntime.MCPScope) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.nextTok++

--- a/pkg/webui/apikeys.go
+++ b/pkg/webui/apikeys.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/dicode/dicode/pkg/db"
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
@@ -26,7 +27,19 @@ func newAPIKeyStore(d db.DB) *apiKeyStore { return &apiKeyStore{db: d} }
 
 // Generate creates a new API key, stores its hash, and returns the raw key.
 // The raw key is returned only once — callers must present it to the user.
+// Unscoped (full access) — see generateScoped for the scoped variant used by
+// ephemeral per-run MCP tokens.
 func (s *apiKeyStore) generate(ctx context.Context, name string) (raw string, info APIKeyInfo, err error) {
+	return s.generateScoped(ctx, name, nil)
+}
+
+// generateScoped is generate with an optional MCP capability scope. A nil
+// scope stores NULL in the scopes column — unscoped/full access, identical
+// to generate's current behavior. A non-nil scope (including the zero value
+// MCPScope{}, which authorizes nothing) is JSON-marshaled and stored, so a
+// caller reading it back via scopeFor gets an enforced restriction rather
+// than an accidental full-access key.
+func (s *apiKeyStore) generateScoped(ctx context.Context, name string, scope *pkgruntime.MCPScope) (raw string, info APIKeyInfo, err error) {
 	rawBytes, err := randomToken()
 	if err != nil {
 		return "", APIKeyInfo{}, err
@@ -45,9 +58,18 @@ func (s *apiKeyStore) generate(ctx context.Context, name string) (raw string, in
 	id := uuid.New().String()
 	now := time.Now().Unix()
 
+	var scopesJSON any // nil -> SQL NULL
+	if scope != nil {
+		b, merr := json.Marshal(scope)
+		if merr != nil {
+			return "", APIKeyInfo{}, fmt.Errorf("marshal mcp scope: %w", merr)
+		}
+		scopesJSON = string(b)
+	}
+
 	if err = s.db.Exec(ctx,
-		`INSERT INTO api_keys (id, name, key_hash, prefix, created_at) VALUES (?, ?, ?, ?, ?)`,
-		id, name, hash, prefix, now,
+		`INSERT INTO api_keys (id, name, key_hash, prefix, created_at, scopes) VALUES (?, ?, ?, ?, ?, ?)`,
+		id, name, hash, prefix, now, scopesJSON,
 	); err != nil {
 		return "", APIKeyInfo{}, err
 	}
@@ -58,6 +80,48 @@ func (s *apiKeyStore) generate(ctx context.Context, name string) (raw string, in
 		CreatedAt: time.Unix(now, 0),
 	}
 	return raw, info, nil
+}
+
+// scopeFor looks up raw's stored MCP scope by hash (same validity rules as
+// lookup: must exist and be unexpired). found reports whether the key
+// validated at all; scope is nil when found but the key is unscoped (NULL/
+// empty scopes column — full access), or non-nil (possibly the zero value,
+// which denies everything) when the key carries an explicit scope.
+func (s *apiKeyStore) scopeFor(ctx context.Context, raw string) (scope *pkgruntime.MCPScope, found bool) {
+	if !strings.HasPrefix(raw, apiKeyPrefix) {
+		return nil, false
+	}
+	hash := hashAPIKey(raw)
+	now := time.Now().Unix()
+
+	var id string
+	var scopesJSON *string
+	_ = s.db.Query(ctx,
+		`SELECT id, scopes FROM api_keys WHERE key_hash = ? AND (expires_at IS NULL OR expires_at > ?)`,
+		[]any{hash, now},
+		func(rows db.Scanner) error {
+			if rows.Next() {
+				found = true
+				return rows.Scan(&id, &scopesJSON)
+			}
+			return nil
+		},
+	)
+	if !found || id == "" {
+		return nil, false
+	}
+	if scopesJSON == nil || *scopesJSON == "" {
+		return nil, true
+	}
+	var s2 pkgruntime.MCPScope
+	if err := json.Unmarshal([]byte(*scopesJSON), &s2); err != nil {
+		// Corrupt/unrecognized scope data: fail closed (deny everything)
+		// rather than silently falling back to unscoped/full access. This
+		// should never happen since only generateScoped ever writes this
+		// column.
+		return &pkgruntime.MCPScope{}, true
+	}
+	return &s2, true
 }
 
 // lookup checks a raw key against stored hashes, updates last_used, and

--- a/pkg/webui/approval_test.go
+++ b/pkg/webui/approval_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dicode/dicode/pkg/db"
 	"github.com/dicode/dicode/pkg/ipc"
 	"github.com/dicode/dicode/pkg/registry"
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
 	"github.com/dicode/dicode/pkg/task"
 	"github.com/dicode/dicode/pkg/trigger"
 	"go.uber.org/zap"
@@ -270,7 +271,7 @@ func TestAPI_ApproveTask_RejectsEphemeralToken(t *testing.T) {
 	gate.pending["repo/pending-task"] = "hash-1"
 	srv.SetApprovalGate(gate)
 
-	ephemeral, err := newMCPTokenMinter(srv.apiKeys).Mint(context.Background(), "run-self")
+	ephemeral, err := newMCPTokenMinter(srv.apiKeys).Mint(context.Background(), "run-self", pkgruntime.MCPScope{ListTasks: true, RunTaskIDs: []string{"*"}})
 	if err != nil {
 		t.Fatalf("mint ephemeral: %v", err)
 	}
@@ -297,7 +298,7 @@ func TestAPI_ApproveTask_RejectsEphemeralToken(t *testing.T) {
 // not exist.
 func TestAPI_ResumeReplay_RejectEphemeralToken(t *testing.T) {
 	srv, _, _ := newApprovalTestServer(t, true)
-	ephemeral, err := newMCPTokenMinter(srv.apiKeys).Mint(context.Background(), "run-self")
+	ephemeral, err := newMCPTokenMinter(srv.apiKeys).Mint(context.Background(), "run-self", pkgruntime.MCPScope{ListTasks: true, RunTaskIDs: []string{"*"}})
 	if err != nil {
 		t.Fatalf("mint ephemeral: %v", err)
 	}

--- a/pkg/webui/mcp_scope_test.go
+++ b/pkg/webui/mcp_scope_test.go
@@ -98,6 +98,41 @@ func TestScopeFor_UnknownKey(t *testing.T) {
 	}
 }
 
+// TestScopeFor_CorruptScopesColumn_FailsClosed writes a malformed JSON
+// string directly into a real key's scopes column (bypassing
+// generateScoped, which only ever writes valid JSON) and asserts scopeFor
+// still fails closed: it must return a non-nil zero-value MCPScope{} (deny
+// everything), never nil (which mcpScopeCheck/handleMCP would read as
+// unscoped/full access) and never found == false (which would be treated as
+// an invalid key rather than a corrupt-but-present one).
+func TestScopeFor_CorruptScopesColumn_FailsClosed(t *testing.T) {
+	ctx := context.Background()
+	keys := newTestAPIKeyStore(t)
+
+	raw, _, err := keys.generateScoped(ctx, "corrupt-scope-key", &pkgruntime.MCPScope{ListTasks: true})
+	if err != nil {
+		t.Fatalf("generateScoped: %v", err)
+	}
+
+	if err := keys.db.Exec(ctx,
+		`UPDATE api_keys SET scopes = ? WHERE key_hash = ?`,
+		"not valid json", hashAPIKey(raw),
+	); err != nil {
+		t.Fatalf("corrupt scopes column: %v", err)
+	}
+
+	got, found := keys.scopeFor(ctx, raw)
+	if !found {
+		t.Fatal("scopeFor: key not found")
+	}
+	if got == nil {
+		t.Fatal("scopeFor: expected a non-nil (zero-value) scope for corrupt data, got nil (unscoped)")
+	}
+	if !reflect.DeepEqual(*got, pkgruntime.MCPScope{}) {
+		t.Errorf("scopeFor() = %+v, want zero value (deny-all)", *got)
+	}
+}
+
 // ── mcpScopeCheck table tests ────────────────────────────────────────────────
 
 func rpcBody(t *testing.T, id any, method, toolName string, args map[string]any) []byte {
@@ -230,6 +265,25 @@ func TestMcpScopeCheck(t *testing.T) {
 			name:        "top-level JSON array (valid JSON, not an object) passes through",
 			scope:       zeroScope,
 			body:        []byte(`[1,2,3]`),
+			wantAllowed: true,
+		},
+		{
+			name:  "JSON-RPC batch array containing a disallowed call passes through (safe: never dispatched)",
+			scope: zeroScope,
+			// Same "not a JSON object" pass-through as above, but shaped
+			// like a JSON-RPC batch request whose single element would be
+			// a denied run_task call if sent as a top-level object.
+			// json.Unmarshal into map[string]any fails for a top-level
+			// array, so mcpScopeCheck allows it through unchanged — this
+			// is safe despite looking like a bypass because
+			// tasks/buildin/mcp/task.ts's handle() reads req.method off
+			// the array itself (not off its elements): arrays have no
+			// .method property, so `method` is undefined/"" in JS and the
+			// switch always falls to the "-32601 method not found"
+			// default. No tool is ever dispatched for a batch array, so
+			// there's no real capability exercised despite the Go-layer
+			// scope check allowing it through.
+			body:        []byte(`[{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"run_task","arguments":{"id":"some-disallowed-task"}}}]`),
 			wantAllowed: true,
 		},
 		{

--- a/pkg/webui/mcp_scope_test.go
+++ b/pkg/webui/mcp_scope_test.go
@@ -1,6 +1,7 @@
 package webui
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -209,6 +210,17 @@ func TestMcpScopeCheck(t *testing.T) {
 			wantAllowed: true,
 		},
 		{
+			name:  "unrecognized tool name denied under restrictive scope (fail-closed default)",
+			scope: zeroScope,
+			// A tool name that doesn't match any case in the switch —
+			// including a hypothetical future tool this switch hasn't been
+			// taught about yet. Before the fail-closed fix this fell into
+			// the allow-everything default; it must now be denied just like
+			// any other capability the scope doesn't grant.
+			body:        rpcBody(t, 18, "tools/call", "totally_unknown_tool", map[string]any{}),
+			wantAllowed: false,
+		},
+		{
 			name:        "malformed non-JSON-RPC body passes through",
 			scope:       zeroScope,
 			body:        []byte("not json"),
@@ -384,5 +396,43 @@ func TestHandleMCP_UnscopedKey_AlwaysForwarded(t *testing.T) {
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404 (forwarded to an empty gateway): %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleMCP_ScopedKey_OversizedBodyRejected covers the body-size cap: a
+// scoped caller posting more than testTaskMaxBodyBytes gets a 400 from the
+// http.MaxBytesReader-wrapped read in handleMCP, rather than the body being
+// buffered in full and either forwarded to the gateway or handed to
+// mcpScopeCheck. The body content doesn't need to be valid JSON-RPC —
+// MaxBytesReader rejects purely on byte count, before mcpScopeCheck ever
+// runs.
+func TestHandleMCP_ScopedKey_OversizedBodyRejected(t *testing.T) {
+	srv, _, _ := newApprovalTestServer(t, true)
+	h := srv.Handler()
+
+	raw, _, err := srv.apiKeys.generateScoped(context.Background(), "scoped-mcp-key",
+		&pkgruntime.MCPScope{RunTaskIDs: []string{"repo/allowed"}})
+	if err != nil {
+		t.Fatalf("generateScoped: %v", err)
+	}
+
+	oversized := bytes.Repeat([]byte("a"), testTaskMaxBodyBytes+1)
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(oversized))
+	req.Header.Set("Authorization", "Bearer "+raw)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (oversized body rejected): %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v (%s)", err, w.Body.String())
+	}
+	if resp.Error == "" {
+		t.Error("expected a non-empty error message in the rejection body")
 	}
 }

--- a/pkg/webui/mcp_scope_test.go
+++ b/pkg/webui/mcp_scope_test.go
@@ -215,6 +215,46 @@ func TestMcpScopeCheck(t *testing.T) {
 			wantAllowed: true,
 		},
 		{
+			name:        "top-level JSON array (valid JSON, not an object) passes through",
+			scope:       zeroScope,
+			body:        []byte(`[1,2,3]`),
+			wantAllowed: true,
+		},
+		{
+			name:  "list_tasks denied when ListTasks false even if arguments is a malformed non-object (regression for #567 bypass)",
+			scope: zeroScope,
+			// arguments is a string, not an object: with a typed struct
+			// decode this makes json.Unmarshal return a non-nil
+			// UnmarshalTypeError for Params.Arguments even though method
+			// and params.name decoded fine — the bug treated that error as
+			// "not JSON-RPC, allow" and let list_tasks through despite
+			// ListTasks: false. Must be denied.
+			body:        []byte(`{"jsonrpc":"2.0","id":15,"method":"tools/call","params":{"name":"list_tasks","arguments":"x"}}`),
+			wantAllowed: false,
+		},
+		{
+			name:  "run_task denied when arguments is a malformed non-object (id unrecoverable, deny-closed)",
+			scope: fullScope,
+			// arguments is a number, not an object: taskID can't be
+			// recovered, so this must fall into the existing
+			// deny-by-default (taskID == "") branch rather than bypassing
+			// enforcement the way the pre-fix "any decode error → allow"
+			// logic did. fullScope's RunTaskIDs ("repo/allowed") does not
+			// contain "*", so an unrecoverable/empty id must not match.
+			body:        []byte(`{"jsonrpc":"2.0","id":16,"method":"tools/call","params":{"name":"run_task","arguments":42}}`),
+			wantAllowed: false,
+		},
+		{
+			name:  "run_task allowed when arguments is a malformed non-object but scope wildcards all ids",
+			scope: wildcardScope,
+			// Same unrecoverable-id shape as above, but RunTaskIDs contains
+			// "*" so it matches regardless of the (unrecoverable) task id —
+			// consistent with the existing wildcard behavior for a
+			// well-formed request.
+			body:        []byte(`{"jsonrpc":"2.0","id":17,"method":"tools/call","params":{"name":"run_task","arguments":42}}`),
+			wantAllowed: true,
+		},
+		{
 			name:        "unknown method passes through",
 			scope:       zeroScope,
 			body:        rpcBody(t, 14, "some/other-method", "", nil),

--- a/pkg/webui/mcp_scope_test.go
+++ b/pkg/webui/mcp_scope_test.go
@@ -1,0 +1,348 @@
+package webui
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
+)
+
+// ── generateScoped / scopeFor round-trip ────────────────────────────────────
+
+// TestGenerateScoped_ScopeFor_RoundTrip covers the storage round-trip: a
+// scope handed to generateScoped comes back unchanged from scopeFor.
+func TestGenerateScoped_ScopeFor_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	keys := newTestAPIKeyStore(t)
+
+	scope := &pkgruntime.MCPScope{ListTasks: true, RunTaskIDs: []string{"repo/a", "repo/b"}}
+	raw, _, err := keys.generateScoped(ctx, "scoped-key", scope)
+	if err != nil {
+		t.Fatalf("generateScoped: %v", err)
+	}
+
+	got, found := keys.scopeFor(ctx, raw)
+	if !found {
+		t.Fatal("scopeFor: key not found")
+	}
+	if got == nil {
+		t.Fatal("scopeFor: expected a non-nil scope")
+	}
+	if !reflect.DeepEqual(*got, *scope) {
+		t.Errorf("scopeFor() = %+v, want %+v", *got, *scope)
+	}
+}
+
+// TestGenerateScoped_ZeroScope_DeniesEverything covers the deny-by-default
+// case: MCPScope{} is stored and read back as a non-nil, empty scope — not
+// conflated with "unscoped" (nil).
+func TestGenerateScoped_ZeroScope_DeniesEverything(t *testing.T) {
+	ctx := context.Background()
+	keys := newTestAPIKeyStore(t)
+
+	raw, _, err := keys.generateScoped(ctx, "zero-scope-key", &pkgruntime.MCPScope{})
+	if err != nil {
+		t.Fatalf("generateScoped: %v", err)
+	}
+	got, found := keys.scopeFor(ctx, raw)
+	if !found {
+		t.Fatal("scopeFor: key not found")
+	}
+	if got == nil {
+		t.Fatal("scopeFor: expected a non-nil (zero-value) scope, got nil (unscoped)")
+	}
+	if !reflect.DeepEqual(*got, pkgruntime.MCPScope{}) {
+		t.Errorf("scopeFor() = %+v, want zero value", *got)
+	}
+}
+
+// TestGenerate_ScopeFor_Unscoped covers the default/back-compat path: keys
+// created via generate (dashboard/CLI) or generateScoped(..., nil) come back
+// as scopeFor == nil, meaning full/unscoped access.
+func TestGenerate_ScopeFor_Unscoped(t *testing.T) {
+	ctx := context.Background()
+	keys := newTestAPIKeyStore(t)
+
+	rawGenerate, _, err := keys.generate(ctx, "dashboard-key")
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	rawGenerateScopedNil, _, err := keys.generateScoped(ctx, "explicit-nil-key", nil)
+	if err != nil {
+		t.Fatalf("generateScoped(nil): %v", err)
+	}
+
+	for _, raw := range []string{rawGenerate, rawGenerateScopedNil} {
+		got, found := keys.scopeFor(ctx, raw)
+		if !found {
+			t.Fatalf("scopeFor(%q): key not found", raw)
+		}
+		if got != nil {
+			t.Errorf("scopeFor(%q) = %+v, want nil (unscoped)", raw, *got)
+		}
+	}
+}
+
+// TestScopeFor_UnknownKey covers the defensive not-found path.
+func TestScopeFor_UnknownKey(t *testing.T) {
+	ctx := context.Background()
+	keys := newTestAPIKeyStore(t)
+	if _, found := keys.scopeFor(ctx, "dck_does-not-exist"); found {
+		t.Error("scopeFor should report not found for an unknown key")
+	}
+}
+
+// ── mcpScopeCheck table tests ────────────────────────────────────────────────
+
+func rpcBody(t *testing.T, id any, method, toolName string, args map[string]any) []byte {
+	t.Helper()
+	body := map[string]any{"jsonrpc": "2.0", "id": id, "method": method}
+	if toolName != "" || args != nil {
+		params := map[string]any{}
+		if toolName != "" {
+			params["name"] = toolName
+		}
+		if args != nil {
+			params["arguments"] = args
+		}
+		body["params"] = params
+	}
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	return b
+}
+
+func TestMcpScopeCheck(t *testing.T) {
+	fullScope := &pkgruntime.MCPScope{ListTasks: true, RunTaskIDs: []string{"repo/allowed"}}
+	wildcardScope := &pkgruntime.MCPScope{RunTaskIDs: []string{"*"}}
+	zeroScope := &pkgruntime.MCPScope{}
+
+	tests := []struct {
+		name        string
+		scope       *pkgruntime.MCPScope
+		body        []byte
+		wantAllowed bool
+	}{
+		{
+			name:        "initialize always allowed",
+			scope:       zeroScope,
+			body:        rpcBody(t, 1, "initialize", "", nil),
+			wantAllowed: true,
+		},
+		{
+			name:        "tools/list always allowed",
+			scope:       zeroScope,
+			body:        rpcBody(t, 2, "tools/list", "", nil),
+			wantAllowed: true,
+		},
+		{
+			name:        "list_tasks allowed when ListTasks true",
+			scope:       fullScope,
+			body:        rpcBody(t, 3, "tools/call", "list_tasks", map[string]any{}),
+			wantAllowed: true,
+		},
+		{
+			name:        "list_tasks denied when ListTasks false",
+			scope:       zeroScope,
+			body:        rpcBody(t, 4, "tools/call", "list_tasks", map[string]any{}),
+			wantAllowed: false,
+		},
+		{
+			name:        "get_task allowed when ListTasks true",
+			scope:       fullScope,
+			body:        rpcBody(t, 5, "tools/call", "get_task", map[string]any{"id": "repo/x"}),
+			wantAllowed: true,
+		},
+		{
+			name:        "get_task denied when ListTasks false",
+			scope:       zeroScope,
+			body:        rpcBody(t, 6, "tools/call", "get_task", map[string]any{"id": "repo/x"}),
+			wantAllowed: false,
+		},
+		{
+			name:        "run_task allowed for a listed id",
+			scope:       fullScope,
+			body:        rpcBody(t, 7, "tools/call", "run_task", map[string]any{"id": "repo/allowed"}),
+			wantAllowed: true,
+		},
+		{
+			name:        "run_task denied for an unlisted id",
+			scope:       fullScope,
+			body:        rpcBody(t, 8, "tools/call", "run_task", map[string]any{"id": "repo/other"}),
+			wantAllowed: false,
+		},
+		{
+			name:        "run_task denied when RunTaskIDs is nil",
+			scope:       zeroScope,
+			body:        rpcBody(t, 9, "tools/call", "run_task", map[string]any{"id": "repo/anything"}),
+			wantAllowed: false,
+		},
+		{
+			name:        "run_task allowed for any id when RunTaskIDs contains *",
+			scope:       wildcardScope,
+			body:        rpcBody(t, 10, "tools/call", "run_task", map[string]any{"id": "repo/anything"}),
+			wantAllowed: true,
+		},
+		{
+			name:        "list_sources always allowed regardless of scope",
+			scope:       zeroScope,
+			body:        rpcBody(t, 11, "tools/call", "list_sources", map[string]any{}),
+			wantAllowed: true,
+		},
+		{
+			name:        "switch_dev_mode always allowed regardless of scope",
+			scope:       zeroScope,
+			body:        rpcBody(t, 12, "tools/call", "switch_dev_mode", map[string]any{"source": "x", "enabled": true}),
+			wantAllowed: true,
+		},
+		{
+			name:        "test_task always allowed regardless of scope",
+			scope:       zeroScope,
+			body:        rpcBody(t, 13, "tools/call", "test_task", map[string]any{"id": "repo/x"}),
+			wantAllowed: true,
+		},
+		{
+			name:        "malformed non-JSON-RPC body passes through",
+			scope:       zeroScope,
+			body:        []byte("not json"),
+			wantAllowed: true,
+		},
+		{
+			name:        "unknown method passes through",
+			scope:       zeroScope,
+			body:        rpcBody(t, 14, "some/other-method", "", nil),
+			wantAllowed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allowed, _, msg := mcpScopeCheck(tt.scope, tt.body)
+			if allowed != tt.wantAllowed {
+				t.Errorf("mcpScopeCheck() allowed = %v, want %v (msg: %q)", allowed, tt.wantAllowed, msg)
+			}
+			if !allowed && msg == "" {
+				t.Error("expected a non-empty denial message")
+			}
+		})
+	}
+}
+
+// TestMcpScopeCheck_EchoesRequestID pins that a denial echoes back the
+// caller's JSON-RPC id, not null, so the client can correlate the error.
+func TestMcpScopeCheck_EchoesRequestID(t *testing.T) {
+	body := rpcBody(t, "my-id", "tools/call", "run_task", map[string]any{"id": "repo/x"})
+	allowed, id, _ := mcpScopeCheck(&pkgruntime.MCPScope{}, body)
+	if allowed {
+		t.Fatal("expected denial")
+	}
+	if id != "my-id" {
+		t.Errorf("id = %v, want %q", id, "my-id")
+	}
+}
+
+// ── end-to-end handleMCP enforcement ────────────────────────────────────────
+
+// TestHandleMCP_ScopedKey_DeniesDisallowedRunTask covers the full path: a
+// scoped ephemeral key posting a run_task for an id outside its
+// RunTaskIDs gets the -32001 JSON-RPC denial and never reaches the gateway
+// (the gateway has no /hooks/mcp handler registered in this test server, so
+// a request that DID reach it would 404 with a plain-text body instead of
+// the JSON-RPC envelope).
+func TestHandleMCP_ScopedKey_DeniesDisallowedRunTask(t *testing.T) {
+	srv, _, _ := newApprovalTestServer(t, true)
+	h := srv.Handler()
+
+	raw, _, err := srv.apiKeys.generateScoped(context.Background(), "scoped-mcp-key",
+		&pkgruntime.MCPScope{RunTaskIDs: []string{"repo/allowed"}})
+	if err != nil {
+		t.Fatalf("generateScoped: %v", err)
+	}
+
+	body := rpcBody(t, 1, "tools/call", "run_task", map[string]any{"id": "repo/forbidden"})
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(body)))
+	req.Header.Set("Authorization", "Bearer "+raw)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Error *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v (%s)", err, w.Body.String())
+	}
+	if resp.Error == nil {
+		t.Fatalf("expected a JSON-RPC error, got: %s", w.Body.String())
+	}
+	if resp.Error.Code != -32001 {
+		t.Errorf("error code = %d, want -32001", resp.Error.Code)
+	}
+}
+
+// TestHandleMCP_ScopedKey_AllowsPermittedRunTask covers the positive path:
+// a run_task for an id the scope permits is forwarded to the gateway rather
+// than denied inline. The test server's gateway has no /hooks/mcp route
+// registered, so a forwarded request 404s with a plain-text body — the
+// signal that enforcement let it through instead of answering itself.
+func TestHandleMCP_ScopedKey_AllowsPermittedRunTask(t *testing.T) {
+	srv, _, _ := newApprovalTestServer(t, true)
+	h := srv.Handler()
+
+	raw, _, err := srv.apiKeys.generateScoped(context.Background(), "scoped-mcp-key",
+		&pkgruntime.MCPScope{RunTaskIDs: []string{"repo/allowed"}})
+	if err != nil {
+		t.Fatalf("generateScoped: %v", err)
+	}
+
+	body := rpcBody(t, 1, "tools/call", "run_task", map[string]any{"id": "repo/allowed"})
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(body)))
+	req.Header.Set("Authorization", "Bearer "+raw)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (forwarded to an empty gateway): %s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "-32001") {
+		t.Errorf("request was denied inline instead of forwarded: %s", w.Body.String())
+	}
+}
+
+// TestHandleMCP_UnscopedKey_AlwaysForwarded covers operator/CLI/dashboard
+// keys (scopeFor returns nil): even a run_task call is forwarded unchanged,
+// never denied at this layer.
+func TestHandleMCP_UnscopedKey_AlwaysForwarded(t *testing.T) {
+	srv, _, _ := newApprovalTestServer(t, true)
+	h := srv.Handler()
+
+	raw, _, err := srv.apiKeys.generate(context.Background(), "operator-key")
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	body := rpcBody(t, 1, "tools/call", "run_task", map[string]any{"id": "repo/anything"})
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(body)))
+	req.Header.Set("Authorization", "Bearer "+raw)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (forwarded to an empty gateway): %s", w.Code, w.Body.String())
+	}
+}

--- a/pkg/webui/mcp_token_minter.go
+++ b/pkg/webui/mcp_token_minter.go
@@ -21,11 +21,14 @@ func newMCPTokenMinter(keys *apiKeyStore) *mcpTokenMinter {
 }
 
 // Mint generates a fresh API key named for this run and returns the raw
-// value. The token is full-surface — the same permissions as an
-// operator-managed key — not yet scoped to the task's declared
-// capabilities; per-capability scoping is a follow-on.
-func (m *mcpTokenMinter) Mint(ctx context.Context, runID string) (string, error) {
-	raw, _, err := m.keys.generate(ctx, ephemeralKeyPrefix+runID)
+// value. The key is stored with scope, restricting the MCP tool surface it
+// may call (via /mcp's mcpScopeCheck) to exactly the calling task's own
+// declared permissions.dicode — never more than the task could already do
+// directly. scope is stored as given, including the zero value MCPScope{}
+// (a spec with no dicode permissions declared), which correctly denies
+// every scoped tool call; it is never treated as "unscoped".
+func (m *mcpTokenMinter) Mint(ctx context.Context, runID string, scope pkgruntime.MCPScope) (string, error) {
+	raw, _, err := m.keys.generateScoped(ctx, ephemeralKeyPrefix+runID, &scope)
 	return raw, err
 }
 

--- a/pkg/webui/mcp_token_minter_test.go
+++ b/pkg/webui/mcp_token_minter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/dicode/dicode/pkg/db"
+	pkgruntime "github.com/dicode/dicode/pkg/runtime"
 )
 
 // newTestAPIKeyStore builds an apiKeyStore over a fresh in-memory SQLite DB.
@@ -28,7 +29,7 @@ func TestMCPTokenMinter_MintValidateRevoke(t *testing.T) {
 	keys := newTestAPIKeyStore(t)
 	minter := newMCPTokenMinter(keys)
 
-	token, err := minter.Mint(ctx, "run-123")
+	token, err := minter.Mint(ctx, "run-123", pkgruntime.MCPScope{ListTasks: true, RunTaskIDs: []string{"*"}})
 	if err != nil {
 		t.Fatalf("Mint: %v", err)
 	}
@@ -107,7 +108,7 @@ func TestValidateNonEphemeral(t *testing.T) {
 	ctx := context.Background()
 	keys := newTestAPIKeyStore(t)
 
-	ephemeral, err := newMCPTokenMinter(keys).Mint(ctx, "run-x")
+	ephemeral, err := newMCPTokenMinter(keys).Mint(ctx, "run-x", pkgruntime.MCPScope{ListTasks: true, RunTaskIDs: []string{"*"}})
 	if err != nil {
 		t.Fatalf("mint ephemeral: %v", err)
 	}

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -2,6 +2,7 @@
 package webui
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"embed"
@@ -2089,6 +2090,14 @@ func randomRunID() string {
 // to /hooks/mcp. GET returns a small server-info doc (so a curl probe still
 // succeeds the way the old Go MCP server did); POST rewrites the URL path
 // and re-enters the trigger engine's webhook dispatch via the gateway.
+//
+// Before forwarding a POST, a Bearer-authenticated caller holding a scoped
+// ephemeral per-run MCP token (#567) is checked against mcpScopeCheck: the
+// buildin/mcp task itself always runs with full dicode permissions
+// (list_tasks: true, tasks: ["*"]), so it cannot be relied on to
+// self-restrict — enforcement has to happen here, before the request ever
+// reaches it. Session-cookie callers and unscoped (operator/CLI/dashboard)
+// API keys are unaffected and forward exactly as before this change.
 func (s *Server) handleMCP(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodGet {
 		w.Header().Set("Content-Type", "application/json")
@@ -2104,8 +2113,116 @@ func (s *Server) handleMCP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
+
+	// Scoping only applies to Bearer API-key auth. A session-cookie caller
+	// (browser dashboard) has no ephemeral scope to check — forward as today.
+	token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if token != "" {
+		scope, found := s.apiKeys.scopeFor(r.Context(), token)
+		// !found: the api-key middleware upstream (requireSessionOrAPIKey)
+		// already validated this token: this is a defensive no-op, not a
+		// second auth gate. scope == nil: unscoped operator/CLI/dashboard
+		// key — full access, forward unchanged.
+		if found && scope != nil {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				jsonErr(w, "failed to read request body", http.StatusBadRequest)
+				return
+			}
+			r.Body = io.NopCloser(bytes.NewReader(body))
+			if allowed, id, deniedMsg := mcpScopeCheck(scope, body); !allowed {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"jsonrpc": "2.0",
+					"id":      id,
+					"error": map[string]any{
+						"code":    -32001,
+						"message": deniedMsg,
+					},
+				})
+				return
+			}
+		}
+	}
+
 	r.URL.Path = "/hooks/mcp"
 	s.gateway.ServeHTTP(w, r)
+}
+
+// mcpJSONRPCCall is the minimal JSON-RPC 2.0 envelope mcpScopeCheck needs to
+// decide whether a scoped ephemeral MCP token may make this call. Fields
+// beyond what enforcement needs are ignored.
+type mcpJSONRPCCall struct {
+	ID     any    `json:"id"`
+	Method string `json:"method"`
+	Params struct {
+		Name      string         `json:"name"`
+		Arguments map[string]any `json:"arguments"`
+	} `json:"params"`
+}
+
+// mcpScopeCheck decides whether a scoped ephemeral MCP token (scope) may
+// make the JSON-RPC call encoded in body, without performing any I/O — pure
+// so it's cheap to table-test. scope is never nil here (callers only invoke
+// this once they've already established the key is scoped); a zero-value
+// *MCPScope correctly denies every tools/call.
+//
+//   - initialize / tools/list: always allowed (discovery, exercises no
+//     dicode capability).
+//   - tools/call list_tasks / get_task: requires scope.ListTasks.
+//   - tools/call run_task: requires scope.RunTaskIDs to contain "*" or the
+//     call's params.arguments["id"].
+//   - tools/call for any other tool name (list_sources, switch_dev_mode,
+//     test_task, or an unrecognized name): always allowed — those three
+//     hint tools exercise no dicode capability and are unscoped by design;
+//     an unrecognized name is left for the task's own "unknown tool" error.
+//   - any other method: always allowed — let the task's own
+//     "-32601 method not found" path handle it.
+//   - a body that doesn't parse as JSON-RPC: always allowed — let the
+//     task's own "-32700 parse error" path handle it, no second error shape.
+//
+// Returns allowed, the request's id (for echoing back in a denial), and a
+// human-readable denial message (empty when allowed).
+func mcpScopeCheck(scope *pkgruntime.MCPScope, body []byte) (allowed bool, id any, deniedMsg string) {
+	var call mcpJSONRPCCall
+	if err := json.Unmarshal(body, &call); err != nil {
+		return true, nil, ""
+	}
+	id = call.ID
+
+	switch call.Method {
+	case "tools/call":
+		// fall through to the tool-name switch below.
+	default:
+		// initialize, tools/list, unknown methods, and anything else: no
+		// scoped capability is exercised here, let the task handle it.
+		return true, id, ""
+	}
+
+	name := call.Params.Name
+	switch name {
+	case "list_tasks", "get_task":
+		if scope.ListTasks {
+			return true, id, ""
+		}
+		return false, id, fmt.Sprintf("capability not granted: %s", name)
+	case "run_task":
+		taskID, _ := call.Params.Arguments["id"].(string)
+		for _, allowedID := range scope.RunTaskIDs {
+			if allowedID == "*" || allowedID == taskID {
+				return true, id, ""
+			}
+		}
+		if taskID != "" {
+			return false, id, fmt.Sprintf("capability not granted: %s for task %q", name, taskID)
+		}
+		return false, id, fmt.Sprintf("capability not granted: %s", name)
+	default:
+		// list_sources, switch_dev_mode, test_task (unscoped by design), or
+		// an unrecognized tool name (left for the task's own error).
+		return true, id, ""
+	}
 }
 
 // apiQueryRuns handles GET /api/runs with one of three filter modes:

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -2150,18 +2150,6 @@ func (s *Server) handleMCP(w http.ResponseWriter, r *http.Request) {
 	s.gateway.ServeHTTP(w, r)
 }
 
-// mcpJSONRPCCall is the minimal JSON-RPC 2.0 envelope mcpScopeCheck needs to
-// decide whether a scoped ephemeral MCP token may make this call. Fields
-// beyond what enforcement needs are ignored.
-type mcpJSONRPCCall struct {
-	ID     any    `json:"id"`
-	Method string `json:"method"`
-	Params struct {
-		Name      string         `json:"name"`
-		Arguments map[string]any `json:"arguments"`
-	} `json:"params"`
-}
-
 // mcpScopeCheck decides whether a scoped ephemeral MCP token (scope) may
 // make the JSON-RPC call encoded in body, without performing any I/O — pure
 // so it's cheap to table-test. scope is never nil here (callers only invoke
@@ -2179,19 +2167,34 @@ type mcpJSONRPCCall struct {
 //     an unrecognized name is left for the task's own "unknown tool" error.
 //   - any other method: always allowed — let the task's own
 //     "-32601 method not found" path handle it.
-//   - a body that doesn't parse as JSON-RPC: always allowed — let the
-//     task's own "-32700 parse error" path handle it, no second error shape.
+//   - a body whose top level isn't a JSON object at all (invalid JSON, or a
+//     JSON array/scalar/etc): always allowed — let the task's own
+//     "-32700 parse error" path handle it, no second error shape.
+//
+// The top-level decode is intentionally into a generic map rather than a
+// typed struct: with a typed struct, a single sibling field failing to
+// type-match (e.g. params.arguments sent as a string instead of an object)
+// makes encoding/json return a non-nil error *after* it has already
+// populated every other field it could, including method and params.name —
+// and treating "any decode error" as "not JSON-RPC, allow" would then
+// discard those correctly-decoded, security-relevant fields and bypass
+// enforcement entirely. Decoding into map[string]any never fails that way;
+// each field of interest is instead extracted defensively below via a
+// type assertion that degrades to its zero value on a shape mismatch,
+// rather than aborting the whole check.
 //
 // Returns allowed, the request's id (for echoing back in a denial), and a
 // human-readable denial message (empty when allowed).
 func mcpScopeCheck(scope *pkgruntime.MCPScope, body []byte) (allowed bool, id any, deniedMsg string) {
-	var call mcpJSONRPCCall
-	if err := json.Unmarshal(body, &call); err != nil {
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		// Top level isn't a JSON object at all: genuinely not JSON-RPC.
 		return true, nil, ""
 	}
-	id = call.ID
+	id = raw["id"]
 
-	switch call.Method {
+	method, _ := raw["method"].(string)
+	switch method {
 	case "tools/call":
 		// fall through to the tool-name switch below.
 	default:
@@ -2200,7 +2203,8 @@ func mcpScopeCheck(scope *pkgruntime.MCPScope, body []byte) (allowed bool, id an
 		return true, id, ""
 	}
 
-	name := call.Params.Name
+	params, _ := raw["params"].(map[string]any)
+	name, _ := params["name"].(string)
 	switch name {
 	case "list_tasks", "get_task":
 		if scope.ListTasks {
@@ -2208,7 +2212,12 @@ func mcpScopeCheck(scope *pkgruntime.MCPScope, body []byte) (allowed bool, id an
 		}
 		return false, id, fmt.Sprintf("capability not granted: %s", name)
 	case "run_task":
-		taskID, _ := call.Params.Arguments["id"].(string)
+		// arguments failing to type-match as an object (e.g. sent as a
+		// string or number) degrades to "no id available" rather than
+		// aborting the check — the existing taskID == "" deny-by-default
+		// branch below still closes the gap.
+		arguments, _ := params["arguments"].(map[string]any)
+		taskID, _ := arguments["id"].(string)
 		for _, allowedID := range scope.RunTaskIDs {
 			if allowedID == "*" || allowedID == taskID {
 				return true, id, ""

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -2124,7 +2124,14 @@ func (s *Server) handleMCP(w http.ResponseWriter, r *http.Request) {
 		// second auth gate. scope == nil: unscoped operator/CLI/dashboard
 		// key — full access, forward unchanged.
 		if found && scope != nil {
-			body, err := io.ReadAll(r.Body)
+			// Cap the read like every other request body in this file (see
+			// apiTestTask / testTaskMaxBodyBytes below): MCP JSON-RPC
+			// envelopes are small, so 64KB is generous headroom while still
+			// preventing a scoped caller from streaming an unbounded body at
+			// the daemon before mcpScopeCheck even runs. A MaxBytesReader
+			// overflow surfaces here as a plain io.ReadAll error, handled by
+			// the same 400 branch as any other malformed read.
+			body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, testTaskMaxBodyBytes))
 			if err != nil {
 				jsonErr(w, "failed to read request body", http.StatusBadRequest)
 				return
@@ -2161,10 +2168,17 @@ func (s *Server) handleMCP(w http.ResponseWriter, r *http.Request) {
 //   - tools/call list_tasks / get_task: requires scope.ListTasks.
 //   - tools/call run_task: requires scope.RunTaskIDs to contain "*" or the
 //     call's params.arguments["id"].
-//   - tools/call for any other tool name (list_sources, switch_dev_mode,
-//     test_task, or an unrecognized name): always allowed — those three
-//     hint tools exercise no dicode capability and are unscoped by design;
-//     an unrecognized name is left for the task's own "unknown tool" error.
+//   - tools/call list_sources / switch_dev_mode / test_task: always
+//     allowed — these three hint tools exercise no dicode capability and are
+//     unscoped by design.
+//   - tools/call for any other (unrecognized, or future) tool name: denied.
+//     This is fail-closed: nothing ties this switch to
+//     tasks/buildin/mcp/task.ts's TOOLS/dispatchTool list, so a future tool
+//     added there that exercises a real scoped capability must not silently
+//     inherit full access just because this switch doesn't know its name
+//     yet. Note this only affects a *scoped* caller — an unscoped caller
+//     (scope == nil) never reaches mcpScopeCheck at all and still gets the
+//     task's own "unknown tool" error unchanged.
 //   - any other method: always allowed — let the task's own
 //     "-32601 method not found" path handle it.
 //   - a body whose top level isn't a JSON object at all (invalid JSON, or a
@@ -2227,10 +2241,16 @@ func mcpScopeCheck(scope *pkgruntime.MCPScope, body []byte) (allowed bool, id an
 			return false, id, fmt.Sprintf("capability not granted: %s for task %q", name, taskID)
 		}
 		return false, id, fmt.Sprintf("capability not granted: %s", name)
-	default:
-		// list_sources, switch_dev_mode, test_task (unscoped by design), or
-		// an unrecognized tool name (left for the task's own error).
+	case "list_sources", "switch_dev_mode", "test_task":
+		// Unscoped by design: hint-only tools that exercise no dicode
+		// capability.
 		return true, id, ""
+	default:
+		// Fail closed: an unrecognized tool name — including any future
+		// tool added to tasks/buildin/mcp/task.ts that this switch hasn't
+		// been taught about — is denied rather than silently inheriting
+		// full access from a scoped token.
+		return false, id, fmt.Sprintf("capability not granted: %s", name)
 	}
 }
 


### PR DESCRIPTION
Closes #567.

## Summary

`#564` (merged) added ephemeral per-run dicode MCP API keys, minted at run start and revoked at run end for tasks that declare `permissions.env: [DICODE_MCP_API_KEY]`. The token was **full-surface** — indistinguishable from an operator-managed key — so any task holding one could call `run_task` on *any* task via `/mcp` → `tasks/buildin/mcp`, regardless of what its own `permissions.dicode` actually granted it. `#582` flagged this leftover ("Capability-scoping the token... remain[s] tracked in #567") and it's the last unchecked item on `#560`'s tracking checklist.

This PR mints a token that only authorizes the calling task's own declared `dicode.*` capabilities.

## Design

The MCP tool surface reachable through `/mcp` (`tasks/buildin/mcp/task.ts`) is: `list_tasks`, `get_task` (need `permissions.dicode.list_tasks: true`), `run_task` (needs `permissions.dicode.tasks: [...]`, `"*"` = any), plus three no-op "hint" tools (`list_sources`, `switch_dev_mode`, `test_task`) that just point at a REST endpoint and exercise no dicode capability — those stay unscoped. `tasks/buildin/mcp/task.ts` itself was **not modified** — it always runs with full permissions (`list_tasks: true`, `tasks: ["*"]`) and can't be relied on to self-restrict, so enforcement happens one layer up, in `pkg/webui.handleMCP`, before a request is ever forwarded to it.

## Changes

- **`pkg/runtime/mcp_token.go`** — new `MCPScope{ListTasks, RunTaskIDs}` type and `MCPScopeFor(spec)`, deriving the scope 1:1 from the task's own `permissions.dicode`. `MCPTokenMinter.Mint` now takes a scope; `ApplyMCPToken` computes and passes it.
- **`pkg/db/sqlite.go`** — nullable `api_keys.scopes TEXT` column via the existing idempotent `addColumnIfMissing` migration pattern. NULL stays the default (unscoped/full access), so every existing dashboard/CLI-managed key is unaffected.
- **`pkg/webui/apikeys.go`** — `generateScoped` (JSON-marshals a scope into the new column; `generate` now delegates to it with `nil`) and `scopeFor` (looks up a key's stored scope; fails closed to a deny-all zero value on corrupt data rather than falling back to unscoped).
- **`pkg/webui/mcp_token_minter.go`** — `Mint` now threads the scope through to `generateScoped`, storing it exactly as given — including the zero value, which correctly denies every scoped tool for a task with no `permissions.dicode` at all.
- **`pkg/webui/server.go`** — `handleMCP` checks a Bearer caller's stored scope (via the new pure, table-tested `mcpScopeCheck`) before forwarding a POST. A denied `tools/call` gets a JSON-RPC `-32001` error and never reaches the gateway. Session-cookie callers and unscoped keys are unaffected.
- **`docs/concepts/mcp-server.md`** — documents the new capability-scoped behavior.

## Why unit-only, not e2e

This is a machine-to-machine HTTP/JSON-RPC protocol path (MCP clients authenticating with a Bearer token), not a browser-reachable UI flow — there's no Playwright surface for it, matching the rationale #565 and #554 used for similar backend-only changes. Regression coverage is Go tests: table tests for `MCPScopeFor` and `mcpScopeCheck`, a `generateScoped`/`scopeFor` round-trip, and `handleMCP` end-to-end tests (built on the existing `newApprovalTestServer` harness) proving a denied `run_task` never reaches the gateway while an allowed one, and an unscoped key, both still forward.

## Gates

- [x] `make build` — clean
- [x] `go vet ./...` — clean
- [x] `make format-check` — clean
- [x] `make lint` — clean
- [x] `make test` — green, **except** a pre-existing, unrelated failure in `pkg/ipc`'s `TestControl_TaskTest_HappyPath` (blocked `deno.land`/GitHub-releases download under this sandbox's egress policy — HTTP 403; confirmed via `git stash` that this fails identically on unmodified `origin/main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_019ebvuguUsXsqDb7UfkKbFN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability-based access controls for ephemeral MCP API keys.
  * MCP permissions can now restrict task listing, task details, and which tasks may be run.
  * Added per-run token creation and automatic revocation.
  * Unscoped operator-created keys retain full MCP access.

* **Bug Fixes**
  * Unauthorized MCP tool calls are blocked before forwarding and return clear JSON-RPC errors.
  * Invalid or unknown scope data now fails closed.
  * Oversized MCP requests are rejected safely.

* **Documentation**
  * Documented MCP token lifecycle, permissions, enforcement behavior, and access rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->