### PR TITLE
feat(ai): relay-reachable HMAC auth on the AI-chat webhook (#611)

### DIFF
--- a/pkg/task/pipeline.go
+++ b/pkg/task/pipeline.go
@@ -130,9 +130,16 @@ func LoadPipelineDir(dir string, extras map[string]string) (*PipelineTask, error
 // fs paths, reusing expandOverrides (which mirrors the envFallback policy from
 // expandSpec: Params[].Default gets envFallback=false, Fs[].Path gets true).
 func expandPipeline(p *PipelineTask, vars map[string]string) {
+	// trigger.webhook_secret: same env-fallback policy as kind: Task (see
+	// expandSpec) — resolved server-side, never readable from task code.
+	p.Trigger.WebhookSecret = expandString(p.Trigger.WebhookSecret, vars, true)
 	for i := range p.Stages {
 		expandOverrides(p.Stages[i].Overrides, vars)
 	}
+	// After expansion: downgrade auth: any to session when the secret is empty
+	// or an unresolved ${VAR} placeholder, so a committed placeholder is never
+	// served as a live HMAC key (mirrors normalizeWebhookAuth for kind: Task).
+	normalizeWebhookAuthFields(&p.Trigger.WebhookAuth, &p.Trigger.WebhookSecret, &p.Warnings)
 }
 
 // Validate runs all load-time (non-registry) checks. Cross-spec checks (stage

--- a/pkg/task/pipeline.go
+++ b/pkg/task/pipeline.go
@@ -139,7 +139,8 @@ func expandPipeline(p *PipelineTask, vars map[string]string) {
 	// After expansion: downgrade auth: any to session when the secret is empty
 	// or an unresolved ${VAR} placeholder, so a committed placeholder is never
 	// served as a live HMAC key (mirrors normalizeWebhookAuth for kind: Task).
-	normalizeWebhookAuthFields(&p.Trigger.WebhookAuth, &p.Trigger.WebhookSecret, &p.Warnings)
+	normalizeWebhookAuthFields(&p.Trigger.WebhookAuth, &p.Trigger.WebhookSecret,
+		&p.Trigger.ReplayProtection, &p.Trigger.RequireTimestamp, &p.Warnings)
 }
 
 // Validate runs all load-time (non-registry) checks. Cross-spec checks (stage

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -193,18 +193,28 @@ func webhookSecretResolved(s string) bool {
 // auth) with the relay HMAC path simply not offered. Must run after template
 // expansion, the only point where a real secret is distinguishable from a
 // placeholder. Shared by kind: Task and kind: PipelineTask.
-func normalizeWebhookAuthFields(mode *WebhookAuthMode, secret *string, warnings *[]string) {
-	if *mode == WebhookAuthAny && !webhookSecretResolved(*secret) {
-		*mode = WebhookAuthSession
-		*secret = ""
-		*warnings = append(*warnings,
-			`trigger.auth: "any" needs a resolved webhook_secret but none is set — serving session auth only (the HMAC/relay path is disabled)`)
+func normalizeWebhookAuthFields(mode *WebhookAuthMode, secret *string, replayProtection, requireTimestamp **bool, warnings *[]string) {
+	if *mode != WebhookAuthAny || webhookSecretResolved(*secret) {
+		return
 	}
+	*mode = WebhookAuthSession
+	*secret = ""
+	// replay_protection / require_timestamp only act on the HMAC path, which
+	// needs a secret — so once we've cleared it they are dead options. Clear
+	// them too, or a re-validation pass (the taskset resolver re-runs Validate,
+	// which rebuilds Warnings from scratch) would drop the downgrade note and
+	// surface a misleading "webhook_secret is empty — the webhook is
+	// unauthenticated" warning on a webhook that is in fact session-gated.
+	*replayProtection = nil
+	*requireTimestamp = nil
+	*warnings = append(*warnings,
+		`trigger.auth: "any" needs a resolved webhook_secret but none is set — serving session auth only (the HMAC/relay path is disabled)`)
 }
 
 // normalizeWebhookAuth applies normalizeWebhookAuthFields to a kind: Task spec.
 func normalizeWebhookAuth(s *Spec) {
-	normalizeWebhookAuthFields(&s.Trigger.WebhookAuth, &s.Trigger.WebhookSecret, &s.Warnings)
+	normalizeWebhookAuthFields(&s.Trigger.WebhookAuth, &s.Trigger.WebhookSecret,
+		&s.Trigger.ReplayProtection, &s.Trigger.RequireTimestamp, &s.Warnings)
 }
 
 // TriggerConfig defines how a task is triggered.

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -183,23 +183,28 @@ func webhookSecretResolved(s string) bool {
 	return s != "" && !strings.Contains(s, "${")
 }
 
-// normalizeWebhookAuth downgrades an auth: any webhook that has no resolved
+// normalizeWebhookAuthFields downgrades an auth: any webhook that has no resolved
 // webhook_secret to plain session auth. auth: any authenticates a machine caller
 // by HMAC over the untrusted relay, so it MUST verify against a real secret;
 // serving it against an unresolved ${VAR} placeholder would let anyone who can
 // read the (often committed) task.yaml sign a valid request. Downgrading to
 // session — and clearing the placeholder so session mode doesn't demand an
 // impossible browser signature — keeps the webhook working (browser/session
-// auth) with the relay HMAC path simply not offered. Runs after template
+// auth) with the relay HMAC path simply not offered. Must run after template
 // expansion, the only point where a real secret is distinguishable from a
-// placeholder.
-func normalizeWebhookAuth(s *Spec) {
-	if s.Trigger.WebhookAuth == WebhookAuthAny && !webhookSecretResolved(s.Trigger.WebhookSecret) {
-		s.Trigger.WebhookAuth = WebhookAuthSession
-		s.Trigger.WebhookSecret = ""
-		s.Warnings = append(s.Warnings,
+// placeholder. Shared by kind: Task and kind: PipelineTask.
+func normalizeWebhookAuthFields(mode *WebhookAuthMode, secret *string, warnings *[]string) {
+	if *mode == WebhookAuthAny && !webhookSecretResolved(*secret) {
+		*mode = WebhookAuthSession
+		*secret = ""
+		*warnings = append(*warnings,
 			`trigger.auth: "any" needs a resolved webhook_secret but none is set — serving session auth only (the HMAC/relay path is disabled)`)
 	}
+}
+
+// normalizeWebhookAuth applies normalizeWebhookAuthFields to a kind: Task spec.
+func normalizeWebhookAuth(s *Spec) {
+	normalizeWebhookAuthFields(&s.Trigger.WebhookAuth, &s.Trigger.WebhookSecret, &s.Warnings)
 }
 
 // TriggerConfig defines how a task is triggered.

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -174,6 +174,34 @@ func (m *WebhookAuthMode) UnmarshalYAML(value *yaml.Node) error {
 	}
 }
 
+// webhookSecretResolved reports whether s is a usable HMAC secret rather than an
+// empty string or an unresolved ${VAR} placeholder (the referenced env var was
+// not set at load time). The ${ check is a heuristic — a real secret is opaque
+// random bytes and won't contain "${" — and it fails safe: a false "unresolved"
+// only downgrades auth: any to session.
+func webhookSecretResolved(s string) bool {
+	return s != "" && !strings.Contains(s, "${")
+}
+
+// normalizeWebhookAuth downgrades an auth: any webhook that has no resolved
+// webhook_secret to plain session auth. auth: any authenticates a machine caller
+// by HMAC over the untrusted relay, so it MUST verify against a real secret;
+// serving it against an unresolved ${VAR} placeholder would let anyone who can
+// read the (often committed) task.yaml sign a valid request. Downgrading to
+// session — and clearing the placeholder so session mode doesn't demand an
+// impossible browser signature — keeps the webhook working (browser/session
+// auth) with the relay HMAC path simply not offered. Runs after template
+// expansion, the only point where a real secret is distinguishable from a
+// placeholder.
+func normalizeWebhookAuth(s *Spec) {
+	if s.Trigger.WebhookAuth == WebhookAuthAny && !webhookSecretResolved(s.Trigger.WebhookSecret) {
+		s.Trigger.WebhookAuth = WebhookAuthSession
+		s.Trigger.WebhookSecret = ""
+		s.Warnings = append(s.Warnings,
+			`trigger.auth: "any" needs a resolved webhook_secret but none is set — serving session auth only (the HMAC/relay path is disabled)`)
+	}
+}
+
 // TriggerConfig defines how a task is triggered.
 // Exactly one of Cron, Webhook, Manual, Chain, or Daemon should be set.
 type TriggerConfig struct {
@@ -651,6 +679,10 @@ func LoadDirWithVars(dir string, extras map[string]string) (*Spec, error) {
 	// keys. Kept narrow — see expandSpec for the allowlist and
 	// pkg/task/template.go for the resolution rules.
 	expandSpec(&spec, builtinVars(dir, extras))
+
+	// Runs AFTER expansion: it can only tell a real secret from an unresolved
+	// ${VAR} placeholder once expansion has been attempted.
+	normalizeWebhookAuth(&spec)
 
 	if spec.Runtime == "" || spec.Runtime == "js" {
 		spec.Runtime = RuntimeDeno

--- a/pkg/task/webhook_auth_normalize_test.go
+++ b/pkg/task/webhook_auth_normalize_test.go
@@ -102,3 +102,56 @@ trigger:
 		}
 	})
 }
+
+// TestLoadPipelineDir_AuthAnySecretResolution is the kind: PipelineTask mirror:
+// the same downgrade guard applies, and (unlike before) a pipeline's
+// webhook_secret ${VAR} is now actually expanded.
+func TestLoadPipelineDir_AuthAnySecretResolution(t *testing.T) {
+	dir := t.TempDir()
+	td := filepath.Join(dir, "pipe-hook")
+	if err := os.MkdirAll(td, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := `apiVersion: dicode/v1
+kind: PipelineTask
+name: pipe-hook
+subtype: sequential
+trigger:
+  webhook: /hooks/pipe
+  auth: any
+  webhook_secret: "${PIPE_TEST_WEBHOOK_SECRET}"
+stages:
+  - task: some-stage
+`
+	if err := os.WriteFile(filepath.Join(td, "task.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("secret unset → session-only", func(t *testing.T) {
+		os.Unsetenv("PIPE_TEST_WEBHOOK_SECRET")
+		p, err := LoadPipelineDir(td, nil)
+		if err != nil {
+			t.Fatalf("LoadPipelineDir: %v", err)
+		}
+		if p.Trigger.WebhookAuth != WebhookAuthSession {
+			t.Errorf("mode = %q, want session (downgraded)", p.Trigger.WebhookAuth)
+		}
+		if p.Trigger.WebhookSecret != "" {
+			t.Errorf("secret should be cleared, got %q", p.Trigger.WebhookSecret)
+		}
+	})
+
+	t.Run("secret set → auth: any with resolved secret", func(t *testing.T) {
+		t.Setenv("PIPE_TEST_WEBHOOK_SECRET", "pipe-real-secret")
+		p, err := LoadPipelineDir(td, nil)
+		if err != nil {
+			t.Fatalf("LoadPipelineDir: %v", err)
+		}
+		if p.Trigger.WebhookAuth != WebhookAuthAny {
+			t.Errorf("mode = %q, want any", p.Trigger.WebhookAuth)
+		}
+		if p.Trigger.WebhookSecret != "pipe-real-secret" {
+			t.Errorf("secret = %q, want the resolved value", p.Trigger.WebhookSecret)
+		}
+	})
+}

--- a/pkg/task/webhook_auth_normalize_test.go
+++ b/pkg/task/webhook_auth_normalize_test.go
@@ -77,6 +77,12 @@ trigger:
 		if spec.Trigger.WebhookSecret != "" {
 			t.Errorf("secret should be cleared, got %q", spec.Trigger.WebhookSecret)
 		}
+		// require_timestamp / replay_protection are HMAC-path options; the
+		// downgrade must clear them so a re-validation pass doesn't surface a
+		// misleading "unauthenticated" warning.
+		if spec.Trigger.RequireTimestamp != nil {
+			t.Errorf("require_timestamp should be cleared on downgrade, got %v", *spec.Trigger.RequireTimestamp)
+		}
 		found := false
 		for _, w := range spec.Warnings {
 			if strings.Contains(w, "session auth only") {
@@ -85,6 +91,16 @@ trigger:
 		}
 		if !found {
 			t.Errorf("expected a downgrade warning, got %v", spec.Warnings)
+		}
+		// Re-validate (as the taskset resolver does) — must NOT surface the
+		// misleading "unauthenticated" gated-field warning for a session webhook.
+		if err := spec.Validate(); err != nil {
+			t.Fatalf("re-validate: %v", err)
+		}
+		for _, w := range spec.Warnings {
+			if strings.Contains(w, "unauthenticated") {
+				t.Errorf("re-validation surfaced a misleading warning: %q", w)
+			}
 		}
 	})
 

--- a/pkg/task/webhook_auth_normalize_test.go
+++ b/pkg/task/webhook_auth_normalize_test.go
@@ -1,0 +1,104 @@
+package task
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeWebhookAuth(t *testing.T) {
+	cases := []struct {
+		name       string
+		mode       WebhookAuthMode
+		secret     string
+		wantMode   WebhookAuthMode
+		wantSecret string
+		wantWarn   bool
+	}{
+		{"any + real secret stays any", WebhookAuthAny, "realsecret", WebhookAuthAny, "realsecret", false},
+		{"any + unresolved var downgrades", WebhookAuthAny, "${MY_SECRET}", WebhookAuthSession, "", true},
+		{"any + embedded unresolved var downgrades", WebhookAuthAny, "pre-${X}", WebhookAuthSession, "", true},
+		{"any + empty downgrades", WebhookAuthAny, "", WebhookAuthSession, "", true},
+		{"session + unresolved var untouched", WebhookAuthSession, "${X}", WebhookAuthSession, "${X}", false},
+		{"none untouched", WebhookAuthNone, "", WebhookAuthNone, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Spec{Trigger: TriggerConfig{Webhook: "/hooks/x", WebhookAuth: tc.mode, WebhookSecret: tc.secret}}
+			normalizeWebhookAuth(s)
+			if s.Trigger.WebhookAuth != tc.wantMode {
+				t.Errorf("mode = %q, want %q", s.Trigger.WebhookAuth, tc.wantMode)
+			}
+			if s.Trigger.WebhookSecret != tc.wantSecret {
+				t.Errorf("secret = %q, want %q", s.Trigger.WebhookSecret, tc.wantSecret)
+			}
+			gotWarn := len(s.Warnings) > 0
+			if gotWarn != tc.wantWarn {
+				t.Errorf("warning present = %v, want %v (warnings: %v)", gotWarn, tc.wantWarn, s.Warnings)
+			}
+		})
+	}
+}
+
+// TestLoadDir_AuthAnySecretResolution exercises the full load path: an auth: any
+// webhook whose secret env var is set keeps HMAC; unset, it degrades to session
+// so a placeholder secret is never served.
+func TestLoadDir_AuthAnySecretResolution(t *testing.T) {
+	dir := t.TempDir()
+	td := filepath.Join(dir, "ai-hook")
+	if err := os.MkdirAll(td, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := `name: ai-hook
+runtime: deno
+trigger:
+  webhook: /hooks/ai
+  auth: any
+  webhook_secret: "${AI_TEST_WEBHOOK_SECRET}"
+  require_timestamp: true
+`
+	if err := os.WriteFile(filepath.Join(td, "task.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(td, "task.ts"), []byte(`export default async () => "ok"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("secret unset → session-only", func(t *testing.T) {
+		os.Unsetenv("AI_TEST_WEBHOOK_SECRET")
+		spec, err := LoadDir(td)
+		if err != nil {
+			t.Fatalf("LoadDir: %v", err)
+		}
+		if spec.Trigger.WebhookAuth != WebhookAuthSession {
+			t.Errorf("mode = %q, want session (downgraded)", spec.Trigger.WebhookAuth)
+		}
+		if spec.Trigger.WebhookSecret != "" {
+			t.Errorf("secret should be cleared, got %q", spec.Trigger.WebhookSecret)
+		}
+		found := false
+		for _, w := range spec.Warnings {
+			if strings.Contains(w, "session auth only") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected a downgrade warning, got %v", spec.Warnings)
+		}
+	})
+
+	t.Run("secret set → auth: any with HMAC", func(t *testing.T) {
+		t.Setenv("AI_TEST_WEBHOOK_SECRET", "a-real-secret-value")
+		spec, err := LoadDir(td)
+		if err != nil {
+			t.Fatalf("LoadDir: %v", err)
+		}
+		if spec.Trigger.WebhookAuth != WebhookAuthAny {
+			t.Errorf("mode = %q, want any", spec.Trigger.WebhookAuth)
+		}
+		if spec.Trigger.WebhookSecret != "a-real-secret-value" {
+			t.Errorf("secret = %q, want the resolved value", spec.Trigger.WebhookSecret)
+		}
+	})
+}

--- a/tasks/buildin/ai-agent-claude-cli/README.md
+++ b/tasks/buildin/ai-agent-claude-cli/README.md
@@ -227,6 +227,48 @@ Then point `on_failure_chain` at `buildin/auto-fix-claude` instead of
 selects which agent task drives the loop; if it doesn't yet, this is a small
 follow-up to the auto-fix override.)
 
+## Webhook auth (session or HMAC)
+
+The task's trigger is `auth: any`: a request authenticates with **either** a valid
+dicode session **or** a valid HMAC signature.
+
+- **Browser / WebUI chat** — authenticates with your dicode session, directly on
+  the daemon's own address. Session cookies never travel over the relay, so the
+  chat UI is **not** reachable through the public relay URL; open it on the
+  daemon's host (or reach the host with a tunnel such as Tailscale/cloudflared).
+  The UI assets (`index.html`, `chat.js`, `style.css`) always require a session —
+  they never fall through to HMAC.
+- **Machine / programmatic** — signs a POST with the shared secret and can
+  authenticate over the public relay URL, where session auth can't reach.
+
+Enable the HMAC path by setting the secret in the daemon environment:
+
+```bash
+export AI_CLAUDE_WEBHOOK_SECRET="$(openssl rand -hex 32)"
+```
+
+When `AI_CLAUDE_WEBHOOK_SECRET` is **unset**, the webhook safely degrades to
+**session-only** (the placeholder is never served as a real secret) — you'll see
+a load-time warning to that effect. `require_timestamp: true` is set, so every
+signed request must also carry a fresh `X-Dicode-Timestamp` — mandatory here
+because this webhook points an MCP-capable agent at the untrusted relay, and the
+timestamp closes the replay window. Sign the request as:
+
+```
+X-Hub-Signature-256: sha256=HMAC-SHA256(secret, "<unix_ts>\n<body>")
+X-Dicode-Timestamp: <unix_ts>
+```
+
+See [docs/webhooks.md](../../../docs/webhooks.md) for a full signing example.
+
+> **Relay caveat — short/programmatic turns only.** The relay forwarder aborts
+> at **25 s**, but a chat turn can run up to 5 minutes, and `?wait=false` can't
+> be selected over the relay (the broker drops query strings). So a long
+> synchronous turn over the relay will 502 regardless of auth. Enabling the HMAC
+> path makes the webhook *reachable*; completing long turns over the relay needs
+> an async, pollable surface (separate work). Use it for short or fire-and-forget
+> turns until then.
+
 ## Limitations
 
 - **Unsandboxed tool access (security).** `claude -p` runs with its full

--- a/tasks/buildin/ai-agent-claude-cli/task.yaml
+++ b/tasks/buildin/ai-agent-claude-cli/task.yaml
@@ -18,7 +18,16 @@ runtime: deno
 
 trigger:
   webhook: /hooks/ai-claude
-  auth: true
+  # session OR HMAC: a browser authenticates directly via its dicode session,
+  # while a machine caller signs a POST and authenticates over the public relay
+  # URL (session cookies never cross the relay). Set AI_CLAUDE_WEBHOOK_SECRET in
+  # the daemon env to enable the HMAC/relay path — when it is unset the secret is
+  # unresolved and the webhook safely degrades to session-only (see
+  # normalizeWebhookAuth in pkg/task). require_timestamp closes the replay window
+  # for this relay-exposed, MCP-capable agent (see docs/webhooks.md).
+  auth: any
+  webhook_secret: "${AI_CLAUDE_WEBHOOK_SECRET}"
+  require_timestamp: true
 
 params:
   prompt:


### PR DESCRIPTION
## Summary

Activates session-OR-HMAC auth (`trigger.auth: any`, from #610) on the built-in AI-chat webhook (`ai-agent-claude-cli`), gated by the mandatory-timestamp replay hardening (#605). A browser authenticates with its dicode session directly on the daemon; a signed machine POST authenticates over the **public relay URL**, where session cookies never travel. `require_timestamp: true` is set because this points an MCP-capable agent at the untrusted relay — the timestamp closes the replay window.

## The safety guard (why this isn't a one-line flip)

`ai-agent-claude-cli` ships **enabled in the default builtin taskset**. A naive flip to `auth: any` + `webhook_secret: "${AI_CLAUDE_WEBHOOK_SECRET}"` is unsafe: template expansion leaves an **unset** `${VAR}` as the literal string, so `webhook_secret` would resolve to the public, in-repo literal `${AI_CLAUDE_WEBHOOK_SECRET}` — passing the "any requires a non-empty secret" validation and shipping a default-enabled webhook whose HMAC key anyone can read and sign with. On a relay-exposed, MCP-capable agent that's an auth bypass.

`normalizeWebhookAuth` (runs **after** template expansion — the only point a real secret is distinguishable from a placeholder) closes this: an `auth: any` webhook whose secret is empty or an unresolved `${…}` placeholder is **downgraded to plain session auth**, and the placeholder is cleared (so session mode doesn't then demand an impossible browser signature), with a load-time warning. Result:

- `AI_CLAUDE_WEBHOOK_SECRET` **set** → `auth: any`, real HMAC, relay path works.
- **unset** → safe **session-only** (unchanged behavior), never a public-literal secret.

This hardens *every* `auth: any` task, not just this builtin.

## Browser-over-relay is still a tunnel's job

Even with `auth: any`, a browser can't sign, so the chat UI stays unreachable through the relay — use the daemon's own address or a tunnel. The UI assets (`index.html`/`chat.js`/`style.css`) always require a session (they never fall through to HMAC, per #610).

## Documented caveat — short/programmatic turns only

The relay forwarder aborts at **25 s** and `?wait=false` can't be selected over the relay, but a chat turn runs up to 5 min — so long synchronous turns over the relay 502 regardless of auth. Enabling auth makes the webhook *reachable*; completing long turns over the relay needs an async pollable surface (separate work). The task README states this plainly.

## Testing

- `normalizeWebhookAuth` unit table + a `LoadDir` integration test (secret set → `any` + real secret; unset → `session`, cleared, warned).
- Verified against the real builtin task.yaml: unset → session-only + warning; set → any + HMAC + require_timestamp.
- Full affected Go suite + `go vet` green.

Closes #611