### PR TITLE
test(e2e): cover auth: any downgrade guard + require_timestamp/replay

### DIFF
--- a/tests/e2e/fixtures/tasks/hello-webhook-any-downgrade/task.js
+++ b/tests/e2e/fixtures/tasks/hello-webhook-any-downgrade/task.js
@@ -1,0 +1,3 @@
+export default async function main({ input }) {
+  return { received: input };
+}

--- a/tests/e2e/fixtures/tasks/hello-webhook-any-downgrade/task.yaml
+++ b/tests/e2e/fixtures/tasks/hello-webhook-any-downgrade/task.yaml
@@ -1,0 +1,15 @@
+apiVersion: dicode/v1
+kind: Task
+name: Hello Webhook Any (downgrade)
+description: >
+  An auth: any webhook whose webhook_secret references an env var the test
+  harness never sets. It exercises the core#611 safety guard: the unresolved
+  ${...} placeholder must NOT be served as a live HMAC key — the webhook
+  degrades to session-only.
+runtime: js
+trigger:
+  webhook: /hooks/test-webhook-downgrade
+  auth: any
+  webhook_secret: "${DICODE_E2E_DOWNGRADE_UNSET}"
+  require_timestamp: true
+timeout: 10s

--- a/tests/e2e/fixtures/tasks/hello-webhook-any-ts/task.js
+++ b/tests/e2e/fixtures/tasks/hello-webhook-any-ts/task.js
@@ -1,0 +1,3 @@
+export default async function main({ input }) {
+  return { received: input };
+}

--- a/tests/e2e/fixtures/tasks/hello-webhook-any-ts/task.yaml
+++ b/tests/e2e/fixtures/tasks/hello-webhook-any-ts/task.yaml
@@ -1,0 +1,14 @@
+apiVersion: dicode/v1
+kind: Task
+name: Hello Webhook Any (require_timestamp)
+description: >
+  An auth: any webhook with require_timestamp: true, for e2e testing of core#605:
+  a signed request must carry a valid X-Dicode-Timestamp, and the replay cache is
+  keyed on the (timestamp, body) digest.
+runtime: js
+trigger:
+  webhook: /hooks/test-webhook-ts
+  auth: any
+  webhook_secret: "${TEST_WEBHOOK_SECRET}"
+  require_timestamp: true
+timeout: 10s

--- a/tests/e2e/fixtures/tasks/taskset.yaml
+++ b/tests/e2e/fixtures/tasks/taskset.yaml
@@ -19,6 +19,12 @@ spec:
     hello-webhook-any:
       ref:
         path: FIXTURES_TASKS_DIR/hello-webhook-any/task.yaml
+    hello-webhook-any-downgrade:
+      ref:
+        path: FIXTURES_TASKS_DIR/hello-webhook-any-downgrade/task.yaml
+    hello-webhook-any-ts:
+      ref:
+        path: FIXTURES_TASKS_DIR/hello-webhook-any-ts/task.yaml
     chain-target:
       ref:
         path: FIXTURES_TASKS_DIR/chain-target/task.yaml

--- a/tests/e2e/webhook-auth-any.spec.ts
+++ b/tests/e2e/webhook-auth-any.spec.ts
@@ -156,31 +156,35 @@ test.describe('Webhook auth: any (session OR HMAC)', () => {
 // as a live HMAC key. The fixture references DICODE_E2E_DOWNGRADE_UNSET, which
 // the harness never sets.
 test.describe('Webhook auth: any downgrade (no resolved secret)', () => {
-  test('unsigned POST, no session → denied (not run via HMAC)', async ({ request }) => {
+  test('unsigned POST, no session → 401 (not run via HMAC)', async ({ request }) => {
     const res = await request.post(DOWNGRADE_PATH, {
       headers: { 'Content-Type': 'application/json' },
       data: { via: 'unsigned' },
       maxRedirects: 0,
     });
-    // Downgraded to session: a no-session POST is rejected (401), never 200.
-    expect(res.status()).not.toBe(200);
-    expect([401, 303]).toContain(res.status());
+    // Downgraded to session → 401. A still-`any` webhook would 403 (missing sig),
+    // so 401 specifically proves the downgrade happened.
+    expect(res.status()).toBe(401);
   });
 
-  test('POST signed with the placeholder literal → denied (placeholder is not a key)', async ({ request }) => {
+  test('POST signed with the placeholder literal → 401 (placeholder is not a key)', async ({ request }) => {
     // An attacker who read the committed task.yaml signs with the public literal.
+    // A fresh timestamp is included so that, under a regression where the webhook
+    // stayed auth: any (require_timestamp still enforced), the request would reach
+    // the signature comparison and — if the literal were the live key — return 200.
+    // The downgrade makes it session-only, so the signature is moot: 401.
+    const ts = String(Math.floor(Date.now() / 1000));
     const body = JSON.stringify({ via: 'placeholder-attack' });
     const res = await request.post(DOWNGRADE_PATH, {
       headers: {
         'Content-Type': 'application/json',
-        'X-Hub-Signature-256': sign('${DICODE_E2E_DOWNGRADE_UNSET}', body),
+        'X-Dicode-Timestamp': ts,
+        'X-Hub-Signature-256': signWithTs('${DICODE_E2E_DOWNGRADE_UNSET}', ts, body),
       },
       data: JSON.parse(body),
       maxRedirects: 0,
     });
-    // The webhook is session-only now; the signature is irrelevant. Never 200.
-    expect(res.status()).not.toBe(200);
-    expect([401, 303]).toContain(res.status());
+    expect(res.status()).toBe(401);
   });
 
   test('POST with a valid session → 200 (session path still works)', async ({ request }) => {

--- a/tests/e2e/webhook-auth-any.spec.ts
+++ b/tests/e2e/webhook-auth-any.spec.ts
@@ -30,6 +30,14 @@ function sign(secret: string, body: string): string {
   return 'sha256=' + crypto.createHmac('sha256', secret).update(body).digest('hex');
 }
 
+/** HMAC over "<ts>\n<body>" — the timestamp-bound preimage (#605). */
+function signWithTs(secret: string, ts: string, body: string): string {
+  return 'sha256=' + crypto.createHmac('sha256', secret).update(ts + '\n' + body).digest('hex');
+}
+
+const DOWNGRADE_PATH = '/hooks/test-webhook-downgrade';
+const TS_PATH = '/hooks/test-webhook-ts';
+
 test.describe('Webhook auth: any (session OR HMAC)', () => {
   // ── HMAC (machine caller, no session) ──────────────────────────────────────
   test('POST with valid HMAC signature, no session → 200', async ({ request }) => {
@@ -140,5 +148,106 @@ test.describe('Webhook auth: any (session OR HMAC)', () => {
     expect(res.status()).toBe(401);
     expect(res.headers()['content-type'] ?? '').toContain('text/html');
     expect(res.headers()['location'] ?? '').toBe('');
+  });
+});
+
+// core#611 safety guard: an auth: any webhook whose secret env var is unset
+// must degrade to session-only, never serving the unresolved ${VAR} placeholder
+// as a live HMAC key. The fixture references DICODE_E2E_DOWNGRADE_UNSET, which
+// the harness never sets.
+test.describe('Webhook auth: any downgrade (no resolved secret)', () => {
+  test('unsigned POST, no session → denied (not run via HMAC)', async ({ request }) => {
+    const res = await request.post(DOWNGRADE_PATH, {
+      headers: { 'Content-Type': 'application/json' },
+      data: { via: 'unsigned' },
+      maxRedirects: 0,
+    });
+    // Downgraded to session: a no-session POST is rejected (401), never 200.
+    expect(res.status()).not.toBe(200);
+    expect([401, 303]).toContain(res.status());
+  });
+
+  test('POST signed with the placeholder literal → denied (placeholder is not a key)', async ({ request }) => {
+    // An attacker who read the committed task.yaml signs with the public literal.
+    const body = JSON.stringify({ via: 'placeholder-attack' });
+    const res = await request.post(DOWNGRADE_PATH, {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Hub-Signature-256': sign('${DICODE_E2E_DOWNGRADE_UNSET}', body),
+      },
+      data: JSON.parse(body),
+      maxRedirects: 0,
+    });
+    // The webhook is session-only now; the signature is irrelevant. Never 200.
+    expect(res.status()).not.toBe(200);
+    expect([401, 303]).toContain(res.status());
+  });
+
+  test('POST with a valid session → 200 (session path still works)', async ({ request }) => {
+    await login(request, TEST_PASSPHRASE);
+    const res = await request.post(DOWNGRADE_PATH, {
+      headers: { 'Content-Type': 'application/json' },
+      data: { via: 'session' },
+    });
+    expect(res.ok()).toBe(true);
+  });
+});
+
+// core#605: require_timestamp gate + timestamp-bound replay cache.
+test.describe('Webhook auth: any + require_timestamp', () => {
+  test('signed with a valid timestamp → 200', async ({ request }) => {
+    const ts = String(Math.floor(Date.now() / 1000));
+    const body = JSON.stringify({ via: 'ts', n: Date.now() });
+    const res = await request.post(TS_PATH, {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Dicode-Timestamp': ts,
+        'X-Hub-Signature-256': signWithTs(TEST_SECRET, ts, body),
+      },
+      data: JSON.parse(body),
+    });
+    expect(res.ok()).toBe(true);
+  });
+
+  test('body-only signature, no timestamp → 403 (require_timestamp)', async ({ request }) => {
+    const body = JSON.stringify({ via: 'no-ts' });
+    const res = await request.post(TS_PATH, {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Hub-Signature-256': sign(TEST_SECRET, body), // valid body-only sig, but no timestamp
+      },
+      data: JSON.parse(body),
+    });
+    expect(res.status()).toBe(403);
+  });
+
+  test('exact (timestamp, body) replay → second is rejected', async ({ request }) => {
+    const ts = String(Math.floor(Date.now() / 1000));
+    const body = JSON.stringify({ via: 'replay', fixed: true });
+    const headers = {
+      'Content-Type': 'application/json',
+      'X-Dicode-Timestamp': ts,
+      'X-Hub-Signature-256': signWithTs(TEST_SECRET, ts, body),
+    };
+    const first = await request.post(TS_PATH, { headers, data: JSON.parse(body) });
+    expect(first.ok()).toBe(true);
+    const second = await request.post(TS_PATH, { headers, data: JSON.parse(body) });
+    expect(second.status()).toBe(409); // duplicate (timestamp, body)
+  });
+
+  test('same body, distinct timestamps → both accepted (no false collision)', async ({ request }) => {
+    const body = JSON.stringify({ via: 'distinct-ts', fixed: true });
+    const ts1 = String(Math.floor(Date.now() / 1000));
+    const ts2 = String(Math.floor(Date.now() / 1000) + 1);
+    const r1 = await request.post(TS_PATH, {
+      headers: { 'Content-Type': 'application/json', 'X-Dicode-Timestamp': ts1, 'X-Hub-Signature-256': signWithTs(TEST_SECRET, ts1, body) },
+      data: JSON.parse(body),
+    });
+    expect(r1.ok()).toBe(true);
+    const r2 = await request.post(TS_PATH, {
+      headers: { 'Content-Type': 'application/json', 'X-Dicode-Timestamp': ts2, 'X-Hub-Signature-256': signWithTs(TEST_SECRET, ts2, body) },
+      data: JSON.parse(body),
+    });
+    expect(r2.ok(), 'distinct timestamp over identical body must not be a replay').toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

The session-OR-HMAC e2e (`webhook-auth-any.spec.ts`) covered the happy paths, but two security-critical behaviors from the relay-auth arc had only Go-unit coverage. This adds end-to-end coverage against a real daemon.

**Downgrade guard (#611)** — a new fixture (`hello-webhook-any-downgrade`) whose `webhook_secret` references `${DICODE_E2E_DOWNGRADE_UNSET}`, an env var the harness never sets. Asserts the unresolved placeholder is never served as a live HMAC key: an unsigned POST and a POST *signed with the public literal* are both denied, while the session path still works. This is the subtlest and most security-relevant behavior of #611, previously untested at the integration level.

**require_timestamp + timestamp-bound replay (#605)** — a new fixture (`hello-webhook-any-ts`) with `require_timestamp: true`. Asserts a valid `ts+body` signature passes, a body-only signature with no `X-Dicode-Timestamp` is 403, an exact `(ts, body)` replay is 409, and an identical body under two distinct timestamps is not a false collision.

Test-only: two fixtures + spec cases, no production change. Full authenticated project passes 18/18; unauthenticated + webui unaffected (100/100).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook authentication behavior when a configured secret is unavailable, safely falling back to session-only authentication.
  * Prevented unresolved secret placeholders from being accepted as valid signing keys.
  * Added timestamp validation and replay protection for signed webhook requests.

* **Tests**
  * Expanded end-to-end coverage for timestamp-bound signatures, invalid timestamps, and replayed requests.
  * Added fixtures covering webhook authentication downgrade scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->