### PR TITLE
feat(cli): dicode ai with no prompt opens an interactive suspend/resume chat

### DIFF
--- a/cmd/dicode/main.go
+++ b/cmd/dicode/main.go
@@ -1431,9 +1431,8 @@ func cmdAI(c *ipc.ControlClient, args []string) error {
 			positional = append(positional, a)
 		}
 	}
-	if len(positional) == 0 {
-		return fmt.Errorf("usage: dicode ai <prompt> [--session-id ID] [--task TASK_ID]")
-	}
+	// No prompt → chat mode: the agent opens an interactive suspend/resume
+	// conversation. A prompt runs a single one-shot turn (backward compatible).
 	prompt := strings.Join(positional, " ")
 
 	resp, err := c.Send(ipc.Request{
@@ -1452,6 +1451,18 @@ func cmdAI(c *ipc.ControlClient, args []string) error {
 	if err := remarshal(resp.Result, &result); err != nil {
 		return err
 	}
+
+	// Chat mode: the agent suspended for the first message. Drive the same
+	// suspend/resume follow loop the wizard path uses; each typed message is a
+	// resume turn, a blank line ends the chat.
+	if result.Suspended {
+		if !stdinIsInteractive() {
+			return fmt.Errorf("chat mode needs an interactive terminal — pass a prompt for a one-shot turn")
+		}
+		prefill, _ := newPrefillPool(nil)
+		return followSuspended(c, result.RunID, prefill, false)
+	}
+
 	// Emit session_id to stderr on first turn so pipelines that consume the
 	// reply on stdout stay clean. When the caller already passed --session-id
 	// we skip this — they already have the id.

--- a/pkg/ipc/control.go
+++ b/pkg/ipc/control.go
@@ -798,9 +798,9 @@ func (cs *ControlServer) handleMetrics() MetricsSnapshot {
 // bare string (treated as the reply with an empty session id), or any other
 // value (marshalled back into reply as JSON text).
 func (cs *ControlServer) handleAI(ctx context.Context, req Request) (AIResult, error) {
-	if req.Prompt == "" {
-		return AIResult{}, errors.New("prompt required")
-	}
+	// A blank prompt is the chat-mode entry: the agent opens the conversation
+	// by suspending for the first message (handled below), rather than running
+	// a single one-shot turn.
 	taskID := req.TaskID
 	if taskID == "" {
 		taskID = cs.defaultAITask
@@ -812,7 +812,10 @@ func (cs *ControlServer) handleAI(ctx context.Context, req Request) (AIResult, e
 		return AIResult{}, fmt.Errorf("ai task %q not registered", taskID)
 	}
 
-	params := map[string]string{"prompt": req.Prompt}
+	params := map[string]string{}
+	if req.Prompt != "" {
+		params["prompt"] = req.Prompt
+	}
 	if req.SessionID != "" {
 		params["session_id"] = req.SessionID
 	}
@@ -821,7 +824,10 @@ func (cs *ControlServer) handleAI(ctx context.Context, req Request) (AIResult, e
 	if err != nil {
 		return AIResult{}, err
 	}
-	run, err := cs.engine.WaitRun(ctx, runID)
+	// WaitRunSettled (not WaitRun): a chat-start run suspends awaiting the first
+	// message and is never resumed here, so WaitRun — which follows the resume
+	// chain — would block forever. WaitRunSettled returns on the suspend.
+	run, err := cs.engine.WaitRunSettled(ctx, runID)
 	if err != nil {
 		return AIResult{}, err
 	}
@@ -829,6 +835,12 @@ func (cs *ControlServer) handleAI(ctx context.Context, req Request) (AIResult, e
 		TaskID:    taskID,
 		RunID:     run.RunID,
 		SessionID: req.SessionID,
+	}
+	// Chat mode: the agent suspended awaiting the first message. Hand the
+	// suspended run back so the CLI drives the resume loop from it.
+	if run.Status == registry.StatusSuspended {
+		out.Suspended = true
+		return out, nil
 	}
 	if run.Status != "success" {
 		// Surface the run id in the error so the CLI user can jump straight

--- a/pkg/ipc/control_ai_chat_test.go
+++ b/pkg/ipc/control_ai_chat_test.go
@@ -1,0 +1,120 @@
+package ipc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/db"
+	"github.com/dicode/dicode/pkg/registry"
+	"github.com/dicode/dicode/pkg/task"
+	"go.uber.org/zap"
+)
+
+// chatSuspendEngine simulates the agent task suspending on a chat-start run.
+type chatSuspendEngine struct {
+	mockEngine
+	firedParams map[string]string
+	usedWaitRun bool
+}
+
+func (e *chatSuspendEngine) FireManual(_ context.Context, _ string, params map[string]string) (string, error) {
+	e.firedParams = params
+	return "run-chat-1", nil
+}
+
+func (e *chatSuspendEngine) WaitRunSettled(_ context.Context, runID string) (RunResult, error) {
+	return RunResult{RunID: runID, Status: registry.StatusSuspended}, nil
+}
+
+// WaitRun following a suspended chat-start run (never resumed here) would block
+// forever; handleAI must not call it.
+func (e *chatSuspendEngine) WaitRun(_ context.Context, runID string) (RunResult, error) {
+	e.usedWaitRun = true
+	return RunResult{RunID: runID, Status: registry.StatusSuspended}, nil
+}
+
+func newAITestServer(t *testing.T, eng EngineRunner) *ControlServer {
+	t.Helper()
+	d, err := db.Open(db.Config{Type: "sqlite", Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	reg := registry.New(d)
+	if err := reg.Register(&task.Spec{
+		ID: "buildin/ai-agent", Name: "ai-agent",
+		Trigger: task.TriggerConfig{Manual: true}, Enabled: true,
+	}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	return &ControlServer{engine: eng, reg: reg, defaultAITask: "buildin/ai-agent", log: zap.NewNop()}
+}
+
+// TestHandleAI_BlankPrompt_EntersChatSuspend: a blank prompt opens chat mode —
+// the run suspends and handleAI surfaces it (Suspended=true + RunID) via the
+// settled waiter, without sending an empty `prompt` param and without blocking
+// on WaitRun.
+func TestHandleAI_BlankPrompt_EntersChatSuspend(t *testing.T) {
+	eng := &chatSuspendEngine{}
+	cs := newAITestServer(t, eng)
+
+	out, err := cs.handleAI(context.Background(), Request{Method: "cli.ai", Prompt: ""})
+	if err != nil {
+		t.Fatalf("handleAI blank prompt: %v", err)
+	}
+	if !out.Suspended {
+		t.Error("blank prompt must surface Suspended=true for chat mode")
+	}
+	if out.RunID != "run-chat-1" {
+		t.Errorf("RunID = %q, want run-chat-1", out.RunID)
+	}
+	if eng.usedWaitRun {
+		t.Error("handleAI used WaitRun on a chat-start run — would block until resume; must use WaitRunSettled")
+	}
+	if _, ok := eng.firedParams["prompt"]; ok {
+		t.Error("blank prompt must not be sent as a param — chat-start keys on its absence")
+	}
+}
+
+// oneShotEngine returns a normal successful run with a reply envelope.
+type oneShotEngine struct {
+	mockEngine
+	firedParams map[string]string
+}
+
+func (e *oneShotEngine) FireManual(_ context.Context, _ string, params map[string]string) (string, error) {
+	e.firedParams = params
+	return "run-1shot", nil
+}
+
+func (e *oneShotEngine) WaitRunSettled(_ context.Context, runID string) (RunResult, error) {
+	return RunResult{
+		RunID:  runID,
+		Status: "success",
+		ReturnValue: map[string]any{
+			"reply":      "hi there",
+			"session_id": "sess-9",
+		},
+	}, nil
+}
+
+// TestHandleAI_Prompt_OneShotUnchanged: a prompt still runs a single turn and
+// returns the reply/session envelope, not suspended.
+func TestHandleAI_Prompt_OneShotUnchanged(t *testing.T) {
+	eng := &oneShotEngine{}
+	cs := newAITestServer(t, eng)
+
+	out, err := cs.handleAI(context.Background(), Request{Method: "cli.ai", Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("handleAI: %v", err)
+	}
+	if out.Suspended {
+		t.Error("a prompted one-shot run must not be marked Suspended")
+	}
+	if out.Reply != "hi there" || out.SessionID != "sess-9" {
+		t.Errorf("out = %+v, want reply/session from the envelope", out)
+	}
+	if eng.firedParams["prompt"] != "hello" {
+		t.Errorf("prompt param = %q, want hello", eng.firedParams["prompt"])
+	}
+}

--- a/pkg/ipc/message.go
+++ b/pkg/ipc/message.go
@@ -315,6 +315,10 @@ type AIResult struct {
 	RunID     string `json:"runID"`
 	SessionID string `json:"sessionID"`
 	Reply     string `json:"reply"`
+	// Suspended is true when a blank-prompt chat run paused awaiting the first
+	// message. The CLI then drives the suspend/resume loop from RunID rather
+	// than printing Reply.
+	Suspended bool `json:"suspended,omitempty"`
 }
 
 // TaskCreateResult is the cli.task.create response. TaskID is the


### PR DESCRIPTION
## Summary

First driver slice of #571b (the second half of #571). With the shared suspend/resume envelope now in both agent tasks (#594), this wires the CLI to *drive* it.

`dicode ai` previously required a prompt and ran a single fire-and-wait turn. Now a bare **`dicode ai`** (no prompt) opens chat mode: the agent's chat-start path suspends for the first message, and the CLI drives the same `followSuspended` loop the wizard uses — each typed line is a resume turn, a blank line ends the chat. A prompt still runs a one-shot turn (backward compatible).

The load-bearing fix: `handleAI` switches from `WaitRun` to `WaitRunSettled`. A chat-start run suspends and is never resumed inside `handleAI`, so `WaitRun` — which follows the resume chain — would block forever. `WaitRunSettled` returns on the suspend (the same reason `cli.run` uses it), so the suspended run surfaces to the CLI, which follows from there.

## Verification

Unit tests for both paths: blank prompt → `Suspended=true` + `RunID`, no empty `prompt` param, and asserts `WaitRun` is not used (a regression guard against the hang); prompt present → one-shot reply/session envelope unchanged. The interactive loop itself reuses the proven `followSuspended` path and needs a TTY to drive end-to-end.

## Deliberately left behind

The WebUI `/api/ai/chat` driver and retiring the agent tasks' `chat:<sessionId>` KV threading remain for the rest of #571b — the KV path is still what the one-shot drivers use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)