### PR TITLE
fix(webui): stop bouncing relay-reached auth webhooks to an unreachable login

### DIFF
--- a/pkg/webui/auth.go
+++ b/pkg/webui/auth.go
@@ -2,6 +2,8 @@ package webui
 
 import (
 	"context"
+	"fmt"
+	"html"
 	"net"
 	"net/http"
 	"net/url"
@@ -26,6 +28,38 @@ func (s *Server) auditDenied(r *http.Request, reason string) {
 		Reason:     reason,
 	})
 }
+
+// relayAuthBlockedPage explains, to a browser that reached a session-gated
+// webhook through the public relay URL, why it can't be served there and where
+// to go instead. Printf args: %d = daemon port, %s = webhook path.
+const relayAuthBlockedPage = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Login required — not available via relay</title>
+<style>
+  body { font-family: system-ui, sans-serif; background: #1e1e2e; color: #cdd6f4;
+         margin: 0; display: flex; min-height: 100vh; align-items: center; justify-content: center; }
+  main { max-width: 34rem; padding: 2rem; }
+  h1 { color: #f9e2af; font-size: 1.3rem; margin: 0 0 1rem; }
+  p { line-height: 1.6; margin: 0 0 1rem; }
+  code { background: #302d41; padding: .15em .4em; border-radius: 4px; font-size: .9em; word-break: break-all; }
+  a { color: #89b4fa; }
+</style>
+</head>
+<body>
+<main>
+<h1>This page needs a login — and the public relay URL can't provide one</h1>
+<p>Session logins never travel over the relay (it forwards webhooks only and
+strips credentials), so a page behind <code>auth: true</code> can't be served here.</p>
+<p>Open it on your dicode server's own address, e.g.
+<code>http://YOUR-DICODE-HOST:%d%s</code>, or reach your server remotely with a
+tunnel such as <a href="https://tailscale.com/">Tailscale</a> or
+<a href="https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/">cloudflared</a>.</p>
+</main>
+</body>
+</html>`
 
 // webhookAuthGuard checks whether the task associated with the requested webhook
 // path has trigger.auth: true. If it does, and the request carries no valid
@@ -69,6 +103,29 @@ func (s *Server) webhookAuthGuard(w http.ResponseWriter, r *http.Request, next h
 
 	if !requiresAuth {
 		next.ServeHTTP(w, r)
+		return
+	}
+
+	// A relayed request carries a trusted X-Relay-Base header — the forwarder
+	// stamps it and drops any inbound copy. Such a request can never carry a
+	// legitimate session: the relay strips every credential header (cookie,
+	// authorization, x-api-key) and forwards only /hooks/*, so /login is
+	// unreachable and no cookie survives the hop. Reject an auth-gated webhook
+	// here BEFORE evaluating any session, so a credential that somehow survived
+	// forwarding can never authenticate a relayed request — the forwarder
+	// strip-list stays defense-in-depth, not the load-bearing control.
+	if r.Header.Get("X-Relay-Base") != "" {
+		s.auditDenied(r, "auth-gated webhook not reachable via relay")
+		// A human who clicked the public relay link gets an explainer page
+		// pointing at the daemon's own address / a tunnel; API callers get JSON.
+		// Without this a browser renders the raw JSON error in the viewport.
+		if r.Method == http.MethodGet && strings.Contains(r.Header.Get("Accept"), "text/html") {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = fmt.Fprintf(w, relayAuthBlockedPage, s.port, html.EscapeString(r.URL.Path))
+			return
+		}
+		jsonErr(w, "this webhook requires authentication and is not reachable via the public relay URL; open it on the daemon's own address, or reach your server via a tunnel (Tailscale/cloudflared)", http.StatusUnauthorized)
 		return
 	}
 

--- a/pkg/webui/auth.go
+++ b/pkg/webui/auth.go
@@ -62,9 +62,12 @@ tunnel such as <a href="https://tailscale.com/">Tailscale</a> or
 </html>`
 
 // webhookAuthGuard checks whether the task associated with the requested webhook
-// path has trigger.auth: true. If it does, and the request carries no valid
-// dicode session, the request is rejected (401 JSON for API callers, redirect
-// for browsers). Public webhooks (no auth: true) pass through unchanged.
+// path has trigger.auth: true. If it does, the request is rejected unless it
+// carries a valid dicode session. A request arriving via the relay (trusted
+// X-Relay-Base) can never be authenticated and is refused outright — HTML
+// explainer for browsers, JSON 401 otherwise. A direct request with no session
+// gets a JSON 401 for API callers or a /login redirect for browsers. Public
+// webhooks (no auth: true) pass through unchanged.
 //
 // The match is longest-prefix so overlapping paths resolve to the most specific
 // spec — the gateway already routes this way, and the auth decision must agree.

--- a/pkg/webui/auth_test.go
+++ b/pkg/webui/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -757,5 +758,82 @@ func TestWebhookAuthGuard_TrailingSlashPattern(t *testing.T) {
 	h.ServeHTTP(w, req)
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("trailing-slash pattern must still gate nested paths: got %d", w.Code)
+	}
+}
+
+// TestWebhookAuthGuard_RelayRejectsAuthWebhook covers the relay branch: an
+// auth:true webhook reached through the relay (trusted X-Relay-Base) can never
+// carry a session (the relay strips credentials and only forwards /hooks/*), so
+// it is rejected before any session is evaluated — a browser GET gets an HTML
+// explainer instead of an unreachable /login bounce, an API call gets JSON. A
+// public webhook still passes through, and the direct (non-relay) path still
+// redirects to /login.
+func TestWebhookAuthGuard_RelayRejectsAuthWebhook(t *testing.T) {
+	srv := newAuthServer(t, "hunter2")
+
+	if err := srv.registry.Register(&task.Spec{
+		ID:      "buildin/ai-claude",
+		Trigger: task.TriggerConfig{Webhook: "/hooks/ai-claude", WebhookAuth: true},
+	}); err != nil {
+		t.Fatalf("register protected: %v", err)
+	}
+	if err := srv.registry.Register(&task.Spec{
+		ID:      "buildin/open",
+		Trigger: task.TriggerConfig{Webhook: "/hooks/open", WebhookAuth: false},
+	}); err != nil {
+		t.Fatalf("register open: %v", err)
+	}
+
+	h := srv.Handler()
+	const relayBase = "/u/0000000000000000000000000000000000000000000000000000000000000000"
+
+	// Relayed browser GET → 401 with an HTML explainer, NOT a login redirect.
+	req := httptest.NewRequest(http.MethodGet, "/hooks/ai-claude", nil)
+	req.Header.Set("X-Relay-Base", relayBase)
+	req.Header.Set("Accept", "text/html")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("relayed browser GET: expected 401, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "text/html") {
+		t.Errorf("relayed browser GET: expected HTML explainer, got Content-Type %q", ct)
+	}
+	if loc := w.Header().Get("Location"); loc != "" {
+		t.Errorf("relayed browser GET must not redirect to login, got Location %q", loc)
+	}
+
+	// Relayed API POST (no text/html Accept) → 401 JSON.
+	req = httptest.NewRequest(http.MethodPost, "/hooks/ai-claude", nil)
+	req.Header.Set("X-Relay-Base", relayBase)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("relayed API POST: expected 401, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Errorf("relayed API POST: expected JSON error, got Content-Type %q", ct)
+	}
+
+	// Relayed request to a public webhook still passes through (not 401): the
+	// relay reject must only fire for auth:true.
+	req = httptest.NewRequest(http.MethodPost, "/hooks/open", nil)
+	req.Header.Set("X-Relay-Base", relayBase)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code == http.StatusUnauthorized {
+		t.Errorf("relayed public webhook: expected pass-through, got 401")
+	}
+
+	// Direct (no relay header) browser GET still redirects to /login unchanged.
+	req = httptest.NewRequest(http.MethodGet, "/hooks/ai-claude", nil)
+	req.Header.Set("Accept", "text/html")
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("direct browser GET: expected 303 login redirect, got %d", w.Code)
+	}
+	if loc := w.Header().Get("Location"); !strings.HasPrefix(loc, "/login") {
+		t.Errorf("direct browser GET: expected /login redirect, got Location %q", loc)
 	}
 }


### PR DESCRIPTION
## Summary
Hitting an `auth: true` webhook through the public relay URL (`/u/<uuid>/hooks/…`) redirected the browser to `/login` — a dead end. The relay only forwards `/hooks/*` and strips every credential header (`cookie`/`authorization`/`x-api-key`), so the login page's assets 404, its POST goes nowhere, and no session could ever be established over the relay anyway. The redirect was misleading, and the forwarder's credential strip-list was the *only* thing standing between a relayed request and an authenticated surface.

## Approach
Reject relayed auth-gated webhooks — detected via the trusted `X-Relay-Base` header the forwarder stamps (and drops any inbound copy of) — **before** evaluating any session. That makes a relayed request anonymous by construction: a credential that somehow survived forwarding can never authenticate it, so the strip-list becomes defense-in-depth rather than the load-bearing control. Browsers (`Accept: text/html` GET) get a small HTML explainer pointing at the daemon's own address or a tunnel; API callers get a JSON 401. The direct (non-relay) path is unchanged — it still redirects to `/login`.

The relay is a public webhook pipe, not an authenticated-UI proxy; interactive remote access to session-gated surfaces is a tunnel's job (Tailscale/cloudflared).

Closes #603.

## Scope boundary
Follow-ups filed separately: webhook replay hardening (#605), the machine-caller signing helper (#606), and the remote-access docs / relay-client startup caveat that make "use a tunnel" a first-class answer rather than a hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)