### PR TITLE
feat(ai): retire KV session-threading from both agent tasks (slice of #571b)

### DIFF
--- a/tasks/buildin/ai-agent-claude-cli/task.test.ts
+++ b/tasks/buildin/ai-agent-claude-cli/task.test.ts
@@ -1,7 +1,7 @@
-// Tests for buildin/ai-agent-claude-cli — verify input validation,
-// the JSON parsing path, and the dicode↔claude session_id mapping
-// stored via kv. The actual `claude` CLI is stubbed via PATH
-// manipulation; tests don't need a real binary.
+// Tests for buildin/ai-agent-claude-cli — verify the one-shot single-turn
+// path, the JSON parsing path, and the suspend/resume chat loop. The actual
+// `claude` CLI is stubbed via PATH manipulation; tests don't need a real
+// binary.
 
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import main, { buildClaudeArgs, decideEntryMode, isChatEnd, steps } from "./task.ts";
@@ -44,15 +44,6 @@ function makeParams(entries: Array<[string, string]>) {
     };
 }
 
-function makeKv() {
-    const store = new Map<string, unknown>();
-    return {
-        store,
-        get: (k: string) => Promise.resolve(store.get(k) ?? null),
-        set: (k: string, v: unknown) => { store.set(k, v); return Promise.resolve(); },
-    };
-}
-
 async function withStubClaude<T>(
     stubBody: string,
     fn: () => Promise<T>,
@@ -89,7 +80,7 @@ Deno.test("no prompt on a fresh run opens the chat loop (suspends to turn)", asy
     const { calls, dicode } = makeSuspendDicode();
     let signalled = false;
     try {
-        await main({ params: makeParams([]), kv: makeKv(), dicode });
+        await main({ params: makeParams([]), dicode });
     } catch (e) {
         if (e instanceof SuspendSignal) signalled = true;
         else throw e;
@@ -113,7 +104,7 @@ Deno.test("no token: falls back to logged-in credentials (does not hard-fail)", 
         `cat <<'JSON'
 {"type":"result","is_error":false,"result":"ok","session_id":"s"}
 JSON`,
-        () => main({ params: makeParams([["prompt", "hi"]]), kv: makeKv(), dicode: fakeDicode }),
+        () => main({ params: makeParams([["prompt", "hi"]]), dicode: fakeDicode }),
     );
     assertEquals(result.ok, true);
 });
@@ -129,29 +120,13 @@ Deno.test("no token: does not inject an empty CLAUDE_CODE_OAUTH_TOKEN into claud
 cat <<'JSON'
 {"type":"result","is_error":false,"result":"ok","session_id":"s"}
 JSON`,
-        () => main({ params: makeParams([["prompt", "hi"]]), kv: makeKv(), dicode: fakeDicode }),
+        () => main({ params: makeParams([["prompt", "hi"]]), dicode: fakeDicode }),
     );
     assertEquals((await Deno.readTextFile(sentinel)).trim(), "[UNSET]");
 });
 
-Deno.test("rejects malformed session_id", async () => {
-    Deno.env.set("CLAUDE_CODE_OAUTH_TOKEN", "stub");
-    const r: any = await main({
-        params: makeParams([
-            ["prompt", "hi"],
-            ["session_id", "../etc/passwd"],
-        ]),
-        kv: makeKv(), dicode: fakeDicode,
-    });
-    assertEquals(r.ok, false);
-    if (!String(r.error ?? "").includes("invalid characters")) {
-        throw new Error(`expected invalid-characters error, got ${r.error}`);
-    }
-});
-
 Deno.test("happy path returns reply + session_id", async () => {
     Deno.env.set("CLAUDE_CODE_OAUTH_TOKEN", "stub");
-    const kv = makeKv();
     const result: any = await withStubClaude(
         `cat <<'JSON'
 {"type":"result","subtype":"success","is_error":false,"result":"hello world","session_id":"sess-abc123","model":"claude-sonnet-4","total_cost_usd":0.001}
@@ -159,60 +134,17 @@ JSON`,
         () =>
             main({
                 params: makeParams([["prompt", "say hello"]]),
-                kv, dicode: fakeDicode,
+                dicode: fakeDicode,
             }),
     );
     assertEquals(result.ok, true);
     assertEquals(result.reply, "hello world");
     assertEquals(result.model, "claude-sonnet-4");
-    // Dicode-side session_id is a fresh UUID — the Claude CLI's id stays
-    // server-side via the kv mapping below.
+    // One-shot is stateless: the returned session_id is a fresh UUID keying the
+    // per-invocation workdir, not the Claude CLI's own id.
     if (!/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i.test(result.session_id)) {
         throw new Error(`expected uuid-shaped session_id, got ${result.session_id}`);
     }
-    assertEquals(kv.store.get("claude:" + result.session_id), "sess-abc123");
-});
-
-Deno.test("reuses kv-mapped Claude session on follow-up turns", async () => {
-    Deno.env.set("CLAUDE_CODE_OAUTH_TOKEN", "stub");
-    const kv = makeKv();
-    const dicodeId = "abc-123-uuid";
-    kv.store.set("claude:" + dicodeId, "sess-pre-existing");
-
-    const result: any = await withStubClaude(
-        `cat <<'JSON'
-{"type":"result","is_error":false,"result":"continued","session_id":"sess-pre-existing"}
-JSON`,
-        () =>
-            main({
-                params: makeParams([
-                    ["prompt", "continue"],
-                    ["session_id", dicodeId],
-                ]),
-                kv, dicode: fakeDicode,
-            }),
-    );
-    assertEquals(result.ok, true);
-    assertEquals(result.session_id, dicodeId);  // dicode id unchanged
-});
-
-Deno.test("rotates Claude session_id mapping when CLI returns a new one", async () => {
-    Deno.env.set("CLAUDE_CODE_OAUTH_TOKEN", "stub");
-    const kv = makeKv();
-    const dicodeId = "rot-uuid-xyz";
-    kv.store.set("claude:" + dicodeId, "sess-old");
-
-    await withStubClaude(
-        `cat <<'JSON'
-{"type":"result","is_error":false,"result":"ok","session_id":"sess-new"}
-JSON`,
-        () =>
-            main({
-                params: makeParams([["prompt", "..."], ["session_id", dicodeId]]),
-                kv, dicode: fakeDicode,
-            }),
-    );
-    assertEquals(kv.store.get("claude:" + dicodeId), "sess-new");
 });
 
 Deno.test("surfaces is_error: true responses", async () => {
@@ -224,7 +156,7 @@ JSON`,
         () =>
             main({
                 params: makeParams([["prompt", "anything"]]),
-                kv: makeKv(), dicode: fakeDicode,
+                dicode: fakeDicode,
             }),
     );
     assertEquals(result.ok, false);
@@ -241,7 +173,7 @@ exit 2`,
         () =>
             main({
                 params: makeParams([["prompt", "anything"]]),
-                kv: makeKv(), dicode: fakeDicode,
+                dicode: fakeDicode,
             }),
     );
     assertEquals(result.ok, false);
@@ -258,7 +190,7 @@ exit 1`,
         () =>
             main({
                 params: makeParams([["prompt", "anything"]]),
-                kv: makeKv(), dicode: fakeDicode,
+                dicode: fakeDicode,
             }),
     );
     assertEquals(result.ok, false);
@@ -281,7 +213,7 @@ exit 1`,
         () =>
             main({
                 params: makeParams([["prompt", "anything"]]),
-                kv: makeKv(), dicode: fakeDicode,
+                dicode: fakeDicode,
             }),
     );
     assertEquals(result.ok, false);
@@ -303,7 +235,7 @@ Deno.test("redacts token in JSON-parse-failure path too", async () => {
         () =>
             main({
                 params: makeParams([["prompt", "anything"]]),
-                kv: makeKv(), dicode: fakeDicode,
+                dicode: fakeDicode,
             }),
     );
     assertEquals(result.ok, false);
@@ -328,7 +260,7 @@ JSON`,
         () =>
             main({
                 params: makeParams([["prompt", "hi"]]),
-                kv: makeKv(), dicode: fakeDicode,
+                dicode: fakeDicode,
             }),
     );
     assertEquals(result.ok, true);
@@ -353,7 +285,7 @@ JSON`,
         () =>
             main({
                 params: makeParams([["prompt", "hi"]]),
-                kv: makeKv(), dicode: fakeDicode,
+                dicode: fakeDicode,
             }),
     );
     assertEquals(result.ok, true);
@@ -378,7 +310,7 @@ JSON`,
                     ["skills", "../../etc/passwd,legit-skill"],
                     ["skills_dir", skillsDir],
                 ]),
-                kv: makeKv(), dicode: fakeDicode,
+                dicode: fakeDicode,
             }),
     );
     assertEquals(result.ok, true);
@@ -442,7 +374,7 @@ Deno.test("passes --strict-mcp-config --mcp-config to claude when MCP is wired",
 cat <<'JSON'
 {"type":"result","is_error":false,"result":"ok","session_id":"s"}
 JSON`,
-        () => main({ params: makeParams([["prompt", "hi"]]), kv: makeKv(), dicode: fakeDicode }),
+        () => main({ params: makeParams([["prompt", "hi"]]), dicode: fakeDicode }),
     );
     assertEquals(result.ok, true);
     const recorded = await Deno.readTextFile(sentinel);
@@ -476,7 +408,6 @@ Deno.test("steps.turn: a blank message ends the chat (returns, no Claude call)",
     const { calls, dicode } = makeSuspendDicode();
     const result: any = await steps.turn({
         params: makeParams([]),
-        kv: makeKv(),
         input: { message: "   " },
         state: { claudeSessionId: "sess-prior", chatId: "c1" },
         dicode,
@@ -501,7 +432,6 @@ JSON`,
             try {
                 await steps.turn({
                     params: makeParams([]),
-                    kv: makeKv(),
                     input: { message: "ping" },
                     state: { claudeSessionId: "", chatId: "chat-abc" },
                     dicode,
@@ -539,7 +469,6 @@ JSON`,
             try {
                 await steps.turn({
                     params: makeParams([]),
-                    kv: makeKv(),
                     input: { message: "again" },
                     state: { claudeSessionId: "sess-1", chatId: "chat-xyz" },
                     dicode,

--- a/tasks/buildin/ai-agent-claude-cli/task.ts
+++ b/tasks/buildin/ai-agent-claude-cli/task.ts
@@ -4,18 +4,16 @@
 // operator's Pro/Max subscription instead of an Anthropic API key.
 //
 // Two shapes over one Claude-invocation core (runClaudeTurn):
-//   - One-shot (a non-empty `prompt` param): run one Claude turn and return
-//     { ok, reply, session_id, model, ... }. A dicode-side session_id maps to
-//     the Claude CLI session via kv["claude:<dicode_uuid>"] so a repeat call
-//     resumes the right conversation; the CLI's session_id never leaks to
-//     clients. The bare-return shape matches buildin/ai-agent so the same chat
-//     UI works in both presets.
+//   - One-shot (a non-empty `prompt` param): run one stateless Claude turn and
+//     return { ok, reply, session_id, model, ... }. Each call is a fresh Claude
+//     session — no --resume, no cross-call state. The bare-return shape matches
+//     buildin/ai-agent so the same chat UI works in both presets.
 //   - Chat loop (no `prompt` on a fresh run): suspend to a `turn` step that
 //     collects a message, runs one turn, and suspends back to itself — a
 //     terminal chat via `dicode run` with no CLI changes. Claude's own session
 //     carries the conversation, so the suspend `state` just holds the CLI
-//     session id (plus a stable chat id keying the cwd that --resume needs);
-//     no kv session mapping is used on this path. A blank message ends it.
+//     session id (plus a stable chat id keying the cwd that --resume needs).
+//     A blank message ends it.
 //
 // Logging: console.error / console.log are captured by the runtime as
 // the run's stderr/stdout log entries. Error returns log to console.error
@@ -34,14 +32,6 @@ interface Params {
     all: () => Promise<Record<string, string>>;
 }
 
-interface KV {
-    get: (key: string) => Promise<unknown>;
-    set: (key: string, value: unknown) => Promise<void>;
-}
-
-const SESSION_ID_RE = /^[a-zA-Z0-9_-]{1,64}$/;
-const KV_PREFIX = "claude:";
-
 interface ClaudeResponse {
     type: string;
     subtype?: string;
@@ -56,7 +46,6 @@ interface ClaudeResponse {
 
 interface SDK {
     params: Params;
-    kv: KV;
     dicode: Dicode;
 }
 
@@ -107,7 +96,7 @@ export function buildClaudeArgs(opts: {
     return args;
 }
 
-export default async function main({ params, kv, dicode }: SDK) {
+export default async function main({ params, dicode }: SDK) {
     const prompt = (await params.get("prompt")) ?? "";
 
     if (decideEntryMode(prompt) === "chat-start") {
@@ -120,7 +109,7 @@ export default async function main({ params, kv, dicode }: SDK) {
         return; // unreachable — suspend() never returns
     }
 
-    return await oneShotTurn({ prompt, params, kv });
+    return await oneShotTurn({ prompt, params });
 }
 
 // The Claude-side state carried across chat turns: the CLI session id (drives
@@ -162,70 +151,29 @@ export const steps = {
     },
 };
 
-// oneShotTurn is the backward-compatible single-turn path: it owns the
-// dicode↔claude session_id mapping (kv["claude:<dicode_uuid>"]) and returns the
-// buildin/ai-agent-shaped result. The Claude invocation itself is delegated to
-// runClaudeTurn, shared with the chat loop.
+// oneShotTurn runs a single stateless Claude turn and returns the
+// buildin/ai-agent-shaped result. Each call starts a fresh Claude session (no
+// --resume); multi-turn conversation lives on the chat loop. The Claude
+// invocation itself is delegated to runClaudeTurn, shared with the chat loop.
 async function oneShotTurn(
-    { prompt, params, kv }: { prompt: string; params: Params; kv: KV },
+    { prompt, params }: { prompt: string; params: Params },
 ): Promise<unknown> {
-    const sessionIdIn = (await params.get("session_id")) ?? "";
-    // session_id is the dicode-side handle. Reject anything not flat-id shaped so
-    // a hostile caller can't forge a key that hits arbitrary KV entries below.
-    if (sessionIdIn && !SESSION_ID_RE.test(sessionIdIn)) {
-        return fail(`session_id ${JSON.stringify(sessionIdIn)} contains invalid characters; expected ^[a-zA-Z0-9_-]{1,64}$`);
-    }
-
-    // dicode-side session id. Generate one if the caller didn't pass one
-    // (matches buildin/ai-agent's UX: first turn returns a fresh uuid).
-    const dicodeSessionId = sessionIdIn || crypto.randomUUID();
-
-    // Look up the Claude-side session id for this dicode session, if any.
-    // First call: kv miss → no --resume → CLI mints a new Claude session.
-    //
-    // Concurrency note: two browser tabs sharing the same localStorage
-    // dicode_uuid will fire simultaneous `claude --resume <same-id>`
-    // subprocesses. The Claude CLI's behaviour under concurrent writes to the
-    // same session is undefined; the kv-set ordering below is non-deterministic.
-    // Same pre-existing pattern as buildin/ai-agent. Mitigation if this becomes
-    // a problem: a per-session lock via kv.set with a TTL'd lease, or a fresh
-    // dicode_uuid per browser tab.
-    let claudeSessionId = "";
-    try {
-        const stored = await kv.get(KV_PREFIX + dicodeSessionId);
-        if (typeof stored === "string") claudeSessionId = stored;
-    } catch (e) {
-        // KV miss is normal; transient KV errors are non-fatal — worst case the
-        // next turn starts a fresh Claude session.
-        console.warn("ai-agent-claude-cli: kv.get failed: " + (e instanceof Error ? e.message : String(e)));
-    }
+    // A fresh id keys the per-invocation workdir and is echoed back as the
+    // handle; it threads no state, so a new one per call is correct.
+    const sessionId = crypto.randomUUID();
 
     const turn = await runClaudeTurn({
         message: prompt,
-        priorClaudeSessionId: claudeSessionId,
-        // Workdir keyed on the (shape-validated) dicode session id so a
-        // follow-up --resume lands in the same cwd the session was created in.
-        workdirKey: dicodeSessionId,
+        priorClaudeSessionId: "",
+        workdirKey: sessionId,
         params,
     });
     if (!turn.ok) return turn;
 
-    // Persist the dicode → claude session id mapping. KV writes are
-    // fire-and-forget per the SDK shim (no ack); the next call with this
-    // dicode_uuid reads it via kv.get above. Skip the write when the CLI didn't
-    // return a session id so a stale mapping isn't introduced.
-    if (turn.claudeSessionId && turn.claudeSessionId !== claudeSessionId) {
-        try {
-            await kv.set(KV_PREFIX + dicodeSessionId, turn.claudeSessionId);
-        } catch (e) {
-            console.warn("ai-agent-claude-cli: kv.set failed (non-fatal): " + (e instanceof Error ? e.message : String(e)));
-        }
-    }
-
     return {
         ok:             true,
         reply:          turn.reply,
-        session_id:     dicodeSessionId,
+        session_id:     sessionId,
         model:          turn.model,
         total_cost_usd: turn.total_cost_usd,
         usage:          turn.usage,

--- a/tasks/buildin/ai-agent/task.test.ts
+++ b/tasks/buildin/ai-agent/task.test.ts
@@ -133,19 +133,10 @@ test("tags the run with the chat session group so the WebUI can collapse turns",
   assert.equal(calls, ["chat:abc-12345"]);
 });
 
-test("provided session_id is echoed back and history is preserved in kv", async () => {
+test("provided session_id is echoed back on the one-shot path", async () => {
   useLocal();
   params.set("prompt", "second message");
   params.set("session_id", "fixed-session-123");
-
-  kv.set("chat:fixed-session-123", {
-    messages: [
-      { role: "user", content: "first message" },
-      { role: "assistant", content: "first reply" },
-    ],
-    created_at: 0,
-    updated_at: 0,
-  });
 
   http.mock("POST", "http://localhost:11434/v1/chat/completions", {
     status: 200,
@@ -212,41 +203,6 @@ test("blank prompt on a fresh run opens the chat loop (suspends to turn)", async
   assert.equal((calls[0].schema as Record<string, unknown>).required, undefined);
   // Conversation state rides in the suspend blob, seeded empty.
   assert.equal((calls[0].state as Record<string, unknown>).messages, []);
-});
-
-test("compaction fires when history exceeds max_history_tokens", async () => {
-  useLocal();
-  params.set("prompt", "new question");
-  params.set("session_id", "compact-test");
-  params.set("max_history_tokens", "10"); // tiny budget forces compaction
-
-  const bigText = "x".repeat(500);
-  kv.set("chat:compact-test", {
-    messages: [
-      { role: "user", content: bigText },
-      { role: "assistant", content: bigText },
-      { role: "user", content: bigText },
-      { role: "assistant", content: bigText },
-      { role: "user", content: bigText },
-      { role: "assistant", content: bigText },
-    ],
-    created_at: 0,
-    updated_at: 0,
-  });
-
-  // First call = compaction summary, second call = the actual response.
-  http.mockOnce("POST", "http://localhost:11434/v1/chat/completions", {
-    status: 200,
-    body: completion("- user asked about stuff\n- assistant replied"),
-  });
-  http.mockOnce("POST", "http://localhost:11434/v1/chat/completions", {
-    status: 200,
-    body: completion("final answer"),
-  });
-
-  const result = await runTask();
-
-  assert.equal(result.reply, "final answer");
 });
 
 test("openai provider round-trip works with real key", async () => {

--- a/tasks/buildin/ai-agent/task.ts
+++ b/tasks/buildin/ai-agent/task.ts
@@ -2,9 +2,7 @@
 //
 // Calls an OpenAI-compatible chat completions API (OpenAI, Anthropic via
 // openai-compat, Ollama, LM Studio, Together, ...) with a tool-use loop that
-// lets the model call other dicode tasks as tools. Conversation history is
-// persisted per session in KV and lazily compacted when it exceeds
-// max_history_tokens.
+// lets the model call other dicode tasks as tools.
 //
 // The task bare-returns { session_id, reply } so browser UIs can parse it
 // as application/json. Never call output.html() here — that would override
@@ -12,9 +10,8 @@
 //
 // Two shapes over one turn core (runAgentTurn), sharing the suspend/resume
 // envelope with the other ai-agent presets:
-//   - One-shot (a non-empty `prompt`): run one turn and return
-//     { session_id, reply }, threading conversation history through KV under
-//     chat:<sessionId> — the drivers depend on this.
+//   - One-shot (a non-empty `prompt`): run a single stateless turn and return
+//     { session_id, reply }. No conversation is carried between one-shot calls.
 //   - Chat loop (blank `prompt` on a fresh run): suspend to a `turn` step that
 //     collects a message, runs one turn, and suspends back. The conversation
 //     rides in the suspend `state` blob (resume_state), not KV. A blank message
@@ -417,8 +414,8 @@ async function resolveAgentRuntime(
 
 // runAgentTurn runs the tool-use loop for a single user message against a
 // resolved runtime, mutating `session` in place and returning the reply. The
-// caller owns where `session` comes from and goes to (KV for one-shot,
-// resume_state for the chat loop).
+// caller owns the session's lifetime: one-shot runs a fresh empty session; the
+// chat loop carries it forward in resume_state.
 async function runAgentTurn(
   session: SessionState,
   message: string,
@@ -430,11 +427,8 @@ async function runAgentTurn(
   // Append user turn
   session.messages.push({ role: "user", content: message });
 
-  // The entire agent loop is wrapped in try/finally so the session — and
-  // all the tool round-trips it successfully completed — is persisted to
-  // KV even if an API call, tool dispatch, or compaction throws. Before
-  // this guard, a single rate-limit blip mid-loop silently discarded the
-  // whole turn plus any prior successful tool calls.
+  // Wrap the loop in try/finally so `session` is stamped with updated_at on
+  // exit even when an API call, tool dispatch, or compaction throws mid-loop.
   try {
     let iterations = 0;
     while (iterations++ < maxToolIterations) {
@@ -560,7 +554,7 @@ async function runAgentTurn(
   return last?.role === "assistant" ? last.content : "";
 }
 
-export default async function main({ params, kv, dicode }: DicodeSdk) {
+export default async function main({ params, dicode }: DicodeSdk) {
   requireTaskId(dicode);
 
   const prompt = (await params.get("prompt")) ?? "";
@@ -573,18 +567,17 @@ export default async function main({ params, kv, dicode }: DicodeSdk) {
     return; // unreachable — suspend() never returns
   }
 
-  return await oneShotTurn({ prompt, params, kv, dicode });
+  return await oneShotTurn({ prompt, params, dicode });
 }
 
-// oneShotTurn is the backward-compatible single-turn path: it threads
-// conversation history through KV under chat:<sessionId> (the drivers depend on
-// this), tags the run's group, and returns the { session_id, reply } shape the
-// browser UIs parse as application/json.
+// oneShotTurn runs a single stateless turn: it tags the run's group and returns
+// the { session_id, reply } shape the browser UIs parse as application/json.
+// Multi-turn conversation lives on the chat loop (carried in resume_state), not
+// here — one-shot calls share no history.
 async function oneShotTurn(
-  { prompt, params, kv, dicode }: {
+  { prompt, params, dicode }: {
     prompt: string;
     params: DicodeSdk["params"];
-    kv: DicodeSdk["kv"];
     dicode: Dicode;
   },
 ): Promise<unknown> {
@@ -611,30 +604,12 @@ async function oneShotTurn(
     return response;
   }
 
-  // Load or init session state from KV
-  const key = `chat:${sessionId}`;
-  const stored = (await kv.get(key)) as SessionState | null;
-  const session: SessionState = stored ?? {
+  const session: SessionState = {
     messages: [],
     created_at: Date.now(),
     updated_at: Date.now(),
   };
-
-  let reply = "";
-  try {
-    reply = await runAgentTurn(session, prompt, resolved.runtime, dicode);
-  } finally {
-    // Best-effort persistence. If KV itself is broken the task was going
-    // to fail anyway, and we don't want the KV error to shadow the real
-    // error from the loop body. Log and move on.
-    try {
-      await kv.set(key, session);
-    } catch (e) {
-      console.error(
-        `ai-agent: failed to persist session ${sessionId.slice(0, 8)} to KV: ${e instanceof Error ? e.message : String(e)}`,
-      );
-    }
-  }
+  const reply = await runAgentTurn(session, prompt, resolved.runtime, dicode);
 
   // Bare return → dicode serializes as application/json.
   // Do NOT call output.html() here; it would override Content-Type and the


### PR DESCRIPTION
## Summary

Retires the KV session-threading from both `ai-agent` presets. The one-shot path is now a **stateless single turn** on both tasks: it no longer loads or saves conversation history to KV. Multi-turn conversation is served entirely by the suspend/resume chat path (already built in earlier #571 slices), which carries state in `resume_state` and never touches KV.

- **`ai-agent`** — `oneShotTurn` runs `runAgentTurn` on a fresh empty `SessionState`; the `chat:<sessionId>` KV read/write is gone. `set_group(chat:<sessionId>)` run-tree grouping and the `{ session_id, reply }` / `not_configured` shapes are unchanged.
- **`ai-agent-claude-cli`** — `oneShotTurn` runs a fresh `runClaudeTurn` (`priorClaudeSessionId: ""`, a fresh `crypto.randomUUID()` workdir key, no `--resume`). The `claude:<id>` KV mapping, the `KV_PREFIX` const, and the `SESSION_ID_RE` const with its `session_id` validation are removed. The one-shot return shape (`session_id`/`model`/cost/usage) is preserved; the returned `session_id` is now the fresh UUID keying the per-invocation workdir.

The suspend/resume chat path in both files (`main`'s chat-start branch, `steps.turn`, the `runTurn`/`runClaudeTurn`/`runAgentTurn` cores) and the shared `ai-agent-core/chat.ts` are untouched. No `task.yaml` or taskset override changed.

Slice of #571b (see `docs/design/ai-task-authoring.md` → "Verified convergence design"). Not a full close of #571.

## Backward compatibility

Explicitly **not required**. WebUI `/api/ai/chat` multi-turn memory intentionally regresses until its driver migrates to the suspend/resume conversation path — the one-shot API is now single-turn by design.

## Verification

- `deno test` on both suites: **37 passed / 0 failed**.
- Full buildin sweep (`tasks/buildin/**/task.test.ts`): **200 passed / 0 failed**.
- `deno check` on `ai-agent/task.ts`, `ai-agent-claude-cli/task.ts`, `ai-agent-core/chat.ts`: clean.

Deleted tests that asserted removed behavior (KV history preservation, KV-mapped Claude session reuse/rotation, KV-seeded compaction, `session_id` validation); kept and adjusted the one-shot single-turn, `not_configured`, and chat-path tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - One-shot AI-agent requests now run statelessly, returning a fresh session ID and response without reusing prior conversation history.
  - Chat-based conversations continue across turns using their existing session context.

- **Bug Fixes**
  - Improved reliability of session handling and error paths.
  - Preserved secure MCP configuration handling, including path-traversal protection and sensitive token redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->