### PR TITLE
feat(ai): shared suspend/resume chat envelope for both agent tasks (#571, first slice)

### DIFF
--- a/tasks/buildin/ai-agent-claude-cli/task.ts
+++ b/tasks/buildin/ai-agent-claude-cli/task.ts
@@ -22,7 +22,12 @@
 // so operators can see what went wrong even when the run exits 0 (returns
 // a value, not throws).
 
-import type { Dicode, DicodeSdk, JSONSchema } from "../../sdk.ts";
+import type { Dicode, DicodeSdk } from "../../sdk.ts";
+import { chatStart, chatTurn, decideEntryMode, isChatEnd, SAFE_SKILL_NAME } from "../ai-agent-core/chat.ts";
+
+// Re-exported so the task's tests (and any importer) reach the shared envelope
+// helpers through the task module.
+export { decideEntryMode, isChatEnd };
 
 interface Params {
     get: (key: string) => Promise<string | null>;
@@ -70,11 +75,6 @@ function fail(error: string): { ok: false; error: string } {
     return { ok: false, error };
 }
 
-// SAFE_SKILL_NAME caps skill filenames to a flat identifier so the
-// `skills` param can't traverse out of skills_dir via "../" or absolute
-// paths. Mirrors the style of ValidateRunID elsewhere in the codebase.
-const SAFE_SKILL_NAME = /^[A-Za-z0-9_][A-Za-z0-9_.-]{0,63}$/;
-
 /**
  * Build the `claude` CLI argument vector. Exported for unit testing.
  *
@@ -107,38 +107,6 @@ export function buildClaudeArgs(opts: {
     return args;
 }
 
-// decideEntryMode picks the shape of a fresh run: a non-empty prompt runs one
-// turn and returns; an empty prompt opens the interactive chat loop. Pure so the
-// branch can be unit-tested without a live Claude.
-export function decideEntryMode(prompt: string): "one-shot" | "chat-start" {
-    return prompt.trim() !== "" ? "one-shot" : "chat-start";
-}
-
-// isChatEnd terminates the chat loop: a blank/whitespace message is the "end"
-// signal (the step returns instead of suspending onward).
-export function isChatEnd(message: string): boolean {
-    return message.trim() === "";
-}
-
-// chatSchema is the resume form for one chat turn: a single `message` field,
-// intentionally NOT required so the interactive CLI prompt accepts a blank line
-// — which steps.turn reads as the end-of-chat signal (isChatEnd). The banner
-// text lives on BOTH the schema and the `message` property — the CLI's
-// interactive resume prompt renders the *property* description above the input
-// (cmd/dicode/main.go promptResumeInput), while the no-field confirmation path
-// renders the schema-level one; setting both keeps the reply visible regardless
-// of which renderer runs.
-function chatSchema(description: string): JSONSchema {
-    return {
-        type: "object",
-        title: "Chat",
-        description,
-        properties: {
-            message: { type: "string", title: "Message", description },
-        },
-    };
-}
-
 export default async function main({ params, kv, dicode }: SDK) {
     const prompt = (await params.get("prompt")) ?? "";
 
@@ -148,42 +116,49 @@ export default async function main({ params, kv, dicode }: SDK) {
         // per-invocation workdir, which must stay constant across turns because
         // Claude CLI's `--resume` only finds sessions created in the same cwd.
         const chatId = crypto.randomUUID();
-        await dicode.suspend({
-            to: "turn",
-            state: { claudeSessionId: "", chatId },
-            schema: chatSchema("Message Claude — leave blank to end."),
-        });
+        await chatStart(dicode, { claudeSessionId: "", chatId }, "Message Claude — leave blank to end.");
         return; // unreachable — suspend() never returns
     }
 
     return await oneShotTurn({ prompt, params, kv });
 }
 
+// The Claude-side state carried across chat turns: the CLI session id (drives
+// --resume) and a stable workdir key.
+interface ClaudeChatState {
+    claudeSessionId?: string;
+    chatId?: string;
+}
+
 export const steps = {
-    // One chat turn: read the submitted message, run Claude resuming its prior
-    // session, then suspend back to `turn` with the reply as the next banner.
-    // A blank message returns (ends the run → the CLI's resume loop exits).
-    async turn({ params, input, state, dicode }: DicodeSdk) {
-        const carried = (state ?? {}) as { claudeSessionId?: string; chatId?: string };
-        const message = String((input as { message?: string } | undefined)?.message ?? "");
-        const prior = carried.claudeSessionId ?? "";
-
-        if (isChatEnd(message)) {
-            return { ok: true, reply: "(chat ended)", session_id: prior };
-        }
-
-        // chatId is minted in main() and carried forward; default-guard it so a
-        // hand-crafted resume without one still runs (a fresh cwd, no --resume).
-        const chatId = carried.chatId ?? crypto.randomUUID();
-        const turn = await runClaudeTurn({ message, priorClaudeSessionId: prior, workdirKey: chatId, params });
-        if (!turn.ok) return turn;
-
-        await dicode.suspend({
-            to: "turn",
-            state: { claudeSessionId: turn.claudeSessionId, chatId },
-            schema: chatSchema(turn.reply),
-        });
-        return; // unreachable — suspend() never returns
+    // One chat turn: run Claude resuming its prior session. The envelope owns the
+    // suspend/resume loop; runTurn here is just the Claude invocation, and onEnd
+    // reports the CLI session id carried in state when a blank message ends it.
+    turn(ctx: DicodeSdk) {
+        const { params } = ctx;
+        return chatTurn(
+            ctx,
+            async ({ message, state }) => {
+                const carried = (state ?? {}) as ClaudeChatState;
+                // chatId is minted in main() and carried forward; default-guard it
+                // so a hand-crafted resume without one still runs (fresh cwd, no
+                // --resume).
+                const chatId = carried.chatId ?? crypto.randomUUID();
+                const turn = await runClaudeTurn({
+                    message,
+                    priorClaudeSessionId: carried.claudeSessionId ?? "",
+                    workdirKey: chatId,
+                    params,
+                });
+                if (!turn.ok) return turn;
+                return { ok: true, reply: turn.reply, state: { claudeSessionId: turn.claudeSessionId, chatId } };
+            },
+            (state) => ({
+                ok: true,
+                reply: "(chat ended)",
+                session_id: (state as ClaudeChatState | undefined)?.claudeSessionId ?? "",
+            }),
+        );
     },
 };
 

--- a/tasks/buildin/ai-agent-core/chat.ts
+++ b/tasks/buildin/ai-agent-core/chat.ts
@@ -1,0 +1,95 @@
+// buildin/ai-agent-core — the shared suspend/resume "chat turn" envelope used
+// by every ai-agent preset. Provider is the only difference between the tasks
+// that build on this: each supplies a `runTurn` that executes one turn against
+// its backend; opening the loop, ending it, and re-suspending for the next
+// message all live here.
+//
+// `state` is provider-opaque: the envelope carries it through suspend/resume
+// verbatim and hands it back to `runTurn`. For the Claude CLI it is the CLI
+// session id + workdir key; for the OpenAI loop it is the cumulative
+// {messages, summary}. The envelope never looks inside it.
+
+import type { Dicode, JSONSchema } from "../../sdk.ts";
+
+// SAFE_SKILL_NAME caps skill filenames to a flat identifier so a `skills` param
+// can't traverse out of skills_dir via "../" or absolute paths (the "/" is
+// outside the class, so a traversal segment never matches). Mirrors the style
+// of ValidateRunID elsewhere in the codebase.
+export const SAFE_SKILL_NAME = /^[A-Za-z0-9_][A-Za-z0-9_.-]{0,63}$/;
+
+// decideEntryMode picks the shape of a fresh run: a non-empty prompt runs one
+// turn and returns; an empty prompt opens the interactive chat loop. Pure so the
+// branch can be unit-tested without a live provider.
+export function decideEntryMode(prompt: string): "one-shot" | "chat-start" {
+    return prompt.trim() !== "" ? "one-shot" : "chat-start";
+}
+
+// isChatEnd terminates the chat loop: a blank/whitespace message is the "end"
+// signal (the turn returns instead of suspending onward).
+export function isChatEnd(message: string): boolean {
+    return message.trim() === "";
+}
+
+// chatSchema is the resume form for one chat turn: a single `message` field,
+// intentionally NOT required so the interactive CLI prompt accepts a blank line
+// — which chatTurn reads as the end-of-chat signal (isChatEnd). The banner text
+// lives on BOTH the schema and the `message` property — the CLI's interactive
+// resume prompt renders the *property* description above the input
+// (cmd/dicode/main.go promptResumeInput), while the no-field confirmation path
+// renders the schema-level one; setting both keeps the reply visible regardless
+// of which renderer runs.
+export function chatSchema(description: string): JSONSchema {
+    return {
+        type: "object",
+        title: "Chat",
+        description,
+        properties: {
+            message: { type: "string", title: "Message", description },
+        },
+    };
+}
+
+// The outcome of one provider turn. Success carries the reply plus the new
+// opaque state to carry into the next turn; failure is any object the provider
+// wants surfaced as the run's result (chatTurn returns it verbatim).
+export type TurnResult =
+    | { ok: true; reply: string; state: unknown }
+    | { ok: false; [k: string]: unknown };
+
+// runTurn is the provider seam: run one turn for `message` given the carried
+// `state`, returning the reply plus the state to carry forward.
+export type RunTurn = (args: { message: string; state: unknown }) => Promise<TurnResult>;
+
+// chatStart opens a fresh chat: suspend to the `turn` step with the seed state
+// and a banner. Never returns — suspend() exits the process.
+export function chatStart(dicode: Dicode, initialState: unknown, banner: string): Promise<never> {
+    return dicode.suspend({
+        to: "turn",
+        state: initialState,
+        schema: chatSchema(banner),
+    });
+}
+
+// chatTurn runs one iteration of the loop: read the submitted message; a blank
+// message ends the chat (onEnd), otherwise run the provider turn and suspend
+// back to `turn` with the new state and the reply as the next banner. onEnd
+// defaults to a bare end marker; providers that carry an identity in `state`
+// (e.g. a session id) shape their own end result.
+export async function chatTurn(
+    ctx: { input: unknown; state?: unknown; dicode: Dicode },
+    runTurn: RunTurn,
+    onEnd: (state: unknown) => unknown = () => ({ ok: true, reply: "(chat ended)" }),
+): Promise<unknown> {
+    const message = String((ctx.input as { message?: string } | undefined)?.message ?? "");
+    if (isChatEnd(message)) return onEnd(ctx.state);
+
+    const turn = await runTurn({ message, state: ctx.state });
+    if (!turn.ok) return turn;
+
+    await ctx.dicode.suspend({
+        to: "turn",
+        state: turn.state,
+        schema: chatSchema(turn.reply),
+    });
+    // unreachable — suspend() never returns
+}

--- a/tasks/buildin/ai-agent/task.test.ts
+++ b/tasks/buildin/ai-agent/task.test.ts
@@ -14,6 +14,41 @@
 import { setupHarness } from "../../sdk-test.ts";
 await setupHarness(import.meta.url);
 
+// Loaded AFTER setupHarness patches globalThis.fetch — a static import would
+// evaluate task.ts's `npm:openai` dependency before the patch, so the client
+// the task builds would bind the real fetch and skip the http mocks.
+const { steps } = await import("./task.ts") as {
+  steps: { turn: (ctx: unknown) => Promise<unknown> };
+};
+
+// dicode.suspend never returns in production (the process exits). Tests must
+// stop execution the same way: install a suspend that records the request and
+// throws a sentinel, then inspect the recorded calls.
+class SuspendSignal extends Error {}
+function recordSuspend(): Array<Record<string, unknown>> {
+  const calls: Array<Record<string, unknown>> = [];
+  (dicode as Record<string, unknown>).suspend = (req: Record<string, unknown>) => {
+    calls.push(req);
+    throw new SuspendSignal();
+  };
+  return calls;
+}
+
+// Drive one chat turn through steps.turn with the harness mocks, mirroring how
+// the runner dispatches a resume.
+// deno-lint-ignore no-explicit-any
+function runTurnStep(input: unknown, state: unknown): Promise<any> {
+  return steps.turn({
+    params,
+    kv,
+    input,
+    state,
+    dicode,
+    output: {},
+    mcp: {},
+  }) as Promise<Record<string, unknown>>;
+}
+
 // Minimal OpenAI chat completion response body.
 function completion(content: string, tool_calls?: unknown[]) {
   return {
@@ -159,11 +194,24 @@ test("throws when api key env var is not set (hosted provider)", async () => {
   await assert.throws(() => runTask(), /OPENAI_API_KEY not set/);
 });
 
-test("throws when prompt is empty", async () => {
-  useLocal();
-  // prompt intentionally not set
+test("blank prompt on a fresh run opens the chat loop (suspends to turn)", async () => {
+  // prompt intentionally not set → chat-start, not the one-shot path.
+  const calls = recordSuspend();
+  let signalled = false;
+  try {
+    await runTask();
+  } catch (e) {
+    if (e instanceof SuspendSignal) signalled = true;
+    else throw e;
+  }
 
-  await assert.throws(() => runTask(), /prompt param is required/);
+  assert.equal(signalled, true);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].to, "turn");
+  // `message` is intentionally NOT required so a blank line ends the chat.
+  assert.equal((calls[0].schema as Record<string, unknown>).required, undefined);
+  // Conversation state rides in the suspend blob, seeded empty.
+  assert.equal((calls[0].state as Record<string, unknown>).messages, []);
 });
 
 test("compaction fires when history exceeds max_history_tokens", async () => {
@@ -262,4 +310,90 @@ test("refuses to run when dicode.task_id is empty", async () => {
   dicode.task_id = "";
 
   await assert.throws(() => runTask(), /dicode\.task_id is empty/);
+});
+
+// --- chat loop -------------------------------------------------------------
+
+test("chat turn runs one OpenAI turn and suspends back with the reply", async () => {
+  useLocal();
+  const calls = recordSuspend();
+
+  http.mock("POST", "http://localhost:11434/v1/chat/completions", {
+    status: 200,
+    body: completion("pong"),
+  });
+
+  let signalled = false;
+  try {
+    await runTurnStep({ message: "ping" }, { messages: [] });
+  } catch (e) {
+    if (e instanceof SuspendSignal) signalled = true;
+    else throw e;
+  }
+
+  assert.equal(signalled, true);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].to, "turn");
+  // The reply becomes the next prompt's banner.
+  assert.equal((calls[0].schema as Record<string, unknown>).description, "pong");
+  // Cumulative conversation is carried forward in the suspend state (not KV).
+  const msgs = (calls[0].state as { messages: Array<{ role: string; content: string }> }).messages;
+  assert.equal(msgs[0].role, "user");
+  assert.equal(msgs[0].content, "ping");
+  assert.equal(msgs[msgs.length - 1].role, "assistant");
+  assert.equal(msgs[msgs.length - 1].content, "pong");
+});
+
+test("chat turn threads prior messages from the carried state", async () => {
+  useLocal();
+  recordSuspend();
+
+  http.mock("POST", "http://localhost:11434/v1/chat/completions", {
+    status: 200,
+    body: completion("second reply"),
+  });
+
+  try {
+    await runTurnStep(
+      { message: "second message" },
+      { messages: [{ role: "user", content: "first message" }, { role: "assistant", content: "first reply" }] },
+    );
+  } catch (e) {
+    if (!(e instanceof SuspendSignal)) throw e;
+  }
+
+  // The prior turns from state are replayed to the model on this turn.
+  const sent = http.lastRequestBody("POST", "http://localhost:11434/v1/chat/completions");
+  const contents: string[] = (sent.messages ?? []).map((m: { content: string }) => m.content);
+  assert.ok(contents.includes("first message"), "prior user turn must be replayed");
+  assert.ok(contents.includes("first reply"), "prior assistant turn must be replayed");
+  assert.ok(contents.includes("second message"), "new user turn must be present");
+});
+
+test("chat turn: a blank message ends the chat (returns, no OpenAI call)", async () => {
+  useLocal();
+  const calls = recordSuspend();
+
+  const result = await runTurnStep(
+    { message: "   " },
+    { messages: [{ role: "user", content: "hi" }, { role: "assistant", content: "hello" }] },
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(result.reply, "(chat ended)");
+  assert.equal(calls.length, 0); // never suspended onward
+  assert.httpNotCalled("POST", "http://localhost:11434/v1/chat/completions");
+});
+
+test("chat turn surfaces not_configured when no provider is set", async () => {
+  // No useLocal(): model/base_url unset. The turn returns a failure the envelope
+  // hands back verbatim instead of suspending onward.
+  const calls = recordSuspend();
+
+  const result = await runTurnStep({ message: "hi" }, { messages: [] });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "not_configured");
+  assert.ok(result.missing.includes("model"));
+  assert.equal(calls.length, 0);
 });

--- a/tasks/buildin/ai-agent/task.ts
+++ b/tasks/buildin/ai-agent/task.ts
@@ -9,7 +9,19 @@
 // The task bare-returns { session_id, reply } so browser UIs can parse it
 // as application/json. Never call output.html() here — that would override
 // the content type.
+//
+// Two shapes over one turn core (runAgentTurn), sharing the suspend/resume
+// envelope with the other ai-agent presets:
+//   - One-shot (a non-empty `prompt`): run one turn and return
+//     { session_id, reply }, threading conversation history through KV under
+//     chat:<sessionId> — the drivers depend on this.
+//   - Chat loop (blank `prompt` on a fresh run): suspend to a `turn` step that
+//     collects a message, runs one turn, and suspends back. The conversation
+//     rides in the suspend `state` blob (resume_state), not KV. A blank message
+//     ends it.
 import OpenAI from "npm:openai@4";
+import type { Dicode, DicodeSdk } from "../../sdk.ts";
+import { chatStart, chatTurn, decideEntryMode } from "../ai-agent-core/chat.ts";
 
 type Role = "system" | "user" | "assistant" | "tool";
 
@@ -224,31 +236,47 @@ interface NotConfiguredResponse {
   hint: string;
 }
 
-export default async function main({ params, kv, dicode }: DicodeSdk) {
-  // Self-identity check before anything else. dicode.task_id is populated
-  // from the IPC handshake and is used below to exclude this task from its
-  // own tool list. An empty value would silently turn that filter into a
-  // no-op, letting the agent call itself as a tool and recurse up to
-  // max_tool_iterations deep per turn. Fail loud instead.
+// requireTaskId fails loud when the IPC handshake didn't populate task_id.
+// dicode.task_id excludes this task from its own tool list; an empty value
+// would silently turn that filter into a no-op, letting the agent call itself
+// as a tool and recurse up to max_tool_iterations deep per turn.
+function requireTaskId(dicode: Dicode): void {
   if (!dicode.task_id) {
     throw new Error(
       "ai-agent: dicode.task_id is empty — refusing to run without a self-identity. " +
         "This indicates the IPC handshake did not populate task_id; check the dicode daemon version.",
     );
   }
+}
 
-  const prompt = (await params.get("prompt")) ?? "";
-  if (!prompt) throw new Error("prompt param is required");
+// AgentRuntime bundles everything one turn needs. Resolved fresh per run from
+// params — each suspend/resume re-enters the file, so nothing is cached.
+interface AgentRuntime {
+  client: OpenAI;
+  model: string;
+  systemPromptBase: string;
+  skillsBlob: string;
+  // deno-lint-ignore no-explicit-any
+  tools: any[];
+  toolNameToTaskId: Record<string, string>;
+  compactionCfg: CompactionConfig;
+  maxToolIterations: number;
+  responseMaxTokens: number;
+}
 
-  // Hybrid session id: use provided or auto-generate
-  let sessionId = (await params.get("session_id")) ?? "";
-  if (!sessionId) sessionId = crypto.randomUUID();
+type ResolveResult =
+  | { ok: true; runtime: AgentRuntime }
+  | { ok: false; missing: string[]; hint: string };
 
-  // Tag the run so the WebUI collapses every turn of a single chat into
-  // one expandable row in the run list (#112). Tool-call children are
-  // already linked via parent_run_id by the engine (#116), so the run
-  // detail view can render this turn as a timeline of sub-runs (#113).
-  await dicode.set_group(`chat:${sessionId}`);
+// resolveAgentRuntime reads the provider config + tunables from params, resolves
+// the API key, loads skills, and builds the tool list. Returns a structured
+// not_configured result when model/base_url are missing (the caller shapes the
+// response); throws on a bad tunable or a missing api key env var.
+async function resolveAgentRuntime(
+  params: DicodeSdk["params"],
+  dicode: Dicode,
+): Promise<ResolveResult> {
+  requireTaskId(dicode);
 
   // Tools: dicode task ids the agent may call. Empty = all except self.
   const toolFilter = ((await params.get("tools")) ?? "")
@@ -290,17 +318,14 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
   if (!baseURL) missing.push("base_url");
 
   if (missing.length > 0) {
-    const response: NotConfiguredResponse = {
-      session_id: sessionId,
-      reply: null,
-      error: "not_configured",
+    return {
+      ok: false,
       missing,
       hint:
         "This is the generic ai-agent buildin. It has no provider configured. " +
         "Either pass model/base_url/api_key_env as params, or use a " +
         "provider-specific sibling task (e.g. examples/ai-agent-ollama).",
     };
-    return response;
   }
 
   // API key resolution is purely param-driven, with no URL sniffing.
@@ -336,20 +361,10 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
   console.log(
     `ai-agent[${new Date().toISOString()}]: task=${dicode.task_id} ` +
       `run=${dicode.run_id.slice(0, 8)} model=${model} baseURL=${baseURL} ` +
-      `session=${sessionId.slice(0, 8)} tools=${toolFilter.length || "*"} ` +
-      `skills=${skillNames.length}`,
+      `tools=${toolFilter.length || "*"} skills=${skillNames.length}`,
   );
 
   const client = new OpenAI({ apiKey, baseURL });
-
-  // Load or init session state from KV
-  const key = `chat:${sessionId}`;
-  const stored = (await kv.get(key)) as SessionState | null;
-  const session: SessionState = stored ?? {
-    messages: [],
-    created_at: Date.now(),
-    updated_at: Date.now(),
-  };
 
   // Build tool list from list_tasks(), filtered by toolFilter. When no
   // explicit allowlist is supplied we exclude exactly this task's own id
@@ -379,15 +394,41 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
     };
   });
 
-  // Append user turn
-  session.messages.push({ role: "user", content: prompt });
-
-  const compactionCfg: CompactionConfig = {
-    maxHistoryTokens,
-    keepTurns: compactionKeepTurns,
-    summaryMaxTokens: compactionMaxTokens,
-    model: compactionModel,
+  return {
+    ok: true,
+    runtime: {
+      client,
+      model,
+      systemPromptBase,
+      skillsBlob,
+      tools,
+      toolNameToTaskId,
+      compactionCfg: {
+        maxHistoryTokens,
+        keepTurns: compactionKeepTurns,
+        summaryMaxTokens: compactionMaxTokens,
+        model: compactionModel,
+      },
+      maxToolIterations,
+      responseMaxTokens,
+    },
   };
+}
+
+// runAgentTurn runs the tool-use loop for a single user message against a
+// resolved runtime, mutating `session` in place and returning the reply. The
+// caller owns where `session` comes from and goes to (KV for one-shot,
+// resume_state for the chat loop).
+async function runAgentTurn(
+  session: SessionState,
+  message: string,
+  rt: AgentRuntime,
+  dicode: Dicode,
+): Promise<string> {
+  const { client, model, systemPromptBase, skillsBlob, tools, toolNameToTaskId, compactionCfg, maxToolIterations, responseMaxTokens } = rt;
+
+  // Append user turn
+  session.messages.push({ role: "user", content: message });
 
   // The entire agent loop is wrapped in try/finally so the session — and
   // all the tool round-trips it successfully completed — is persisted to
@@ -513,6 +554,76 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
     }
   } finally {
     session.updated_at = Date.now();
+  }
+
+  const last = session.messages[session.messages.length - 1];
+  return last?.role === "assistant" ? last.content : "";
+}
+
+export default async function main({ params, kv, dicode }: DicodeSdk) {
+  requireTaskId(dicode);
+
+  const prompt = (await params.get("prompt")) ?? "";
+
+  if (decideEntryMode(prompt) === "chat-start") {
+    // Blank prompt on a fresh run → open the chat loop. The conversation rides
+    // in the suspend `state` blob (resume_state), seeded empty; steps.turn runs
+    // each turn. A blank message ends it.
+    await chatStart(dicode, { messages: [] }, "Message the agent — leave blank to end.");
+    return; // unreachable — suspend() never returns
+  }
+
+  return await oneShotTurn({ prompt, params, kv, dicode });
+}
+
+// oneShotTurn is the backward-compatible single-turn path: it threads
+// conversation history through KV under chat:<sessionId> (the drivers depend on
+// this), tags the run's group, and returns the { session_id, reply } shape the
+// browser UIs parse as application/json.
+async function oneShotTurn(
+  { prompt, params, kv, dicode }: {
+    prompt: string;
+    params: DicodeSdk["params"];
+    kv: DicodeSdk["kv"];
+    dicode: Dicode;
+  },
+): Promise<unknown> {
+  // Hybrid session id: use provided or auto-generate
+  let sessionId = (await params.get("session_id")) ?? "";
+  if (!sessionId) sessionId = crypto.randomUUID();
+
+  // Tag the run so the WebUI collapses every turn of a single chat into
+  // one expandable row in the run list (#112). Tool-call children are
+  // already linked via parent_run_id by the engine (#116), so the run
+  // detail view can render this turn as a timeline of sub-runs (#113).
+  // set_group is provided by the runtime shim but not yet on the typed surface.
+  await (dicode as Dicode & { set_group(label: string): Promise<void> }).set_group(`chat:${sessionId}`);
+
+  const resolved = await resolveAgentRuntime(params, dicode);
+  if (!resolved.ok) {
+    const response: NotConfiguredResponse = {
+      session_id: sessionId,
+      reply: null,
+      error: "not_configured",
+      missing: resolved.missing,
+      hint: resolved.hint,
+    };
+    return response;
+  }
+
+  // Load or init session state from KV
+  const key = `chat:${sessionId}`;
+  const stored = (await kv.get(key)) as SessionState | null;
+  const session: SessionState = stored ?? {
+    messages: [],
+    created_at: Date.now(),
+    updated_at: Date.now(),
+  };
+
+  let reply = "";
+  try {
+    reply = await runAgentTurn(session, prompt, resolved.runtime, dicode);
+  } finally {
     // Best-effort persistence. If KV itself is broken the task was going
     // to fail anyway, and we don't want the KV error to shadow the real
     // error from the loop body. Log and move on.
@@ -525,11 +636,32 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
     }
   }
 
-  const last = session.messages[session.messages.length - 1];
-  const reply = last?.role === "assistant" ? last.content : "";
-
   // Bare return → dicode serializes as application/json.
   // Do NOT call output.html() here; it would override Content-Type and the
   // browser UI would have to parse HTML instead of JSON.
   return { session_id: sessionId, reply };
 }
+
+export const steps = {
+  // One chat turn: run one OpenAI turn for the submitted message. The envelope
+  // owns the suspend/resume loop; runTurn here carries the cumulative
+  // {messages, summary} forward in the suspend state (not KV).
+  turn(ctx: DicodeSdk) {
+    const { params, dicode } = ctx;
+    return chatTurn(ctx, async ({ message, state }) => {
+      const resolved = await resolveAgentRuntime(params, dicode);
+      if (!resolved.ok) {
+        return { ok: false, error: "not_configured", missing: resolved.missing, hint: resolved.hint };
+      }
+      const carried = (state ?? {}) as { messages?: StoredMessage[]; summary?: string };
+      const session: SessionState = {
+        messages: carried.messages ?? [],
+        summary: carried.summary,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+      };
+      const reply = await runAgentTurn(session, message, resolved.runtime, dicode);
+      return { ok: true, reply, state: { messages: session.messages, summary: session.summary } };
+    });
+  },
+};


### PR DESCRIPTION
## Summary

The Claude-CLI agent already carries a working suspend/resume "chat turn" envelope: a fresh run with a prompt runs one-shot, a blank prompt opens an interactive chat loop that suspends for each message and resumes with the reply as the next banner. This is the **first slice of #571** — it lifts that envelope out of `ai-agent-claude-cli` into a shared module and refactors **both** agent tasks onto it, so the provider becomes the only real difference between them.

New module `tasks/buildin/ai-agent-core/chat.ts` owns the provider-agnostic parts:
- `decideEntryMode` / `isChatEnd` / `chatSchema` / `SAFE_SKILL_NAME` (previously duplicated)
- `chatStart(dicode, state, banner)` — the fresh-chat suspend
- `chatTurn(ctx, runTurn, onEnd?)` — one loop iteration: read the message, end on blank, else run the provider turn and re-suspend with the new state + reply banner

`state` is provider-opaque: the envelope carries it through suspend/resume verbatim and hands it back to `runTurn`. Each task keeps its own `task.yaml` permission surface (the CLI family needs `run:["claude"]`+fs+env; the OpenAI family needs `net:`), which is exactly why the seam is a shared module rather than one mega-task.

`ai-agent-claude-cli` is refactored with no behavior change: `main`/`steps.turn` delegate to `chatStart`/`chatTurn`, `runTurn` wraps the existing `runClaudeTurn`, provider state is `{claudeSessionId, chatId}`.

`ai-agent` gains the same dual-path shape. A non-empty `prompt` keeps the existing one-shot path unchanged — it still returns `{session_id, reply}` and threads history through KV `chat:<sessionId>`, which the drivers depend on. A blank `prompt` now opens the chat loop (the old `prompt required` throw is removed) and carries the cumulative `{messages, summary}` in the suspend `state` (resume_state), not KV. One OpenAI turn is the existing tool-use loop for a single message.

## Scope boundaries

- **`ai-agent` stays on the capability-gated SDK tool path — not converged onto MCP** (that's #560/#567).
- **KV session threading is preserved, not deleted** — the driver migration + KV retirement are the second half of #571.
- No `task.yaml` permissions/params changed; the `dicodai`/`auto-fix` taskset overrides of `ai-agent` keep working unchanged.
- The shared module is imported cross-directory; Deno's module loader is not gated by `--allow-read`, so no permission change is needed (verified empirically against the bundled Deno 2.3.3). `ai-agent-core/` has no `task.yaml`, so the reconciler treats it as a library, not a task.

This is the **FIRST SLICE** of #571; the driver migration + KV deletion remain.

## Tests

Both task suites pass under the repo's task-test loop (bundled Deno):
`deno test --allow-all --config=tasks/deno.json` → **41 passed** (26 claude-cli unchanged, 15 ai-agent incl. new chat-start / turn-resume / blank-end / not-configured cases). Full buildin sweep: 204 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-turn chat mode for AI agents, with conversation context preserved between messages.
  * Added support for continuing chats across suspended and resumed sessions.
  * Added automatic conversation summarization while retaining recent messages and tool interactions.
* **Bug Fixes**
  * Blank or whitespace-only messages now end chats cleanly without triggering provider requests.
  * Missing provider configuration now returns a clear structured response instead of failing during execution.
  * Added safeguards against accidental self-recursion during agent startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->