### PR TITLE
fix(notify): default notify_task is buildin/notifications, not buildin/notify

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -179,7 +179,7 @@ type AIConfig struct {
 
 	// NotifyTask is fired when a run suspends awaiting input (and when a
 	// suspended conversation ends), so the operator gets pinged to come answer
-	// the agent. Defaults to "buildin/notify" (a native desktop notification)
+	// the agent. Defaults to "buildin/notifications" (a native desktop notification)
 	// for a zero-config ping — a delivery task (slack/ntfy/email) can be swapped
 	// in and receives both a rendered title/body and the structured
 	// run_id/task_id/resume_url. Fires for any suspending run, not only AI ones.
@@ -588,10 +588,10 @@ func applyDefaults(cfg *Config, configDir string) {
 	if cfg.AI.CreateSessionTTL == 0 {
 		cfg.AI.CreateSessionTTL = 24 * time.Hour
 	}
-	// AI.NotifyTask defaults to buildin/notify so a suspended agent pings the
+	// AI.NotifyTask defaults to buildin/notifications so a suspended agent pings the
 	// operator out of the box. Same empty-or-default rule as AI.Task.
 	if cfg.AI.NotifyTask == "" {
-		cfg.AI.NotifyTask = "buildin/notify"
+		cfg.AI.NotifyTask = "buildin/notifications"
 	}
 	// RunInputs defaults: 30-day retention, local-storage backend.
 	if cfg.Defaults.RunInputs.Retention == 0 {

--- a/pkg/daemon/suspend_notify.go
+++ b/pkg/daemon/suspend_notify.go
@@ -42,7 +42,7 @@ func (n suspendNotifier) onRunFinished(taskID, runID, status, triggerSource stri
 			body += " Resume: " + resume
 		}
 		n.dispatch(taskID, runID, map[string]string{
-			// Rendered fields for buildin/notify (title + body required);
+			// Rendered fields for buildin/notifications (title + body required);
 			// structured fields for custom delivery tasks.
 			"title": "dicode: an agent needs your reply", "body": body, "priority": "default",
 			"event": "suspended", "run_id": runID, "task_id": taskID, "resume_url": resume,
@@ -74,7 +74,7 @@ func (n suspendNotifier) dispatch(taskID, runID string, params map[string]string
 			}
 		}()
 		if err := n.fire(n.notifyTask, params); err != nil && n.log != nil {
-			// Best-effort and default-on (buildin/notify), which legitimately
+			// Best-effort and default-on (buildin/notifications), which legitimately
 			// fails on a headless daemon with no desktop — Debug, not Warn, so
 			// it doesn't spam a server's log every suspend.
 			n.log.Debug("suspend notify task did not fire",

--- a/pkg/daemon/suspend_notify_test.go
+++ b/pkg/daemon/suspend_notify_test.go
@@ -12,7 +12,7 @@ import (
 func TestSuspendNotifier_FiresOnSuspendWithRenderedAndStructuredParams(t *testing.T) {
 	done := make(chan map[string]string, 1)
 	n := &suspendNotifier{
-		notifyTask: "buildin/notify",
+		notifyTask: "buildin/notifications",
 		resumeURL:  func(runID string) string { return "http://ui/?run=" + runID },
 		fire: func(_ string, params map[string]string) error {
 			done <- params
@@ -25,7 +25,7 @@ func TestSuspendNotifier_FiresOnSuspendWithRenderedAndStructuredParams(t *testin
 
 	params := <-done
 	if params["title"] == "" || params["body"] == "" {
-		t.Errorf("buildin/notify needs title+body; got %+v", params)
+		t.Errorf("buildin/notifications needs title+body; got %+v", params)
 	}
 	if params["event"] != "suspended" || params["run_id"] != "run-9" || params["task_id"] != "repo/agent" {
 		t.Errorf("structured params wrong: %+v", params)
@@ -51,12 +51,12 @@ func TestSuspendNotifier_DisabledWhenNoTask(t *testing.T) {
 func TestSuspendNotifier_SkipsOwnRuns(t *testing.T) {
 	fired := false
 	n := &suspendNotifier{
-		notifyTask: "buildin/notify",
+		notifyTask: "buildin/notifications",
 		fire:       func(string, map[string]string) error { fired = true; return nil },
 		log:        zap.NewNop(),
 	}
 	// The notify task's own run must not notify (would loop / self-spam).
-	n.onRunFinished("buildin/notify", "r", string(registry.StatusSuspended), "manual", 0)
+	n.onRunFinished("buildin/notifications", "r", string(registry.StatusSuspended), "manual", 0)
 	if fired {
 		t.Error("notify task's own run must not fire a notification")
 	}
@@ -65,7 +65,7 @@ func TestSuspendNotifier_SkipsOwnRuns(t *testing.T) {
 func TestSuspendNotifier_EndOnlyForResumeContinuation(t *testing.T) {
 	done := make(chan map[string]string, 1)
 	n := &suspendNotifier{
-		notifyTask: "buildin/notify",
+		notifyTask: "buildin/notifications",
 		fire:       func(_ string, p map[string]string) error { done <- p; return nil },
 		log:        zap.NewNop(),
 	}
@@ -83,7 +83,7 @@ func TestSuspendNotifier_NoEndForChainOrOneShot(t *testing.T) {
 	for _, src := range []string{"manual", "chain", "pipeline", "cron", "webhook"} {
 		fired := make(chan struct{}, 1)
 		n := &suspendNotifier{
-			notifyTask: "buildin/notify",
+			notifyTask: "buildin/notifications",
 			fire:       func(string, map[string]string) error { fired <- struct{}{}; return nil },
 			log:        zap.NewNop(),
 		}


### PR DESCRIPTION
## Summary

Follow-up to #584/#597, caught by driving the loop locally. The default `ai.notify_task` was set to `buildin/notify`, but the native-desktop-notification task registers under the id **`buildin/notifications`** (its taskset entry is `notifications:` → `./notify/task.yaml`). So the zero-config default resolved to a non-existent task and the suspend ping silently no-op'd (the miss is best-effort, logged at Debug).

Static tests all passed on #597 — this only showed up when a real suspend fired: the daemon log had no notify run, and `dicode run buildin/notify` returned "task not found". With the corrected id, `buildin/notifications` fires on every suspend (verified live against a fresh daemon; it reports `failure` only on a headless box with no desktop for `notify-send`, which is the expected best-effort case).

One-line default fix plus the matching comment/test references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)