### PR TITLE
fix(relay): pin dicode-relay to 0.1.9 (WebSocket tunnel flap fix)

### DIFF
--- a/tasks/buildin/auth-relay/task.ts
+++ b/tasks/buildin/auth-relay/task.ts
@@ -20,7 +20,7 @@ import {
   Identity,
   decryptTokenEnvelope,
   type StoredIdentity,
-} from "npm:dicode-relay@^0.1.4/client";
+} from "npm:dicode-relay@0.1.9/client";
 
 const IDENTITY_CTX   = "dicode/relay-identity/v1";
 const BROKER_PIN_CTX = "dicode/relay-broker-pin/v1";

--- a/tasks/buildin/auth-start/task.ts
+++ b/tasks/buildin/auth-start/task.ts
@@ -13,7 +13,7 @@ import {
   Identity,
   buildAuthURL,
   type StoredIdentity,
-} from "npm:dicode-relay@^0.1.4/client";
+} from "npm:dicode-relay@0.1.9/client";
 
 const IDENTITY_CTX   = "dicode/relay-identity/v1";
 const PENDING_CTX    = "dicode/oauth-pending/v1";

--- a/tasks/buildin/relay-client/task.ts
+++ b/tasks/buildin/relay-client/task.ts
@@ -9,7 +9,7 @@ import {
   RelayClient,
   type StoredIdentity,
   type TofuResult,
-} from "npm:dicode-relay@^0.1.4/client";
+} from "npm:dicode-relay@0.1.9/client";
 
 import type { DicodeSdk } from "../../sdk.ts";
 

--- a/tasks/buildin/relay-server-body/task.test.ts
+++ b/tasks/buildin/relay-server-body/task.test.ts
@@ -35,7 +35,7 @@ import { assertEquals, assertThrows } from "jsr:@std/assert@1";
 import { createPrivateKey, generateKeyPairSync } from "node:crypto";
 import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { startServer } from "npm:dicode-relay@^0.1.6/start";
+import { startServer } from "npm:dicode-relay@0.1.9/start";
 
 import { ensureSigningKey } from "./task.ts";
 

--- a/tasks/buildin/relay-server-body/task.ts
+++ b/tasks/buildin/relay-server-body/task.ts
@@ -15,7 +15,7 @@
 import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { generateKeyPairSync } from "node:crypto";
-import { startServer } from "npm:dicode-relay@^0.1.6/start";
+import { startServer } from "npm:dicode-relay@0.1.9/start";
 import type { DicodeSdk } from "../../sdk.ts";
 
 // Pre-create the broker signing key under ${DICODE_DATADIR}/relay/ so

--- a/tasks/deno.lock
+++ b/tasks/deno.lock
@@ -6,6 +6,7 @@
     "jsr:@std/internal@^1.0.12": "1.0.13",
     "jsr:@std/yaml@1": "1.1.0",
     "npm:@types/node@*": "22.15.15",
+    "npm:dicode-relay@0.1.9": "0.1.9",
     "npm:dicode-relay@~0.1.4": "0.1.4",
     "npm:dicode-relay@~0.1.6": "0.1.6",
     "npm:openai@4": "4.104.0"
@@ -167,7 +168,7 @@
         "express",
         "express-basic-auth",
         "grant",
-        "js-yaml",
+        "js-yaml@4.1.1",
         "lru-cache",
         "uuid@14.0.0",
         "ws",
@@ -182,7 +183,23 @@
         "express",
         "express-basic-auth",
         "grant",
-        "js-yaml",
+        "js-yaml@4.1.1",
+        "lru-cache",
+        "uuid@14.0.0",
+        "ws",
+        "zod"
+      ],
+      "bin": true
+    },
+    "dicode-relay@0.1.9": {
+      "integrity": "sha512-ijrXxSppayECxAK0dojpmNg2vjvIVZvOF++6nt8sHDn1jJA3leixk2US7Pk4omsj88yzxVHru8uvqKcQOf2O0Q==",
+      "dependencies": [
+        "@bufbuild/protobuf",
+        "escape-html",
+        "express",
+        "express-basic-auth",
+        "grant",
+        "js-yaml@5.2.1",
         "lru-cache",
         "uuid@14.0.0",
         "ws",
@@ -433,6 +450,13 @@
     },
     "js-yaml@4.1.1": {
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dependencies": [
+        "argparse"
+      ],
+      "bin": true
+    },
+    "js-yaml@5.2.1": {
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
       "dependencies": [
         "argparse"
       ],


### PR DESCRIPTION
## Summary

The relay-client's WebSocket tunnel flapped ~every 15s under Deno, so relay (public) webhook URLs intermittently returned `{"error":"daemon not connected"}`. Root cause was in the `dicode-relay` npm package: its client passed ws's `{ handshakeTimeout }`, whose timer Deno's `node:http` polyfill leaves armed after `open` — firing `abortHandshake()` on a nulled request (`setHeader of null`) and tearing down a healthy connection. Fixed upstream in **dicode-relay 0.1.9** (dicode-ayo/dicode-relay#91).

This pins all `dicode-relay` imports (relay-client, auth-start, auth-relay, relay-server-body) from floating `^0.1.4` / `^0.1.6` to an **exact `0.1.9`**, and updates `tasks/deno.lock` accordingly, so the fix is picked up deterministically and version drift can't silently skip it.

## Verification

Verified live against the local daemon: after the pin, the relay webhook that returned "daemon not connected" now returns the task's rendered dashboard HTML, and the tunnel stays connected past the former ~15s flap window. `relay-server-body` task tests pass on 0.1.9.

Resolves the dicode-core side of #600 (root fix: dicode-relay#91, released as 0.1.9).