### PR TITLE
harden(agent-tasks): validate carried resume state before subprocess arg / workdir path / KV key

### DIFF
--- a/docs/claude-cli-agent.md
+++ b/docs/claude-cli-agent.md
@@ -36,9 +36,15 @@ the response carries a `session_id` you can pass back on subsequent
 turns to continue. The wrapper itself is stateless beyond the OAuth
 token cache the CLI maintains under `$HOME/.claude/`.
 
-The wrapper validates `session_id` shape before passing it to `--resume`
-to defang any path-traversal attempt at the CLI layer, and redacts the
-OAuth token from any error output forwarded back to the caller.
+The interactive chat loop carries two ids across suspend/resume turns: a
+dicode-minted `chatId` (keys the per-invocation workdir) and the Claude CLI's
+own `claudeSessionId` (passed to `--resume`). Both are attacker-influenceable
+via a crafted resume submission, so the wrapper validates each as a UUID
+before use — an off-shape `chatId` gets a fresh workdir instead of reaching
+`Deno.Command`'s `cwd` (defanging path traversal), and an off-shape
+`claudeSessionId` is dropped instead of reaching the `--resume` subprocess
+argument (defanging argument injection). The wrapper also redacts the OAuth
+token from any error output forwarded back to the caller.
 
 ## Install paths
 

--- a/docs/claude-cli-agent.md
+++ b/docs/claude-cli-agent.md
@@ -38,13 +38,15 @@ token cache the CLI maintains under `$HOME/.claude/`.
 
 The interactive chat loop carries two ids across suspend/resume turns: a
 dicode-minted `chatId` (keys the per-invocation workdir) and the Claude CLI's
-own `claudeSessionId` (passed to `--resume`). Both are attacker-influenceable
-via a crafted resume submission, so the wrapper validates each as a UUID
-before use — an off-shape `chatId` gets a fresh workdir instead of reaching
-`Deno.Command`'s `cwd` (defanging path traversal), and an off-shape
-`claudeSessionId` is dropped instead of reaching the `--resume` subprocess
-argument (defanging argument injection). The wrapper also redacts the OAuth
-token from any error output forwarded back to the caller.
+own `claudeSessionId` (passed to `--resume`). dicode's resume API only ever
+lets a caller submit the chat `message`; the carried ids themselves are
+server round-tripped from this task's own prior `suspend()` call, not
+directly client-suppliable. Even so, the wrapper validates each as a UUID
+before use as defense-in-depth — an off-shape `chatId` gets a fresh workdir
+instead of reaching `Deno.Command`'s `cwd`, and an off-shape `claudeSessionId`
+is dropped instead of reaching the `--resume` subprocess argument — so the
+sink stays safe regardless of how the id got there. The wrapper also redacts
+the OAuth token from any error output forwarded back to the caller.
 
 ## Install paths
 

--- a/pkg/runtime/deno/sdk/sdk.d.ts
+++ b/pkg/runtime/deno/sdk/sdk.d.ts
@@ -115,6 +115,10 @@ declare interface Dicode {
   run_task:       (taskID: string, params?: Record<string, string>) => Promise<unknown>;
   list_tasks:     ()                                                 => Promise<TaskSummary[]>;
   get_runs:       (taskID: string, opts?: { limit?: number })        => Promise<unknown>;
+  /** set_group labels the current run with a free-text string used by the
+   *  WebUI to collapse same-group siblings (#116). Last write wins; only
+   *  affects the current run. */
+  set_group:      (label: string)      => Promise<void>;
   /** Pause the run: hand the runtime `schema` + carried `state`, then never
    *  resolve — the process exits cleanly and the run ends as `suspended`. On
    *  resume the runner dispatches the matching handler (steps[to], resume, or

--- a/tasks/buildin/ai-agent-claude-cli/task.test.ts
+++ b/tasks/buildin/ai-agent-claude-cli/task.test.ts
@@ -587,3 +587,38 @@ JSON`,
         throw new Error(`malicious claudeSessionId leaked into claude args:\n${args.join(" ")}`);
     }
 });
+
+Deno.test("steps.turn: an invalid chatId also drops a valid carried claudeSessionId (cwd-scoped --resume would otherwise fail)", async () => {
+    // Regression for a bug caught in review: Claude CLI sessions are
+    // cwd-scoped, so pairing a fresh workdir (minted because chatId was
+    // off-shape) with the OLD claudeSessionId would make --resume fail
+    // ("No conversation found") instead of gracefully starting fresh.
+    Deno.env.set("CLAUDE_CODE_OAUTH_TOKEN", "stub");
+    const { dicode } = makeSuspendDicode();
+    const sentinelDir = await Deno.makeTempDir();
+    const sentinel = `${sentinelDir}/args-recorded`;
+    await withStubClaude(
+        `printf '%s\\n' "$@" > ${sentinel}
+cat <<'JSON'
+{"type":"result","is_error":false,"result":"ok","session_id":"sess-new"}
+JSON`,
+        async () => {
+            try {
+                await steps.turn({
+                    params: makeParams([]),
+                    input: { message: "hi" },
+                    state: { claudeSessionId: VALID_PRIOR_SESSION_ID, chatId: "not-a-uuid" },
+                    dicode,
+                    output: {} as any,
+                    mcp: {} as any,
+                } as any);
+            } catch (e) {
+                if (!(e instanceof SuspendSignal)) throw e;
+            }
+        },
+    );
+    const args = (await Deno.readTextFile(sentinel)).split("\n");
+    if (args.includes("--resume")) {
+        throw new Error(`expected --resume to be omitted when chatId had to be replaced, got:\n${args.join(" ")}`);
+    }
+});

--- a/tasks/buildin/ai-agent-claude-cli/task.test.ts
+++ b/tasks/buildin/ai-agent-claude-cli/task.test.ts
@@ -420,6 +420,13 @@ Deno.test("steps.turn: a blank message ends the chat (returns, no Claude call)",
     assertEquals(calls.length, 0); // never suspended onward
 });
 
+// UUID-shaped fixtures: chatId/claudeSessionId now go through isValidSessionId
+// before use, so carried-state fixtures in these tests must be UUID-shaped to
+// exercise the "valid, passed through" path. The off-shape/rejection path is
+// covered separately below.
+const VALID_CHAT_ID = "11111111-1111-1111-1111-111111111111";
+const VALID_PRIOR_SESSION_ID = "33333333-3333-3333-3333-333333333333";
+
 Deno.test("steps.turn: a message runs one turn and suspends back with the reply", async () => {
     Deno.env.set("CLAUDE_CODE_OAUTH_TOKEN", "stub");
     const { calls, dicode } = makeSuspendDicode();
@@ -433,7 +440,7 @@ JSON`,
                 await steps.turn({
                     params: makeParams([]),
                     input: { message: "ping" },
-                    state: { claudeSessionId: "", chatId: "chat-abc" },
+                    state: { claudeSessionId: "", chatId: VALID_CHAT_ID },
                     dicode,
                     output: {} as any,
                     mcp: {} as any,
@@ -449,7 +456,7 @@ JSON`,
     assertEquals(calls[0].to, "turn");
     // Claude's new session id is carried forward; chatId (the workdir key) is stable.
     assertEquals(calls[0].state.claudeSessionId, "sess-new");
-    assertEquals(calls[0].state.chatId, "chat-abc");
+    assertEquals(calls[0].state.chatId, VALID_CHAT_ID);
     // The reply becomes the next prompt's banner — on the schema and the field.
     assertEquals(calls[0].schema.description, "pong");
     assertEquals(calls[0].schema.properties.message.description, "pong");
@@ -470,7 +477,7 @@ JSON`,
                 await steps.turn({
                     params: makeParams([]),
                     input: { message: "again" },
-                    state: { claudeSessionId: "sess-1", chatId: "chat-xyz" },
+                    state: { claudeSessionId: VALID_PRIOR_SESSION_ID, chatId: "chat-xyz" },
                     dicode,
                     output: {} as any,
                     mcp: {} as any,
@@ -482,7 +489,78 @@ JSON`,
     );
     const lines = (await Deno.readTextFile(sentinel)).split("\n");
     const i = lines.indexOf("--resume");
-    if (i < 0 || lines[i + 1] !== "sess-1") {
-        throw new Error(`expected --resume sess-1, got:\n${lines.join(" ")}`);
+    if (i < 0 || lines[i + 1] !== VALID_PRIOR_SESSION_ID) {
+        throw new Error(`expected --resume ${VALID_PRIOR_SESSION_ID}, got:\n${lines.join(" ")}`);
+    }
+});
+
+Deno.test("steps.turn: rejects a path-traversal chatId in resume state; falls back to a fresh UUID workdir", async () => {
+    Deno.env.set("CLAUDE_CODE_OAUTH_TOKEN", "stub");
+    const { dicode } = makeSuspendDicode();
+    const sentinelDir = await Deno.makeTempDir();
+    const sentinel = `${sentinelDir}/cwd-recorded`;
+    await withStubClaude(
+        `pwd > ${sentinel}
+cat <<'JSON'
+{"type":"result","is_error":false,"result":"ok","session_id":"sess-new"}
+JSON`,
+        async () => {
+            try {
+                await steps.turn({
+                    params: makeParams([]),
+                    input: { message: "hi" },
+                    state: { claudeSessionId: "", chatId: "../../../../tmp/dicode-chatid-escape" },
+                    dicode,
+                    output: {} as any,
+                    mcp: {} as any,
+                } as any);
+            } catch (e) {
+                if (!(e instanceof SuspendSignal)) throw e;
+            }
+        },
+    );
+    const recordedCwd = (await Deno.readTextFile(sentinel)).trim();
+    if (recordedCwd.includes("dicode-chatid-escape")) {
+        throw new Error(`chatId path traversal reached the subprocess cwd: ${recordedCwd}`);
+    }
+    const basename = recordedCwd.split("/").pop() ?? "";
+    if (!/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i.test(basename)) {
+        throw new Error(`expected a fresh UUID-shaped workdir, got cwd: ${recordedCwd}`);
+    }
+});
+
+Deno.test("steps.turn: rejects a flag-shaped claudeSessionId in resume state; omits --resume entirely", async () => {
+    Deno.env.set("CLAUDE_CODE_OAUTH_TOKEN", "stub");
+    const { dicode } = makeSuspendDicode();
+    const sentinelDir = await Deno.makeTempDir();
+    const sentinel = `${sentinelDir}/args-recorded`;
+    await withStubClaude(
+        `printf '%s\\n' "$@" > ${sentinel}
+cat <<'JSON'
+{"type":"result","is_error":false,"result":"ok","session_id":"sess-new"}
+JSON`,
+        async () => {
+            try {
+                await steps.turn({
+                    params: makeParams([]),
+                    input: { message: "hi" },
+                    // A crafted resume submission trying to smuggle an extra CLI flag
+                    // in as the "session id".
+                    state: { claudeSessionId: "--dangerously-skip-permissions", chatId: VALID_CHAT_ID },
+                    dicode,
+                    output: {} as any,
+                    mcp: {} as any,
+                } as any);
+            } catch (e) {
+                if (!(e instanceof SuspendSignal)) throw e;
+            }
+        },
+    );
+    const args = (await Deno.readTextFile(sentinel)).split("\n");
+    if (args.includes("--resume")) {
+        throw new Error(`expected --resume to be omitted for an invalid carried claudeSessionId, got:\n${args.join(" ")}`);
+    }
+    if (args.includes("--dangerously-skip-permissions")) {
+        throw new Error(`malicious claudeSessionId leaked into claude args:\n${args.join(" ")}`);
     }
 });

--- a/tasks/buildin/ai-agent-claude-cli/task.test.ts
+++ b/tasks/buildin/ai-agent-claude-cli/task.test.ts
@@ -5,6 +5,7 @@
 
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import main, { buildClaudeArgs, decideEntryMode, isChatEnd, steps } from "./task.ts";
+import { isValidSessionId } from "../ai-agent-core/chat.ts";
 
 const fakeDicode = {} as any;
 
@@ -142,7 +143,7 @@ JSON`,
     assertEquals(result.model, "claude-sonnet-4");
     // One-shot is stateless: the returned session_id is a fresh UUID keying the
     // per-invocation workdir, not the Claude CLI's own id.
-    if (!/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i.test(result.session_id)) {
+    if (!isValidSessionId(result.session_id)) {
         throw new Error(`expected uuid-shaped session_id, got ${result.session_id}`);
     }
 });
@@ -404,28 +405,47 @@ Deno.test("isChatEnd: blank/whitespace ends, content continues", () => {
     assertEquals(isChatEnd("hello"), false);
 });
 
-Deno.test("steps.turn: a blank message ends the chat (returns, no Claude call)", async () => {
-    const { calls, dicode } = makeSuspendDicode();
-    const result: any = await steps.turn({
-        params: makeParams([]),
-        input: { message: "   " },
-        state: { claudeSessionId: "sess-prior", chatId: "c1" },
-        dicode,
-        output: {} as any,
-        mcp: {} as any,
-    } as any);
-    assertEquals(result.ok, true);
-    assertEquals(result.reply, "(chat ended)");
-    assertEquals(result.session_id, "sess-prior");
-    assertEquals(calls.length, 0); // never suspended onward
-});
-
 // UUID-shaped fixtures: chatId/claudeSessionId now go through isValidSessionId
 // before use, so carried-state fixtures in these tests must be UUID-shaped to
 // exercise the "valid, passed through" path. The off-shape/rejection path is
 // covered separately below.
 const VALID_CHAT_ID = "11111111-1111-1111-1111-111111111111";
 const VALID_PRIOR_SESSION_ID = "33333333-3333-3333-3333-333333333333";
+
+Deno.test("steps.turn: a blank message ends the chat (returns, no Claude call)", async () => {
+    const { calls, dicode } = makeSuspendDicode();
+    const result: any = await steps.turn({
+        params: makeParams([]),
+        input: { message: "   " },
+        state: { claudeSessionId: VALID_PRIOR_SESSION_ID, chatId: "c1" },
+        dicode,
+        output: {} as any,
+        mcp: {} as any,
+    } as any);
+    assertEquals(result.ok, true);
+    assertEquals(result.reply, "(chat ended)");
+    assertEquals(result.session_id, VALID_PRIOR_SESSION_ID);
+    assertEquals(calls.length, 0); // never suspended onward
+});
+
+Deno.test("steps.turn: a blank message ending the chat rejects an invalid carried claudeSessionId instead of echoing it", async () => {
+    // The onEnd path (chatTurn's isChatEnd short-circuit) never runs runTurn,
+    // so it has its own resolveSessionId call — this guards that it's actually
+    // wired up, not just the non-blank-message path covered above.
+    const { calls, dicode } = makeSuspendDicode();
+    const result: any = await steps.turn({
+        params: makeParams([]),
+        input: { message: "" },
+        state: { claudeSessionId: "--dangerously-skip-permissions", chatId: VALID_CHAT_ID },
+        dicode,
+        output: {} as any,
+        mcp: {} as any,
+    } as any);
+    assertEquals(result.ok, true);
+    assertEquals(result.reply, "(chat ended)");
+    assertEquals(result.session_id, "");
+    assertEquals(calls.length, 0);
+});
 
 Deno.test("steps.turn: a message runs one turn and suspends back with the reply", async () => {
     Deno.env.set("CLAUDE_CODE_OAUTH_TOKEN", "stub");
@@ -462,9 +482,9 @@ JSON`,
     assertEquals(calls[0].schema.properties.message.description, "pong");
 });
 
-Deno.test("steps.turn: resumes Claude's prior session via --resume", async () => {
+Deno.test("steps.turn: resumes Claude's prior session via --resume, and chatId stays stable", async () => {
     Deno.env.set("CLAUDE_CODE_OAUTH_TOKEN", "stub");
-    const { dicode } = makeSuspendDicode();
+    const { calls, dicode } = makeSuspendDicode();
     const sentinelDir = await Deno.makeTempDir();
     const sentinel = `${sentinelDir}/args-recorded`;
     await withStubClaude(
@@ -477,7 +497,7 @@ JSON`,
                 await steps.turn({
                     params: makeParams([]),
                     input: { message: "again" },
-                    state: { claudeSessionId: VALID_PRIOR_SESSION_ID, chatId: "chat-xyz" },
+                    state: { claudeSessionId: VALID_PRIOR_SESSION_ID, chatId: VALID_CHAT_ID },
                     dicode,
                     output: {} as any,
                     mcp: {} as any,
@@ -492,6 +512,9 @@ JSON`,
     if (i < 0 || lines[i + 1] !== VALID_PRIOR_SESSION_ID) {
         throw new Error(`expected --resume ${VALID_PRIOR_SESSION_ID}, got:\n${lines.join(" ")}`);
     }
+    // A valid carried chatId must pass through unchanged (not silently
+    // replaced), same as the workdir it keys.
+    assertEquals(calls[0].state.chatId, VALID_CHAT_ID);
 });
 
 Deno.test("steps.turn: rejects a path-traversal chatId in resume state; falls back to a fresh UUID workdir", async () => {
@@ -524,7 +547,7 @@ JSON`,
         throw new Error(`chatId path traversal reached the subprocess cwd: ${recordedCwd}`);
     }
     const basename = recordedCwd.split("/").pop() ?? "";
-    if (!/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i.test(basename)) {
+    if (!isValidSessionId(basename)) {
         throw new Error(`expected a fresh UUID-shaped workdir, got cwd: ${recordedCwd}`);
     }
 });

--- a/tasks/buildin/ai-agent-claude-cli/task.ts
+++ b/tasks/buildin/ai-agent-claude-cli/task.ts
@@ -135,13 +135,22 @@ export const steps = {
                 // hand-crafted resume can't be trusted to hand back a safe value —
                 // validate as a UUID and mint a fresh one (fresh cwd, no --resume)
                 // rather than let an off-shape string reach Deno.Command's cwd.
+                const hasValidChatId = !!carried.chatId && isValidSessionId(carried.chatId);
                 const chatId = resolveSessionId(carried.chatId, "ai-agent-claude-cli: chatId", { autoMint: true });
 
                 // claudeSessionId becomes the `claude --resume <id>` subprocess
                 // argument. Same reasoning: validate before use, and treat an
                 // off-shape carried value as absent (fresh Claude session) rather
-                // than pass it through to the CLI invocation.
-                const priorClaudeSessionId = resolveSessionId(carried.claudeSessionId, "ai-agent-claude-cli: claudeSessionId", { autoMint: false });
+                // than pass it through to the CLI invocation. Also: Claude CLI
+                // sessions are cwd-scoped (--resume only finds sessions created in
+                // the same workdir), so if chatId had to be replaced above, any
+                // carried claudeSessionId is now orphaned for the NEW workdir too
+                // — drop it rather than pass a validly-shaped but unresumable id
+                // to --resume (which would fail the turn instead of gracefully
+                // starting a fresh session).
+                const priorClaudeSessionId = hasValidChatId
+                    ? resolveSessionId(carried.claudeSessionId, "ai-agent-claude-cli: claudeSessionId", { autoMint: false })
+                    : "";
 
                 const turn = await runClaudeTurn({
                     message,

--- a/tasks/buildin/ai-agent-claude-cli/task.ts
+++ b/tasks/buildin/ai-agent-claude-cli/task.ts
@@ -21,7 +21,7 @@
 // a value, not throws).
 
 import type { Dicode, DicodeSdk } from "../../sdk.ts";
-import { chatStart, chatTurn, decideEntryMode, isChatEnd, isValidSessionId, SAFE_SKILL_NAME } from "../ai-agent-core/chat.ts";
+import { chatStart, chatTurn, decideEntryMode, isChatEnd, isValidSessionId, resolveSessionId, SAFE_SKILL_NAME } from "../ai-agent-core/chat.ts";
 
 // Re-exported so the task's tests (and any importer) reach the shared envelope
 // helpers through the task module.
@@ -135,22 +135,13 @@ export const steps = {
                 // hand-crafted resume can't be trusted to hand back a safe value —
                 // validate as a UUID and mint a fresh one (fresh cwd, no --resume)
                 // rather than let an off-shape string reach Deno.Command's cwd.
-                let chatId = carried.chatId ?? "";
-                if (chatId && !isValidSessionId(chatId)) {
-                    console.warn(`ai-agent-claude-cli: rejected invalid chatId in resume state; starting a fresh workdir`);
-                    chatId = "";
-                }
-                if (!chatId) chatId = crypto.randomUUID();
+                const chatId = resolveSessionId(carried.chatId, "ai-agent-claude-cli: chatId", { autoMint: true });
 
                 // claudeSessionId becomes the `claude --resume <id>` subprocess
                 // argument. Same reasoning: validate before use, and treat an
                 // off-shape carried value as absent (fresh Claude session) rather
                 // than pass it through to the CLI invocation.
-                let priorClaudeSessionId = carried.claudeSessionId ?? "";
-                if (priorClaudeSessionId && !isValidSessionId(priorClaudeSessionId)) {
-                    console.warn(`ai-agent-claude-cli: rejected invalid claudeSessionId in resume state; starting a fresh Claude session`);
-                    priorClaudeSessionId = "";
-                }
+                const priorClaudeSessionId = resolveSessionId(carried.claudeSessionId, "ai-agent-claude-cli: claudeSessionId", { autoMint: false });
 
                 const turn = await runClaudeTurn({
                     message,
@@ -164,7 +155,10 @@ export const steps = {
             (state) => ({
                 ok: true,
                 reply: "(chat ended)",
-                session_id: (state as ClaudeChatState | undefined)?.claudeSessionId ?? "",
+                // A blank message short-circuits straight to this callback — the
+                // runTurn validation above never runs — so validate here too rather
+                // than echo a possibly off-shape carried id back to the caller.
+                session_id: resolveSessionId((state as ClaudeChatState | undefined)?.claudeSessionId, "ai-agent-claude-cli: claudeSessionId(end)", { autoMint: false }),
             }),
         );
     },
@@ -211,6 +205,19 @@ async function runClaudeTurn(opts: {
     params: Params;
 }): Promise<TurnResult> {
     const { message, priorClaudeSessionId, workdirKey, params } = opts;
+
+    // Defense-in-depth: workdirKey becomes Deno.Command's cwd and
+    // priorClaudeSessionId (when non-empty) becomes the `--resume` argument.
+    // Both callers (steps.turn, oneShotTurn) already validate/self-generate
+    // these before calling in, so this should never trip — but runClaudeTurn
+    // is the function that actually owns the sink, so it shouldn't rely
+    // entirely on caller discipline to keep an off-shape id from reaching it.
+    if (!isValidSessionId(workdirKey)) {
+        return fail(`internal error: workdirKey is not a valid session id — refusing to build a workdir path from it`);
+    }
+    if (priorClaudeSessionId && !isValidSessionId(priorClaudeSessionId)) {
+        return fail(`internal error: priorClaudeSessionId is not a valid session id — refusing to pass it to --resume`);
+    }
 
     const model         = (await params.get("model"))         ?? "";
     const systemPrompt  = (await params.get("system_prompt")) ?? "";

--- a/tasks/buildin/ai-agent-claude-cli/task.ts
+++ b/tasks/buildin/ai-agent-claude-cli/task.ts
@@ -21,7 +21,7 @@
 // a value, not throws).
 
 import type { Dicode, DicodeSdk } from "../../sdk.ts";
-import { chatStart, chatTurn, decideEntryMode, isChatEnd, SAFE_SKILL_NAME } from "../ai-agent-core/chat.ts";
+import { chatStart, chatTurn, decideEntryMode, isChatEnd, isValidSessionId, SAFE_SKILL_NAME } from "../ai-agent-core/chat.ts";
 
 // Re-exported so the task's tests (and any importer) reach the shared envelope
 // helpers through the task module.
@@ -129,13 +129,32 @@ export const steps = {
             ctx,
             async ({ message, state }) => {
                 const carried = (state ?? {}) as ClaudeChatState;
-                // chatId is minted in main() and carried forward; default-guard it
-                // so a hand-crafted resume without one still runs (fresh cwd, no
-                // --resume).
-                const chatId = carried.chatId ?? crypto.randomUUID();
+
+                // chatId is minted in main() and carried forward; it becomes a
+                // filesystem path component (the per-invocation workdir), so a
+                // hand-crafted resume can't be trusted to hand back a safe value —
+                // validate as a UUID and mint a fresh one (fresh cwd, no --resume)
+                // rather than let an off-shape string reach Deno.Command's cwd.
+                let chatId = carried.chatId ?? "";
+                if (chatId && !isValidSessionId(chatId)) {
+                    console.warn(`ai-agent-claude-cli: rejected invalid chatId in resume state; starting a fresh workdir`);
+                    chatId = "";
+                }
+                if (!chatId) chatId = crypto.randomUUID();
+
+                // claudeSessionId becomes the `claude --resume <id>` subprocess
+                // argument. Same reasoning: validate before use, and treat an
+                // off-shape carried value as absent (fresh Claude session) rather
+                // than pass it through to the CLI invocation.
+                let priorClaudeSessionId = carried.claudeSessionId ?? "";
+                if (priorClaudeSessionId && !isValidSessionId(priorClaudeSessionId)) {
+                    console.warn(`ai-agent-claude-cli: rejected invalid claudeSessionId in resume state; starting a fresh Claude session`);
+                    priorClaudeSessionId = "";
+                }
+
                 const turn = await runClaudeTurn({
                     message,
-                    priorClaudeSessionId: carried.claudeSessionId ?? "",
+                    priorClaudeSessionId,
                     workdirKey: chatId,
                     params,
                 });

--- a/tasks/buildin/ai-agent-core/chat.ts
+++ b/tasks/buildin/ai-agent-core/chat.ts
@@ -17,6 +17,21 @@ import type { Dicode, JSONSchema } from "../../sdk.ts";
 // of ValidateRunID elsewhere in the codebase.
 export const SAFE_SKILL_NAME = /^[A-Za-z0-9_][A-Za-z0-9_.-]{0,63}$/;
 
+// SESSION_ID_RE caps chat/session identifiers to the UUID shape dicode itself
+// mints via crypto.randomUUID() — and the shape the Claude CLI's own session
+// ids take. Every place a chat/session id is carried through resume `state` or
+// accepted as a param is attacker-influenceable (a resume submission, or a
+// hand-crafted webhook body); once such a value reaches a subprocess arg
+// (`claude --resume <id>`), a filesystem path component (the per-invocation
+// workdir), or a KV/run-group key, an unvalidated string is a path-traversal /
+// argument-injection vector. Reject anything off-shape rather than trying to
+// escape it — the caller falls back to minting a fresh id.
+export const SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isValidSessionId(id: string): boolean {
+    return SESSION_ID_RE.test(id);
+}
+
 // decideEntryMode picks the shape of a fresh run: a non-empty prompt runs one
 // turn and returns; an empty prompt opens the interactive chat loop. Pure so the
 // branch can be unit-tested without a live provider.

--- a/tasks/buildin/ai-agent-core/chat.ts
+++ b/tasks/buildin/ai-agent-core/chat.ts
@@ -32,6 +32,28 @@ export function isValidSessionId(id: string): boolean {
     return SESSION_ID_RE.test(id);
 }
 
+// resolveSessionId centralizes the "validate a carried/param-supplied id;
+// reject it if off-shape; optionally mint a fresh one" shape shared by every
+// place a chat/session id enters (ai-agent-claude-cli's chatId + claudeSessionId,
+// ai-agent's session_id). `autoMint: true` means absent-or-invalid becomes a
+// fresh crypto.randomUUID() (used where the caller needs a stable handle
+// regardless, e.g. a workdir key); `autoMint: false` means absent-or-invalid
+// becomes "" (used where the caller should treat it as "no prior session",
+// e.g. --resume — omitting the flag rather than resuming a hijacked one).
+export function resolveSessionId(
+    carried: string | undefined,
+    label: string,
+    opts: { autoMint: boolean },
+): string {
+    const id = carried ?? "";
+    if (id && !isValidSessionId(id)) {
+        console.warn(`${label}: rejected invalid session id; ${opts.autoMint ? "minting a fresh one" : "treating as absent"}`);
+        return opts.autoMint ? crypto.randomUUID() : "";
+    }
+    if (!id && opts.autoMint) return crypto.randomUUID();
+    return id;
+}
+
 // decideEntryMode picks the shape of a fresh run: a non-empty prompt runs one
 // turn and returns; an empty prompt opens the interactive chat loop. Pure so the
 // branch can be unit-tested without a live provider.

--- a/tasks/buildin/ai-agent/task.test.ts
+++ b/tasks/buildin/ai-agent/task.test.ts
@@ -12,6 +12,7 @@
  *   make test-tasks
  */
 import { setupHarness } from "../../sdk-test.ts";
+import { isValidSessionId } from "../ai-agent-core/chat.ts";
 await setupHarness(import.meta.url);
 
 // Loaded AFTER setupHarness patches globalThis.fetch — a static import would
@@ -168,8 +169,7 @@ test("rejects a malformed session_id param; generates a fresh UUID instead of ec
 
   const result = await runTask();
 
-  const uuidRe = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
-  assert.ok(uuidRe.test(result.session_id as string), `expected a fresh UUID, got ${result.session_id}`);
+  assert.ok(isValidSessionId(result.session_id as string), `expected a fresh UUID, got ${result.session_id}`);
 
   const calls = (dicode as Record<string, unknown>)._setGroupCalls as string[];
   assert.equal(calls.length, 1);

--- a/tasks/buildin/ai-agent/task.test.ts
+++ b/tasks/buildin/ai-agent/task.test.ts
@@ -114,13 +114,18 @@ test("first turn auto-generates a session_id and returns reply", async () => {
   assert.httpCalled("POST", "http://localhost:11434/v1/chat/completions");
 });
 
+// A UUID-shaped fixture: session_id now goes through isValidSessionId before
+// it's used as the chat: group label / echoed back, so a valid-path test needs
+// a UUID-shaped value. The rejection path is covered separately below.
+const VALID_SESSION_ID = "44444444-4444-4444-4444-444444444444";
+
 test("tags the run with the chat session group so the WebUI can collapse turns", async () => {
   // #112: every chat turn calls dicode.set_group(`chat:<sessionId>`) so all
   // turns of one conversation collapse into one expandable row in the run
   // list, while a new session_id produces a new group row.
   useLocal();
   params.set("prompt", "hello");
-  params.set("session_id", "abc-12345");
+  params.set("session_id", VALID_SESSION_ID);
 
   http.mock("POST", "http://localhost:11434/v1/chat/completions", {
     status: 200,
@@ -130,13 +135,13 @@ test("tags the run with the chat session group so the WebUI can collapse turns",
   await runTask();
 
   const calls = (dicode as Record<string, unknown>)._setGroupCalls as string[];
-  assert.equal(calls, ["chat:abc-12345"]);
+  assert.equal(calls, [`chat:${VALID_SESSION_ID}`]);
 });
 
 test("provided session_id is echoed back on the one-shot path", async () => {
   useLocal();
   params.set("prompt", "second message");
-  params.set("session_id", "fixed-session-123");
+  params.set("session_id", VALID_SESSION_ID);
 
   http.mock("POST", "http://localhost:11434/v1/chat/completions", {
     status: 200,
@@ -145,8 +150,31 @@ test("provided session_id is echoed back on the one-shot path", async () => {
 
   const result = await runTask();
 
-  assert.equal(result.session_id, "fixed-session-123");
+  assert.equal(result.session_id, VALID_SESSION_ID);
   assert.equal(result.reply, "second reply");
+});
+
+test("rejects a malformed session_id param; generates a fresh UUID instead of echoing it", async () => {
+  useLocal();
+  params.set("prompt", "hello");
+  // A crafted caller trying to smuggle something odd into the run-group label
+  // / KV-style handle instead of a dicode-minted UUID.
+  params.set("session_id", "../../etc/passwd\nSET x=1");
+
+  http.mock("POST", "http://localhost:11434/v1/chat/completions", {
+    status: 200,
+    body: completion("hi"),
+  });
+
+  const result = await runTask();
+
+  const uuidRe = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
+  assert.ok(uuidRe.test(result.session_id as string), `expected a fresh UUID, got ${result.session_id}`);
+
+  const calls = (dicode as Record<string, unknown>)._setGroupCalls as string[];
+  assert.equal(calls.length, 1);
+  assert.ok(!calls[0].includes("passwd"), `malformed session_id leaked into set_group label: ${calls[0]}`);
+  assert.equal(calls[0], `chat:${result.session_id}`);
 });
 
 test("tool-use loop calls run_task and feeds result back to model", async () => {

--- a/tasks/buildin/ai-agent/task.ts
+++ b/tasks/buildin/ai-agent/task.ts
@@ -18,7 +18,7 @@
 //     ends it.
 import OpenAI from "npm:openai@4";
 import type { Dicode, DicodeSdk } from "../../sdk.ts";
-import { chatStart, chatTurn, decideEntryMode, isValidSessionId } from "../ai-agent-core/chat.ts";
+import { chatStart, chatTurn, decideEntryMode, resolveSessionId } from "../ai-agent-core/chat.ts";
 
 type Role = "system" | "user" | "assistant" | "tool";
 
@@ -586,12 +586,7 @@ async function oneShotTurn(
   // continuation handle), so validate it the same way claude-cli validates its
   // carried session/chat ids — an off-shape value is treated as absent rather
   // than passed through.
-  let sessionId = (await params.get("session_id")) ?? "";
-  if (sessionId && !isValidSessionId(sessionId)) {
-    console.warn(`ai-agent: rejected invalid session_id param; generating a fresh one`);
-    sessionId = "";
-  }
-  if (!sessionId) sessionId = crypto.randomUUID();
+  const sessionId = resolveSessionId(await params.get("session_id") ?? undefined, "ai-agent: session_id", { autoMint: true });
 
   // Tag the run so the WebUI collapses every turn of a single chat into
   // one expandable row in the run list (#112). Tool-call children are

--- a/tasks/buildin/ai-agent/task.ts
+++ b/tasks/buildin/ai-agent/task.ts
@@ -18,7 +18,7 @@
 //     ends it.
 import OpenAI from "npm:openai@4";
 import type { Dicode, DicodeSdk } from "../../sdk.ts";
-import { chatStart, chatTurn, decideEntryMode } from "../ai-agent-core/chat.ts";
+import { chatStart, chatTurn, decideEntryMode, isValidSessionId } from "../ai-agent-core/chat.ts";
 
 type Role = "system" | "user" | "assistant" | "tool";
 
@@ -581,16 +581,23 @@ async function oneShotTurn(
     dicode: Dicode;
   },
 ): Promise<unknown> {
-  // Hybrid session id: use provided or auto-generate
+  // Hybrid session id: use provided or auto-generate. A caller-supplied value
+  // ends up in the `chat:<id>` run-group label (and is echoed back as the
+  // continuation handle), so validate it the same way claude-cli validates its
+  // carried session/chat ids — an off-shape value is treated as absent rather
+  // than passed through.
   let sessionId = (await params.get("session_id")) ?? "";
+  if (sessionId && !isValidSessionId(sessionId)) {
+    console.warn(`ai-agent: rejected invalid session_id param; generating a fresh one`);
+    sessionId = "";
+  }
   if (!sessionId) sessionId = crypto.randomUUID();
 
   // Tag the run so the WebUI collapses every turn of a single chat into
   // one expandable row in the run list (#112). Tool-call children are
   // already linked via parent_run_id by the engine (#116), so the run
   // detail view can render this turn as a timeline of sub-runs (#113).
-  // set_group is provided by the runtime shim but not yet on the typed surface.
-  await (dicode as Dicode & { set_group(label: string): Promise<void> }).set_group(`chat:${sessionId}`);
+  await dicode.set_group(`chat:${sessionId}`);
 
   const resolved = await resolveAgentRuntime(params, dicode);
   if (!resolved.ok) {

--- a/tasks/sdk.ts
+++ b/tasks/sdk.ts
@@ -122,6 +122,10 @@ export interface Dicode {
   run_task(taskID: string, params?: Record<string, string>): Promise<unknown>;
   list_tasks(): Promise<unknown[]>;
   get_runs(taskID: string, opts?: { limit?: number }): Promise<unknown[]>;
+  // set_group labels the current run with a free-text string used by the
+  // WebUI to collapse same-group siblings (#116). Last write wins; only
+  // affects the current run.
+  set_group(label: string): Promise<void>;
   // Pause the run: hand the runtime `schema` + carried `state`, then never
   // resolve — the process exits cleanly and the run ends as `suspended`. On
   // resume the runner dispatches the matching handler (steps[to], resume, or


### PR DESCRIPTION
Closes #595

## Summary

Surfaced by the #594 security review as pre-existing (dates to the #578 claude-cli chat-loop). Under the #392 threat model the adversary is prompt-injected/crafted content, and a resumed run's `input`/`state` is attacker-influenceable — so these flows were unvalidated:

- **`ai-agent-claude-cli`** chat loop (`steps.turn`): carried `state.chatId` fed straight into the per-invocation **workdir filesystem path** (`Deno.Command`'s `cwd`), and `state.claudeSessionId` fed straight into the **`claude --resume <id>` subprocess argument** — both without validation.
- **`ai-agent`** one-shot path: `session_id` fed straight into the `chat:<id>` **run-group label** (`dicode.set_group`) without validation.

## Changes

- `tasks/buildin/ai-agent-core/chat.ts`: new shared `SESSION_ID_RE` (UUID shape, matching what `crypto.randomUUID()` mints and the Claude CLI's own session-id shape) + `isValidSessionId()` helper, alongside the existing `SAFE_SKILL_NAME`.
- `tasks/buildin/ai-agent-claude-cli/task.ts`: `steps.turn` now validates the carried `chatId` and `claudeSessionId` before use. An off-shape value is treated as absent — a fresh `chatId` (fresh workdir, no traversal) or a fresh Claude session (no `--resume`, no argument injection) — rather than passed through.
- `tasks/buildin/ai-agent/task.ts`: `oneShotTurn` applies the same guard to the `session_id` param before it reaches `set_group`. Also removed the narrow inline cast (`dicode as Dicode & { set_group... }`) now that `set_group` is on the typed surface.
- `tasks/sdk.ts` / `pkg/runtime/deno/sdk/sdk.d.ts`: added `set_group` to the `Dicode` interface (it was already implemented in the runtime shim, just missing from both typed declaration surfaces).
- `docs/claude-cli-agent.md`: corrected the validation description — it previously described a generic "validates `session_id` shape" that didn't match the actual (unvalidated) code; now names both carried ids and what each defangs.

## Regression coverage (unit, Deno test harness)

Every behavior change is locked in by a test that would have failed before this change:

- `tasks/buildin/ai-agent-claude-cli/task.test.ts`:
  - *"rejects a path-traversal chatId in resume state; falls back to a fresh UUID workdir"* — asserts the subprocess `cwd` never contains the malicious traversal string and is a fresh UUID-shaped path.
  - *"rejects a flag-shaped claudeSessionId in resume state; omits --resume entirely"* — asserts `--resume` is never invoked with a crafted flag-shaped value (argument-injection attempt).
  - Updated the two existing `steps.turn` tests to use UUID-shaped fixtures for the "valid, passed through" path (previously used arbitrary strings like `"chat-abc"`/`"sess-1"`, which the new validation now correctly rejects).
- `tasks/buildin/ai-agent/task.test.ts`:
  - *"rejects a malformed session_id param; generates a fresh UUID instead of echoing it"* — asserts a crafted `session_id` never reaches the `set_group` label and a fresh UUID is used instead.
  - Updated two existing tests to use a UUID-shaped `session_id` fixture for the same reason.

**Unit-only, not e2e**: this is Deno task-layer input validation with no live Claude/OpenAI backend in CI (per #578, "No e2e of the real Claude path — no LLM in CI"). The existing coverage for this exact task (OAuth-token redaction, skills-path-traversal rejection, `buildClaudeArgs`) already uses this same Deno-test-harness unit modality rather than e2e, so this follows established precedent for the file.

## Docs

Updated `docs/claude-cli-agent.md`'s description of the session-id validation to match what's actually implemented now (previously described validation behavior that didn't exist in code).

## Verification in this environment

`make build`, `go vet ./...`, `make format-check`, and `make lint` are all clean. `make test` is green except for one **pre-existing, unrelated** failure (`TestControl_TaskTest_HappyPath` in `pkg/ipc`) — confirmed present on unmodified `origin/main` too — caused by this sandbox's network policy blocking the Deno-binary download from `github.com/denoland/deno`, not by this change.

That same network restriction means neither `make test-tasks` (Deno unit tests) nor `make test-e2e` (Playwright, which needs a live daemon that itself requires Deno to start) could be executed locally — the daemon fails at startup with `init deno runtime: ... HTTP 403`. I sanity-checked the diff with `tsc --noEmit` (no syntax errors, no errors touching the new/changed identifiers) and reviewed it carefully by hand. I'll watch this PR's CI (which has real network access) for the actual `make test-tasks`/`make test-e2e` results and fix anything that surfaces.

🤖 Generated with a scheduled autonomous backlog-grooming run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GCiss4L5z27UDc9hsDnjdG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for labeling runs in the WebUI with custom group names.
  * Chat sessions now retain and resume conversations more reliably across turns.
  * Session identifiers are validated and safely regenerated when missing or invalid.

* **Bug Fixes**
  * Improved protection against malformed session data, path traversal, and unsafe command arguments.
  * Sensitive OAuth tokens are redacted from forwarded error messages.

* **Documentation**
  * Updated CLI wrapper documentation to explain suspend/resume behavior and session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->