### PR TITLE
feat(webui): trigger.auth "any" — session OR HMAC webhook auth (#610)

### DIFF
--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -132,6 +132,19 @@ trigger:
 - `dicode.js` handles 401 automatically: silent refresh via device token, then redirects to login
 - Open webhooks (no `auth: true`) remain fully public — no behaviour change
 
+`auth` accepts three values:
+
+- `true` / `"session"` — a valid dicode session is required (as above). If a `webhook_secret` is also set, a session **and** a valid HMAC signature are both required.
+- `"any"` — a valid session **or** a valid HMAC signature authenticates. Requires a `webhook_secret`. Because HMAC is the only credential that traverses the [relay](../webhooks.md), this is the way to let a **signed machine caller** authenticate over the public relay URL while a browser still uses its session directly. A plain browser (no signature) still can't authenticate over the relay — that stays a tunnel's job. `GET`/UI-asset requests always require a session, never a signature.
+- absent / `false` — public.
+
+```yaml
+trigger:
+  webhook: /hooks/my-machine-endpoint
+  auth: any
+  webhook_secret: "${MY_WEBHOOK_SECRET}"
+```
+
 **Manual** — only fires when explicitly triggered via API or UI:
 
 ```yaml

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -61,6 +61,19 @@ trigger:
 
 Public webhooks (no `auth: true`) remain fully open.
 
+`auth` is tri-valued:
+
+- `true` / `"session"` — session required. With a `webhook_secret` also set, session **and** signature are both required.
+- `"any"` — session **or** a valid HMAC signature (requires `webhook_secret`). Lets a signed machine caller authenticate over the public relay URL, where session cookies never travel; a browser still authenticates directly via its session. `GET`/asset requests always require a session, never a signature.
+- absent / `false` — public.
+
+```yaml
+trigger:
+  webhook: /hooks/my-machine-endpoint
+  auth: any
+  webhook_secret: "${MY_WEBHOOK_SECRET}"
+```
+
 ### GET requests not supported with webhook_secret
 
 When `webhook_secret` is configured, only POST requests are accepted.

--- a/pkg/approval/content_hash_test.go
+++ b/pkg/approval/content_hash_test.go
@@ -36,7 +36,7 @@ func TestContentHashStableAcrossCalls(t *testing.T) {
 		s.Runtime = task.RuntimeDeno
 		s.Permissions.Net = []string{"api.github.com"}
 		s.Permissions.Dicode = &task.DicodePermissions{Tasks: []string{"repo/other"}}
-		s.Trigger.WebhookAuth = true
+		s.Trigger.WebhookAuth = task.WebhookAuthSession
 	})
 	h1 := mustHash(t, spec)
 	h2 := mustHash(t, spec)
@@ -58,7 +58,7 @@ func TestContentHashFoldsResolvedSecurityFields(t *testing.T) {
 		"fs write grant":   func(s *task.Spec) { s.Permissions.FS = []task.FSEntry{{Path: "/etc", Permission: "w"}} },
 		"dicode tasks":     func(s *task.Spec) { s.Permissions.Dicode = &task.DicodePermissions{Tasks: []string{"*"}} },
 		"runtime swap":     func(s *task.Spec) { s.Runtime = task.Runtime("python") },
-		"webhook auth off": func(s *task.Spec) { s.Trigger.WebhookAuth = true },
+		"webhook auth on":  func(s *task.Spec) { s.Trigger.WebhookAuth = task.WebhookAuthSession },
 		"param default":    func(s *task.Spec) { s.Params = task.Params{{Name: "url", Default: "https://evil.example"}} },
 		"timeout widened":  func(s *task.Spec) { s.Timeout = 4 * time.Hour },
 	}
@@ -69,6 +69,35 @@ func TestContentHashFoldsResolvedSecurityFields(t *testing.T) {
 		if got == baseHash {
 			t.Errorf("%s: hash unchanged despite elevated resolved field", name)
 		}
+	}
+}
+
+// TestContentHashDistinguishesAuthModes: session and any are distinct security
+// postures (any opens a relay-reachable HMAC path), so they must hash
+// differently — switching to any re-pends the task for approval. none and
+// session keep the pre-tri-value bool wire format (see WebhookAuthMode.
+// MarshalJSON), so an existing auth: true task does not spuriously re-pend.
+func TestContentHashDistinguishesAuthModes(t *testing.T) {
+	base := writeTaskDir(t, t.TempDir(), "repo/deploy", "x")
+	withSecret := func(m task.WebhookAuthMode) func(*task.Spec) {
+		return func(s *task.Spec) {
+			s.Trigger.Webhook = "/hooks/x"
+			s.Trigger.WebhookSecret = "s3cr3t"
+			s.Trigger.WebhookAuth = m
+		}
+	}
+	none := mustHash(t, specVariant(base, withSecret(task.WebhookAuthNone)))
+	session := mustHash(t, specVariant(base, withSecret(task.WebhookAuthSession)))
+	anyMode := mustHash(t, specVariant(base, withSecret(task.WebhookAuthAny)))
+
+	if session == anyMode {
+		t.Error("session and any must hash differently (any opens an HMAC-over-relay path)")
+	}
+	if none == session {
+		t.Error("none and session must hash differently")
+	}
+	if none == anyMode {
+		t.Error("none and any must hash differently")
 	}
 }
 

--- a/pkg/approval/gate.go
+++ b/pkg/approval/gate.go
@@ -436,13 +436,13 @@ type resolvedSecurityFields struct {
 	// are deliberately excluded: TriggerPatch cannot set them, the secret
 	// is already covered by the dir hash, and a secret must never feed a
 	// non-secret hash input.
-	Webhook     string             `json:"webhook"`
-	WebhookAuth bool               `json:"webhook_auth"`
-	Cron        string             `json:"cron"`
-	Manual      bool               `json:"manual"`
-	Daemon      bool               `json:"daemon"`
-	Restart     string             `json:"restart"`
-	Chain       *task.ChainTrigger `json:"chain,omitempty"`
+	Webhook     string               `json:"webhook"`
+	WebhookAuth task.WebhookAuthMode `json:"webhook_auth"`
+	Cron        string               `json:"cron"`
+	Manual      bool                 `json:"manual"`
+	Daemon      bool                 `json:"daemon"`
+	Restart     string               `json:"restart"`
+	Chain       *task.ChainTrigger   `json:"chain,omitempty"`
 }
 
 // resolvedPipelineSecurityFields mirrors resolvedSecurityFields for
@@ -453,12 +453,12 @@ type resolvedSecurityFields struct {
 // approval. PipelineTrigger has no Daemon/Restart; WebhookSecret and
 // ReplayProtection are excluded for the same reasons as on Spec.
 type resolvedPipelineSecurityFields struct {
-	Timeout     time.Duration      `json:"timeout"`
-	Webhook     string             `json:"webhook"`
-	WebhookAuth bool               `json:"webhook_auth"`
-	Cron        string             `json:"cron"`
-	Manual      bool               `json:"manual"`
-	Chain       *task.ChainTrigger `json:"chain,omitempty"`
+	Timeout     time.Duration        `json:"timeout"`
+	Webhook     string               `json:"webhook"`
+	WebhookAuth task.WebhookAuthMode `json:"webhook_auth"`
+	Cron        string               `json:"cron"`
+	Manual      bool                 `json:"manual"`
+	Chain       *task.ChainTrigger   `json:"chain,omitempty"`
 }
 
 // hashDirResolved combines the task-dir hash with the canonical JSON of the

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -414,8 +414,8 @@ func newArmDisarm(cfg *config.Config, eng *trigger.Engine, gateway *ipc.Gateway,
 		if !isSpec {
 			return nil
 		}
-		if spec.Trigger.WebhookAuth.RequiresSession() && !cfg.Server.Auth {
-			log.Warn("task declares trigger.auth:true but server.auth is disabled — any password logs in",
+		if spec.Trigger.WebhookAuth.Enabled() && !cfg.Server.Auth {
+			log.Warn("task declares trigger.auth but server.auth is disabled — any password logs in (and an auth: any webhook's session path then bypasses HMAC)",
 				zap.String("task", spec.ID),
 				zap.String("webhook", spec.Trigger.Webhook),
 				zap.String("hint", "set server.auth: true in dicode.yaml to require a real passphrase"))

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -414,7 +414,7 @@ func newArmDisarm(cfg *config.Config, eng *trigger.Engine, gateway *ipc.Gateway,
 		if !isSpec {
 			return nil
 		}
-		if spec.Trigger.WebhookAuth && !cfg.Server.Auth {
+		if spec.Trigger.WebhookAuth.RequiresSession() && !cfg.Server.Auth {
 			log.Warn("task declares trigger.auth:true but server.auth is disabled — any password logs in",
 				zap.String("task", spec.ID),
 				zap.String("webhook", spec.Trigger.Webhook),

--- a/pkg/ipc/session_auth.go
+++ b/pkg/ipc/session_auth.go
@@ -1,0 +1,24 @@
+package ipc
+
+import "context"
+
+// sessionAuthKey is the unexported context key marking a request as
+// session-authenticated. Unexported-typed so no other package can set or forge
+// it — the flag is load-bearing (it suppresses HMAC/replay verification), so it
+// must be settable in exactly one place (the webui auth guard) and absent must
+// mean "not session-authed".
+type sessionAuthKey struct{}
+
+// WithSessionAuth marks ctx as belonging to a request that passed dicode session
+// auth. Set by the webui webhook auth guard, and only after confirming the
+// request did not arrive via the relay.
+func WithSessionAuth(ctx context.Context) context.Context {
+	return context.WithValue(ctx, sessionAuthKey{}, true)
+}
+
+// SessionAuthed reports whether ctx was marked session-authenticated. Absent ⇒
+// false ⇒ fail-closed: HMAC signature and replay checks stay in force.
+func SessionAuthed(ctx context.Context) bool {
+	v, _ := ctx.Value(sessionAuthKey{}).(bool)
+	return v
+}

--- a/pkg/ipc/session_auth_test.go
+++ b/pkg/ipc/session_auth_test.go
@@ -1,0 +1,24 @@
+package ipc
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSessionAuth(t *testing.T) {
+	// Absent ⇒ false ⇒ fail-closed.
+	if SessionAuthed(context.Background()) {
+		t.Error("bare context must not be session-authed")
+	}
+	// Round-trips through WithSessionAuth.
+	ctx := WithSessionAuth(context.Background())
+	if !SessionAuthed(ctx) {
+		t.Error("WithSessionAuth context must be session-authed")
+	}
+	// A derived child context still carries the flag.
+	child, cancel := context.WithCancel(ctx)
+	defer cancel()
+	if !SessionAuthed(child) {
+		t.Error("child context must inherit the session-auth flag")
+	}
+}

--- a/pkg/task/pipeline.go
+++ b/pkg/task/pipeline.go
@@ -35,13 +35,13 @@ type PipelineTask struct {
 // Notably no Daemon: a pipeline is daemon-shaped iff its terminal stage is a
 // kind: Task with trigger.daemon: true.
 type PipelineTrigger struct {
-	Manual           bool          `yaml:"manual,omitempty"`
-	Cron             string        `yaml:"cron,omitempty"`
-	Webhook          string        `yaml:"webhook,omitempty"`
-	WebhookSecret    string        `yaml:"webhook_secret,omitempty"`
-	WebhookAuth      bool          `yaml:"auth,omitempty"`
-	ReplayProtection *bool         `yaml:"replay_protection,omitempty"`
-	Chain            *ChainTrigger `yaml:"chain,omitempty"`
+	Manual           bool            `yaml:"manual,omitempty"`
+	Cron             string          `yaml:"cron,omitempty"`
+	Webhook          string          `yaml:"webhook,omitempty"`
+	WebhookSecret    string          `yaml:"webhook_secret,omitempty"`
+	WebhookAuth      WebhookAuthMode `yaml:"auth,omitempty"`
+	ReplayProtection *bool           `yaml:"replay_protection,omitempty"`
+	Chain            *ChainTrigger   `yaml:"chain,omitempty"`
 }
 
 // Stage is one entry in a PipelineTask.Stages list: a task ID plus optional
@@ -155,6 +155,9 @@ func (p *PipelineTask) Validate() error {
 	}
 	if p.Trigger.count() > 1 {
 		return fmt.Errorf("pipeline: at most one trigger type may be set")
+	}
+	if p.Trigger.WebhookAuth == WebhookAuthAny && p.Trigger.WebhookSecret == "" {
+		return fmt.Errorf(`pipeline: trigger.auth: "any" requires webhook_secret (the HMAC path has nothing to verify without it)`)
 	}
 	if len(p.Stages) == 0 {
 		return fmt.Errorf("pipeline: at least one stage is required")

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -107,18 +107,85 @@ type ChainTrigger struct {
 	Overrides *Overrides     `yaml:"overrides,omitempty"` // per-firing override applied to the downstream spec
 }
 
+// WebhookAuthMode is the auth posture of a webhook trigger. In YAML it accepts a
+// bool (true = session, false/absent = public) or a string ("session", "any").
+//   - session: a valid dicode session is required for GET (UI) and POST (run);
+//     a webhook_secret, if also set, still ANDs on top.
+//   - any: session OR a valid HMAC signature. HMAC is the only auth that
+//     traverses the relay, so this is the machine-caller-over-relay path.
+type WebhookAuthMode string
+
+const (
+	WebhookAuthNone    WebhookAuthMode = ""
+	WebhookAuthSession WebhookAuthMode = "session"
+	WebhookAuthAny     WebhookAuthMode = "any"
+)
+
+// Enabled reports whether the webhook is auth-gated at all.
+func (m WebhookAuthMode) Enabled() bool { return m != WebhookAuthNone }
+
+// RequiresSession reports whether a session is the sole accepted credential
+// (session mode). Distinguished from "any", where HMAC is an alternative.
+func (m WebhookAuthMode) RequiresSession() bool { return m == WebhookAuthSession }
+
+// MarshalJSON preserves the pre-tri-value wire format so approval content
+// hashes stay stable across the bool→WebhookAuthMode change: none→false,
+// session→true (byte-identical to the old bool encoding, so an existing
+// auth: true task does not spuriously re-pend), any→"any" (distinct, so
+// switching a task to "any" re-pends it — it opens a relay-reachable HMAC path).
+func (m WebhookAuthMode) MarshalJSON() ([]byte, error) {
+	switch m {
+	case WebhookAuthAny:
+		return []byte(`"any"`), nil
+	case WebhookAuthSession:
+		return []byte(`true`), nil
+	default:
+		return []byte(`false`), nil
+	}
+}
+
+// UnmarshalYAML accepts a bool (back-compat: true→session, false→none) or a
+// string ("session"/"any"). Any other scalar or node kind is an error.
+func (m *WebhookAuthMode) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.ScalarNode {
+		return fmt.Errorf("trigger.auth must be a bool or string, got %s", value.Tag)
+	}
+	switch value.Tag {
+	case "!!bool":
+		var b bool
+		if err := value.Decode(&b); err != nil {
+			return err
+		}
+		if b {
+			*m = WebhookAuthSession
+		} else {
+			*m = WebhookAuthNone
+		}
+		return nil
+	case "!!str":
+		switch WebhookAuthMode(value.Value) {
+		case WebhookAuthNone, WebhookAuthSession, WebhookAuthAny:
+			*m = WebhookAuthMode(value.Value)
+			return nil
+		}
+		return fmt.Errorf("invalid trigger.auth %q (want true, false, \"session\", or \"any\")", value.Value)
+	default:
+		return fmt.Errorf("trigger.auth must be a bool or string, got %s", value.Tag)
+	}
+}
+
 // TriggerConfig defines how a task is triggered.
 // Exactly one of Cron, Webhook, Manual, Chain, or Daemon should be set.
 type TriggerConfig struct {
-	Cron             string        `yaml:"cron,omitempty"`              // cron expression e.g. "0 9 * * *"
-	Webhook          string        `yaml:"webhook,omitempty"`           // HTTP path e.g. "/hooks/my-task"
-	WebhookSecret    string        `yaml:"webhook_secret,omitempty"`    // HMAC-SHA256 secret for webhook auth
-	WebhookAuth      bool          `yaml:"auth,omitempty"`              // require dicode session for GET (UI) and POST (run)
-	ReplayProtection *bool         `yaml:"replay_protection,omitempty"` // nonce-cache replay guard; default true when webhook_secret is set
-	Manual           bool          `yaml:"manual,omitempty"`            // only via explicit trigger
-	Chain            *ChainTrigger `yaml:"chain,omitempty"`             // fire when another task completes
-	Daemon           bool          `yaml:"daemon,omitempty"`            // start on app start, restart on exit
-	Restart          string        `yaml:"restart,omitempty"`           // daemon only: "always"(default)|"on-failure"|"never"
+	Cron             string          `yaml:"cron,omitempty"`              // cron expression e.g. "0 9 * * *"
+	Webhook          string          `yaml:"webhook,omitempty"`           // HTTP path e.g. "/hooks/my-task"
+	WebhookSecret    string          `yaml:"webhook_secret,omitempty"`    // HMAC-SHA256 secret for webhook auth
+	WebhookAuth      WebhookAuthMode `yaml:"auth,omitempty"`              // session-required (true/"session") or session-OR-HMAC ("any")
+	ReplayProtection *bool           `yaml:"replay_protection,omitempty"` // nonce-cache replay guard; default true when webhook_secret is set
+	Manual           bool            `yaml:"manual,omitempty"`            // only via explicit trigger
+	Chain            *ChainTrigger   `yaml:"chain,omitempty"`             // fire when another task completes
+	Daemon           bool            `yaml:"daemon,omitempty"`            // start on app start, restart on exit
+	Restart          string          `yaml:"restart,omitempty"`           // daemon only: "always"(default)|"on-failure"|"never"
 }
 
 // Param defines a user-configurable input for a task.
@@ -661,6 +728,11 @@ func (s *Spec) validate() error {
 	}
 	if s.Trigger.Webhook != "" {
 		triggers++
+	}
+	// "any" mode has a dead HMAC path (and misleadingly implies relay-reachability)
+	// without a secret to verify against.
+	if s.Trigger.WebhookAuth == WebhookAuthAny && s.Trigger.WebhookSecret == "" {
+		return fmt.Errorf(`trigger.auth: "any" requires webhook_secret (the HMAC path has nothing to verify without it)`)
 	}
 	if s.Trigger.Manual {
 		triggers++

--- a/pkg/task/webhook_auth_mode_test.go
+++ b/pkg/task/webhook_auth_mode_test.go
@@ -1,0 +1,120 @@
+package task
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestWebhookAuthMode_MarshalJSON pins the backward-stable wire format that
+// keeps approval content hashes unchanged for existing configs: none and
+// session encode exactly as the old bool field (false/true), and only any
+// diverges — so switching a task to any re-pends it while a plain auth: true
+// task does not spuriously re-pend on upgrade.
+func TestWebhookAuthMode_MarshalJSON(t *testing.T) {
+	cases := map[WebhookAuthMode]string{
+		WebhookAuthNone:    `false`,
+		WebhookAuthSession: `true`,
+		WebhookAuthAny:     `"any"`,
+	}
+	for mode, want := range cases {
+		b, err := json.Marshal(mode)
+		if err != nil {
+			t.Fatalf("marshal %q: %v", mode, err)
+		}
+		if string(b) != want {
+			t.Errorf("marshal %q = %s, want %s", mode, b, want)
+		}
+	}
+}
+
+func TestWebhookAuthMode_UnmarshalYAML(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		want    WebhookAuthMode
+		wantErr bool
+	}{
+		{"bool true → session", "auth: true", WebhookAuthSession, false},
+		{"bool false → none", "auth: false", WebhookAuthNone, false},
+		{"string session", `auth: "session"`, WebhookAuthSession, false},
+		{"string any", `auth: "any"`, WebhookAuthAny, false},
+		{"empty string → none", `auth: ""`, WebhookAuthNone, false},
+		{"absent → none", "webhook: /hooks/x", WebhookAuthNone, false},
+		{"invalid string", `auth: "always"`, WebhookAuthNone, true},
+		{"invalid int", "auth: 3", WebhookAuthNone, true},
+		{"invalid mapping", "auth: {mode: any}", WebhookAuthNone, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var tr TriggerConfig
+			err := yaml.Unmarshal([]byte(tc.yaml), &tr)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got mode %q", tr.WebhookAuth)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if tr.WebhookAuth != tc.want {
+				t.Errorf("got %q, want %q", tr.WebhookAuth, tc.want)
+			}
+		})
+	}
+}
+
+func TestWebhookAuthMode_Predicates(t *testing.T) {
+	cases := []struct {
+		mode            WebhookAuthMode
+		enabled         bool
+		requiresSession bool
+	}{
+		{WebhookAuthNone, false, false},
+		{WebhookAuthSession, true, true},
+		{WebhookAuthAny, true, false},
+	}
+	for _, tc := range cases {
+		if got := tc.mode.Enabled(); got != tc.enabled {
+			t.Errorf("%q.Enabled() = %v, want %v", tc.mode, got, tc.enabled)
+		}
+		if got := tc.mode.RequiresSession(); got != tc.requiresSession {
+			t.Errorf("%q.RequiresSession() = %v, want %v", tc.mode, got, tc.requiresSession)
+		}
+	}
+}
+
+func TestValidate_AnyRequiresSecret(t *testing.T) {
+	base := func() *Spec {
+		return &Spec{
+			Name:    "t",
+			Runtime: RuntimeDeno,
+			Trigger: TriggerConfig{Webhook: "/hooks/x"},
+		}
+	}
+
+	t.Run("any without secret errors", func(t *testing.T) {
+		s := base()
+		s.Trigger.WebhookAuth = WebhookAuthAny
+		if err := s.Validate(); err == nil {
+			t.Fatal("expected error for auth: any without webhook_secret")
+		}
+	})
+	t.Run("any with secret ok", func(t *testing.T) {
+		s := base()
+		s.Trigger.WebhookAuth = WebhookAuthAny
+		s.Trigger.WebhookSecret = "s3cr3t"
+		if err := s.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	t.Run("session without secret ok", func(t *testing.T) {
+		s := base()
+		s.Trigger.WebhookAuth = WebhookAuthSession
+		if err := s.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/pkg/taskset/override.go
+++ b/pkg/taskset/override.go
@@ -73,7 +73,7 @@ func applyTriggerPatch(t *task.TriggerConfig, p *TriggerPatch) {
 	if p.Cron != nil {
 		t.Cron = *p.Cron
 		t.Webhook = ""
-		t.WebhookAuth = false
+		t.WebhookAuth = task.WebhookAuthNone
 		t.Manual = false
 		t.Chain = nil
 		t.Daemon = false
@@ -86,13 +86,19 @@ func applyTriggerPatch(t *task.TriggerConfig, p *TriggerPatch) {
 		t.Daemon = false
 	}
 	if p.Auth != nil {
-		t.WebhookAuth = *p.Auth
+		// TriggerPatch.Auth is a *bool; taskset overrides can toggle session vs
+		// public but cannot select "any" (that stays a task-spec-level opt-in).
+		if *p.Auth {
+			t.WebhookAuth = task.WebhookAuthSession
+		} else {
+			t.WebhookAuth = task.WebhookAuthNone
+		}
 	}
 	if p.Manual != nil {
 		t.Manual = *p.Manual
 		t.Cron = ""
 		t.Webhook = ""
-		t.WebhookAuth = false
+		t.WebhookAuth = task.WebhookAuthNone
 		t.Chain = nil
 		t.Daemon = false
 	}
@@ -100,7 +106,7 @@ func applyTriggerPatch(t *task.TriggerConfig, p *TriggerPatch) {
 		t.Chain = p.Chain
 		t.Cron = ""
 		t.Webhook = ""
-		t.WebhookAuth = false
+		t.WebhookAuth = task.WebhookAuthNone
 		t.Manual = false
 		t.Daemon = false
 	}
@@ -108,7 +114,7 @@ func applyTriggerPatch(t *task.TriggerConfig, p *TriggerPatch) {
 		t.Daemon = *p.Daemon
 		t.Cron = ""
 		t.Webhook = ""
-		t.WebhookAuth = false
+		t.WebhookAuth = task.WebhookAuthNone
 		t.Manual = false
 		t.Chain = nil
 	}

--- a/pkg/taskset/override_exhaustiveness_test.go
+++ b/pkg/taskset/override_exhaustiveness_test.go
@@ -226,7 +226,7 @@ func TestApplyTriggerPatch_Exhaustive(t *testing.T) {
 			return expectEq(tc.Webhook, "/hooks/x")
 		}},
 		"Auth": {TriggerPatch{Auth: boolPtr(true)}, func(tc task.TriggerConfig) error {
-			return expectEq(tc.WebhookAuth, true)
+			return expectEq(tc.WebhookAuth, task.WebhookAuthSession)
 		}},
 		"Manual": {TriggerPatch{Manual: boolPtr(true)}, func(tc task.TriggerConfig) error {
 			return expectEq(tc.Manual, true)

--- a/pkg/taskset/override_test.go
+++ b/pkg/taskset/override_test.go
@@ -173,22 +173,22 @@ func TestApplyTriggerPatch_WebhookAuth(t *testing.T) {
 	// the dicode session cookie.
 	tr := task.TriggerConfig{Webhook: "/hooks/ai/dicodai"}
 	applyTriggerPatch(&tr, &TriggerPatch{Auth: boolPtr(true)})
-	if !tr.WebhookAuth {
-		t.Error("WebhookAuth should be true after auth patch")
+	if tr.WebhookAuth != task.WebhookAuthSession {
+		t.Errorf("WebhookAuth should be session after auth patch, got %q", tr.WebhookAuth)
 	}
 	// Flipping it back off must also work.
 	applyTriggerPatch(&tr, &TriggerPatch{Auth: boolPtr(false)})
-	if tr.WebhookAuth {
-		t.Error("WebhookAuth should be false after auth:false patch")
+	if tr.WebhookAuth.Enabled() {
+		t.Errorf("WebhookAuth should be none after auth:false patch, got %q", tr.WebhookAuth)
 	}
 }
 
 func TestApplyTriggerPatch_AuthNilPreservesWebhookAuth(t *testing.T) {
 	// A nil Auth pointer must not clobber an existing WebhookAuth value —
 	// otherwise a webhook-only patch would silently disable auth.
-	tr := task.TriggerConfig{Webhook: "/hooks/x", WebhookAuth: true}
+	tr := task.TriggerConfig{Webhook: "/hooks/x", WebhookAuth: task.WebhookAuthSession}
 	applyTriggerPatch(&tr, &TriggerPatch{Webhook: strPtr("/hooks/y")})
-	if !tr.WebhookAuth {
+	if tr.WebhookAuth != task.WebhookAuthSession {
 		t.Error("WebhookAuth should be preserved when Auth is nil")
 	}
 }
@@ -209,12 +209,12 @@ func TestApplyTriggerPatch_TypeSwitchClearsAuth(t *testing.T) {
 		{"Daemon", &TriggerPatch{Daemon: boolPtr(true)}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			tr := task.TriggerConfig{Webhook: "/hooks/x", WebhookAuth: true}
+			tr := task.TriggerConfig{Webhook: "/hooks/x", WebhookAuth: task.WebhookAuthSession}
 			applyTriggerPatch(&tr, tc.patch)
 			if tr.Webhook != "" {
 				t.Errorf("%s patch should clear Webhook, got %q", tc.name, tr.Webhook)
 			}
-			if tr.WebhookAuth {
+			if tr.WebhookAuth.Enabled() {
 				t.Errorf("%s patch should clear WebhookAuth alongside Webhook", tc.name)
 			}
 		})

--- a/pkg/trigger/engine.go
+++ b/pkg/trigger/engine.go
@@ -564,6 +564,10 @@ func (e *Engine) unregisterTriggers(id string) {
 // Register re-registers (Engine.Start at boot, the reconciler on every content
 // change), so a live webhook could 404 for no reason the caller could see.
 func (e *Engine) unregisterTriggersKeeping(id, keepWebhookPath string) {
+	// Match the trailing-slash normalisation registerWebhookPath applies to map
+	// keys, so the keep comparison below doesn't delete (then transiently drop)
+	// a path the caller is about to re-claim.
+	keepWebhookPath = strings.TrimSuffix(keepWebhookPath, "/")
 	e.mu.Lock()
 	hadCron := false
 	if entryID, ok := e.cronEntries[id]; ok {

--- a/pkg/trigger/webhook.go
+++ b/pkg/trigger/webhook.go
@@ -492,12 +492,17 @@ func (e *Engine) resolveWebhookPath(path string) (taskID, matchedHook, assetPath
 }
 
 // WebhookAuthInfo describes the auth posture of the webhook that claims a URL
-// path. Matched is false when no registered webhook claims the path.
+// path. Matched is false when no registered webhook claims the path. IsAsset is
+// true when the path resolves to a static asset under a webhook UI (a sub-path
+// of the hook), rather than the hook endpoint itself — such requests must never
+// fall through to HMAC, or an auth: any webhook's UI assets would be served to
+// unauthenticated callers.
 type WebhookAuthInfo struct {
 	Matched   bool
 	TaskID    string
 	Mode      task.WebhookAuthMode
 	HasSecret bool
+	IsAsset   bool
 }
 
 // ResolveWebhookAuth reports the auth posture of the webhook claiming urlPath,
@@ -510,7 +515,7 @@ type WebhookAuthInfo struct {
 // — the guard then treats it as public, and the gateway 404s it, so nothing is
 // served and no auth is bypassed.
 func (e *Engine) ResolveWebhookAuth(urlPath string) WebhookAuthInfo {
-	taskID, _, _, ok := e.resolveWebhookPath(urlPath)
+	taskID, _, assetPath, ok := e.resolveWebhookPath(urlPath)
 	if !ok {
 		return WebhookAuthInfo{}
 	}
@@ -518,11 +523,12 @@ func (e *Engine) ResolveWebhookAuth(urlPath string) WebhookAuthInfo {
 	if !ok {
 		return WebhookAuthInfo{}
 	}
+	isAsset := assetPath != ""
 	switch t := k.(type) {
 	case *task.Spec:
-		return WebhookAuthInfo{Matched: true, TaskID: taskID, Mode: t.Trigger.WebhookAuth, HasSecret: t.Trigger.WebhookSecret != ""}
+		return WebhookAuthInfo{Matched: true, TaskID: taskID, Mode: t.Trigger.WebhookAuth, HasSecret: t.Trigger.WebhookSecret != "", IsAsset: isAsset}
 	case *task.PipelineTask:
-		return WebhookAuthInfo{Matched: true, TaskID: taskID, Mode: t.Trigger.WebhookAuth, HasSecret: t.Trigger.WebhookSecret != ""}
+		return WebhookAuthInfo{Matched: true, TaskID: taskID, Mode: t.Trigger.WebhookAuth, HasSecret: t.Trigger.WebhookSecret != "", IsAsset: isAsset}
 	default:
 		return WebhookAuthInfo{}
 	}

--- a/pkg/trigger/webhook.go
+++ b/pkg/trigger/webhook.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/dicode/dicode/internal/pathguard"
+	"github.com/dicode/dicode/pkg/ipc"
 	"github.com/dicode/dicode/pkg/registry"
 	pkgruntime "github.com/dicode/dicode/pkg/runtime"
 	"github.com/dicode/dicode/pkg/task"
@@ -52,6 +53,13 @@ func (e *Engine) registerWebhookPath(id, path string) {
 			zap.String("path", reservedOAuthCompletePath))
 		return
 	}
+	// Normalise a trailing slash away so the map key matches how the gateway
+	// dispatches (ipc.PathMatches trims the pattern's trailing slash before
+	// prefix-matching). Without this, a `/hooks/x/` registration is dispatched
+	// for `/hooks/x/sub` by the gateway but missed by resolveWebhookPath's exact
+	// segment walk — the request 404s at the handler and the auth guard (which
+	// shares this lookup) reads it as public.
+	path = strings.TrimSuffix(path, "/")
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	// Reject duplicate registrations: a task from a watched repo must not be
@@ -341,21 +349,27 @@ func (e *Engine) handlePipelineWebhook(w http.ResponseWriter, r *http.Request, p
 	body := readWebhookBody(r)
 	input, _ := decodeWebhookPayload(r, body) // isForm ignored — pipelines don't redirect
 
-	if err := verifyWebhookSignatureSecret(pipe.Trigger.WebhookSecret, r, body); err != nil {
-		e.log.Warn("pipeline webhook signature verification failed",
-			zap.String("path", r.URL.Path), zap.String("task", pipe.ID), zap.Error(err))
-		http.Error(w, "forbidden: "+err.Error(), http.StatusForbidden)
-		return
-	}
+	// A session-authenticated request (auth: any, direct with a valid session)
+	// was already vouched for by the auth guard; skip BOTH signature and replay.
+	// Skipping only the signature would leave checkWebhookReplay to 409 a browser
+	// that legitimately submits the same body twice.
+	if !ipc.SessionAuthed(r.Context()) {
+		if err := verifyWebhookSignatureSecret(pipe.Trigger.WebhookSecret, r, body); err != nil {
+			e.log.Warn("pipeline webhook signature verification failed",
+				zap.String("path", r.URL.Path), zap.String("task", pipe.ID), zap.Error(err))
+			http.Error(w, "forbidden: "+err.Error(), http.StatusForbidden)
+			return
+		}
 
-	// Replay protection: reject duplicate bodies within the nonce cache TTL.
-	if err := e.checkWebhookReplay(pipe.Trigger.WebhookSecret, pipe.Trigger.ReplayProtection, body); err != nil {
-		e.log.Warn("pipeline webhook replay rejected",
-			zap.String("path", r.URL.Path),
-			zap.String("task", pipe.ID),
-		)
-		writeWebhookReplayRejected(w)
-		return
+		// Replay protection: reject duplicate bodies within the nonce cache TTL.
+		if err := e.checkWebhookReplay(pipe.Trigger.WebhookSecret, pipe.Trigger.ReplayProtection, body); err != nil {
+			e.log.Warn("pipeline webhook replay rejected",
+				zap.String("path", r.URL.Path),
+				zap.String("task", pipe.ID),
+			)
+			writeWebhookReplayRejected(w)
+			return
+		}
 	}
 
 	params := flatStringMap(input)
@@ -477,6 +491,43 @@ func (e *Engine) resolveWebhookPath(path string) (taskID, matchedHook, assetPath
 	return "", "", "", false
 }
 
+// WebhookAuthInfo describes the auth posture of the webhook that claims a URL
+// path. Matched is false when no registered webhook claims the path.
+type WebhookAuthInfo struct {
+	Matched   bool
+	TaskID    string
+	Mode      task.WebhookAuthMode
+	HasSecret bool
+}
+
+// ResolveWebhookAuth reports the auth posture of the webhook claiming urlPath,
+// resolved through the SAME longest-prefix lookup the gateway dispatches on
+// (resolveWebhookPath). The auth guard consumes this so the decision it makes
+// and the route the gateway will serve can never diverge.
+//
+// A path claimed at the gateway but not yet present in the engine's webhooks map
+// (a daemon task whose route is reserved before it starts) returns Matched:false
+// — the guard then treats it as public, and the gateway 404s it, so nothing is
+// served and no auth is bypassed.
+func (e *Engine) ResolveWebhookAuth(urlPath string) WebhookAuthInfo {
+	taskID, _, _, ok := e.resolveWebhookPath(urlPath)
+	if !ok {
+		return WebhookAuthInfo{}
+	}
+	k, ok := e.registry.GetKinded(taskID)
+	if !ok {
+		return WebhookAuthInfo{}
+	}
+	switch t := k.(type) {
+	case *task.Spec:
+		return WebhookAuthInfo{Matched: true, TaskID: taskID, Mode: t.Trigger.WebhookAuth, HasSecret: t.Trigger.WebhookSecret != ""}
+	case *task.PipelineTask:
+		return WebhookAuthInfo{Matched: true, TaskID: taskID, Mode: t.Trigger.WebhookAuth, HasSecret: t.Trigger.WebhookSecret != ""}
+	default:
+		return WebhookAuthInfo{}
+	}
+}
+
 // serveTaskUI serves the task directory's index.html with the dicode client
 // SDK injected, when one is present. Returns false — without writing to w —
 // when the task has no readable index.html, so callers fall through to their
@@ -511,25 +562,31 @@ func (e *Engine) fireWebhookTask(w http.ResponseWriter, r *http.Request, spec *t
 	body := readWebhookBody(r)
 	input, isFormSubmit := decodeWebhookPayload(r, body)
 
-	// Verify HMAC signature when a secret is configured on the task.
-	if err := verifyWebhookSignature(spec, r, body); err != nil {
-		e.log.Warn("webhook signature verification failed",
-			zap.String("path", path),
-			zap.String("task", taskID),
-			zap.Error(err),
-		)
-		http.Error(w, "forbidden: "+err.Error(), http.StatusForbidden)
-		return
-	}
+	// A session-authenticated request (auth: any, direct with a valid session)
+	// was already vouched for by the auth guard; skip BOTH signature and replay.
+	// Skipping only the signature would leave checkWebhookReplay to 409 a browser
+	// that legitimately submits the same body twice.
+	if !ipc.SessionAuthed(r.Context()) {
+		// Verify HMAC signature when a secret is configured on the task.
+		if err := verifyWebhookSignature(spec, r, body); err != nil {
+			e.log.Warn("webhook signature verification failed",
+				zap.String("path", path),
+				zap.String("task", taskID),
+				zap.Error(err),
+			)
+			http.Error(w, "forbidden: "+err.Error(), http.StatusForbidden)
+			return
+		}
 
-	// Replay protection: reject duplicate bodies within the nonce cache TTL.
-	if err := e.checkWebhookReplay(spec.Trigger.WebhookSecret, spec.Trigger.ReplayProtection, body); err != nil {
-		e.log.Warn("webhook replay rejected",
-			zap.String("path", path),
-			zap.String("task", taskID),
-		)
-		writeWebhookReplayRejected(w)
-		return
+		// Replay protection: reject duplicate bodies within the nonce cache TTL.
+		if err := e.checkWebhookReplay(spec.Trigger.WebhookSecret, spec.Trigger.ReplayProtection, body); err != nil {
+			e.log.Warn("webhook replay rejected",
+				zap.String("path", path),
+				zap.String("task", taskID),
+			)
+			writeWebhookReplayRejected(w)
+			return
+		}
 	}
 
 	// Extract a flat string map from the input so it is accessible via

--- a/pkg/trigger/webhook_session_auth_test.go
+++ b/pkg/trigger/webhook_session_auth_test.go
@@ -1,0 +1,70 @@
+package trigger
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dicode/dicode/pkg/ipc"
+	"github.com/dicode/dicode/pkg/task"
+)
+
+// TestWebhookHandler_SessionAuthSkipsSignature verifies that a request marked
+// session-authenticated (ipc.WithSessionAuth) bypasses HMAC signature
+// verification on a secret-protected webhook, while an unmarked request with no
+// signature is still rejected.
+func TestWebhookHandler_SessionAuthSkipsSignature(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+	spec := writeTask(t, dir, "sec-hook",
+		`export default async function main() { return "ran" }`,
+		task.TriggerConfig{Webhook: "/hooks/sec", WebhookAuth: task.WebhookAuthAny, WebhookSecret: "s3cr3t"})
+	_ = e.reg.Register(spec)
+	e.engine.Register(spec)
+	handler := e.engine.WebhookHandler()
+
+	// No signature, not session-authed → HMAC rejects with 403.
+	req := httptest.NewRequest(http.MethodPost, "/hooks/sec", strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("unsigned + no session: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// No signature, session-authed → verification skipped, task runs.
+	req = httptest.NewRequest(http.MethodPost, "/hooks/sec", strings.NewReader(`{}`))
+	req = req.WithContext(ipc.WithSessionAuth(req.Context()))
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("unsigned + session: expected 200 (verification skipped), got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "ran") {
+		t.Errorf("expected task to run, got: %s", w.Body.String())
+	}
+}
+
+// TestWebhookHandler_SessionAuthSkipsReplay verifies that two identical
+// session-authed submissions both succeed — the replay cache (which keys on the
+// body) must not 409 a browser that legitimately submits the same body twice.
+func TestWebhookHandler_SessionAuthSkipsReplay(t *testing.T) {
+	dir := t.TempDir()
+	e := newTestEnv(t)
+	spec := writeTask(t, dir, "replay-hook",
+		`export default async function main() { return "ran" }`,
+		task.TriggerConfig{Webhook: "/hooks/replay", WebhookAuth: task.WebhookAuthAny, WebhookSecret: "s3cr3t"})
+	_ = e.reg.Register(spec)
+	e.engine.Register(spec)
+	handler := e.engine.WebhookHandler()
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/hooks/replay", strings.NewReader(`{"same":"body"}`))
+		req = req.WithContext(ipc.WithSessionAuth(req.Context()))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("submission %d: expected 200, got %d: %s", i, w.Code, w.Body.String())
+		}
+	}
+}

--- a/pkg/webui/auth.go
+++ b/pkg/webui/auth.go
@@ -74,15 +74,23 @@ const (
 
 // resolveWebhookAuth is the pure, table-testable auth decision for a webhook
 // request. It never consults the session on a relayed request (session
-// evaluation has side effects that must not be relay-drivable), and it only
-// lets "any" fall through to HMAC for non-GET methods — a GET is served by the
-// webhook handler as UI/assets before any signature check, so falling GET
-// through would publish an auth-gated UI.
-func resolveWebhookAuth(mode task.WebhookAuthMode, hasSecret bool, method string, relayed, hasSession bool) webhookAuthOutcome {
+// evaluation has side effects that must not be relay-drivable).
+//
+// HMAC fall-through ("any" mode) is restricted to a non-GET request for the hook
+// endpoint itself: a GET or a static-asset sub-path is served by the webhook
+// handler as UI before any signature check, so letting either fall through would
+// publish an auth-gated UI to unauthenticated callers.
+//
+// The session outcome differs by mode. "any" is session-OR-HMAC, so a session
+// alone authenticates — webhookPassSession stamps the request so the handler
+// skips signature + replay. "session" keeps AND semantics: a session satisfies
+// the guard, but if a webhook_secret is also configured the handler must still
+// verify the signature, so the request passes WITHOUT the skip flag.
+func resolveWebhookAuth(mode task.WebhookAuthMode, hasSecret, isAsset bool, method string, relayed, hasSession bool) webhookAuthOutcome {
 	if !mode.Enabled() {
 		return webhookPass
 	}
-	canHMAC := mode == task.WebhookAuthAny && hasSecret && method != http.MethodGet
+	canHMAC := mode == task.WebhookAuthAny && hasSecret && method != http.MethodGet && !isAsset
 	if relayed {
 		if canHMAC {
 			return webhookHMAC
@@ -90,7 +98,10 @@ func resolveWebhookAuth(mode task.WebhookAuthMode, hasSecret bool, method string
 		return webhookDeny
 	}
 	if hasSession {
-		return webhookPassSession
+		if mode == task.WebhookAuthAny {
+			return webhookPassSession
+		}
+		return webhookPass
 	}
 	if canHMAC {
 		return webhookHMAC
@@ -128,7 +139,7 @@ func (s *Server) webhookAuthGuard(w http.ResponseWriter, r *http.Request, next h
 		hasSession = s.hasValidSession(w, r)
 	}
 
-	switch resolveWebhookAuth(info.Mode, info.HasSecret, r.Method, relayed, hasSession) {
+	switch resolveWebhookAuth(info.Mode, info.HasSecret, info.IsAsset, r.Method, relayed, hasSession) {
 	case webhookPassSession:
 		next.ServeHTTP(w, r.WithContext(ipc.WithSessionAuth(r.Context())))
 	case webhookHMAC, webhookPass:

--- a/pkg/webui/auth.go
+++ b/pkg/webui/auth.go
@@ -61,68 +61,94 @@ tunnel such as <a href="https://tailscale.com/">Tailscale</a> or
 </body>
 </html>`
 
-// webhookAuthGuard checks whether the task associated with the requested webhook
-// path has trigger.auth: true. If it does, the request is rejected unless it
-// carries a valid dicode session. A request arriving via the relay (trusted
-// X-Relay-Base) can never be authenticated and is refused outright — HTML
-// explainer for browsers, JSON 401 otherwise. A direct request with no session
-// gets a JSON 401 for API callers or a /login redirect for browsers. Public
-// webhooks (no auth: true) pass through unchanged.
-//
-// The match is longest-prefix so overlapping paths resolve to the most specific
-// spec — the gateway already routes this way, and the auth decision must agree.
-// With a short-prefix-wins loop, a public `/hooks/ai` would shadow a private
-// `/hooks/ai/dicodai` and silently drop `auth: true` at the door.
-func (s *Server) webhookAuthGuard(w http.ResponseWriter, r *http.Request, next http.Handler) {
-	var requiresAuth bool
-	var bestLen = -1
-	// Consider every task kind: a kind: PipelineTask can also carry a webhook
-	// trigger with auth: true, and its protection must be enforced here just
-	// like a kind: Task's. Using AllKinded (not All) is what keeps a pipeline
-	// webhook from being silently public.
-	for _, k := range s.registry.AllKinded() {
-		var wp string
-		var auth bool
-		switch t := k.(type) {
-		case *task.Spec:
-			wp, auth = t.Trigger.Webhook, t.Trigger.WebhookAuth
-		case *task.PipelineTask:
-			wp, auth = t.Trigger.Webhook, t.Trigger.WebhookAuth
-		default:
-			continue
-		}
-		if wp == "" || !ipc.PathMatches(wp, r.URL.Path) {
-			continue
-		}
-		// Compare normalised pattern length so a trailing slash on the
-		// registered webhook cannot artificially shorten the match and
-		// shadow a longer protected path.
-		l := len(strings.TrimSuffix(wp, "/"))
-		if l > bestLen {
-			bestLen = l
-			requiresAuth = auth
-		}
-	}
+// webhookAuthOutcome is the decision resolveWebhookAuth reaches for a request to
+// a webhook path.
+type webhookAuthOutcome int
 
-	if !requiresAuth {
+const (
+	webhookPass        webhookAuthOutcome = iota // public — serve as-is
+	webhookPassSession                           // session-authed — serve, mark ctx session-authed
+	webhookHMAC                                  // fall through so downstream HMAC gates
+	webhookDeny                                  // reject
+)
+
+// resolveWebhookAuth is the pure, table-testable auth decision for a webhook
+// request. It never consults the session on a relayed request (session
+// evaluation has side effects that must not be relay-drivable), and it only
+// lets "any" fall through to HMAC for non-GET methods — a GET is served by the
+// webhook handler as UI/assets before any signature check, so falling GET
+// through would publish an auth-gated UI.
+func resolveWebhookAuth(mode task.WebhookAuthMode, hasSecret bool, method string, relayed, hasSession bool) webhookAuthOutcome {
+	if !mode.Enabled() {
+		return webhookPass
+	}
+	canHMAC := mode == task.WebhookAuthAny && hasSecret && method != http.MethodGet
+	if relayed {
+		if canHMAC {
+			return webhookHMAC
+		}
+		return webhookDeny
+	}
+	if hasSession {
+		return webhookPassSession
+	}
+	if canHMAC {
+		return webhookHMAC
+	}
+	return webhookDeny
+}
+
+// webhookAuthGuard enforces a webhook's trigger.auth posture. The matched
+// webhook is resolved through the engine's own path lookup (ResolveWebhookAuth),
+// the same one the gateway dispatches on, so the guard and the served route can
+// never disagree — a public `/hooks/ai` cannot shadow a protected
+// `/hooks/ai/dicodai`.
+//
+//   - Public (no auth) → pass through.
+//   - session → a valid dicode session is required for GET (UI) and POST (run).
+//   - any → session OR a valid HMAC signature. HMAC is the only credential that
+//     survives the relay, so a relayed non-GET falls through to the signature
+//     check; a session (never relayed) marks the request context so the
+//     downstream handler skips signature + replay.
+//
+// A relayed request (trusted X-Relay-Base, stamped by the forwarder) is checked
+// BEFORE any session evaluation: the relay strips every credential header, so no
+// session can legitimately arrive relayed, and hasValidSession has side effects
+// (device-token renewal, cookie clearing) that must not be relay-drivable.
+func (s *Server) webhookAuthGuard(w http.ResponseWriter, r *http.Request, next http.Handler) {
+	info := s.engine.ResolveWebhookAuth(r.URL.Path)
+	if !info.Mode.Enabled() {
 		next.ServeHTTP(w, r)
 		return
 	}
 
-	// A relayed request carries a trusted X-Relay-Base header — the forwarder
-	// stamps it and drops any inbound copy. Such a request can never carry a
-	// legitimate session: the relay strips every credential header (cookie,
-	// authorization, x-api-key) and forwards only /hooks/*, so /login is
-	// unreachable and no cookie survives the hop. Reject an auth-gated webhook
-	// here BEFORE evaluating any session, so a credential that somehow survived
-	// forwarding can never authenticate a relayed request — the forwarder
-	// strip-list stays defense-in-depth, not the load-bearing control.
-	if r.Header.Get("X-Relay-Base") != "" {
+	relayed := r.Header.Get("X-Relay-Base") != ""
+	hasSession := false
+	if !relayed {
+		hasSession = s.hasValidSession(w, r)
+	}
+
+	switch resolveWebhookAuth(info.Mode, info.HasSecret, r.Method, relayed, hasSession) {
+	case webhookPassSession:
+		next.ServeHTTP(w, r.WithContext(ipc.WithSessionAuth(r.Context())))
+	case webhookHMAC, webhookPass:
+		next.ServeHTTP(w, r)
+	default: // webhookDeny
+		s.denyWebhook(w, r, relayed)
+	}
+}
+
+// denyWebhook renders the rejection for an auth-gated webhook. A relayed request
+// gets the "not reachable via relay" explainer (HTML for browsers, JSON
+// otherwise); a direct request gets a /login redirect for browsers or a JSON 401
+// for API callers.
+func (s *Server) denyWebhook(w http.ResponseWriter, r *http.Request, relayed bool) {
+	isBrowserGet := r.Method == http.MethodGet &&
+		strings.Contains(r.Header.Get("Accept"), "text/html")
+
+	if relayed {
 		s.auditDenied(r, "auth-gated webhook not reachable via relay")
-		// A human who clicked the public relay link gets an explainer page
-		// pointing at the daemon's own address / a tunnel; API callers get JSON.
-		// Without this a browser renders the raw JSON error in the viewport.
-		if r.Method == http.MethodGet && strings.Contains(r.Header.Get("Accept"), "text/html") {
+		if isBrowserGet {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			w.WriteHeader(http.StatusUnauthorized)
 			_, _ = fmt.Fprintf(w, relayAuthBlockedPage, s.port, html.EscapeString(r.URL.Path))
@@ -132,19 +158,7 @@ func (s *Server) webhookAuthGuard(w http.ResponseWriter, r *http.Request, next h
 		return
 	}
 
-	// Task requires a valid dicode session.
-	if s.hasValidSession(w, r) {
-		next.ServeHTTP(w, r)
-		return
-	}
-
 	s.auditDenied(r, "webhook requires authenticated session")
-
-	// For webhook paths, a GET from a browser includes "text/html" in Accept.
-	// API clients (curl, fetch without custom headers, etc.) typically don't,
-	// so we use that to decide redirect vs 401.
-	isBrowserGet := r.Method == http.MethodGet &&
-		strings.Contains(r.Header.Get("Accept"), "text/html")
 	if !isBrowserGet {
 		jsonErr(w, "unauthorized", http.StatusUnauthorized)
 		return

--- a/pkg/webui/auth_test.go
+++ b/pkg/webui/auth_test.go
@@ -851,29 +851,39 @@ func TestResolveWebhookAuth(t *testing.T) {
 		name       string
 		mode       task.WebhookAuthMode
 		hasSecret  bool
+		isAsset    bool
 		method     string
 		relayed    bool
 		hasSession bool
 		want       webhookAuthOutcome
 	}{
-		{"public passes", task.WebhookAuthNone, false, P, false, false, webhookPass},
-		{"public passes even relayed", task.WebhookAuthNone, false, P, true, false, webhookPass},
-		{"session+session passes", task.WebhookAuthSession, false, P, false, true, webhookPassSession},
-		{"session no session denies", task.WebhookAuthSession, false, P, false, false, webhookDeny},
-		{"session relayed denies", task.WebhookAuthSession, true, P, true, false, webhookDeny},
-		{"any+session passes", task.WebhookAuthAny, true, P, false, true, webhookPassSession},
-		{"any direct POST no session → HMAC", task.WebhookAuthAny, true, P, false, false, webhookHMAC},
-		{"any direct GET never falls through", task.WebhookAuthAny, true, G, false, false, webhookDeny},
-		{"any relayed POST → HMAC", task.WebhookAuthAny, true, P, true, false, webhookHMAC},
-		{"any relayed GET denies", task.WebhookAuthAny, true, G, true, false, webhookDeny},
-		{"any without secret denies", task.WebhookAuthAny, false, P, false, false, webhookDeny},
+		{"public passes", task.WebhookAuthNone, false, false, P, false, false, webhookPass},
+		{"public passes even relayed", task.WebhookAuthNone, false, false, P, true, false, webhookPass},
+		// session mode: a session passes WITHOUT the skip flag, so a configured
+		// secret still ANDs (the handler verifies the signature).
+		{"session+session passes (no skip flag)", task.WebhookAuthSession, false, false, P, false, true, webhookPass},
+		{"session+secret+session passes (AND preserved)", task.WebhookAuthSession, true, false, P, false, true, webhookPass},
+		{"session no session denies", task.WebhookAuthSession, false, false, P, false, false, webhookDeny},
+		{"session relayed denies", task.WebhookAuthSession, true, false, P, true, false, webhookDeny},
+		// any mode: a session alone authenticates and skips HMAC+replay.
+		{"any+session skips HMAC", task.WebhookAuthAny, true, false, P, false, true, webhookPassSession},
+		{"any direct POST no session → HMAC", task.WebhookAuthAny, true, false, P, false, false, webhookHMAC},
+		{"any direct GET never falls through", task.WebhookAuthAny, true, false, G, false, false, webhookDeny},
+		{"any relayed POST → HMAC", task.WebhookAuthAny, true, false, P, true, false, webhookHMAC},
+		{"any relayed GET denies", task.WebhookAuthAny, true, false, G, true, false, webhookDeny},
+		{"any without secret denies", task.WebhookAuthAny, false, false, P, false, false, webhookDeny},
+		// Asset sub-paths must never fall through to HMAC, even a non-GET one —
+		// that would serve auth-gated UI assets to unauthenticated callers.
+		{"any asset POST no session denies", task.WebhookAuthAny, true, true, P, false, false, webhookDeny},
+		{"any asset POST relayed denies", task.WebhookAuthAny, true, true, P, true, false, webhookDeny},
+		{"any asset POST with session skips", task.WebhookAuthAny, true, true, P, false, true, webhookPassSession},
 		// Relayed requests must never honour a session, even one that somehow
 		// surfaced — HMAC is the only relay credential.
-		{"any relayed ignores session", task.WebhookAuthAny, true, P, true, true, webhookHMAC},
+		{"any relayed ignores session", task.WebhookAuthAny, true, false, P, true, true, webhookHMAC},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := resolveWebhookAuth(tc.mode, tc.hasSecret, tc.method, tc.relayed, tc.hasSession)
+			got := resolveWebhookAuth(tc.mode, tc.hasSecret, tc.isAsset, tc.method, tc.relayed, tc.hasSession)
 			if got != tc.want {
 				t.Errorf("resolveWebhookAuth = %d, want %d", got, tc.want)
 			}
@@ -927,5 +937,15 @@ func TestWebhookAuthGuard_AnyMode(t *testing.T) {
 	h.ServeHTTP(w, req)
 	if w.Code == http.StatusUnauthorized {
 		t.Errorf("any POST with session: expected delegation, got 401")
+	}
+
+	// Unsigned POST to a static-asset sub-path must NOT fall through to HMAC —
+	// that would serve the auth-gated UI unauthenticated. The guard denies it
+	// (401) rather than delegating.
+	req = httptest.NewRequest(http.MethodPost, "/hooks/ai-claude/app.js", nil)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("any unsigned POST to asset sub-path: expected guard 401, got %d", w.Code)
 	}
 }

--- a/pkg/webui/auth_test.go
+++ b/pkg/webui/auth_test.go
@@ -61,6 +61,57 @@ func login(t *testing.T, h http.Handler, password string, trust bool) *http.Cook
 	return nil
 }
 
+// armSpecWebhook registers an enabled webhook Spec on both the registry and the
+// trigger engine, mirroring a live daemon. The engine's webhook dispatch map is
+// what the auth guard resolves against, so a registry-only registration would
+// not be seen (and would 404 as an inactive path).
+func armSpecWebhook(t *testing.T, srv *Server, id, path string, mode task.WebhookAuthMode, secret string) {
+	t.Helper()
+	s := &task.Spec{
+		ID:      id,
+		Name:    id,
+		Enabled: true,
+		Trigger: task.TriggerConfig{Webhook: path, WebhookAuth: mode, WebhookSecret: secret},
+	}
+	if err := srv.registry.Register(s); err != nil {
+		t.Fatalf("register %s: %v", id, err)
+	}
+	if err := srv.engine.Register(s); err != nil {
+		t.Fatalf("engine register %s: %v", id, err)
+	}
+}
+
+// armPipelineWebhook registers a minimal valid enabled pipeline (one stage, plus
+// its stage task) on both the registry and the engine, so its webhook path lands
+// in the engine's dispatch map.
+func armPipelineWebhook(t *testing.T, srv *Server, id, path string, mode task.WebhookAuthMode) {
+	t.Helper()
+	stageID := id + "-stage"
+	stage := &task.Spec{ID: stageID, Name: stageID, Enabled: true}
+	if err := srv.registry.Register(stage); err != nil {
+		t.Fatalf("register stage %s: %v", stageID, err)
+	}
+	if err := srv.engine.Register(stage); err != nil {
+		t.Fatalf("engine register stage %s: %v", stageID, err)
+	}
+	p := &task.PipelineTask{
+		APIVersion: "dicode/v1",
+		Kind:       task.KindPipelineTask,
+		ID:         id,
+		Name:       id,
+		Subtype:    "sequential",
+		Enabled:    true,
+		Trigger:    task.PipelineTrigger{Webhook: path, WebhookAuth: mode},
+		Stages:     []task.Stage{{Task: stageID}},
+	}
+	if err := srv.registry.Register(p); err != nil {
+		t.Fatalf("register pipeline %s: %v", id, err)
+	}
+	if err := srv.engine.Register(p); err != nil {
+		t.Fatalf("engine register pipeline %s: %v", id, err)
+	}
+}
+
 // ── Auth wall ─────────────────────────────────────────────────────────────────
 
 func TestAuth_PublicPathsAlwaysAccessible(t *testing.T) {
@@ -621,18 +672,8 @@ func TestWebhookAuthGuard_LongestPrefixWins(t *testing.T) {
 	// matters: "ai-agent" sorts before "dicodai" alphabetically, so the
 	// bug-producing iteration order is exactly what registry.All()
 	// produces on real deployments.
-	if err := srv.registry.Register(&task.Spec{
-		ID:      "buildin/ai-agent",
-		Trigger: task.TriggerConfig{Webhook: "/hooks/ai", WebhookAuth: false},
-	}); err != nil {
-		t.Fatalf("register ai-agent: %v", err)
-	}
-	if err := srv.registry.Register(&task.Spec{
-		ID:      "buildin/dicodai",
-		Trigger: task.TriggerConfig{Webhook: "/hooks/ai/dicodai", WebhookAuth: true},
-	}); err != nil {
-		t.Fatalf("register dicodai: %v", err)
-	}
+	armSpecWebhook(t, srv, "buildin/ai-agent", "/hooks/ai", task.WebhookAuthNone, "")
+	armSpecWebhook(t, srv, "buildin/dicodai", "/hooks/ai/dicodai", task.WebhookAuthSession, "")
 
 	h := srv.Handler()
 
@@ -663,18 +704,8 @@ func TestWebhookAuthGuard_LongestPrefixWins(t *testing.T) {
 func TestWebhookAuthGuard_PipelineAuth(t *testing.T) {
 	srv := newAuthServer(t, "hunter2")
 
-	if err := srv.registry.Register(&task.PipelineTask{
-		ID:      "deploy-pipe",
-		Trigger: task.PipelineTrigger{Webhook: "/hooks/deploy", WebhookAuth: true},
-	}); err != nil {
-		t.Fatalf("register protected pipeline: %v", err)
-	}
-	if err := srv.registry.Register(&task.PipelineTask{
-		ID:      "public-pipe",
-		Trigger: task.PipelineTrigger{Webhook: "/hooks/public", WebhookAuth: false},
-	}); err != nil {
-		t.Fatalf("register public pipeline: %v", err)
-	}
+	armPipelineWebhook(t, srv, "deploy-pipe", "/hooks/deploy", task.WebhookAuthSession)
+	armPipelineWebhook(t, srv, "public-pipe", "/hooks/public", task.WebhookAuthNone)
 
 	h := srv.Handler()
 
@@ -704,18 +735,8 @@ func TestWebhookAuthGuard_PipelineAuth(t *testing.T) {
 func TestWebhookAuthGuard_LongestPrefixWins_Inverse(t *testing.T) {
 	srv := newAuthServer(t, "hunter2")
 
-	if err := srv.registry.Register(&task.Spec{
-		ID:      "buildin/ai-agent",
-		Trigger: task.TriggerConfig{Webhook: "/hooks/ai", WebhookAuth: true},
-	}); err != nil {
-		t.Fatalf("register ai-agent: %v", err)
-	}
-	if err := srv.registry.Register(&task.Spec{
-		ID:      "buildin/dicodai",
-		Trigger: task.TriggerConfig{Webhook: "/hooks/ai/dicodai", WebhookAuth: false},
-	}); err != nil {
-		t.Fatalf("register dicodai: %v", err)
-	}
+	armSpecWebhook(t, srv, "buildin/ai-agent", "/hooks/ai", task.WebhookAuthSession, "")
+	armSpecWebhook(t, srv, "buildin/dicodai", "/hooks/ai/dicodai", task.WebhookAuthNone, "")
 
 	h := srv.Handler()
 
@@ -745,12 +766,7 @@ func TestWebhookAuthGuard_LongestPrefixWins_Inverse(t *testing.T) {
 func TestWebhookAuthGuard_TrailingSlashPattern(t *testing.T) {
 	srv := newAuthServer(t, "hunter2")
 
-	if err := srv.registry.Register(&task.Spec{
-		ID:      "buildin/trailing",
-		Trigger: task.TriggerConfig{Webhook: "/hooks/trail/", WebhookAuth: true},
-	}); err != nil {
-		t.Fatalf("register: %v", err)
-	}
+	armSpecWebhook(t, srv, "buildin/trailing", "/hooks/trail/", task.WebhookAuthSession, "")
 
 	h := srv.Handler()
 	req := httptest.NewRequest(http.MethodPost, "/hooks/trail/sub", nil)
@@ -771,18 +787,8 @@ func TestWebhookAuthGuard_TrailingSlashPattern(t *testing.T) {
 func TestWebhookAuthGuard_RelayRejectsAuthWebhook(t *testing.T) {
 	srv := newAuthServer(t, "hunter2")
 
-	if err := srv.registry.Register(&task.Spec{
-		ID:      "buildin/ai-claude",
-		Trigger: task.TriggerConfig{Webhook: "/hooks/ai-claude", WebhookAuth: true},
-	}); err != nil {
-		t.Fatalf("register protected: %v", err)
-	}
-	if err := srv.registry.Register(&task.Spec{
-		ID:      "buildin/open",
-		Trigger: task.TriggerConfig{Webhook: "/hooks/open", WebhookAuth: false},
-	}); err != nil {
-		t.Fatalf("register open: %v", err)
-	}
+	armSpecWebhook(t, srv, "buildin/ai-claude", "/hooks/ai-claude", task.WebhookAuthSession, "")
+	armSpecWebhook(t, srv, "buildin/open", "/hooks/open", task.WebhookAuthNone, "")
 
 	h := srv.Handler()
 	const relayBase = "/u/0000000000000000000000000000000000000000000000000000000000000000"
@@ -835,5 +841,91 @@ func TestWebhookAuthGuard_RelayRejectsAuthWebhook(t *testing.T) {
 	}
 	if loc := w.Header().Get("Location"); !strings.HasPrefix(loc, "/login") {
 		t.Errorf("direct browser GET: expected /login redirect, got Location %q", loc)
+	}
+}
+
+// TestResolveWebhookAuth is the pure decision table — no server, no I/O.
+func TestResolveWebhookAuth(t *testing.T) {
+	const P, G = http.MethodPost, http.MethodGet
+	cases := []struct {
+		name       string
+		mode       task.WebhookAuthMode
+		hasSecret  bool
+		method     string
+		relayed    bool
+		hasSession bool
+		want       webhookAuthOutcome
+	}{
+		{"public passes", task.WebhookAuthNone, false, P, false, false, webhookPass},
+		{"public passes even relayed", task.WebhookAuthNone, false, P, true, false, webhookPass},
+		{"session+session passes", task.WebhookAuthSession, false, P, false, true, webhookPassSession},
+		{"session no session denies", task.WebhookAuthSession, false, P, false, false, webhookDeny},
+		{"session relayed denies", task.WebhookAuthSession, true, P, true, false, webhookDeny},
+		{"any+session passes", task.WebhookAuthAny, true, P, false, true, webhookPassSession},
+		{"any direct POST no session → HMAC", task.WebhookAuthAny, true, P, false, false, webhookHMAC},
+		{"any direct GET never falls through", task.WebhookAuthAny, true, G, false, false, webhookDeny},
+		{"any relayed POST → HMAC", task.WebhookAuthAny, true, P, true, false, webhookHMAC},
+		{"any relayed GET denies", task.WebhookAuthAny, true, G, true, false, webhookDeny},
+		{"any without secret denies", task.WebhookAuthAny, false, P, false, false, webhookDeny},
+		// Relayed requests must never honour a session, even one that somehow
+		// surfaced — HMAC is the only relay credential.
+		{"any relayed ignores session", task.WebhookAuthAny, true, P, true, true, webhookHMAC},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveWebhookAuth(tc.mode, tc.hasSecret, tc.method, tc.relayed, tc.hasSession)
+			if got != tc.want {
+				t.Errorf("resolveWebhookAuth = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWebhookAuthGuard_AnyMode exercises the guard's decisions for auth: any.
+// The guard's only rejection output is a 401/redirect; any other status means
+// it delegated the request downstream (to the HMAC-gated handler), which is the
+// machine-caller-over-relay path this feature unlocks. The test gateway has no
+// route registered, so a delegated request surfaces as 404 — distinct from the
+// guard's own 401.
+func TestWebhookAuthGuard_AnyMode(t *testing.T) {
+	srv := newAuthServer(t, "hunter2")
+	armSpecWebhook(t, srv, "buildin/ai-claude", "/hooks/ai-claude", task.WebhookAuthAny, "s3cr3t")
+	h := srv.Handler()
+
+	// Direct POST, no session → guard delegates to HMAC (not its own 401).
+	req := httptest.NewRequest(http.MethodPost, "/hooks/ai-claude", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code == http.StatusUnauthorized {
+		t.Errorf("any POST no session: guard must delegate to HMAC, got its own 401")
+	}
+
+	// Direct GET, no session → guard denies (GET must never fall through to HMAC,
+	// or an auth-gated UI would be served). Non-browser GET → 401.
+	req = httptest.NewRequest(http.MethodGet, "/hooks/ai-claude", nil)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("any GET no session: expected guard 401, got %d", w.Code)
+	}
+
+	// Relayed POST → guard delegates to HMAC (the whole point: a signed machine
+	// caller authenticates over the relay).
+	req = httptest.NewRequest(http.MethodPost, "/hooks/ai-claude", nil)
+	req.Header.Set("X-Relay-Base", "/u/0000000000000000000000000000000000000000000000000000000000000000")
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code == http.StatusUnauthorized {
+		t.Errorf("any relayed POST: guard must delegate to HMAC, got its own 401")
+	}
+
+	// Direct POST with a valid session → guard delegates (session path); the
+	// downstream skip of signature/replay is covered in the trigger package.
+	req = httptest.NewRequest(http.MethodPost, "/hooks/ai-claude", nil)
+	req.AddCookie(login(t, h, "hunter2", false))
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code == http.StatusUnauthorized {
+		t.Errorf("any POST with session: expected delegation, got 401")
 	}
 }

--- a/pkg/webui/server_test.go
+++ b/pkg/webui/server_test.go
@@ -788,6 +788,10 @@ func TestSPA_RunRoute(t *testing.T) {
 
 func registerWebhookTask(t *testing.T, reg *registry.Registry, srv *Server, id, hookPath string, requireAuth bool) *task.Spec {
 	t.Helper()
+	authMode := task.WebhookAuthNone
+	if requireAuth {
+		authMode = task.WebhookAuthSession
+	}
 	dir := t.TempDir()
 	td := filepath.Join(dir, id)
 	_ = os.MkdirAll(td, 0755)
@@ -797,13 +801,14 @@ func registerWebhookTask(t *testing.T, reg *registry.Registry, srv *Server, id, 
 	spec := &task.Spec{
 		ID:      id,
 		Name:    id,
+		Enabled: true, // the engine only maps webhooks for enabled tasks
 		Runtime: task.RuntimeDeno,
-		Trigger: task.TriggerConfig{Webhook: hookPath, WebhookAuth: requireAuth},
+		Trigger: task.TriggerConfig{Webhook: hookPath, WebhookAuth: authMode},
 		Timeout: 5 * time.Second,
 		TaskDir: td,
 	}
 	_ = reg.Register(spec)
-	srv.engine.Register(spec)
+	_ = srv.engine.Register(spec)
 	return spec
 }
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -75,7 +75,7 @@ export default defineConfig({
     // Run:  DICODE_AUTH_MODE=authenticated npx playwright test --project=authenticated
     {
       name: 'authenticated',
-      testMatch: ['**/auth.spec.ts', '**/auth-providers.spec.ts'],
+      testMatch: ['**/auth.spec.ts', '**/auth-providers.spec.ts', '**/webhook-auth-any.spec.ts'],
       use: {
         ...devices['Desktop Chrome'],
         baseURL: BASE_URL,

--- a/tests/e2e/fixtures/tasks/hello-webhook-any/app.js
+++ b/tests/e2e/fixtures/tasks/hello-webhook-any/app.js
@@ -1,0 +1,4 @@
+// Static UI asset for the hello-webhook-any fixture. Used by the e2e test that
+// verifies an auth: any webhook's assets are not served to unauthenticated
+// callers (core#610 asset fall-through fix).
+export const MARKER = 'hello-webhook-any-asset-marker';

--- a/tests/e2e/fixtures/tasks/hello-webhook-any/task.js
+++ b/tests/e2e/fixtures/tasks/hello-webhook-any/task.js
@@ -1,0 +1,4 @@
+export default async function main({ input }) {
+  console.log('any-auth webhook received ' + JSON.stringify(input));
+  return { received: input };
+}

--- a/tests/e2e/fixtures/tasks/hello-webhook-any/task.yaml
+++ b/tests/e2e/fixtures/tasks/hello-webhook-any/task.yaml
@@ -1,0 +1,12 @@
+apiVersion: dicode/v1
+kind: Task
+name: Hello Webhook Any
+description: >
+  A webhook task with trigger.auth "any" (session OR HMAC) for e2e testing of
+  core#610. A valid dicode session OR a valid HMAC signature authenticates.
+runtime: js
+trigger:
+  webhook: /hooks/test-webhook-any
+  auth: any
+  webhook_secret: "${TEST_WEBHOOK_SECRET}"
+timeout: 10s

--- a/tests/e2e/fixtures/tasks/taskset.yaml
+++ b/tests/e2e/fixtures/tasks/taskset.yaml
@@ -16,6 +16,9 @@ spec:
     hello-webhook-secure:
       ref:
         path: FIXTURES_TASKS_DIR/hello-webhook-secure/task.yaml
+    hello-webhook-any:
+      ref:
+        path: FIXTURES_TASKS_DIR/hello-webhook-any/task.yaml
     chain-target:
       ref:
         path: FIXTURES_TASKS_DIR/chain-target/task.yaml

--- a/tests/e2e/webhook-auth-any.spec.ts
+++ b/tests/e2e/webhook-auth-any.spec.ts
@@ -113,6 +113,25 @@ test.describe('Webhook auth: any (session OR HMAC)', () => {
     expect(res.status()).toBe(403);
   });
 
+  // ── Static UI assets stay session-gated (asset fall-through fix) ───────────
+  test('unsigned POST to a static asset sub-path is not served', async ({ request }) => {
+    const res = await request.post(`${ANY_WEBHOOK_PATH}/app.js`, {
+      headers: { 'Content-Type': 'application/json' },
+      data: { via: 'asset-probe' },
+    });
+    expect(res.status()).not.toBe(200);
+    expect(await res.text()).not.toContain('hello-webhook-any-asset-marker');
+  });
+
+  test('GET to a static asset sub-path without a session is not served', async ({ request }) => {
+    const res = await request.get(`${ANY_WEBHOOK_PATH}/app.js`, {
+      headers: { Accept: 'text/html' },
+      maxRedirects: 0,
+    });
+    expect(res.status()).not.toBe(200);
+    expect(await res.text()).not.toContain('hello-webhook-any-asset-marker');
+  });
+
   test('relayed browser GET → 401 HTML explainer, not a login bounce', async ({ request }) => {
     const res = await request.get(ANY_WEBHOOK_PATH, {
       headers: { Accept: 'text/html', 'X-Relay-Base': RELAY_BASE },

--- a/tests/e2e/webhook-auth-any.spec.ts
+++ b/tests/e2e/webhook-auth-any.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * webhook-auth-any.spec.ts
+ *
+ * End-to-end coverage for trigger.auth: "any" (core#610) — a webhook that
+ * authenticates via EITHER a valid dicode session OR a valid HMAC signature.
+ *
+ * Runs in the 'authenticated' project (server.auth: true, passphrase
+ * test-passphrase-12345) so both credentials are exercisable against one
+ * fixture: hello-webhook-any, which declares
+ *   trigger: { auth: any, webhook_secret: "${TEST_WEBHOOK_SECRET}" }
+ *
+ * The server is started with TEST_WEBHOOK_SECRET in its env, so the secret is
+ * expanded at task load time. These tests are meaningful only when that env var
+ * is set (it is in the CI e2e job).
+ */
+
+import { test, expect } from '@playwright/test';
+import * as crypto from 'crypto';
+import { TEST_PASSPHRASE, login } from './helpers/auth';
+
+const ANY_WEBHOOK_PATH = '/hooks/test-webhook-any';
+const TEST_SECRET = process.env.TEST_WEBHOOK_SECRET ?? 'test-webhook-secret-12345';
+
+// A syntactically-valid but non-relayed relay base — the guard only checks for
+// the header's presence to classify a request as relayed.
+const RELAY_BASE = '/u/' + '0'.repeat(64);
+
+/** Compute the GitHub-style sha256 HMAC header value over body. */
+function sign(secret: string, body: string): string {
+  return 'sha256=' + crypto.createHmac('sha256', secret).update(body).digest('hex');
+}
+
+test.describe('Webhook auth: any (session OR HMAC)', () => {
+  // ── HMAC (machine caller, no session) ──────────────────────────────────────
+  test('POST with valid HMAC signature, no session → 200', async ({ request }) => {
+    const bodyStr = JSON.stringify({ via: 'hmac', ts: Date.now() });
+    const res = await request.post(ANY_WEBHOOK_PATH, {
+      headers: { 'Content-Type': 'application/json', 'X-Hub-Signature-256': sign(TEST_SECRET, bodyStr) },
+      data: JSON.parse(bodyStr),
+    });
+    expect(res.ok()).toBe(true);
+    expect(res.headers()['x-run-id']).toBeTruthy();
+  });
+
+  test('POST without signature, no session → 403', async ({ request }) => {
+    const res = await request.post(ANY_WEBHOOK_PATH, {
+      headers: { 'Content-Type': 'application/json' },
+      data: { via: 'nothing' },
+    });
+    expect(res.status()).toBe(403);
+  });
+
+  test('POST with wrong signature, no session → 403', async ({ request }) => {
+    const res = await request.post(ANY_WEBHOOK_PATH, {
+      headers: { 'Content-Type': 'application/json', 'X-Hub-Signature-256': 'sha256=deadbeef' },
+      data: { via: 'bad-sig' },
+    });
+    expect(res.status()).toBe(403);
+  });
+
+  // ── Session (browser, no signature) ────────────────────────────────────────
+  test('POST with a valid session and NO signature → 200 (HMAC skipped)', async ({ request }) => {
+    await login(request, TEST_PASSPHRASE); // populates the context cookie jar
+    const res = await request.post(ANY_WEBHOOK_PATH, {
+      headers: { 'Content-Type': 'application/json' },
+      data: { via: 'session', ts: Date.now() },
+    });
+    expect(res.ok()).toBe(true);
+  });
+
+  test('session request repeats an identical body without a 409 (replay skipped)', async ({ request }) => {
+    await login(request, TEST_PASSPHRASE);
+    const identical = { via: 'session-dup', fixed: 'body' };
+    for (let i = 0; i < 2; i++) {
+      const res = await request.post(ANY_WEBHOOK_PATH, {
+        headers: { 'Content-Type': 'application/json' },
+        data: identical,
+      });
+      expect(res.ok(), `submission ${i}`).toBe(true);
+    }
+  });
+
+  // ── GET must never fall through to HMAC (trap 1) ───────────────────────────
+  test('GET without a session is not served (auth-gated UI stays private)', async ({ request }) => {
+    const res = await request.get(ANY_WEBHOOK_PATH, {
+      headers: { Accept: 'text/html' },
+      maxRedirects: 0,
+    });
+    // Browser GET → 303 login redirect; never 200 (which would serve/run it).
+    expect(res.status()).not.toBe(200);
+    expect([303, 401]).toContain(res.status());
+  });
+
+  // ── Relay (only HMAC crosses it) ───────────────────────────────────────────
+  test('relayed POST with valid HMAC → 200', async ({ request }) => {
+    const bodyStr = JSON.stringify({ via: 'relay-hmac', ts: Date.now() });
+    const res = await request.post(ANY_WEBHOOK_PATH, {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Hub-Signature-256': sign(TEST_SECRET, bodyStr),
+        'X-Relay-Base': RELAY_BASE,
+      },
+      data: JSON.parse(bodyStr),
+    });
+    expect(res.ok()).toBe(true);
+  });
+
+  test('relayed POST without signature → 403', async ({ request }) => {
+    const res = await request.post(ANY_WEBHOOK_PATH, {
+      headers: { 'Content-Type': 'application/json', 'X-Relay-Base': RELAY_BASE },
+      data: { via: 'relay-nosig' },
+    });
+    expect(res.status()).toBe(403);
+  });
+
+  test('relayed browser GET → 401 HTML explainer, not a login bounce', async ({ request }) => {
+    const res = await request.get(ANY_WEBHOOK_PATH, {
+      headers: { Accept: 'text/html', 'X-Relay-Base': RELAY_BASE },
+      maxRedirects: 0,
+    });
+    expect(res.status()).toBe(401);
+    expect(res.headers()['content-type'] ?? '').toContain('text/html');
+    expect(res.headers()['location'] ?? '').toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

A webhook's auth is today a rigid bool: `auth: true` is session-only — and therefore unreachable over the relay, which strips every credential header by design — while `webhook_secret` alone is HMAC-only, relay-reachable but with no browser/session path. Neither expresses "authenticate via a session when hit directly, or via an HMAC signature when a machine calls over the relay." OR composition does.

`trigger.auth` becomes tri-valued:
- `true` / `"session"` — unchanged (session required; a secret, if also set, still ANDs on top).
- `"any"` — session **OR** a valid HMAC signature.
- absent / `false` — public.

The default is byte-for-byte unchanged; `"any"` is opt-in and requires a `webhook_secret` (an `any` webhook with no secret has a dead HMAC path). Auth terminates at the daemon — **zero relay changes**; `X-Hub-Signature-256` / `X-Dicode-Timestamp` already traverse the relay unstripped.

## Design notes

- **Unified resolution.** The guard no longer runs its own longest-prefix scan; it resolves the matched webhook through the engine's own path lookup — the same one the gateway dispatches on — so the auth decision and the served route can never diverge. This surfaced and fixes a latent bug: a trailing-slash registration (`/hooks/x/`) was dispatched by the gateway but 404'd by the engine's exact-segment walk; the engine now normalizes the trailing slash at registration.
- **Session flag is a fail-closed context value**, set in exactly one place (the guard, after confirming a valid session and no `X-Relay-Base`). A session-authed request skips **both** signature and replay downstream (skipping only the signature would 409 a browser that submits the same body twice).
- **GET never falls through to HMAC** — the handler serves `index.html`/assets on GET before any signature check, so falling GET through would publish an auth-gated UI. A relayed request is never evaluated for a session (that path has device-token/cookie side effects that must not be relay-drivable).
- **Approval re-pend:** switching a task to `"any"` changes its content hash (it opens a relay-reachable machine-auth path), so the trust-on-change gate re-pends it. none/session preserve the pre-change bool wire format via `WebhookAuthMode.MarshalJSON`, so existing `auth: true` tasks do **not** spuriously re-pend on upgrade.

## What was deliberately left behind

This is the **mechanism only**. Activating it on the AI-chat webhook (#611) and the mandatory-`X-Dicode-Timestamp` + ts-keyed replay hardening (#605) are separate — both gate #611, not this PR. Taskset overrides keep `Auth *bool` (they can toggle session/none, not `any`).

## Testing

- Go: unit + integration across `task`, `ipc`, `trigger`, `webui`, `approval`, `taskset` — a pure decision-table test for the guard, session-skips-signature/replay through the real webhook handler (real Deno runs), and auth-mode hash divergence. Full `go test ./...` green; race-clean on the context-flag path.
- E2E (Playwright, real daemon): a new `hello-webhook-any` fixture + `webhook-auth-any.spec.ts` (9 tests) covering all three OR-paths — HMAC-only (valid→200, missing/wrong→403), session-skips-HMAC, session replay, GET-stays-private, and relayed (signed→200, unsigned→403, browser GET→401 explainer). Full suite 132 passed, no regressions.

Closes #610