### PR TITLE
chore(task): hash_include for shared-module content hashing (approval-gate integrity)

### DIFF
--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -1402,11 +1402,18 @@ Notes:
   change rather than a silent no-op.
 - This is moot for gate-exempt buildin tasks; it matters for **user-source**
   tasks that import a shared library the operator has approved separately.
-- Each entry is bounded to the task's **parent directory** — i.e. the
-  directory containing the task and its siblings (this is exactly the scope
-  the two examples above use: one `../` hop up, then anywhere below that).
-  An entry that tries to escape further up the filesystem (e.g.
-  `../../../../etc/passwd`) is rejected outright rather than read.
+- Each entry must resolve to a **strict descendant** of the task's parent
+  directory — i.e. somewhere under the directory containing the task and its
+  siblings, but not that directory itself (this is exactly the scope the two
+  examples above use: one `../` hop up, then anywhere below that). An entry
+  that tries to escape further up the filesystem (e.g.
+  `../../../../etc/passwd`), or that resolves to the parent directory itself
+  (e.g. bare `..`, which would pull every *other* sibling task into this
+  one's hash too), is rejected outright rather than read — including when
+  the escape only becomes visible after resolving a symlink partway through
+  the path. A task nested more than one directory below its taskset root
+  that needs to reach a shared module further up is out of scope for this
+  feature today.
 - Don't point `hash_include` at anything containing secret material. Its
   content is folded into the same digest the approval gate persists in
   `dicode.lock`, which is designed to be committed/shared — use

--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -98,6 +98,7 @@ permissions:
 | `mcp_exposed` | bool | | When `false` (default), the task is hidden from MCP `tools/list` and `tools/call`. Set to `true` to expose the task to MCP clients. |
 | `run_result` | object | | Per-task return-value persistence config — see [Suppressing return-value persistence](#suppressing-return-value-persistence) |
 | `run_result.enabled` | bool | | When `false`, the JSON return value is not written to `runs.return_value`; in-memory delivery (`dicode.run_task`, chain `input.output`) is unaffected. Default `true`. |
+| `hash_include` | list of strings | | Extra files/directories outside this task's own directory whose content should also count toward its content hash — see [Content hash and `hash_include`](#content-hash-and-hash_include) below. |
 
 ### Trigger types
 
@@ -1350,6 +1351,57 @@ permissions:
 - `task.test.js` / `task.test.ts` is optional. `dicode task test` skips tasks without it.
 - Any other files in the folder are ignored (useful for README, schema files, etc.).
 - Subdirectories are ignored — task folders are flat.
+
+These rules govern which files the **config loader** reads to build a task's
+`Spec`. The **content hash** used for change detection and the approval gate
+(see below) is a separate mechanism and does cover a task's full directory
+tree, subdirectories included — see the next section.
+
+---
+
+## Content hash and `hash_include`
+
+Every reconciler poll (~30s) computes a content hash per task and diffs it
+against the registry: an unchanged hash is a no-op, a changed hash reloads the
+task, and (when the [approval gate](./security.md#approval-lock-integrity-hmac-signed-dicodelock)
+is enabled) re-pends it for operator approval.
+
+By default the hash covers **every file recursively under the task's own
+directory** — `task.yaml`, the script, and any sibling file it imports (e.g.
+`lib/helper.ts`). This matches what's actually reachable: the Deno sandbox
+allow-reads the whole task directory and Python imports sibling modules, so
+any in-dir file is executable content whether or not the config loader itself
+reads it.
+
+That coverage stops at the directory boundary. A task that imports a **shared
+module living outside its own directory** — e.g. a sibling buildin task's
+helper library — has a blind spot: editing that module changes the code that
+runs on the task's next invocation (Deno/Python re-read the file at exec
+time), but does **not** change this task's content hash, so it silently skips
+both the reconciler reload and the approval-gate re-pend.
+
+`hash_include` closes that gap. List the extra files or directories (each
+resolved relative to the task's own directory) that the task imports from
+outside it:
+
+```yaml
+name: my-task
+hash_include:
+  - "../shared-lib/helper.ts"
+  - "../shared-lib/vendored"   # directories are walked recursively
+```
+
+Notes:
+
+- Only tasks that actually import something outside their own directory need
+  this — the default (no `hash_include`) already covers everything a normal,
+  self-contained task can reach.
+- A missing `hash_include` path (e.g. the shared module was deleted, or the
+  path has a typo) does not error the hash computation — it still folds in a
+  distinguishing marker, so the missing/mistyped path is itself a detectable
+  change rather than a silent no-op.
+- This is moot for gate-exempt buildin tasks; it matters for **user-source**
+  tasks that import a shared library the operator has approved separately.
 
 ---
 

--- a/docs/concepts/task-format.md
+++ b/docs/concepts/task-format.md
@@ -1402,6 +1402,16 @@ Notes:
   change rather than a silent no-op.
 - This is moot for gate-exempt buildin tasks; it matters for **user-source**
   tasks that import a shared library the operator has approved separately.
+- Each entry is bounded to the task's **parent directory** — i.e. the
+  directory containing the task and its siblings (this is exactly the scope
+  the two examples above use: one `../` hop up, then anywhere below that).
+  An entry that tries to escape further up the filesystem (e.g.
+  `../../../../etc/passwd`) is rejected outright rather than read.
+- Don't point `hash_include` at anything containing secret material. Its
+  content is folded into the same digest the approval gate persists in
+  `dicode.lock`, which is designed to be committed/shared — use
+  `permissions.dicode.crypto` or the secrets store for sensitive data
+  instead.
 
 ---
 

--- a/docs/design/ai-task-authoring.md
+++ b/docs/design/ai-task-authoring.md
@@ -244,7 +244,7 @@ line (1 existing file changed). A local vLLM / any OpenAI-compat = 0 code, 1 yam
 | 5 | **#571b** — drivers (`handleAI` / `/api/ai/chat` / `dicode ai`) drive suspend→resume | shipped CLI resume loop |
 | 6 | **Suspend-notify** — `suspendNotifier` on `runFinishedHook` | `approval_notify` pattern, `buildin/notify` |
 | 7 | **`task-create` + prompt-threading** — kills #288 | `auto-fix` override, `handleAI` |
-| 8 | Follow-up — `hash_include` for shared-module hash coverage | — |
+| 8 | ~~Follow-up — `hash_include` for shared-module hash coverage~~ — done (#585) | — |
 
 ## Open questions
 

--- a/pkg/approval/content_hash_test.go
+++ b/pkg/approval/content_hash_test.go
@@ -1,6 +1,8 @@
 package approval
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -344,5 +346,97 @@ func TestOverrideElevationRePend(t *testing.T) {
 				t.Fatalf("lock record changed on re-pend: %+v → %+v (ok=%v)", approvedRec, rec, ok)
 			}
 		})
+	}
+}
+
+// TestHashIncludeRePendsOnSharedModuleEdit is the approval-gate integrity
+// regression for issue #585: task.Hash only digests a task's own dir, so
+// without hash_include, editing a shared module living outside it never
+// re-pends importers even though the new code runs on next spawn (Deno
+// re-reads at exec). hash_include closes that gap end-to-end through the
+// real Gate, not just at the task.Hash unit level.
+func TestHashIncludeRePendsOnSharedModuleEdit(t *testing.T) {
+	root := t.TempDir()
+	shared := filepath.Join(root, "shared", "helper.ts")
+	if err := os.MkdirAll(filepath.Dir(shared), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(shared, []byte("export const v = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	base := writeTaskDir(t, root, "repo/importer", "import '../shared/helper.ts'")
+	withInclude := specVariant(base, func(s *task.Spec) {
+		s.HashInclude = []string{"../shared/helper.ts"}
+	})
+
+	g, arm, lock := newTestGate(t, enabledPolicy())
+	if armed, err := g.Admit(withInclude); err != nil || armed {
+		t.Fatalf("Admit initial = (%v, %v), want pending", armed, err)
+	}
+	if err := g.Approve("repo/importer"); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	approvedRec, _ := lock.Get("repo/importer")
+
+	// Edit ONLY the shared module — the task dir itself is byte-identical.
+	if err := os.WriteFile(shared, []byte("export const v = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	armed, err := g.Admit(withInclude)
+	if err != nil {
+		t.Fatalf("Admit after shared-module edit: %v", err)
+	}
+	if armed {
+		t.Fatal("editing a hash_include'd shared module must re-pend the importer, got armed")
+	}
+	if !g.IsPending("repo/importer") {
+		t.Fatal("importer not in pending set after shared-module edit")
+	}
+	if got := arm.armedIDs(); len(got) != 1 {
+		t.Fatalf("armed = %v, want only the original approval", got)
+	}
+	if rec, ok := lock.Get("repo/importer"); !ok || rec != approvedRec {
+		t.Fatalf("lock record changed on re-pend: %+v -> %+v (ok=%v)", approvedRec, rec, ok)
+	}
+}
+
+// TestWithoutHashInclude_SharedModuleEditDoesNotRePend is the control for
+// the test above: the identical edit, without hash_include configured, must
+// NOT re-pend — pinning the pre-#585 gap this feature closes, so a future
+// change can't silently make every task's approval hash-sensitive to the
+// whole filesystem (which would defeat the "operator approves the source,
+// not every transitive file" trusted-author model task.Hash documents).
+func TestWithoutHashInclude_SharedModuleEditDoesNotRePend(t *testing.T) {
+	root := t.TempDir()
+	shared := filepath.Join(root, "shared", "helper.ts")
+	if err := os.MkdirAll(filepath.Dir(shared), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(shared, []byte("export const v = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	base := writeTaskDir(t, root, "repo/importer", "import '../shared/helper.ts'")
+
+	g, _, _ := newTestGate(t, enabledPolicy())
+	if armed, err := g.Admit(base); err != nil || armed {
+		t.Fatalf("Admit initial = (%v, %v), want pending", armed, err)
+	}
+	if err := g.Approve("repo/importer"); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+
+	if err := os.WriteFile(shared, []byte("export const v = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	armed, err := g.Admit(base)
+	if err != nil {
+		t.Fatalf("Admit after shared-module edit: %v", err)
+	}
+	if !armed {
+		t.Fatal("without hash_include, a shared-module-only edit must stay armed (approval scope is dir-only by design without it)")
 	}
 }

--- a/pkg/approval/gate.go
+++ b/pkg/approval/gate.go
@@ -463,8 +463,10 @@ type resolvedPipelineSecurityFields struct {
 
 // hashDirResolved combines the task-dir hash with the canonical JSON of the
 // resolved security fields under the versioned domain prefix, NUL-delimited.
-func hashDirResolved(taskID, dir string, resolved any) (string, error) {
-	dirHash, err := task.Hash(dir)
+// hashInclude is forwarded to task.Hash unchanged — see task.Spec.HashInclude
+// (#585) for why a task may need its content hash to cover files outside dir.
+func hashDirResolved(taskID, dir string, resolved any, hashInclude ...string) (string, error) {
+	dirHash, err := task.Hash(dir, hashInclude...)
 	if err != nil {
 		return "", err
 	}
@@ -528,7 +530,7 @@ func ContentHash(k task.Kinded) (string, error) {
 				Daemon:      s.Trigger.Daemon,
 				Restart:     s.Trigger.Restart,
 				Chain:       s.Trigger.Chain,
-			})
+			}, s.HashInclude...)
 		}
 		// Dir-less fallback: hash a shallow copy with secrets stripped so the
 		// committable lock never embeds a digest over secret material.

--- a/pkg/runtime/envresolve/resolver.go
+++ b/pkg/runtime/envresolve/resolver.go
@@ -287,7 +287,7 @@ func contentHashOf(spec *task.Spec) (string, error) {
 	if spec.TaskDir == "" {
 		return "", nil
 	}
-	h, err := task.Hash(spec.TaskDir)
+	h, err := task.Hash(spec.TaskDir, spec.HashInclude...)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/task/hash.go
+++ b/pkg/task/hash.go
@@ -26,6 +26,63 @@ var heavyDirs = map[string]bool{
 	".git":         true,
 }
 
+// hashEntry is one file or symlink folded into a Hash digest. label is the
+// string written into the digest to identify the entry — for in-dir entries
+// it's the dir-relative slash path; for hash_include entries it's prefixed
+// with "include:" (see Hash) so an include can never collide with an in-dir
+// path of the same name. abs is the absolute filesystem path read to fill in
+// file content (unused for symlinks, whose target string is the content).
+type hashEntry struct {
+	label  string
+	abs    string
+	isLink bool
+	target string
+	// missing marks an include path that doesn't exist. Folded into the
+	// digest as a sentinel (rather than silently contributing nothing) so
+	// deleting or mistyping a hash_include entry still changes the hash.
+	missing bool
+}
+
+// walkTree walks root recursively (skipping heavyDirs, same rules as the
+// top-level dir walk) and appends one hashEntry per regular file or symlink,
+// labelling each with labelPrefix + the root-relative slash path. Shared by
+// Hash's own dir walk (labelPrefix "") and by hash_include directory entries
+// (labelPrefix "include:<path>/").
+func walkTree(root, labelPrefix string) ([]hashEntry, error) {
+	var entries []hashEntry
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if path != root && heavyDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		label := labelPrefix + filepath.ToSlash(rel)
+		switch {
+		case d.Type()&fs.ModeSymlink != 0:
+			target, err := os.Readlink(path)
+			if err != nil {
+				return fmt.Errorf("readlink %s: %w", path, err)
+			}
+			entries = append(entries, hashEntry{label: label, isLink: true, target: target})
+		case d.Type().IsRegular():
+			entries = append(entries, hashEntry{label: label, abs: path})
+		}
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	return entries, nil
+}
+
 // Hash computes a content hash over the regular files under dir, recursively,
 // in sorted dir-relative path order. The runtime allows the task script to
 // import any sibling file (the Deno sandbox allow-reads the whole task dir;
@@ -50,69 +107,92 @@ var heavyDirs = map[string]bool{
 // block and they carry no task content.
 //
 // A missing dir hashes like an empty one (callers race task removal).
-func Hash(dir string) (string, error) {
-	type entry struct {
-		rel    string
-		isLink bool
-		target string
-	}
-	var entries []entry
-	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			if path != dir && heavyDirs[d.Name()] {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		rel, err := filepath.Rel(dir, path)
-		if err != nil {
-			return err
-		}
-		rel = filepath.ToSlash(rel)
-		switch {
-		case d.Type()&fs.ModeSymlink != 0:
-			target, err := os.Readlink(path)
-			if err != nil {
-				return fmt.Errorf("readlink %s: %w", path, err)
-			}
-			entries = append(entries, entry{rel: rel, isLink: true, target: target})
-		case d.Type().IsRegular():
-			entries = append(entries, entry{rel: rel})
-		}
-		return nil
-	})
-	if err != nil && !os.IsNotExist(err) {
+//
+// includes (task.yaml's hash_include field) name additional files or
+// directories, each resolved relative to dir, whose content is folded into
+// the same digest — for a task that imports a shared module living outside
+// its own dir (e.g. a sibling buildin task's helper library), editing that
+// module would otherwise never perturb this task's hash and so would never
+// re-trip the reconciler reload or the #392 approval-gate re-pend (#585). A
+// directory include is walked recursively like dir itself; a file include is
+// hashed as a single entry. Each include is labelled "include:<path>[/...]"
+// in the digest so it can never collide with an in-dir path of the same
+// name, and a missing include folds in a sentinel rather than silently
+// contributing nothing, so a mistyped or deleted include path still changes
+// the hash instead of degrading to a no-op.
+func Hash(dir string, includes ...string) (string, error) {
+	entries, err := walkTree(dir, "")
+	if err != nil {
 		return "", fmt.Errorf("hash %s: %w", dir, err)
 	}
-	sort.Slice(entries, func(i, j int) bool { return entries[i].rel < entries[j].rel })
+
+	sortedIncludes := append([]string(nil), includes...)
+	sort.Strings(sortedIncludes)
+	for _, inc := range sortedIncludes {
+		if inc == "" {
+			continue
+		}
+		label := "include:" + filepath.ToSlash(inc)
+		incAbs := filepath.Join(dir, filepath.FromSlash(inc))
+		info, err := os.Lstat(incAbs)
+		if err != nil {
+			if os.IsNotExist(err) {
+				entries = append(entries, hashEntry{label: label, missing: true})
+				continue
+			}
+			return "", fmt.Errorf("hash include %s: %w", inc, err)
+		}
+		switch {
+		case info.Mode()&fs.ModeSymlink != 0:
+			target, err := os.Readlink(incAbs)
+			if err != nil {
+				return "", fmt.Errorf("hash include %s: readlink: %w", inc, err)
+			}
+			entries = append(entries, hashEntry{label: label, isLink: true, target: target})
+		case info.IsDir():
+			sub, err := walkTree(incAbs, label+"/")
+			if err != nil {
+				return "", fmt.Errorf("hash include %s: %w", inc, err)
+			}
+			entries = append(entries, sub...)
+		default:
+			entries = append(entries, hashEntry{label: label, abs: incAbs})
+		}
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].label < entries[j].label })
 
 	h := sha256.New()
 	for _, e := range entries {
-		// Path and kind act as separators so hash(A+B) != hash(AB) and a
+		// Label and kind act as separators so hash(A+B) != hash(AB) and a
 		// regular file can never collide with a link whose target holds the
 		// same bytes.
 		kind := byte('f')
-		if e.isLink {
+		switch {
+		case e.isLink:
 			kind = 'l'
+		case e.missing:
+			kind = 'm'
 		}
-		fmt.Fprintf(h, "%s\x00%c\x00", e.rel, kind)
-		if e.isLink {
+		fmt.Fprintf(h, "%s\x00%c\x00", e.label, kind)
+		switch {
+		case e.isLink:
 			h.Write([]byte(e.target))
-		} else {
-			abs := filepath.Join(dir, filepath.FromSlash(e.rel))
-			info, err := os.Stat(abs)
+		case e.missing:
+			// No content to fold in beyond the label+kind separator above —
+			// that alone is enough to make a missing include distinguishable
+			// from both "not configured" and "present with any content".
+		default:
+			info, err := os.Stat(e.abs)
 			if err != nil {
-				return "", fmt.Errorf("hash %s: %w", abs, err)
+				return "", fmt.Errorf("hash %s: %w", e.abs, err)
 			}
 			if info.Size() > maxHashedFileBytes {
 				fmt.Fprintf(h, "%d\x00%d", info.Size(), info.ModTime().UnixNano())
 			} else {
-				data, err := os.ReadFile(abs)
+				data, err := os.ReadFile(e.abs)
 				if err != nil {
-					return "", fmt.Errorf("hash %s: %w", abs, err)
+					return "", fmt.Errorf("hash %s: %w", e.abs, err)
 				}
 				h.Write(data)
 			}

--- a/pkg/task/hash.go
+++ b/pkg/task/hash.go
@@ -75,19 +75,35 @@ func walkTree(root, labelPrefix string) ([]hashEntry, error) {
 			}
 			return nil
 		}
+		// Classify via a real stat (d.Info(), backed by Lstat), not
+		// d.Type(): the latter comes straight from the raw directory entry
+		// with no syscall, and on filesystems that don't populate d_type
+		// (DT_UNKNOWN — some FUSE/NFS mounts, older XFS configurations) Go
+		// reports it as 0, which is indistinguishable from "regular file" —
+		// IsRegular() would then wrongly accept a FIFO/socket/device for
+		// os.ReadFile below, which can block indefinitely on a FIFO with no
+		// writer. d.Info() is cached by the walker per entry, so this isn't
+		// an extra syscall over what a portable classification requires.
+		info, err := d.Info()
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil // vanished mid-walk (race) — skip, don't fail the scan
+			}
+			return err
+		}
 		rel, err := filepath.Rel(root, path)
 		if err != nil {
 			return err
 		}
 		label := labelPrefix + filepath.ToSlash(rel)
 		switch {
-		case d.Type()&fs.ModeSymlink != 0:
+		case info.Mode()&fs.ModeSymlink != 0:
 			target, err := os.Readlink(path)
 			if err != nil {
 				return fmt.Errorf("readlink %s: %w", path, err)
 			}
 			entries = append(entries, hashEntry{label: label, isLink: true, target: target})
-		case d.Type().IsRegular():
+		case info.Mode().IsRegular():
 			entries = append(entries, hashEntry{label: label, abs: path})
 		}
 		return nil
@@ -135,14 +151,41 @@ func resolveInclude(absDir, boundary, inc string) (string, error) {
 		return "", fmt.Errorf("hash_include %q escapes %s — hash_include may only reference paths strictly within the task's parent directory (sibling tasks/libraries), not arbitrary host paths", inc, boundary)
 	}
 
-	within, err := pathguard.WithinResolved(boundary, candidate)
+	// Resolve every symlink in the path — including a top-level one AT
+	// candidate itself — before using it for anything, and return that
+	// resolved path rather than the lexical one. This closes two gaps at
+	// once, both only reachable through a real symlink on disk:
+	//  1. A git-committed symlink INSIDE the boundary that physically
+	//     redirects outside it (go-git materializes repo-committed
+	//     symlinks as real on-disk links) would otherwise pass the purely
+	//     lexical check above.
+	//  2. If the include entry itself names a symlink (an alias to the
+	//     real shared file/dir), Hash operating on the resolved real path
+	//     — instead of the symlink's target STRING the way an ordinary
+	//     in-dir symlink is treated — means editing the content behind it
+	//     actually changes the digest. hash_include's whole purpose is
+	//     detecting edits to a module living outside dir; a symlink
+	//     indirection to that module must not reopen the exact gap the
+	//     feature exists to close.
+	// Inlines pathguard.WithinResolved (rather than calling it directly) so
+	// the resolved path it computes internally can be returned to the
+	// caller instead of discarded.
+	realBoundary, err := filepath.EvalSymlinks(filepath.Clean(boundary))
+	if err != nil {
+		return "", fmt.Errorf("hash_include %q: %w", inc, err)
+	}
+	realCandidate, err := pathguard.ResolveExisting(candidate)
+	if err != nil {
+		return "", fmt.Errorf("hash_include %q: %w", inc, err)
+	}
+	within, err := pathguard.Within(realBoundary, realCandidate)
 	if err != nil {
 		return "", fmt.Errorf("hash_include %q: %w", inc, err)
 	}
 	if !within {
 		return "", fmt.Errorf("hash_include %q resolves outside %s through a symlink", inc, boundary)
 	}
-	return candidate, nil
+	return realCandidate, nil
 }
 
 // Hash computes a content hash over the regular files under dir, recursively,

--- a/pkg/task/hash.go
+++ b/pkg/task/hash.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 // maxHashedFileBytes bounds the contents read into the digest per file. The
@@ -83,6 +84,33 @@ func walkTree(root, labelPrefix string) ([]hashEntry, error) {
 	return entries, nil
 }
 
+// resolveInclude validates and resolves a single hash_include entry against
+// dir, returning the absolute path Hash may safely read.
+//
+// includes are meant to reach a *sibling* task's file (see the Hash doc
+// comment's "shared buildin helper library" example) — never an arbitrary
+// host path. So the resolved path is required to stay within dir's parent
+// directory (the directory containing dir and its siblings): this bounds
+// "../" traversal to exactly the sibling-task scope the feature is for,
+// instead of letting a task.yaml author's hash_include value walk arbitrarily
+// far up the filesystem (e.g. "../../../../etc/shadow") to read and fold
+// host files having nothing to do with the taskset into the digest. The
+// check runs before any filesystem call touches the resolved path, so an
+// out-of-bounds entry is rejected rather than stat'd/read/walked.
+func resolveInclude(dir, inc string) (string, error) {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s: %w", dir, err)
+	}
+	boundary := filepath.Dir(absDir)
+	abs := filepath.Clean(filepath.Join(absDir, filepath.FromSlash(inc)))
+	rel, err := filepath.Rel(boundary, abs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("hash_include %q escapes %s — hash_include may only reference paths within the task's parent directory (sibling tasks/libraries), not arbitrary host paths", inc, boundary)
+	}
+	return abs, nil
+}
+
 // Hash computes a content hash over the regular files under dir, recursively,
 // in sorted dir-relative path order. The runtime allows the task script to
 // import any sibling file (the Deno sandbox allow-reads the whole task dir;
@@ -120,6 +148,16 @@ func walkTree(root, labelPrefix string) ([]hashEntry, error) {
 // name, and a missing include folds in a sentinel rather than silently
 // contributing nothing, so a mistyped or deleted include path still changes
 // the hash instead of degrading to a no-op.
+//
+// Each include is resolved via resolveInclude, which bounds it to dir's
+// parent directory (the sibling-task scope this feature is for) — an entry
+// that tries to escape that boundary (e.g. "../../../../etc/shadow") is
+// rejected with an error rather than read. Content folded in via
+// hash_include still flows into the hash the approval gate persists in
+// dicode.lock (a file its own doc comment documents as committable/shared —
+// see pkg/approval/lock.go), so hash_include must never be pointed at a path
+// containing secret material: prefer permissions.dicode.crypto / the secrets
+// store for anything sensitive.
 func Hash(dir string, includes ...string) (string, error) {
 	entries, err := walkTree(dir, "")
 	if err != nil {
@@ -133,7 +171,10 @@ func Hash(dir string, includes ...string) (string, error) {
 			continue
 		}
 		label := "include:" + filepath.ToSlash(inc)
-		incAbs := filepath.Join(dir, filepath.FromSlash(inc))
+		incAbs, err := resolveInclude(dir, inc)
+		if err != nil {
+			return "", err
+		}
 		info, err := os.Lstat(incAbs)
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/pkg/task/hash.go
+++ b/pkg/task/hash.go
@@ -9,6 +9,9 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/dicode/dicode/internal/pathguard"
+	"gopkg.in/yaml.v3"
 )
 
 // maxHashedFileBytes bounds the contents read into the digest per file. The
@@ -30,8 +33,11 @@ var heavyDirs = map[string]bool{
 // hashEntry is one file or symlink folded into a Hash digest. label is the
 // string written into the digest to identify the entry — for in-dir entries
 // it's the dir-relative slash path; for hash_include entries it's prefixed
-// with "include:" (see Hash) so an include can never collide with an in-dir
-// path of the same name. abs is the absolute filesystem path read to fill in
+// with "include:" (see Hash) so an include is extremely unlikely to collide
+// with an in-dir path of the same name (only possible if a real file's own
+// name literally starts with "include:", which the label+kind-separated
+// digest still doesn't corrupt — it just means both entries fold into the
+// same label bucket). abs is the absolute filesystem path read to fill in
 // file content (unused for symlinks, whose target string is the content).
 type hashEntry struct {
 	label  string
@@ -42,6 +48,14 @@ type hashEntry struct {
 	// digest as a sentinel (rather than silently contributing nothing) so
 	// deleting or mistyping a hash_include entry still changes the hash.
 	missing bool
+	// info, when non-nil, is the os.FileInfo already obtained while
+	// classifying a hash_include entry (via os.Lstat, on a confirmed
+	// non-symlink path — so it's identical to what os.Stat would return).
+	// Reused by the hashing loop below to avoid a second stat syscall on the
+	// same path. In-dir entries from walkTree leave this nil (WalkDir's
+	// fs.DirEntry doesn't carry a size), so they still take that loop's
+	// single os.Stat.
+	info os.FileInfo
 }
 
 // walkTree walks root recursively (skipping heavyDirs, same rules as the
@@ -85,30 +99,50 @@ func walkTree(root, labelPrefix string) ([]hashEntry, error) {
 }
 
 // resolveInclude validates and resolves a single hash_include entry against
-// dir, returning the absolute path Hash may safely read.
+// absDir (dir's absolute form) and boundary (absDir's parent — see Hash),
+// returning the absolute path Hash may safely read.
 //
 // includes are meant to reach a *sibling* task's file (see the Hash doc
 // comment's "shared buildin helper library" example) — never an arbitrary
-// host path. So the resolved path is required to stay within dir's parent
-// directory (the directory containing dir and its siblings): this bounds
-// "../" traversal to exactly the sibling-task scope the feature is for,
-// instead of letting a task.yaml author's hash_include value walk arbitrarily
-// far up the filesystem (e.g. "../../../../etc/shadow") to read and fold
-// host files having nothing to do with the taskset into the digest. The
-// check runs before any filesystem call touches the resolved path, so an
-// out-of-bounds entry is rejected rather than stat'd/read/walked.
-func resolveInclude(dir, inc string) (string, error) {
-	absDir, err := filepath.Abs(dir)
+// host path, and never dir's own parent directory itself (which would pull
+// every OTHER sibling task in the taskset into this one's digest, not just
+// the intended sibling). So the resolved path is required to be a STRICT
+// descendant of boundary: this bounds "../" traversal to exactly the
+// sibling-task scope the feature is for, instead of letting a task.yaml
+// author's hash_include value walk arbitrarily far up the filesystem (e.g.
+// "../../../../etc/shadow", or bare ".." to pull in the whole taskset) to
+// read and fold host files having nothing to do with the taskset into the
+// digest.
+//
+// The lexical check alone isn't sufficient: go-git materializes
+// repo-committed symlinks as real on-disk links (see internal/pathguard's
+// doc comment), so a git-committed symlink *inside* the boundary could
+// physically redirect an in-bounds-looking include somewhere else entirely
+// (e.g. tasks/buildin/evil-link -> /etc, then hash_include:
+// ["../evil-link/passwd"] is lexically inside tasks/buildin/ but physically
+// reads /etc/passwd). pathguard.WithinResolved — the same helper
+// pkg/trigger/webhook.go and pkg/webui/task_delete.go already use for this
+// exact git-sourced-symlink class of bug — canonicalizes symlinks on both
+// sides before the containment check, closing that gap.
+//
+// Both checks run before any filesystem read touches the resolved path, so
+// an out-of-bounds entry is rejected rather than stat'd/read/walked.
+func resolveInclude(absDir, boundary, inc string) (string, error) {
+	candidate := filepath.Clean(filepath.Join(absDir, filepath.FromSlash(inc)))
+
+	rel, err := filepath.Rel(boundary, candidate)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("hash_include %q escapes %s — hash_include may only reference paths strictly within the task's parent directory (sibling tasks/libraries), not arbitrary host paths", inc, boundary)
+	}
+
+	within, err := pathguard.WithinResolved(boundary, candidate)
 	if err != nil {
-		return "", fmt.Errorf("resolve %s: %w", dir, err)
+		return "", fmt.Errorf("hash_include %q: %w", inc, err)
 	}
-	boundary := filepath.Dir(absDir)
-	abs := filepath.Clean(filepath.Join(absDir, filepath.FromSlash(inc)))
-	rel, err := filepath.Rel(boundary, abs)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("hash_include %q escapes %s — hash_include may only reference paths within the task's parent directory (sibling tasks/libraries), not arbitrary host paths", inc, boundary)
+	if !within {
+		return "", fmt.Errorf("hash_include %q resolves outside %s through a symlink", inc, boundary)
 	}
-	return abs, nil
+	return candidate, nil
 }
 
 // Hash computes a content hash over the regular files under dir, recursively,
@@ -144,60 +178,81 @@ func resolveInclude(dir, inc string) (string, error) {
 // re-trip the reconciler reload or the #392 approval-gate re-pend (#585). A
 // directory include is walked recursively like dir itself; a file include is
 // hashed as a single entry. Each include is labelled "include:<path>[/...]"
-// in the digest so it can never collide with an in-dir path of the same
-// name, and a missing include folds in a sentinel rather than silently
+// in the digest so it is extremely unlikely to collide with an in-dir path
+// of the same name (see hashEntry's doc comment), and a missing include
+// folds in a sentinel rather than silently
 // contributing nothing, so a mistyped or deleted include path still changes
 // the hash instead of degrading to a no-op.
 //
-// Each include is resolved via resolveInclude, which bounds it to dir's
-// parent directory (the sibling-task scope this feature is for) — an entry
-// that tries to escape that boundary (e.g. "../../../../etc/shadow") is
-// rejected with an error rather than read. Content folded in via
-// hash_include still flows into the hash the approval gate persists in
-// dicode.lock (a file its own doc comment documents as committable/shared —
-// see pkg/approval/lock.go), so hash_include must never be pointed at a path
-// containing secret material: prefer permissions.dicode.crypto / the secrets
-// store for anything sensitive.
+// Each include is resolved via resolveInclude, which bounds it to a STRICT
+// descendant of dir's parent directory (the sibling-task scope this feature
+// is for) — an entry that tries to escape that boundary (e.g.
+// "../../../../etc/shadow", or bare ".." itself, which would otherwise pull
+// in every sibling task in the taskset) is rejected with an error rather
+// than read. Content folded in via hash_include still flows into the hash
+// the approval gate persists in dicode.lock (a file its own doc comment
+// documents as committable/shared — see pkg/approval/lock.go), so
+// hash_include must never be pointed at a path containing secret material:
+// prefer permissions.dicode.crypto / the secrets store for anything
+// sensitive.
+//
+// hash_include is deliberately scoped to exactly one directory level above
+// dir (immediate siblings) — the design doc's own motivating example (a
+// sibling buildin task's shared helper module) is one hop, and it keeps the
+// boundary a single, auditable rule instead of an arbitrary depth. A task
+// nested more than one level below its taskset root that needs to reach a
+// shared module further up is out of scope for this feature today.
 func Hash(dir string, includes ...string) (string, error) {
 	entries, err := walkTree(dir, "")
 	if err != nil {
 		return "", fmt.Errorf("hash %s: %w", dir, err)
 	}
 
-	sortedIncludes := append([]string(nil), includes...)
-	sort.Strings(sortedIncludes)
-	for _, inc := range sortedIncludes {
-		if inc == "" {
-			continue
-		}
-		label := "include:" + filepath.ToSlash(inc)
-		incAbs, err := resolveInclude(dir, inc)
+	if len(includes) > 0 {
+		absDir, err := filepath.Abs(dir)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("resolve %s: %w", dir, err)
 		}
-		info, err := os.Lstat(incAbs)
-		if err != nil {
-			if os.IsNotExist(err) {
-				entries = append(entries, hashEntry{label: label, missing: true})
+		boundary := filepath.Dir(absDir)
+
+		for _, inc := range includes {
+			if inc == "" {
 				continue
 			}
-			return "", fmt.Errorf("hash include %s: %w", inc, err)
-		}
-		switch {
-		case info.Mode()&fs.ModeSymlink != 0:
-			target, err := os.Readlink(incAbs)
+			label := "include:" + filepath.ToSlash(inc)
+			incAbs, err := resolveInclude(absDir, boundary, inc)
 			if err != nil {
-				return "", fmt.Errorf("hash include %s: readlink: %w", inc, err)
+				return "", err
 			}
-			entries = append(entries, hashEntry{label: label, isLink: true, target: target})
-		case info.IsDir():
-			sub, err := walkTree(incAbs, label+"/")
+			info, err := os.Lstat(incAbs)
 			if err != nil {
+				if os.IsNotExist(err) {
+					entries = append(entries, hashEntry{label: label, missing: true})
+					continue
+				}
 				return "", fmt.Errorf("hash include %s: %w", inc, err)
 			}
-			entries = append(entries, sub...)
-		default:
-			entries = append(entries, hashEntry{label: label, abs: incAbs})
+			switch {
+			case info.Mode()&fs.ModeSymlink != 0:
+				target, err := os.Readlink(incAbs)
+				if err != nil {
+					return "", fmt.Errorf("hash include %s: readlink: %w", inc, err)
+				}
+				entries = append(entries, hashEntry{label: label, isLink: true, target: target})
+			case info.IsDir():
+				sub, err := walkTree(incAbs, label+"/")
+				if err != nil {
+					return "", fmt.Errorf("hash include %s: %w", inc, err)
+				}
+				entries = append(entries, sub...)
+			case info.Mode().IsRegular():
+				entries = append(entries, hashEntry{label: label, abs: incAbs, info: info})
+			default:
+				// Socket, device, FIFO, etc. — skip, matching walkTree's
+				// handling of the same types encountered during a normal
+				// dir walk: reading them can block indefinitely (e.g. a
+				// FIFO with no writer), and they carry no task content.
+			}
 		}
 	}
 
@@ -224,9 +279,18 @@ func Hash(dir string, includes ...string) (string, error) {
 			// that alone is enough to make a missing include distinguishable
 			// from both "not configured" and "present with any content".
 		default:
-			info, err := os.Stat(e.abs)
-			if err != nil {
-				return "", fmt.Errorf("hash %s: %w", e.abs, err)
+			// Reuse the FileInfo already obtained while classifying a
+			// hash_include entry (identical to what os.Stat would return,
+			// since we confirmed it's not a symlink) instead of stat'ing the
+			// same path a second time. In-dir entries from walkTree never
+			// have one cached — they take the os.Stat below as before.
+			info := e.info
+			if info == nil {
+				var statErr error
+				info, statErr = os.Stat(e.abs)
+				if statErr != nil {
+					return "", fmt.Errorf("hash %s: %w", e.abs, statErr)
+				}
 			}
 			if info.Size() > maxHashedFileBytes {
 				fmt.Fprintf(h, "%d\x00%d", info.Size(), info.ModTime().UnixNano())
@@ -246,6 +310,14 @@ func Hash(dir string, includes ...string) (string, error) {
 
 // ScanDir scans the tasks/ directory in a repo and returns a map of
 // taskID → content hash for all valid task directories.
+//
+// This is the change-detection primitive for the flat local/git source
+// types (pkg/source/local, pkg/source/git) — unlike pkg/taskset/source.go's
+// resolver-based Source, it never fully loads a task.Spec (LoadDirWithVars),
+// only checking that task.yaml exists. So a task's hash_include list (#585)
+// has to be read separately here via readHashInclude — a best-effort partial
+// parse, not the full loader — or hash_include would silently do nothing for
+// any task registered through these two source types.
 func ScanDir(tasksDir string) (map[string]string, error) {
 	entries, err := os.ReadDir(tasksDir)
 	if err != nil {
@@ -261,15 +333,38 @@ func ScanDir(tasksDir string) (map[string]string, error) {
 			continue
 		}
 		dir := filepath.Join(tasksDir, e.Name())
+		yamlPath := filepath.Join(dir, "task.yaml")
 		// skip directories that don't contain task.yaml
-		if _, err := os.Stat(filepath.Join(dir, "task.yaml")); os.IsNotExist(err) {
+		if _, err := os.Stat(yamlPath); os.IsNotExist(err) {
 			continue
 		}
-		hash, err := Hash(dir)
+		hash, err := Hash(dir, readHashInclude(yamlPath)...)
 		if err != nil {
 			return nil, err
 		}
 		result[e.Name()] = hash
 	}
 	return result, nil
+}
+
+// readHashInclude does a lenient, minimal parse of yamlPath's hash_include
+// field only — every other field, and any parse/read failure, is ignored
+// (returns nil). ScanDir must tolerate an in-progress or otherwise invalid
+// edit without aborting the whole reconciler scan the way the full loader
+// (LoadDirWithVars) is allowed to fail loudly; a task.yaml this function
+// can't parse just means "no includes counted this poll" — the task's own
+// dir hash still reflects the edit, and the full loader reports the real
+// error once the reconciler actually tries to load it.
+func readHashInclude(yamlPath string) []string {
+	data, err := os.ReadFile(yamlPath)
+	if err != nil {
+		return nil
+	}
+	var probe struct {
+		HashInclude []string `yaml:"hash_include"`
+	}
+	if err := yaml.Unmarshal(data, &probe); err != nil {
+		return nil
+	}
+	return probe.HashInclude
 }

--- a/pkg/task/hash_test.go
+++ b/pkg/task/hash_test.go
@@ -781,3 +781,51 @@ func TestHash_IncludeOrderIndependent(t *testing.T) {
 		t.Fatalf("include order changed the hash: %q vs %q", forward, reverse)
 	}
 }
+
+// TestHash_IncludeEscapingSiblingScopeIsRejected is the path-traversal
+// regression: hash_include must not be able to walk arbitrarily far up the
+// filesystem to read host files unrelated to the taskset (e.g. "/etc/passwd"
+// via enough "../" hops) — it is bounded to dir's parent directory (the
+// sibling-task scope the feature exists for). Reported by CodeQL as
+// "Uncontrolled data used in path expression" against the pre-fix code.
+func TestHash_IncludeEscapingSiblingScopeIsRejected(t *testing.T) {
+	// tasksRoot/task-a is the task dir; tasksRoot/../outside sits one level
+	// above tasksRoot itself, i.e. two hops up from task-a — outside the
+	// sibling-task boundary (tasksRoot).
+	parent := t.TempDir()
+	tasksRoot := filepath.Join(parent, "tasks-root")
+	outside := filepath.Join(parent, "outside")
+	if err := os.MkdirAll(outside, 0755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("host-secret"), 0644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+
+	dir := filepath.Join(tasksRoot, "task-a")
+	writeTaskFiles(t, dir, "name: a\n", "js")
+
+	_, err := Hash(dir, "../../outside/secret.txt")
+	if err == nil {
+		t.Fatal("Hash allowed a hash_include entry to escape the sibling-task boundary — path traversal not rejected")
+	}
+}
+
+// TestHash_IncludeWithinSiblingScopeStillAllowed is the control for the test
+// above: a "../" that stays within the sibling-task boundary (one hop up,
+// into a sibling of dir) must still be accepted — this is the feature's
+// entire purpose (a sibling buildin task's shared helper library).
+func TestHash_IncludeWithinSiblingScopeStillAllowed(t *testing.T) {
+	tasksRoot := t.TempDir()
+	sibling := filepath.Join(tasksRoot, "sibling.ts")
+	if err := os.WriteFile(sibling, []byte("shared"), 0644); err != nil {
+		t.Fatalf("write sibling: %v", err)
+	}
+
+	dir := filepath.Join(tasksRoot, "task-a")
+	writeTaskFiles(t, dir, "name: a\n", "js")
+
+	if _, err := Hash(dir, "../sibling.ts"); err != nil {
+		t.Fatalf("Hash rejected an in-bounds sibling include: %v", err)
+	}
+}

--- a/pkg/task/hash_test.go
+++ b/pkg/task/hash_test.go
@@ -596,3 +596,188 @@ func TestScanDir_SkipsDirsWithoutTaskYaml(t *testing.T) {
 		t.Errorf("scratch dir without task.yaml should not register")
 	}
 }
+
+// ── hash_include (#585) ─────────────────────────────────────────────────
+
+// TestHash_IncludeFileEditChangesHash is the core regression gate for #585:
+// a shared module living outside the task dir must perturb the hash when
+// edited, as long as it's named in includes — otherwise the approval gate
+// never re-pends importers of a changed shared module.
+func TestHash_IncludeFileEditChangesHash(t *testing.T) {
+	root := t.TempDir()
+	shared := filepath.Join(root, "shared", "chat.ts")
+	if err := os.MkdirAll(filepath.Dir(shared), 0755); err != nil {
+		t.Fatalf("mkdir shared: %v", err)
+	}
+	if err := os.WriteFile(shared, []byte("export const v = 1\n"), 0644); err != nil {
+		t.Fatalf("write shared v1: %v", err)
+	}
+
+	dir := filepath.Join(root, "task-a")
+	writeTaskFiles(t, dir, "name: a\nhash_include: [\"../shared/chat.ts\"]\n", "import '../shared/chat.ts'\n")
+
+	before, err := Hash(dir, "../shared/chat.ts")
+	if err != nil {
+		t.Fatalf("before: %v", err)
+	}
+	if err := os.WriteFile(shared, []byte("export const v = 2\n"), 0644); err != nil {
+		t.Fatalf("rewrite shared: %v", err)
+	}
+	after, err := Hash(dir, "../shared/chat.ts")
+	if err != nil {
+		t.Fatalf("after: %v", err)
+	}
+	if before == after {
+		t.Fatalf("Hash ignored an edit to an included shared module: before == after == %q", before)
+	}
+}
+
+// TestHash_WithoutInclude_SharedModuleEditInvisible is the control for the
+// test above: without hash_include, the same edit to the same shared module
+// must NOT change the hash — this is the pre-#585 hole the feature closes,
+// pinned here so a future refactor can't silently make Hash always walk
+// outward (which would break the "sandbox only reads TaskDir" invariant).
+func TestHash_WithoutInclude_SharedModuleEditInvisible(t *testing.T) {
+	root := t.TempDir()
+	shared := filepath.Join(root, "shared", "chat.ts")
+	if err := os.MkdirAll(filepath.Dir(shared), 0755); err != nil {
+		t.Fatalf("mkdir shared: %v", err)
+	}
+	if err := os.WriteFile(shared, []byte("export const v = 1\n"), 0644); err != nil {
+		t.Fatalf("write shared v1: %v", err)
+	}
+
+	dir := filepath.Join(root, "task-a")
+	writeTaskFiles(t, dir, "name: a\n", "import '../shared/chat.ts'\n")
+
+	before, err := Hash(dir) // no includes
+	if err != nil {
+		t.Fatalf("before: %v", err)
+	}
+	if err := os.WriteFile(shared, []byte("export const v = 2\n"), 0644); err != nil {
+		t.Fatalf("rewrite shared: %v", err)
+	}
+	after, err := Hash(dir)
+	if err != nil {
+		t.Fatalf("after: %v", err)
+	}
+	if before != after {
+		t.Fatalf("Hash without includes unexpectedly saw an out-of-dir edit: %q -> %q", before, after)
+	}
+}
+
+// TestHash_IncludeDirWalkedRecursively covers a directory include: every
+// file under it participates in the digest, not just the top level.
+func TestHash_IncludeDirWalkedRecursively(t *testing.T) {
+	root := t.TempDir()
+	sharedDir := filepath.Join(root, "shared")
+	nested := filepath.Join(sharedDir, "nested")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "deep.ts"), []byte("v1"), 0644); err != nil {
+		t.Fatalf("write deep.ts: %v", err)
+	}
+
+	dir := filepath.Join(root, "task-a")
+	writeTaskFiles(t, dir, "name: a\n", "js")
+
+	before, err := Hash(dir, "../shared")
+	if err != nil {
+		t.Fatalf("before: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "deep.ts"), []byte("v2"), 0644); err != nil {
+		t.Fatalf("rewrite deep.ts: %v", err)
+	}
+	after, err := Hash(dir, "../shared")
+	if err != nil {
+		t.Fatalf("after: %v", err)
+	}
+	if before == after {
+		t.Fatalf("Hash ignored an edit nested inside a directory include: before == after == %q", before)
+	}
+}
+
+// TestHash_MissingIncludeFoldsSentinel_NotError: a hash_include path that
+// doesn't exist (deleted shared module, typo) must not error the hash — the
+// reconciler runs Hash on every poll and a hard error there would break
+// change-detection for the whole task — but it must still perturb the
+// digest relative to "include not configured at all", so a deleted include
+// is itself a detectable change rather than a silent no-op.
+func TestHash_MissingIncludeFoldsSentinel_NotError(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "task-a")
+	writeTaskFiles(t, dir, "name: a\n", "js")
+
+	withMissingInclude, err := Hash(dir, "../nonexistent/module.ts")
+	if err != nil {
+		t.Fatalf("Hash errored on a missing include: %v", err)
+	}
+	withoutInclude, err := Hash(dir)
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	if withMissingInclude == withoutInclude {
+		t.Fatalf("a missing include produced the same hash as no include at all: %q", withMissingInclude)
+	}
+}
+
+// TestHash_IncludeLabelDoesNotCollideWithInDirFile: an include path and an
+// in-dir file of the same base name must not be hashed as the same digest
+// contribution — the "include:" label prefix exists precisely to keep these
+// two namespaces distinct (see the Hash doc comment).
+func TestHash_IncludeLabelDoesNotCollideWithInDirFile(t *testing.T) {
+	root := t.TempDir()
+	shared := filepath.Join(root, "shared.ts")
+	if err := os.WriteFile(shared, []byte("shared-content"), 0644); err != nil {
+		t.Fatalf("write shared: %v", err)
+	}
+
+	// Task with an in-dir file literally named "shared.ts" plus an include of
+	// the same base name pointing outside — these must be treated as two
+	// independent entries in the digest, not merged/aliased.
+	dir := filepath.Join(root, "task-a")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "shared.ts"), []byte("in-dir-content"), 0644); err != nil {
+		t.Fatalf("write in-dir shared.ts: %v", err)
+	}
+
+	withInclude, err := Hash(dir, "../shared.ts")
+	if err != nil {
+		t.Fatalf("withInclude: %v", err)
+	}
+	withoutInclude, err := Hash(dir)
+	if err != nil {
+		t.Fatalf("withoutInclude: %v", err)
+	}
+	if withInclude == withoutInclude {
+		t.Fatalf("including an out-of-dir file with the same base name as an in-dir file was a no-op: %q", withInclude)
+	}
+}
+
+// TestHash_IncludeOrderIndependent: includes are sorted before hashing, so
+// declaring them in a different order in task.yaml must not change the hash
+// — otherwise reordering an unrelated list would spuriously re-pend approval.
+func TestHash_IncludeOrderIndependent(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"one.ts", "two.ts"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(name), 0644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	dir := filepath.Join(root, "task-a")
+	writeTaskFiles(t, dir, "name: a\n", "js")
+
+	forward, err := Hash(dir, "../one.ts", "../two.ts")
+	if err != nil {
+		t.Fatalf("forward: %v", err)
+	}
+	reverse, err := Hash(dir, "../two.ts", "../one.ts")
+	if err != nil {
+		t.Fatalf("reverse: %v", err)
+	}
+	if forward != reverse {
+		t.Fatalf("include order changed the hash: %q vs %q", forward, reverse)
+	}
+}

--- a/pkg/task/hash_test.go
+++ b/pkg/task/hash_test.go
@@ -957,3 +957,116 @@ func TestScanDir_HonorsHashInclude(t *testing.T) {
 		t.Fatalf("ScanDir ignored an edit to a hash_include'd shared module: before == after == %q", before["task-a"])
 	}
 }
+
+// TestHash_IncludeSymlinkTargetContentIsHashed is the regression for a
+// finding caught in review: when the hash_include entry ITSELF is a
+// symlink (an alias to the real shared file), resolveInclude now resolves
+// through it and hashes the REAL target's content — unlike an ordinary
+// in-dir symlink (TestHash_SymlinkTargetStringHashed_NotFollowed), which
+// deliberately hashes only the target string. If it didn't, editing the
+// content behind an included symlink would reopen the exact gap
+// hash_include exists to close (#585): the code that actually runs would
+// change on next spawn without the hash ever reflecting it.
+func TestHash_IncludeSymlinkTargetContentIsHashed(t *testing.T) {
+	tasksRoot := t.TempDir()
+	real := filepath.Join(tasksRoot, "real.ts")
+	if err := os.WriteFile(real, []byte("v1"), 0644); err != nil {
+		t.Fatalf("write real: %v", err)
+	}
+	alias := filepath.Join(tasksRoot, "alias.ts")
+	if err := os.Symlink(real, alias); err != nil {
+		t.Skipf("symlinks unsupported here: %v", err)
+	}
+
+	dir := filepath.Join(tasksRoot, "task-a")
+	writeTaskFiles(t, dir, "name: a\n", "js")
+
+	before, err := Hash(dir, "../alias.ts")
+	if err != nil {
+		t.Fatalf("before: %v", err)
+	}
+	if err := os.WriteFile(real, []byte("v2"), 0644); err != nil {
+		t.Fatalf("rewrite real: %v", err)
+	}
+	after, err := Hash(dir, "../alias.ts")
+	if err != nil {
+		t.Fatalf("after: %v", err)
+	}
+	if before == after {
+		t.Fatalf("Hash ignored a content edit behind a hash_include symlink alias: before == after == %q", before)
+	}
+}
+
+// TestHash_IncludeSymlinkDirTargetContentIsHashed is the directory-include
+// counterpart of the test above: the include entry is a symlink TO A
+// DIRECTORY, and a file edited inside the real directory (reached only
+// through the symlink) must still change the hash.
+func TestHash_IncludeSymlinkDirTargetContentIsHashed(t *testing.T) {
+	tasksRoot := t.TempDir()
+	realDir := filepath.Join(tasksRoot, "real-shared")
+	if err := os.MkdirAll(realDir, 0755); err != nil {
+		t.Fatalf("mkdir realDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(realDir, "helper.ts"), []byte("v1"), 0644); err != nil {
+		t.Fatalf("write helper: %v", err)
+	}
+	aliasDir := filepath.Join(tasksRoot, "alias-shared")
+	if err := os.Symlink(realDir, aliasDir); err != nil {
+		t.Skipf("symlinks unsupported here: %v", err)
+	}
+
+	dir := filepath.Join(tasksRoot, "task-a")
+	writeTaskFiles(t, dir, "name: a\n", "js")
+
+	before, err := Hash(dir, "../alias-shared")
+	if err != nil {
+		t.Fatalf("before: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(realDir, "helper.ts"), []byte("v2"), 0644); err != nil {
+		t.Fatalf("rewrite helper: %v", err)
+	}
+	after, err := Hash(dir, "../alias-shared")
+	if err != nil {
+		t.Fatalf("after: %v", err)
+	}
+	if before == after {
+		t.Fatalf("Hash ignored a content edit inside a hash_include symlinked directory: before == after == %q", before)
+	}
+}
+
+// TestHash_InDirFifoIsSkipped covers walkTree's own entry classification
+// (used for the main dir walk and directory includes) with a real stat
+// (d.Info()) rather than the raw directory-entry type (d.Type()) — the
+// latter can report 0 ("unknown", indistinguishable from "regular") on
+// filesystems that don't populate d_type, which would otherwise let a FIFO
+// slip through IsRegular() and into a blocking os.ReadFile. This doesn't
+// reproduce the DT_UNKNOWN condition itself (filesystem-dependent, not
+// under test control), but pins that a FIFO sitting directly in the walked
+// dir is still skipped, not hashed as content, after the d.Info() switch.
+func TestHash_InDirFifoIsSkipped(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "task-a")
+	writeTaskFiles(t, dir, "name: a\n", "js")
+	fifoPath := filepath.Join(dir, "a.fifo")
+	if err := syscall.Mkfifo(fifoPath, 0644); err != nil {
+		t.Skipf("mkfifo unsupported here: %v", err)
+	}
+
+	done := make(chan struct{})
+	var hash string
+	var hashErr error
+	go func() {
+		hash, hashErr = Hash(dir)
+		close(done)
+	}()
+	select {
+	case <-done:
+		if hashErr != nil {
+			t.Fatalf("Hash errored on an in-dir FIFO: %v", hashErr)
+		}
+		if hash == "" {
+			t.Fatal("Hash returned an empty digest")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Hash blocked reading an in-dir FIFO instead of skipping it")
+	}
+}

--- a/pkg/task/hash_test.go
+++ b/pkg/task/hash_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -827,5 +828,132 @@ func TestHash_IncludeWithinSiblingScopeStillAllowed(t *testing.T) {
 
 	if _, err := Hash(dir, "../sibling.ts"); err != nil {
 		t.Fatalf("Hash rejected an in-bounds sibling include: %v", err)
+	}
+}
+
+// TestHash_IncludeExactlyTheBoundaryIsRejected is the regression for a
+// critical off-by-one caught in review: hash_include: [".."] resolves to
+// EXACTLY dir's parent directory (the boundary itself), which the original
+// "rel == '..' or has prefix '../'" check did not reject (rel == "." in that
+// case). Left unfixed, this would let a single hash_include entry pull the
+// ENTIRE taskset root — every sibling task, not just one — into this task's
+// content hash, defeating the whole point of scoping to "sibling task".
+func TestHash_IncludeExactlyTheBoundaryIsRejected(t *testing.T) {
+	tasksRoot := t.TempDir()
+	dirA := filepath.Join(tasksRoot, "task-a")
+	writeTaskFiles(t, dirA, "name: a\n", "js")
+	dirB := filepath.Join(tasksRoot, "task-b")
+	writeTaskFiles(t, dirB, "name: b\n", "js")
+
+	if _, err := Hash(dirA, ".."); err == nil {
+		t.Fatal("Hash accepted hash_include: [\"..\"] — the boundary itself, which would pull in every sibling task, not just one")
+	}
+}
+
+// TestHash_IncludeThroughSymlinkedIntermediateDirIsRejected is the
+// regression for the git-committed-symlink escape caught in review:
+// resolveInclude's lexical containment check alone can't see that a
+// directory COMPONENT of the include path is itself a symlink pointing
+// outside the sibling-task boundary — go-git materializes repo-committed
+// symlinks as real on-disk links, so this is reachable from an ordinary git
+// source, not just a local filesystem trick. pathguard.WithinResolved must
+// catch it.
+func TestHash_IncludeThroughSymlinkedIntermediateDirIsRejected(t *testing.T) {
+	parent := t.TempDir()
+	tasksRoot := filepath.Join(parent, "tasks-root")
+	if err := os.MkdirAll(tasksRoot, 0755); err != nil {
+		t.Fatalf("mkdir tasksRoot: %v", err)
+	}
+	outside := filepath.Join(parent, "outside")
+	if err := os.MkdirAll(outside, 0755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("host-secret"), 0644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+
+	// A symlinked directory INSIDE the sibling-task boundary that physically
+	// redirects outside it.
+	evilLink := filepath.Join(tasksRoot, "evil-link")
+	if err := os.Symlink(outside, evilLink); err != nil {
+		t.Skipf("symlinks unsupported here: %v", err)
+	}
+
+	dir := filepath.Join(tasksRoot, "task-a")
+	writeTaskFiles(t, dir, "name: a\n", "js")
+
+	// Lexically, "../evil-link/secret.txt" looks like it stays inside
+	// tasksRoot (the boundary) — only resolving the symlink reveals it
+	// actually reaches outside/secret.txt.
+	if _, err := Hash(dir, "../evil-link/secret.txt"); err == nil {
+		t.Fatal("Hash followed a git-committed symlink out of the sibling-task boundary — path traversal via intermediate symlink not rejected")
+	}
+}
+
+// TestHash_IncludeFifoIsSkippedNotRead is the regression for a hang caught
+// in review: a hash_include entry naming a non-regular, non-symlink,
+// non-directory path (a FIFO here) must be silently skipped, exactly like
+// walkTree already does for the same file types found during a normal dir
+// walk — not read via os.ReadFile, which blocks indefinitely on a FIFO with
+// no writer.
+func TestHash_IncludeFifoIsSkippedNotRead(t *testing.T) {
+	tasksRoot := t.TempDir()
+	fifoPath := filepath.Join(tasksRoot, "a.fifo")
+	if err := syscall.Mkfifo(fifoPath, 0644); err != nil {
+		t.Skipf("mkfifo unsupported here: %v", err)
+	}
+
+	dir := filepath.Join(tasksRoot, "task-a")
+	writeTaskFiles(t, dir, "name: a\n", "js")
+
+	done := make(chan struct{})
+	var hash string
+	var hashErr error
+	go func() {
+		hash, hashErr = Hash(dir, "../a.fifo")
+		close(done)
+	}()
+	select {
+	case <-done:
+		if hashErr != nil {
+			t.Fatalf("Hash errored on a FIFO include: %v", hashErr)
+		}
+		if hash == "" {
+			t.Fatal("Hash returned an empty digest")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Hash blocked reading a FIFO hash_include entry instead of skipping it")
+	}
+}
+
+// TestScanDir_HonorsHashInclude is the regression for a gap caught in
+// review: ScanDir (the change-detection primitive for the flat local/git
+// source types, which never fully load a task.Spec) must still read each
+// task's hash_include list — via the lightweight readHashInclude parse —
+// or hash_include silently does nothing for any task registered through
+// those source types, even though the same task registered via a taskset.yaml
+// source (pkg/taskset/source.go's snapHash) would correctly honor it.
+func TestScanDir_HonorsHashInclude(t *testing.T) {
+	root := t.TempDir()
+	shared := filepath.Join(root, "shared.ts")
+	if err := os.WriteFile(shared, []byte("v1"), 0644); err != nil {
+		t.Fatalf("write shared: %v", err)
+	}
+	writeTaskFiles(t, filepath.Join(root, "task-a"),
+		"name: a\nhash_include: [\"../shared.ts\"]\n", "js")
+
+	before, err := ScanDir(root)
+	if err != nil {
+		t.Fatalf("ScanDir before: %v", err)
+	}
+	if err := os.WriteFile(shared, []byte("v2"), 0644); err != nil {
+		t.Fatalf("rewrite shared: %v", err)
+	}
+	after, err := ScanDir(root)
+	if err != nil {
+		t.Fatalf("ScanDir after: %v", err)
+	}
+	if before["task-a"] == after["task-a"] {
+		t.Fatalf("ScanDir ignored an edit to a hash_include'd shared module: before == after == %q", before["task-a"])
 	}
 }

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -559,6 +559,18 @@ type Spec struct {
 	// Independent of RunInputs (which controls persistence). Used by #238.
 	AutoFix *AutoFixConfig `yaml:"auto_fix,omitempty" json:"auto_fix,omitempty"`
 
+	// HashInclude names additional files or directories, each resolved
+	// relative to TaskDir, whose content is folded into this task's content
+	// hash (task.Hash) alongside its own dir. A task can import a shared
+	// module living outside its own dir (e.g. a sibling buildin task's
+	// helper library); without this, editing that module never perturbs the
+	// importer's hash, so it never re-trips the reconciler reload or the
+	// #392 approval-gate re-pend for the importer (#585). Most tasks don't
+	// need this — the Deno/Python sandbox already only reads within TaskDir,
+	// so only a task that explicitly imports a path outside it should set
+	// this to the same path(s) it imports.
+	HashInclude []string `yaml:"hash_include,omitempty" json:"hash_include,omitempty"`
+
 	// Enabled is false when this task has been disabled via an override or
 	// entry-level `enabled: false`. Disabled tasks remain in the registry and
 	// appear in the API (with enabled:false) but are not scheduled, spawned,
@@ -768,6 +780,14 @@ func (s *Spec) validate() error {
 	for _, e := range s.Permissions.Env {
 		if e.Name == "*" {
 			return fmt.Errorf(`permissions.env: a name-only "*" entry is no longer accepted; set "env_read_exposed: true" to grant the Deno sandbox bare --allow-env`)
+		}
+	}
+	for _, inc := range s.HashInclude {
+		if inc == "" {
+			return fmt.Errorf("hash_include: entries must not be empty")
+		}
+		if filepath.IsAbs(inc) {
+			return fmt.Errorf("hash_include: %q must be relative to the task directory, not absolute", inc)
 		}
 	}
 	triggers := 0

--- a/pkg/task/spec.go
+++ b/pkg/task/spec.go
@@ -789,6 +789,9 @@ func (s *Spec) validate() error {
 		if filepath.IsAbs(inc) {
 			return fmt.Errorf("hash_include: %q must be relative to the task directory, not absolute", inc)
 		}
+		if !hashIncludeLexicallyInBounds(inc) {
+			return fmt.Errorf("hash_include: %q must resolve within the task's parent directory — at most one \"..\" hop up (e.g. \"../sibling-task/file.ts\"), never further up the filesystem or to the parent directory itself", inc)
+		}
 	}
 	triggers := 0
 	if s.Trigger.Cron != "" {
@@ -884,6 +887,39 @@ func (s *Spec) validate() error {
 		// Any other non-empty runtime is accepted; executor presence is checked at run time.
 	}
 	return nil
+}
+
+// hashIncludeLexicallyInBounds reports whether inc, as a hash_include entry,
+// stays within the strict-descendant boundary task.Hash's resolveInclude
+// enforces at hash time — dir's parent directory, i.e. at most one ".." hop
+// up from the task's own directory. Checked here too, at config-load time,
+// rather than leaving it to fail only inside task.Hash later: an entry that
+// fails there causes pkg/taskset/source.go's snapHash to silently fall back
+// to a spec-only hash, dropping ALL dir-content change detection for the
+// task (not just the broken include's contribution) until the entry is
+// fixed — a config error should surface immediately instead.
+//
+// Purely lexical, no filesystem access (symlink-aware containment is
+// task.Hash's job, once an absolute dir is known — see resolveInclude).
+// filepath.Join(dir, inc) always cleans inc as a standalone relative path
+// first, so counting inc's own leading ".." segments (via filepath.Clean
+// from a virtual "." origin) determines how many levels above dir the
+// resolved path would land, independent of dir's actual value — true for
+// any clean, non-".."-containing absolute dir, i.e. any real filesystem
+// path.
+func hashIncludeLexicallyInBounds(inc string) bool {
+	cleaned := filepath.Clean(filepath.FromSlash(inc))
+	if cleaned == ".." {
+		return false // resolves to exactly the boundary itself
+	}
+	depth := 0
+	for _, seg := range strings.Split(cleaned, string(filepath.Separator)) {
+		if seg != ".." {
+			break
+		}
+		depth++
+	}
+	return depth <= 1
 }
 
 // webhookSecretGatedFieldWarnings flags trigger.replay_protection /

--- a/pkg/task/spec_test.go
+++ b/pkg/task/spec_test.go
@@ -222,6 +222,65 @@ func TestSpec_Validate_RejectsAbsoluteHashIncludeEntry(t *testing.T) {
 	}
 }
 
+// TestSpec_Validate_RejectsLexicallyOutOfScopeHashInclude is the regression
+// for a finding caught in review: a hash_include entry that resolves past
+// the task's parent directory boundary (task.Hash's resolveInclude enforces
+// this at hash time) must be rejected here too, at config-load time —
+// otherwise it only fails inside task.Hash later, where
+// pkg/taskset/source.go's snapHash silently falls back to a spec-only hash
+// on any Hash() error, dropping ALL dir-content change detection for the
+// task (not just the broken include) until the entry is fixed.
+func TestSpec_Validate_RejectsLexicallyOutOfScopeHashInclude(t *testing.T) {
+	cases := []string{
+		"..",                   // exactly the boundary itself
+		"../..",                // one hop past the boundary
+		"../../outside",        // two hops up, then a path
+		"sub/../../../outside", // "sub/.." cancels to the start; the remaining two ".." net two hops up
+	}
+	for _, inc := range cases {
+		t.Run(inc, func(t *testing.T) {
+			s := Spec{
+				Name:        "test",
+				Runtime:     RuntimeDeno,
+				Trigger:     TriggerConfig{Manual: true},
+				HashInclude: []string{inc},
+			}
+			err := s.Validate()
+			if err == nil {
+				t.Fatalf("hash_include %q must be rejected as lexically out of scope", inc)
+			}
+			if !strings.Contains(err.Error(), "hash_include") {
+				t.Errorf("error should mention hash_include, got %v", err)
+			}
+		})
+	}
+}
+
+// TestSpec_Validate_AcceptsLexicallyInScopeHashInclude is the control for
+// the test above: entries that stay within the one-hop sibling-task
+// boundary (or don't escape dir at all) must still validate.
+func TestSpec_Validate_AcceptsLexicallyInScopeHashInclude(t *testing.T) {
+	cases := []string{
+		"../sibling-task/file.ts", // one hop up, then down — the feature's actual use case
+		"../sibling.ts",
+		"foo.ts",     // stays inside dir itself — redundant but harmless
+		"lib/foo.ts", // same, nested
+	}
+	for _, inc := range cases {
+		t.Run(inc, func(t *testing.T) {
+			s := Spec{
+				Name:        "test",
+				Runtime:     RuntimeDeno,
+				Trigger:     TriggerConfig{Manual: true},
+				HashInclude: []string{inc},
+			}
+			if err := s.Validate(); err != nil {
+				t.Fatalf("hash_include %q should validate, got %v", inc, err)
+			}
+		})
+	}
+}
+
 func TestSpec_RunResultOverride_Omitted(t *testing.T) {
 	yamlSrc := []byte(`
 name: test

--- a/pkg/task/spec_test.go
+++ b/pkg/task/spec_test.go
@@ -159,6 +159,69 @@ permissions:
 	}
 }
 
+func TestSpec_HashInclude_Parses(t *testing.T) {
+	yamlSrc := []byte(`
+name: test
+runtime: deno
+trigger: { manual: true }
+hash_include:
+  - "../ai-agent-core/chat.ts"
+  - "../shared"
+`)
+	var s Spec
+	if err := yaml.Unmarshal(yamlSrc, &s); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"../ai-agent-core/chat.ts", "../shared"}
+	if len(s.HashInclude) != len(want) {
+		t.Fatalf("HashInclude = %v, want %v", s.HashInclude, want)
+	}
+	for i, w := range want {
+		if s.HashInclude[i] != w {
+			t.Errorf("HashInclude[%d] = %q, want %q", i, s.HashInclude[i], w)
+		}
+	}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("valid hash_include should validate, got %v", err)
+	}
+}
+
+func TestSpec_Validate_RejectsEmptyHashIncludeEntry(t *testing.T) {
+	s := Spec{
+		Name:    "test",
+		Runtime: RuntimeDeno,
+		Trigger: TriggerConfig{Manual: true},
+		HashInclude: []string{
+			"",
+		},
+	}
+	err := s.Validate()
+	if err == nil {
+		t.Fatal("an empty hash_include entry must be rejected")
+	}
+	if !strings.Contains(err.Error(), "hash_include") {
+		t.Errorf("error should mention hash_include, got %v", err)
+	}
+}
+
+func TestSpec_Validate_RejectsAbsoluteHashIncludeEntry(t *testing.T) {
+	s := Spec{
+		Name:    "test",
+		Runtime: RuntimeDeno,
+		Trigger: TriggerConfig{Manual: true},
+		HashInclude: []string{
+			"/etc/passwd",
+		},
+	}
+	err := s.Validate()
+	if err == nil {
+		t.Fatal("an absolute hash_include entry must be rejected")
+	}
+	if !strings.Contains(err.Error(), "hash_include") {
+		t.Errorf("error should mention hash_include, got %v", err)
+	}
+}
+
 func TestSpec_RunResultOverride_Omitted(t *testing.T) {
 	yamlSrc := []byte(`
 name: test

--- a/pkg/taskset/override.go
+++ b/pkg/taskset/override.go
@@ -302,6 +302,10 @@ func copySpec(s *task.Spec) *task.Spec {
 		out.Permissions.Sys = make([]string, len(s.Permissions.Sys))
 		copy(out.Permissions.Sys, s.Permissions.Sys)
 	}
+	if s.HashInclude != nil {
+		out.HashInclude = make([]string, len(s.HashInclude))
+		copy(out.HashInclude, s.HashInclude)
+	}
 	if s.Trigger.Chain != nil {
 		chain := *s.Trigger.Chain
 		out.Trigger.Chain = &chain

--- a/pkg/taskset/source.go
+++ b/pkg/taskset/source.go
@@ -787,7 +787,11 @@ func snapHash(k task.Kinded, taskDir string) string {
 	if taskDir == "" {
 		return specHash
 	}
-	dirHash, err := task.Hash(taskDir)
+	var hashInclude []string
+	if s, ok := k.(*task.Spec); ok {
+		hashInclude = s.HashInclude
+	}
+	dirHash, err := task.Hash(taskDir, hashInclude...)
 	if err != nil {
 		return specHash
 	}


### PR DESCRIPTION
## Summary

`task.Hash` (`pkg/task/hash.go`) only digests a task's own directory. A task that imports a shared module living outside its directory (e.g. `tasks/buildin/ai-agent-core/chat.ts`, imported by sibling tasks) can have that module edited without the importer's content hash ever changing — the edited code runs on the very next spawn (Deno/Python re-read at exec time), but the reconciler never sees a hash change, so it never reloads the task and the #392 trust-on-change approval gate never re-pends it. Moot for gate-exempt buildins; a real integrity gap for **user-source** tasks that import a shared lib.

This adds an optional `hash_include:` list to `task.yaml`, folded into `task.Hash()` alongside the task's own directory.

## Changes

- `pkg/task/hash.go`: refactored the walk into a shared `walkTree` helper; `Hash(dir string, includes ...string)` now folds each include (file or directory, resolved relative to `dir`) into the digest under an `"include:<path>"` label so it can never collide with an in-dir path of the same name. A missing include path folds in a sentinel rather than erroring, so a deleted/mistyped include is itself a detectable change instead of a silent no-op.
- `pkg/task/spec.go`: new `Spec.HashInclude []string` field (`hash_include` in YAML), validated in `Spec.validate()` (no empty entries, must be relative).
- Threaded `HashInclude` through all three production callers of `task.Hash`:
  - `pkg/approval/gate.go` (`ContentHash` / `hashDirResolved`) — the approval-gate hash itself.
  - `pkg/taskset/source.go` (`snapHash`) — reconciler change-detection.
  - `pkg/runtime/envresolve/resolver.go` (`contentHashOf`) — env-resolution cache invalidation.
- `pkg/taskset/override.go`: added `HashInclude` to `copySpec`'s deep-clone — caught live by the existing reflection-based exhaustiveness test (`TestCopySpec_Exhaustive`, from #388) when I first added the field without cloning it.
- Docs: `docs/concepts/task-format.md` gets a new "Content hash and `hash_include`" section plus a table row; `docs/design/ai-task-authoring.md`'s follow-up-items table row is marked done.

## Test plan

Unit-only — this is backend hashing/config-loader logic with no UI or webhook surface to drive through Playwright; nothing changes about what's reachable from a browser. Coverage:

- `pkg/task/hash_test.go`: new tests for include-file edits changing the hash, the no-include control (proves the pre-#585 gap is exactly what's closed), recursive directory includes, missing-include sentinel behavior (no error), include-vs-in-dir label collision safety, and include-order independence.
- `pkg/task/spec_test.go`: `hash_include` YAML parsing + validation (rejects empty/absolute entries).
- `pkg/approval/content_hash_test.go`: **end-to-end regression through the real `Gate`** — `TestHashIncludeRePendsOnSharedModuleEdit` proves an approved task re-pends when its `hash_include`'d shared module is edited (dir itself byte-identical), with `TestWithoutHashInclude_SharedModuleEditDoesNotRePend` as the control.

All of the above pass, plus the full existing suite (`make build`, `go vet ./...`, `make format-check`, `make lint`, `make test`, and `go test -race` on every touched package). One pre-existing, unrelated failure: `TestControl_TaskTest_HappyPath` fails in this sandbox because outbound network is blocked for the Deno binary download (`HTTP 403`) — reproduced identically on a clean `origin/main` checkout before any of these changes.

Closes #585.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wet9W4TAVbNy36Vq6oT823)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `hash_include` configuration to include external files or directories in task content hashing.
  * Changes to included content now trigger task reloads and approval re-evaluation.
  * Added validation for invalid or unsafe include paths, including absolute paths and boundary escapes.

* **Documentation**
  * Documented content hashing behavior, configuration, path rules, and security guidance.
  * Updated the authoring plan to mark shared-module hash coverage as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->